### PR TITLE
fix: cursor clamp, OSC warnings, OSC 22 pointer shape, scrollback truncation

### DIFF
--- a/freminal-buffer/src/buffer.rs
+++ b/freminal-buffer/src/buffer.rs
@@ -582,31 +582,10 @@ impl Buffer {
                     return; // nothing left to insert
                 }
 
-                // Scroll-region-aware wrap: if the cursor is at the bottom
-                // margin of the DECSTBM scroll region, scroll the region up
-                // and keep the cursor on the (now-blanked) bottom row — do
-                // NOT advance past the region boundary.
-                let at_region_bottom = self.is_cursor_at_scroll_region_bottom();
-                if at_region_bottom {
-                    self.scroll_region_up_for_wrap();
-                    // row_idx stays the same — it now points to the freshly
-                    // blanked bottom row of the scroll region.
-                } else {
-                    row_idx += 1;
-                }
+                // Scroll-region-aware wrap: advance to the next row,
+                // preserving scrollback on full-screen primary buffers.
+                row_idx = self.advance_row_for_wrap(row_idx, wrap_start_col);
                 col = wrap_start_col;
-
-                if !at_region_bottom {
-                    if row_idx >= self.rows.len() {
-                        // brand new soft-wrap continuation row
-                        self.push_row(RowOrigin::SoftWrap, RowJoin::ContinueLogicalLine);
-                    } else {
-                        // reuse existing row as a soft-wrap continuation
-                        self.reuse_row_as_softwrap(row_idx);
-                    }
-                }
-
-                self.cursor.pos.y = row_idx;
             }
 
             // ┌─────────────────────────────────────────────┐
@@ -699,30 +678,58 @@ impl Buffer {
                     start += leftover_start;
 
                     // Scroll-region-aware wrap: same logic as PRE-WRAP.
-                    let at_region_bottom = self.is_cursor_at_scroll_region_bottom();
-                    if at_region_bottom {
-                        self.scroll_region_up_for_wrap();
-                    } else {
-                        row_idx += 1;
-                    }
+                    row_idx = self.advance_row_for_wrap(row_idx, wrap_start_col);
                     col = wrap_start_col;
-
-                    // POST-WRAP: we now know a wrap actually occurred.
-                    if !at_region_bottom {
-                        if row_idx >= self.rows.len() {
-                            // brand new continuation
-                            self.push_row(RowOrigin::SoftWrap, RowJoin::ContinueLogicalLine);
-                        } else {
-                            // reuse existing row as continuation
-                            self.reuse_row_as_softwrap(row_idx);
-                        }
-                    }
-
-                    self.cursor.pos.y = row_idx;
                     // `col` stays wrap_start_col; next iteration writes there.
                 }
             }
         }
+    }
+
+    /// Handle soft-wrap advancement: move the cursor to the next row when a
+    /// line wraps.  Returns the new `row_idx`.
+    ///
+    /// On a full-screen primary buffer the top visible row is preserved as
+    /// scrollback by pushing a new row at the bottom (the `handle_lf` fast-path
+    /// strategy).  For partial DECSTBM regions or alternate buffers the old
+    /// `scroll_region_up_for_wrap` rotation is used.
+    ///
+    /// When the cursor is NOT at the scroll region bottom, a new soft-wrap
+    /// continuation row is either allocated or reused from the existing row
+    /// vector.
+    fn advance_row_for_wrap(&mut self, row_idx: usize, wrap_start_col: usize) -> usize {
+        let at_region_bottom = self.is_cursor_at_scroll_region_bottom();
+        let is_full_screen_region = self.scroll_region_top == 0
+            && self.scroll_region_bottom == self.height.saturating_sub(1);
+
+        let new_row_idx =
+            if at_region_bottom && self.kind == BufferType::Primary && is_full_screen_region {
+                // Full-screen primary: push a new row, advance cursor.
+                // Content naturally scrolls into scrollback via visible_window_start().
+                let next = row_idx + 1;
+                self.push_row(RowOrigin::SoftWrap, RowJoin::ContinueLogicalLine);
+                next
+            } else if at_region_bottom {
+                self.scroll_region_up_for_wrap();
+                // row_idx stays the same — it now points to the freshly blanked
+                // bottom row of the scroll region.
+                row_idx
+            } else {
+                let next = row_idx + 1;
+                if next >= self.rows.len() {
+                    self.push_row(RowOrigin::SoftWrap, RowJoin::ContinueLogicalLine);
+                } else {
+                    self.reuse_row_as_softwrap(next);
+                }
+                next
+            };
+
+        // Initialise cursor column to the wrap start column — the caller
+        // still needs to set `col = wrap_start_col` in its own local variable,
+        // but we ensure the cursor struct is consistent.
+        self.cursor.pos.x = wrap_start_col;
+        self.cursor.pos.y = new_row_idx;
+        new_row_idx
     }
 
     /// Resize the terminal buffer and return the adjusted `scroll_offset`.
@@ -7703,5 +7710,157 @@ mod line_width_tests {
         assert_eq!(buf.rows[0].line_width, LineWidth::DoubleWidth);
         buf.set_cursor_line_width(LineWidth::Normal);
         assert_eq!(buf.rows[0].line_width, LineWidth::Normal);
+    }
+}
+
+/// Regression tests for scrollback preservation during soft-wrap in
+/// `insert_text`.  Before the fix, `scroll_region_up_for_wrap()` used an
+/// in-place rotation (`scroll_slice_up`) that destroyed the top visible
+/// row instead of preserving it in scrollback.  Long soft-wrapped lines
+/// (e.g. a 1539-char direnv export at width 128) would lose ~10 rows of
+/// history.
+#[cfg(test)]
+mod softwrap_scrollback_tests {
+    use super::*;
+    use freminal_common::buffer_states::tchar::TChar;
+
+    fn t(s: &str) -> Vec<TChar> {
+        s.bytes().map(TChar::Ascii).collect()
+    }
+
+    /// Fill a 10-column, 5-row primary buffer with 5 identifiable rows,
+    /// then write a long line that soft-wraps ~6 times.  The original 5
+    /// rows must all survive in scrollback.
+    #[test]
+    fn long_softwrap_preserves_scrollback() {
+        let width = 10;
+        let height = 5;
+        let mut buf = Buffer::new(width, height);
+
+        // Write 5 full-width identifiable rows.  Each row is exactly
+        // `width` chars so it fills the row without wrapping.  The LF
+        // after each row moves the cursor to the next line.
+        let labels: Vec<String> = (0..height)
+            .map(|i| {
+                let tag = format!("R{i}");
+                // Pad to exactly `width` with a filler character unique to
+                // the row, so every cell is identifiable.
+                // SAFETY for cast: i < height (5), so always fits in u8.
+                #[allow(clippy::cast_possible_truncation)]
+                let filler = (b'a' + i as u8) as char;
+                let pad_len = width - tag.len();
+                format!(
+                    "{tag}{}",
+                    std::iter::repeat_n(filler, pad_len).collect::<String>()
+                )
+            })
+            .collect();
+
+        for label in &labels {
+            buf.insert_text(&t(label));
+            buf.handle_cr();
+            buf.handle_lf();
+        }
+
+        // The 5 LFs pushed the visible window down.  Row 0 in `rows[]`
+        // is now scrollback.  Write a long line that soft-wraps 5 more
+        // times, each wrap pushing another row into scrollback.
+        let long_line: String = "X".repeat(width * 6); // 60 chars → 6 screen rows
+        buf.insert_text(&t(&long_line));
+
+        // We should now have scrollback.  The earliest rows (R0–R4)
+        // must be accessible.
+        let max_off = buf.max_scroll_offset();
+        assert!(
+            max_off >= 5,
+            "expected at least 5 rows of scrollback, got {max_off}"
+        );
+
+        // Scroll all the way back and check the first 5 rows' content.
+        let vis_start_at_max_scroll = buf.visible_window_start(max_off);
+        for i in 0..5 {
+            let row = &buf.rows[vis_start_at_max_scroll + i];
+            let first_char = row.cells().first().map(Cell::into_utf8);
+            let expected_prefix = format!("R{i}");
+            // The row should start with "Ri" (R0, R1, ...).
+            let row_text: String = row.cells().iter().map(Cell::into_utf8).collect();
+            assert!(
+                row_text.starts_with(&expected_prefix),
+                "scrollback row {i} should start with {expected_prefix:?}, got {row_text:?} (first_char={first_char:?})"
+            );
+        }
+    }
+
+    /// Verify that an alternate buffer still uses `scroll_region_up`
+    /// rotation (no scrollback), so we haven't broken alt-screen wrapping.
+    #[test]
+    fn alt_buffer_softwrap_does_not_grow_scrollback() {
+        let width = 10;
+        let height = 5;
+        let mut buf = Buffer::new(width, height);
+        buf.enter_alternate(0);
+
+        // Fill the screen.
+        for _ in 0..height {
+            buf.insert_text(&t("AAAAAAAAAA"));
+            buf.handle_lf();
+        }
+
+        // Long soft-wrapping line on the alt buffer.
+        let long_line: String = "B".repeat(60);
+        buf.insert_text(&t(&long_line));
+
+        // Alternate buffers must never have scrollback.
+        assert_eq!(
+            buf.max_scroll_offset(),
+            0,
+            "alt buffer must have no scrollback"
+        );
+        assert_eq!(
+            buf.rows.len(),
+            height,
+            "alt buffer row count must stay == height"
+        );
+    }
+
+    /// Ensure that partial DECSTBM regions still use the old rotation
+    /// path (not the new push-row path).  A partial region scroll should
+    /// discard the top line of the region, not grow the buffer.
+    #[test]
+    fn partial_decstbm_softwrap_uses_rotation() {
+        let width = 10;
+        let height = 10;
+        let mut buf = Buffer::new(width, height);
+
+        // Fill the buffer so all `height` rows exist.
+        for i in 0..height {
+            buf.insert_text(&t(&format!("L{i}")));
+            if i < height - 1 {
+                buf.handle_lf();
+            }
+        }
+
+        // Set a partial scroll region: rows 2–7 (0-indexed).
+        buf.scroll_region_top = 2;
+        buf.scroll_region_bottom = 7;
+
+        // Position cursor at the bottom of the scroll region.
+        buf.cursor.pos.y = buf.visible_window_start(0) + 7;
+        buf.cursor.pos.x = 0;
+
+        let initial_row_count = buf.rows.len();
+
+        // Write a long line that wraps several times while at the bottom
+        // of a partial scroll region.
+        let long_line: String = "C".repeat(60);
+        buf.insert_text(&t(&long_line));
+
+        // With a partial DECSTBM, the buffer should NOT grow beyond
+        // the initial size (rotation keeps row count stable).
+        assert_eq!(
+            buf.rows.len(),
+            initial_row_count,
+            "partial DECSTBM wrap must not grow the buffer"
+        );
     }
 }

--- a/freminal-buffer/src/buffer.rs
+++ b/freminal-buffer/src/buffer.rs
@@ -1161,10 +1161,17 @@ impl Buffer {
                 }
             } else {
                 // Primary buffer: extra rows become scrollback (handled by
-                // enforce_scrollback_limit later).  Just clamp cursor.
-                if self.cursor.pos.y >= new_height {
-                    self.cursor.pos.y = new_height.saturating_sub(1);
-                }
+                // enforce_scrollback_limit later).  The cursor's absolute row
+                // index is left unchanged — `clamp_cursor_after_resize()` (below)
+                // ensures it stays within `rows.len()`, and `visible_window_start(0)`
+                // already anchors the visible window to the bottom of the buffer.
+                //
+                // Previous code clamped `cursor.pos.y` to `new_height - 1`, which
+                // was wrong: `cursor.pos.y` is an absolute index into `self.rows`,
+                // not a screen-relative position.  That clamp moved the cursor from
+                // its real row (e.g. the shell prompt) into the middle of whatever
+                // content happened to be at row `new_height - 1`, causing the
+                // SIGWINCH-triggered shell redraw to overwrite that content.
             }
         }
 
@@ -5684,18 +5691,47 @@ mod tests_gui_resize {
     }
 
     // ------------------------------------------------------------------
-    // 4. Cursor must clamp within new height
+    // 4. Primary buffer: cursor stays at absolute position after shrink
     // ------------------------------------------------------------------
     #[test]
-    fn resize_clamps_cursor() {
+    fn resize_primary_cursor_stays_at_absolute_position() {
         let mut buf = buffer_with_rows_and_config(10, 80, 10, 1000, false);
+
+        buf.cursor.pos.y = 9; // last row (absolute index into rows[])
+        buf.set_size(80, 5, 0); // shrink height from 10 to 5
+
+        // Primary buffer: cursor.pos.y is an absolute index into rows[], NOT
+        // screen-relative.  Shrinking the height does not remove rows (they
+        // become scrollback), so row 9 is still valid (9 < rows.len() == 10).
+        // The cursor must NOT be clamped to `new_height - 1`.
+        assert_eq!(
+            buf.cursor.pos.y, 9,
+            "primary buffer cursor must keep its absolute row position after shrink"
+        );
+        assert_eq!(
+            buf.rows.len(),
+            10,
+            "primary buffer rows must not be deleted on shrink"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // 4b. Alternate buffer: cursor IS clamped on shrink (screen-relative)
+    // ------------------------------------------------------------------
+    #[test]
+    fn resize_alternate_cursor_clamped_on_shrink() {
+        let mut buf = buffer_with_rows_and_config(10, 80, 10, 1000, false);
+        buf.kind = BufferType::Alternate;
 
         buf.cursor.pos.y = 9; // last row
         buf.set_size(80, 5, 0); // shrink
 
+        // Alternate buffer: excess rows are drained from the top, cursor is
+        // adjusted by the number of removed rows.  With 10 rows shrunk to
+        // height 5, 5 rows are removed, cursor moves from 9 to 4.
         assert!(
             buf.cursor.pos.y <= 4,
-            "cursor must clamp into new visible height"
+            "alternate buffer cursor must clamp into new visible height"
         );
     }
 

--- a/freminal-buffer/src/terminal_handler/mod.rs
+++ b/freminal-buffer/src/terminal_handler/mod.rs
@@ -1936,6 +1936,7 @@ impl TerminalHandler {
                 | Mode::Decnkm(_)
                 | Mode::Decbkm(_)
                 | Mode::AlternateScroll(_)
+                | Mode::Theming(_)
                 | Mode::GraphemeClustering(
                     GraphemeClustering::Unicode | GraphemeClustering::Legacy,
                 ) => {}
@@ -1988,7 +1989,7 @@ impl TerminalHandler {
                 }
 
                 // ── Modes parsed but not yet acted on ─────────────────
-                Mode::NoOp | Mode::Decsclm(_) | Mode::Theming(_) | Mode::Unknown(_) => {
+                Mode::NoOp | Mode::Decsclm(_) | Mode::Unknown(_) => {
                     tracing::warn!("Mode not acted on by TerminalHandler: {mode}");
                 }
             },

--- a/freminal-buffer/src/terminal_handler/mod.rs
+++ b/freminal-buffer/src/terminal_handler/mod.rs
@@ -37,6 +37,7 @@ use freminal_common::{
         modes::xtcblink::XtCBlink,
         modes::xtextscrn::{AltScreen47, SaveCursor1048, XtExtscrn},
         osc::{AnsiOscType, ITerm2InlineImageData, UrlResponse},
+        pointer_shape::PointerShape,
         tchar::TChar,
         terminal_output::TerminalOutput,
         terminal_sections::TerminalSections,
@@ -185,6 +186,11 @@ pub struct TerminalHandler {
     /// When `Some`, the cursor is rendered in this color instead of the
     /// theme's `cursor` field.
     cursor_color_override: Option<(u8, u8, u8)>,
+    /// Pointer (mouse cursor) shape requested via OSC 22.
+    ///
+    /// Defaults to `PointerShape::Default` (OS default arrow).
+    /// Reset to `Default` by `OSC 22 ; ST` (empty name) or full reset.
+    pointer_shape: PointerShape,
     /// In-progress iTerm2 multipart file transfer, if any.
     ///
     /// Set by `ITerm2MultipartBegin`, appended by `ITerm2FilePart`, consumed
@@ -342,6 +348,7 @@ impl TerminalHandler {
             fg_color_override: None,
             bg_color_override: None,
             cursor_color_override: None,
+            pointer_shape: PointerShape::Default,
             multipart_state: None,
             kitty_state: None,
             virtual_placements: HashMap::new(),
@@ -405,6 +412,14 @@ impl TerminalHandler {
         self.cursor_color_override
     }
 
+    /// Get the current pointer (mouse cursor) shape requested via OSC 22.
+    ///
+    /// Returns `PointerShape::Default` when no override is active.
+    #[must_use]
+    pub const fn pointer_shape(&self) -> PointerShape {
+        self.pointer_shape
+    }
+
     /// Full terminal reset (RIS — Reset to Initial State).
     ///
     /// Restores the handler and buffer to initial startup state.
@@ -436,6 +451,7 @@ impl TerminalHandler {
         self.fg_color_override = None;
         self.bg_color_override = None;
         self.cursor_color_override = None;
+        self.pointer_shape = PointerShape::Default;
         self.allow_column_mode_switch = AllowColumnModeSwitch::AllowColumnModeSwitch;
         self.virtual_placements.clear();
         self.prev_placeholder = None;
@@ -1261,27 +1277,7 @@ impl TerminalHandler {
                 }
             }
             AnsiOscType::Ftcs(marker) => {
-                tracing::debug!("OSC 133 FTCS marker: {marker}");
-                match &marker {
-                    FtcsMarker::PromptStart => {
-                        self.ftcs_state = FtcsState::InPrompt;
-                    }
-                    FtcsMarker::CommandStart => {
-                        self.ftcs_state = FtcsState::InCommand;
-                    }
-                    FtcsMarker::OutputStart => {
-                        self.ftcs_state = FtcsState::InOutput;
-                    }
-                    FtcsMarker::CommandFinished(exit_code) => {
-                        self.last_exit_code = *exit_code;
-                        self.ftcs_state = FtcsState::None;
-                    }
-                    FtcsMarker::PromptProperty(_kind) => {
-                        // Prompt property is informational metadata — it annotates
-                        // the type of the next prompt (initial, continuation, right)
-                        // but does not change the FTCS state machine.
-                    }
-                }
+                self.handle_osc_ftcs(marker);
             }
             AnsiOscType::ITerm2FileInline(data) => {
                 self.handle_iterm2_inline_image(data);
@@ -1332,7 +1328,37 @@ impl TerminalHandler {
                 self.palette.reset_all();
             }
 
+            // OSC 22 — set pointer (mouse cursor) shape.
+            AnsiOscType::SetPointerShape(shape) => {
+                self.pointer_shape = *shape;
+            }
+
             AnsiOscType::NoOp => {}
+        }
+    }
+
+    /// Handle an OSC 133 (FTCS) shell integration marker.
+    fn handle_osc_ftcs(&mut self, marker: &FtcsMarker) {
+        tracing::debug!("OSC 133 FTCS marker: {marker}");
+        match marker {
+            FtcsMarker::PromptStart => {
+                self.ftcs_state = FtcsState::InPrompt;
+            }
+            FtcsMarker::CommandStart => {
+                self.ftcs_state = FtcsState::InCommand;
+            }
+            FtcsMarker::OutputStart => {
+                self.ftcs_state = FtcsState::InOutput;
+            }
+            FtcsMarker::CommandFinished(exit_code) => {
+                self.last_exit_code = *exit_code;
+                self.ftcs_state = FtcsState::None;
+            }
+            FtcsMarker::PromptProperty(_kind) => {
+                // Prompt property is informational metadata — it annotates
+                // the type of the next prompt (initial, continuation, right)
+                // but does not change the FTCS state machine.
+            }
         }
     }
 
@@ -2921,6 +2947,66 @@ mod tests {
             handler.window_commands.len(),
             2,
             "each Bell output should produce one WindowManipulation::Bell"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // OSC 22 — pointer shape
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn osc22_default_pointer_shape_on_new() {
+        let handler = TerminalHandler::new(80, 24);
+        assert_eq!(
+            handler.pointer_shape(),
+            freminal_common::buffer_states::pointer_shape::PointerShape::Default,
+            "initial pointer shape must be Default"
+        );
+    }
+
+    #[test]
+    fn osc22_set_and_read_pointer_shape() {
+        let mut handler = TerminalHandler::new(80, 24);
+
+        handler.handle_osc(&AnsiOscType::SetPointerShape(
+            freminal_common::buffer_states::pointer_shape::PointerShape::Text,
+        ));
+        assert_eq!(
+            handler.pointer_shape(),
+            freminal_common::buffer_states::pointer_shape::PointerShape::Text,
+            "OSC 22 must update pointer_shape to Text"
+        );
+    }
+
+    #[test]
+    fn osc22_reset_via_default_shape() {
+        let mut handler = TerminalHandler::new(80, 24);
+
+        handler.handle_osc(&AnsiOscType::SetPointerShape(
+            freminal_common::buffer_states::pointer_shape::PointerShape::Crosshair,
+        ));
+        handler.handle_osc(&AnsiOscType::SetPointerShape(
+            freminal_common::buffer_states::pointer_shape::PointerShape::Default,
+        ));
+        assert_eq!(
+            handler.pointer_shape(),
+            freminal_common::buffer_states::pointer_shape::PointerShape::Default,
+            "OSC 22 with Default shape must reset to Default"
+        );
+    }
+
+    #[test]
+    fn osc22_full_reset_clears_pointer_shape() {
+        let mut handler = TerminalHandler::new(80, 24);
+
+        handler.handle_osc(&AnsiOscType::SetPointerShape(
+            freminal_common::buffer_states::pointer_shape::PointerShape::Pointer,
+        ));
+        handler.full_reset();
+        assert_eq!(
+            handler.pointer_shape(),
+            freminal_common::buffer_states::pointer_shape::PointerShape::Default,
+            "full_reset must clear pointer_shape to Default"
         );
     }
 }

--- a/freminal-common/src/buffer_states/mod.rs
+++ b/freminal-common/src/buffer_states/mod.rs
@@ -33,6 +33,8 @@ pub mod mode;
 pub mod modes;
 /// OSC parameter types and inline-image data.
 pub mod osc;
+/// `PointerShape` — typed cursor shape set by OSC 22.
+pub mod pointer_shape;
 /// Sixel graphics types.
 pub mod sixel;
 /// `TChar` — a single terminal character with optional wide-character metadata.

--- a/freminal-common/src/buffer_states/osc.rs
+++ b/freminal-common/src/buffer_states/osc.rs
@@ -6,7 +6,7 @@
 use anyhow::{Error, Result};
 use std::str::FromStr;
 
-use crate::buffer_states::{ftcs::FtcsMarker, url::Url};
+use crate::buffer_states::{ftcs::FtcsMarker, pointer_shape::PointerShape, url::Url};
 use std::fmt;
 
 /// iTerm2 inline image dimension specification.
@@ -161,7 +161,7 @@ pub enum OscTarget {
     /// silently consumed; candidate for future response implementation.
     HighlightForeground,
     /// OSC 22 — set/reset the X11 pointer (mouse cursor) shape.  One-way
-    /// command, no response expected.  Silently consumed.
+    /// command, no response expected.
     PointerShape,
     /// OSC 66 — Konsole/zsh color-scheme notification (one-way; no response).
     /// Silently consumed.
@@ -315,6 +315,10 @@ pub enum AnsiOscType {
     ResetForegroundColor,
     /// OSC 111 — reset the dynamic background color override.
     ResetBackgroundColor,
+    /// OSC 22 — set the pointer (mouse cursor) shape.
+    ///
+    /// An empty name or `"default"` resets to the OS default.
+    SetPointerShape(PointerShape),
 }
 
 impl std::fmt::Display for AnsiOscType {
@@ -365,6 +369,7 @@ impl std::fmt::Display for AnsiOscType {
             Self::ResetPaletteColor(idx) => write!(f, "ResetPaletteColor({idx:?})"),
             Self::ResetForegroundColor => write!(f, "ResetForegroundColor"),
             Self::ResetBackgroundColor => write!(f, "ResetBackgroundColor"),
+            Self::SetPointerShape(shape) => write!(f, "SetPointerShape({shape})"),
         }
     }
 }

--- a/freminal-common/src/buffer_states/osc.rs
+++ b/freminal-common/src/buffer_states/osc.rs
@@ -142,6 +142,30 @@ pub enum OscTarget {
     ResetForeground,
     /// OSC 111 — reset text background color to the theme default.
     ResetBackground,
+    /// OSC 13 — mouse cursor foreground color (X11 concept; not applicable to
+    /// GPU-rendered terminals).  Recognised and silently consumed.
+    MouseForeground,
+    /// OSC 14 — mouse cursor background color (X11 concept; not applicable to
+    /// GPU-rendered terminals).  Recognised and silently consumed.
+    MouseBackground,
+    /// OSC 15 — Tektronix foreground color (legacy VT100 graphics mode;
+    /// unimplemented).  Recognised and silently consumed.
+    TekForeground,
+    /// OSC 16 — Tektronix cursor/background color (legacy VT100 graphics mode;
+    /// unimplemented).  Recognised and silently consumed.
+    TekBackground,
+    /// OSC 17 — highlight (selection) background color.  Recognised and
+    /// silently consumed; candidate for future response implementation.
+    HighlightBackground,
+    /// OSC 19 — highlight (selection) foreground color.  Recognised and
+    /// silently consumed; candidate for future response implementation.
+    HighlightForeground,
+    /// OSC 22 — set/reset the X11 pointer (mouse cursor) shape.  One-way
+    /// command, no response expected.  Silently consumed.
+    PointerShape,
+    /// OSC 66 — Konsole/zsh color-scheme notification (one-way; no response).
+    /// Silently consumed.
+    ColorSchemeNotification,
     Unknown,
     ITerm2,
 }
@@ -186,7 +210,15 @@ impl From<&AnsiOscToken> for OscTarget {
             AnsiOscToken::OscValue(11) => Self::Background,
             AnsiOscToken::OscValue(10) => Self::Foreground,
             AnsiOscToken::OscValue(12) => Self::CursorColor,
+            AnsiOscToken::OscValue(13) => Self::MouseForeground,
+            AnsiOscToken::OscValue(14) => Self::MouseBackground,
+            AnsiOscToken::OscValue(15) => Self::TekForeground,
+            AnsiOscToken::OscValue(16) => Self::TekBackground,
+            AnsiOscToken::OscValue(17) => Self::HighlightBackground,
+            AnsiOscToken::OscValue(19) => Self::HighlightForeground,
+            AnsiOscToken::OscValue(22) => Self::PointerShape,
             AnsiOscToken::OscValue(52) => Self::Clipboard,
+            AnsiOscToken::OscValue(66) => Self::ColorSchemeNotification,
             AnsiOscToken::OscValue(104) => Self::ResetPaletteColor,
             AnsiOscToken::OscValue(112) => Self::ResetCursorColor,
             AnsiOscToken::OscValue(133) => Self::Ftcs,

--- a/freminal-common/src/buffer_states/pointer_shape.rs
+++ b/freminal-common/src/buffer_states/pointer_shape.rs
@@ -1,0 +1,401 @@
+// Copyright (C) 2024-2026 Fred Clausen
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! `PointerShape` — typed representation of the X11/CSS pointer cursor shape
+//! set by `OSC 22 ; <name> ST`.
+//!
+//! The variants map 1-to-1 onto `egui::CursorIcon` so the GUI can convert
+//! without carrying an egui dependency into the common crate.
+
+use std::fmt;
+
+/// The mouse pointer (cursor) shape requested by the running application via
+/// OSC 22.
+///
+/// An application sends `OSC 22 ; <name> ST` to request a specific X11 /
+/// CSS pointer shape.  An empty name or `"default"` resets to the OS default.
+///
+/// The variants are named after their `egui::CursorIcon` counterparts so that
+/// the GUI layer can convert with a simple `match` — no string comparison at
+/// render time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PointerShape {
+    /// Default OS pointer (arrow).  Also the reset / "no override" state.
+    #[default]
+    Default,
+    /// Hide the cursor entirely.
+    None,
+    /// I-beam for text selection.
+    Text,
+    /// Vertical I-beam.
+    VerticalText,
+    /// Pointing-hand (links / clickable items).
+    Pointer,
+    /// Context-menu cursor.
+    ContextMenu,
+    /// Help / question-mark cursor.
+    Help,
+    /// Spinning progress indicator (cursor + busy).
+    Progress,
+    /// Hourglass / busy wait — no interaction.
+    Wait,
+    /// Cell / plus cross (spreadsheet cell).
+    Cell,
+    /// Crosshair / precision cursor.
+    Crosshair,
+    /// Move (four-direction).
+    Move,
+    /// No-drop indicator.
+    NoDrop,
+    /// Not-allowed / forbidden.
+    NotAllowed,
+    /// Grab (open hand).
+    Grab,
+    /// Grabbing (closed hand).
+    Grabbing,
+    /// Alias / shortcut arrow.
+    Alias,
+    /// Copy arrow.
+    Copy,
+    /// All-scroll (four arrows).
+    AllScroll,
+    /// Horizontal resize (east–west).
+    ResizeHorizontal,
+    /// Vertical resize (north–south).
+    ResizeVertical,
+    /// North-east / south-west resize diagonal.
+    ResizeNeSw,
+    /// North-west / south-east resize diagonal.
+    ResizeNwSe,
+    /// Resize east.
+    ResizeEast,
+    /// Resize south-east.
+    ResizeSouthEast,
+    /// Resize south.
+    ResizeSouth,
+    /// Resize south-west.
+    ResizeSouthWest,
+    /// Resize west.
+    ResizeWest,
+    /// Resize north-west.
+    ResizeNorthWest,
+    /// Resize north.
+    ResizeNorth,
+    /// Resize north-east.
+    ResizeNorthEast,
+    /// Zoom in.
+    ZoomIn,
+    /// Zoom out.
+    ZoomOut,
+}
+
+impl fmt::Display for PointerShape {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Default => write!(f, "default"),
+            Self::None => write!(f, "none"),
+            Self::Text => write!(f, "text"),
+            Self::VerticalText => write!(f, "vertical-text"),
+            Self::Pointer => write!(f, "pointer"),
+            Self::ContextMenu => write!(f, "context-menu"),
+            Self::Help => write!(f, "help"),
+            Self::Progress => write!(f, "progress"),
+            Self::Wait => write!(f, "wait"),
+            Self::Cell => write!(f, "cell"),
+            Self::Crosshair => write!(f, "crosshair"),
+            Self::Move => write!(f, "move"),
+            Self::NoDrop => write!(f, "no-drop"),
+            Self::NotAllowed => write!(f, "not-allowed"),
+            Self::Grab => write!(f, "grab"),
+            Self::Grabbing => write!(f, "grabbing"),
+            Self::Alias => write!(f, "alias"),
+            Self::Copy => write!(f, "copy"),
+            Self::AllScroll => write!(f, "all-scroll"),
+            Self::ResizeHorizontal => write!(f, "col-resize"),
+            Self::ResizeVertical => write!(f, "row-resize"),
+            Self::ResizeNeSw => write!(f, "nesw-resize"),
+            Self::ResizeNwSe => write!(f, "nwse-resize"),
+            Self::ResizeEast => write!(f, "e-resize"),
+            Self::ResizeSouthEast => write!(f, "se-resize"),
+            Self::ResizeSouth => write!(f, "s-resize"),
+            Self::ResizeSouthWest => write!(f, "sw-resize"),
+            Self::ResizeWest => write!(f, "w-resize"),
+            Self::ResizeNorthWest => write!(f, "nw-resize"),
+            Self::ResizeNorth => write!(f, "n-resize"),
+            Self::ResizeNorthEast => write!(f, "ne-resize"),
+            Self::ZoomIn => write!(f, "zoom-in"),
+            Self::ZoomOut => write!(f, "zoom-out"),
+        }
+    }
+}
+
+impl From<&str> for PointerShape {
+    /// Convert an xcursor / CSS cursor name to a `PointerShape`.
+    ///
+    /// Unknown names and empty strings map to `PointerShape::Default`.
+    fn from(name: &str) -> Self {
+        match name.trim() {
+            // Hide cursor
+            "none" => Self::None,
+            // Text
+            "text" | "xterm" => Self::Text,
+            "vertical-text" => Self::VerticalText,
+            // Pointer
+            "pointer" | "hand" | "hand2" => Self::Pointer,
+            // Help
+            "help" => Self::Help,
+            // Context menu
+            "context-menu" => Self::ContextMenu,
+            // Progress
+            "progress" | "left_ptr_watch" => Self::Progress,
+            // Wait
+            "wait" | "watch" => Self::Wait,
+            // Crosshair
+            "crosshair" => Self::Crosshair,
+            // Cell
+            "cell" => Self::Cell,
+            // Move
+            "move" | "fleur" => Self::Move,
+            // No-drop
+            "no-drop" => Self::NoDrop,
+            // Not-allowed
+            "not-allowed" => Self::NotAllowed,
+            // Grab
+            "grab" => Self::Grab,
+            // Grabbing
+            "grabbing" => Self::Grabbing,
+            // Alias
+            "alias" => Self::Alias,
+            // Copy
+            "copy" => Self::Copy,
+            // All-scroll
+            "all-scroll" => Self::AllScroll,
+            // Horizontal resize
+            "col-resize" | "ew-resize" => Self::ResizeHorizontal,
+            // Vertical resize
+            "row-resize" | "ns-resize" => Self::ResizeVertical,
+            // Diagonal resize NE-SW
+            "nesw-resize" => Self::ResizeNeSw,
+            // Diagonal resize NW-SE
+            "nwse-resize" => Self::ResizeNwSe,
+            // Directional resizes
+            "e-resize" => Self::ResizeEast,
+            "se-resize" => Self::ResizeSouthEast,
+            "s-resize" => Self::ResizeSouth,
+            "sw-resize" => Self::ResizeSouthWest,
+            "w-resize" => Self::ResizeWest,
+            "nw-resize" => Self::ResizeNorthWest,
+            "n-resize" => Self::ResizeNorth,
+            "ne-resize" => Self::ResizeNorthEast,
+            // Zoom
+            "zoom-in" => Self::ZoomIn,
+            "zoom-out" => Self::ZoomOut,
+            // Unknown names, empty string, and explicit "default"/"arrow"/"left_ptr" all map here
+            _ => Self::Default,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PointerShape;
+
+    #[test]
+    fn empty_string_maps_to_default() {
+        assert_eq!(PointerShape::from(""), PointerShape::Default);
+    }
+
+    #[test]
+    fn whitespace_only_maps_to_default() {
+        assert_eq!(PointerShape::from("   "), PointerShape::Default);
+    }
+
+    #[test]
+    fn explicit_default_names() {
+        assert_eq!(PointerShape::from("default"), PointerShape::Default);
+        assert_eq!(PointerShape::from("arrow"), PointerShape::Default);
+        assert_eq!(PointerShape::from("left_ptr"), PointerShape::Default);
+    }
+
+    #[test]
+    fn none_cursor() {
+        assert_eq!(PointerShape::from("none"), PointerShape::None);
+    }
+
+    #[test]
+    fn text_cursor_variants() {
+        assert_eq!(PointerShape::from("text"), PointerShape::Text);
+        assert_eq!(PointerShape::from("xterm"), PointerShape::Text);
+    }
+
+    #[test]
+    fn vertical_text() {
+        assert_eq!(
+            PointerShape::from("vertical-text"),
+            PointerShape::VerticalText
+        );
+    }
+
+    #[test]
+    fn pointer_variants() {
+        assert_eq!(PointerShape::from("pointer"), PointerShape::Pointer);
+        assert_eq!(PointerShape::from("hand"), PointerShape::Pointer);
+        assert_eq!(PointerShape::from("hand2"), PointerShape::Pointer);
+    }
+
+    #[test]
+    fn help_cursor() {
+        assert_eq!(PointerShape::from("help"), PointerShape::Help);
+    }
+
+    #[test]
+    fn context_menu_cursor() {
+        assert_eq!(
+            PointerShape::from("context-menu"),
+            PointerShape::ContextMenu
+        );
+    }
+
+    #[test]
+    fn progress_variants() {
+        assert_eq!(PointerShape::from("progress"), PointerShape::Progress);
+        assert_eq!(PointerShape::from("left_ptr_watch"), PointerShape::Progress);
+    }
+
+    #[test]
+    fn wait_variants() {
+        assert_eq!(PointerShape::from("wait"), PointerShape::Wait);
+        assert_eq!(PointerShape::from("watch"), PointerShape::Wait);
+    }
+
+    #[test]
+    fn crosshair() {
+        assert_eq!(PointerShape::from("crosshair"), PointerShape::Crosshair);
+    }
+
+    #[test]
+    fn cell_cursor() {
+        assert_eq!(PointerShape::from("cell"), PointerShape::Cell);
+    }
+
+    #[test]
+    fn move_variants() {
+        assert_eq!(PointerShape::from("move"), PointerShape::Move);
+        assert_eq!(PointerShape::from("fleur"), PointerShape::Move);
+    }
+
+    #[test]
+    fn no_drop() {
+        assert_eq!(PointerShape::from("no-drop"), PointerShape::NoDrop);
+    }
+
+    #[test]
+    fn not_allowed() {
+        assert_eq!(PointerShape::from("not-allowed"), PointerShape::NotAllowed);
+    }
+
+    #[test]
+    fn grab_and_grabbing() {
+        assert_eq!(PointerShape::from("grab"), PointerShape::Grab);
+        assert_eq!(PointerShape::from("grabbing"), PointerShape::Grabbing);
+    }
+
+    #[test]
+    fn alias_and_copy() {
+        assert_eq!(PointerShape::from("alias"), PointerShape::Alias);
+        assert_eq!(PointerShape::from("copy"), PointerShape::Copy);
+    }
+
+    #[test]
+    fn all_scroll() {
+        assert_eq!(PointerShape::from("all-scroll"), PointerShape::AllScroll);
+    }
+
+    #[test]
+    fn horizontal_resize_variants() {
+        assert_eq!(
+            PointerShape::from("col-resize"),
+            PointerShape::ResizeHorizontal
+        );
+        assert_eq!(
+            PointerShape::from("ew-resize"),
+            PointerShape::ResizeHorizontal
+        );
+    }
+
+    #[test]
+    fn vertical_resize_variants() {
+        assert_eq!(
+            PointerShape::from("row-resize"),
+            PointerShape::ResizeVertical
+        );
+        assert_eq!(
+            PointerShape::from("ns-resize"),
+            PointerShape::ResizeVertical
+        );
+    }
+
+    #[test]
+    fn diagonal_resizes() {
+        assert_eq!(PointerShape::from("nesw-resize"), PointerShape::ResizeNeSw);
+        assert_eq!(PointerShape::from("nwse-resize"), PointerShape::ResizeNwSe);
+    }
+
+    #[test]
+    fn directional_resizes() {
+        assert_eq!(PointerShape::from("e-resize"), PointerShape::ResizeEast);
+        assert_eq!(
+            PointerShape::from("se-resize"),
+            PointerShape::ResizeSouthEast
+        );
+        assert_eq!(PointerShape::from("s-resize"), PointerShape::ResizeSouth);
+        assert_eq!(
+            PointerShape::from("sw-resize"),
+            PointerShape::ResizeSouthWest
+        );
+        assert_eq!(PointerShape::from("w-resize"), PointerShape::ResizeWest);
+        assert_eq!(
+            PointerShape::from("nw-resize"),
+            PointerShape::ResizeNorthWest
+        );
+        assert_eq!(PointerShape::from("n-resize"), PointerShape::ResizeNorth);
+        assert_eq!(
+            PointerShape::from("ne-resize"),
+            PointerShape::ResizeNorthEast
+        );
+    }
+
+    #[test]
+    fn zoom_in_and_out() {
+        assert_eq!(PointerShape::from("zoom-in"), PointerShape::ZoomIn);
+        assert_eq!(PointerShape::from("zoom-out"), PointerShape::ZoomOut);
+    }
+
+    #[test]
+    fn unknown_name_maps_to_default() {
+        assert_eq!(PointerShape::from("banana"), PointerShape::Default);
+        assert_eq!(PointerShape::from("not-a-cursor"), PointerShape::Default);
+    }
+
+    #[test]
+    fn default_display_roundtrip() {
+        assert_eq!(PointerShape::Default.to_string(), "default");
+    }
+
+    #[test]
+    fn text_display_roundtrip() {
+        assert_eq!(PointerShape::Text.to_string(), "text");
+    }
+
+    #[test]
+    fn pointer_display_roundtrip() {
+        assert_eq!(PointerShape::Pointer.to_string(), "pointer");
+    }
+
+    #[test]
+    fn default_trait_is_default_variant() {
+        assert_eq!(PointerShape::default(), PointerShape::Default);
+    }
+}

--- a/freminal-terminal-emulator/src/ansi_components/osc.rs
+++ b/freminal-terminal-emulator/src/ansi_components/osc.rs
@@ -10,6 +10,7 @@ use freminal_common::buffer_states::ftcs::parse_ftcs_params;
 use freminal_common::buffer_states::osc::{
     AnsiOscInternalType, AnsiOscToken, AnsiOscType, OscTarget, UrlResponse,
 };
+use freminal_common::buffer_states::pointer_shape::PointerShape;
 use freminal_common::buffer_states::terminal_output::TerminalOutput;
 
 use super::osc_clipboard::handle_osc_clipboard;
@@ -187,6 +188,26 @@ impl AnsiOscParser {
     }
 }
 
+/// Extract the cursor-shape name from OSC 22 params and push a  response.
+///
+///  →  contains the xcursor/CSS name string.
+/// An empty or absent token resets to the default shape.
+fn handle_osc_pointer_shape(params: &[Option<AnsiOscToken>], output: &mut Vec<TerminalOutput>) {
+    let shape_name = params
+        .get(1)
+        .and_then(|t| {
+            if let Some(AnsiOscToken::String(s)) = t {
+                Some(s.as_str())
+            } else {
+                None
+            }
+        })
+        .unwrap_or("");
+    output.push(TerminalOutput::OscResponse(AnsiOscType::SetPointerShape(
+        PointerShape::from(shape_name),
+    )));
+}
+
 fn dispatch_osc_target(
     osc_target: &OscTarget,
     osc_internal_type: AnsiOscInternalType,
@@ -272,10 +293,14 @@ fn dispatch_osc_target(
         OscTarget::ITerm2 => {
             handle_osc_iterm2(raw_params, seq_trace, output);
         }
+        // OSC 22 — set the pointer (mouse cursor) shape.
+        OscTarget::PointerShape => {
+            handle_osc_pointer_shape(&params, output);
+        }
         // Known-but-unimplemented OSC targets.  These are recognised
         // sequences sent by common programs (vim/neovim, zsh, tmux) that
         // Freminal cannot meaningfully act on (X11 mouse colors, Tektronix
-        // graphics, xcursor shape, color-scheme notifications).  Silently
+        // graphics, color-scheme notifications).  Silently
         // consumed at trace level to avoid warn! spam during normal use.
         OscTarget::MouseForeground
         | OscTarget::MouseBackground
@@ -283,7 +308,6 @@ fn dispatch_osc_target(
         | OscTarget::TekBackground
         | OscTarget::HighlightBackground
         | OscTarget::HighlightForeground
-        | OscTarget::PointerShape
         | OscTarget::ColorSchemeNotification => {
             tracing::trace!(
                 "Recognised but unimplemented OSC (silently consumed): target={osc_target:?}, recent='{}'",

--- a/freminal-terminal-emulator/src/ansi_components/osc.rs
+++ b/freminal-terminal-emulator/src/ansi_components/osc.rs
@@ -188,10 +188,11 @@ impl AnsiOscParser {
     }
 }
 
-/// Extract the cursor-shape name from OSC 22 params and push a  response.
+/// Extract the pointer-shape name from OSC 22 parameters and emit the
+/// corresponding terminal output.
 ///
-///  →  contains the xcursor/CSS name string.
-/// An empty or absent token resets to the default shape.
+/// The second parameter contains the xcursor/CSS name string. An empty or
+/// absent token resets the pointer shape to the default.
 fn handle_osc_pointer_shape(params: &[Option<AnsiOscToken>], output: &mut Vec<TerminalOutput>) {
     let shape_name = params
         .get(1)

--- a/freminal-terminal-emulator/src/ansi_components/osc.rs
+++ b/freminal-terminal-emulator/src/ansi_components/osc.rs
@@ -272,6 +272,24 @@ fn dispatch_osc_target(
         OscTarget::ITerm2 => {
             handle_osc_iterm2(raw_params, seq_trace, output);
         }
+        // Known-but-unimplemented OSC targets.  These are recognised
+        // sequences sent by common programs (vim/neovim, zsh, tmux) that
+        // Freminal cannot meaningfully act on (X11 mouse colors, Tektronix
+        // graphics, xcursor shape, color-scheme notifications).  Silently
+        // consumed at trace level to avoid warn! spam during normal use.
+        OscTarget::MouseForeground
+        | OscTarget::MouseBackground
+        | OscTarget::TekForeground
+        | OscTarget::TekBackground
+        | OscTarget::HighlightBackground
+        | OscTarget::HighlightForeground
+        | OscTarget::PointerShape
+        | OscTarget::ColorSchemeNotification => {
+            tracing::trace!(
+                "Recognised but unimplemented OSC (silently consumed): target={osc_target:?}, recent='{}'",
+                seq_trace.as_str()
+            );
+        }
         OscTarget::Unknown => {
             // Unknown OSC sequences are silently consumed (like
             // xterm/VTE).  Downgraded from error!/Invalid to warn!

--- a/freminal-terminal-emulator/src/interface.rs
+++ b/freminal-terminal-emulator/src/interface.rs
@@ -646,6 +646,7 @@ impl TerminalEmulator {
             #[cfg(feature = "playback")]
             playback_info: None,
             cursor_color_override: self.internal.handler.cursor_color_override(),
+            pointer_shape: self.internal.handler.pointer_shape(),
         }
     }
 

--- a/freminal-terminal-emulator/src/snapshot.rs
+++ b/freminal-terminal-emulator/src/snapshot.rs
@@ -30,6 +30,7 @@ use freminal_common::{
             mouse::{MouseEncoding, MouseTrack},
             rl_bracket::RlBracket,
         },
+        pointer_shape::PointerShape,
         tchar::TChar,
     },
     cursor::CursorVisualStyle,
@@ -293,6 +294,12 @@ pub struct TerminalSnapshot {
     /// the theme's `cursor` field.
     pub cursor_color_override: Option<(u8, u8, u8)>,
 
+    /// Pointer (mouse cursor) shape requested by the application via OSC 22.
+    ///
+    /// The GUI maps this to `egui::CursorIcon` during the render pass.
+    /// `PointerShape::Default` means no override — use the OS default arrow.
+    pub pointer_shape: PointerShape,
+
     /// All inline images referenced by the visible window.
     ///
     /// The map contains only the images that appear in `visible_image_placements`
@@ -376,6 +383,7 @@ impl TerminalSnapshot {
             #[cfg(feature = "playback")]
             playback_info: None,
             cursor_color_override: None,
+            pointer_shape: PointerShape::Default,
         }
     }
 }
@@ -417,5 +425,13 @@ mod tests {
     #[test]
     fn empty_visible_line_widths_is_empty() {
         assert!(TerminalSnapshot::empty().visible_line_widths.is_empty());
+    }
+
+    #[test]
+    fn empty_pointer_shape_is_default() {
+        assert_eq!(
+            TerminalSnapshot::empty().pointer_shape,
+            PointerShape::Default
+        );
     }
 }

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -1730,14 +1730,11 @@ impl FreminalTerminalWidget {
     }
 }
 
-/// POSIX shell-escape a file path for safe pasting into a terminal.
+/// Convert a [`PointerShape`] (from [`TerminalSnapshot`]) to the corresponding
+/// [`egui::CursorIcon`].
 ///
-/// Wraps the path in single quotes and escapes any embedded single quotes
-/// Convert a `PointerShape` (from `TerminalSnapshot`) to the corresponding
-/// `egui::CursorIcon`.
-///
-/// `PointerShape::Default` and any value that has no direct egui equivalent
-/// both produce `CursorIcon::Default`.
+/// [`PointerShape::Default`] and any value that has no direct egui equivalent
+/// both produce [`CursorIcon::Default`].
 const fn pointer_shape_to_cursor_icon(shape: PointerShape) -> CursorIcon {
     match shape {
         PointerShape::Default => CursorIcon::Default,
@@ -1776,6 +1773,9 @@ const fn pointer_shape_to_cursor_icon(shape: PointerShape) -> CursorIcon {
     }
 }
 
+/// POSIX shell-escape a file path for safe pasting into a terminal.
+///
+/// Wraps the path in single quotes and escapes any embedded single quotes
 /// with the `'\''` idiom.  The result is safe to paste into `sh`, `bash`,
 /// `zsh`, and `fish`.
 fn shell_escape_path(path: &std::path::Path) -> String {

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -604,8 +604,6 @@ pub struct PaneRenderCache {
     /// Pointer identity of the `visible_chars` `Arc` used for the last URL
     /// hover lookup.
     pub(super) hover_snap_ptr: usize,
-    /// The cursor icon that was last written via `output_mut`.
-    pub(super) previous_cursor_icon: CursorIcon,
     /// Per-pane shaping cache for text layout.
     pub(crate) shaping_cache: crate::gui::shaping::ShapingCache,
 }
@@ -634,7 +632,6 @@ impl PaneRenderCache {
             previous_hover_cell: None,
             cached_hovered_url: None,
             hover_snap_ptr: 0,
-            previous_cursor_icon: CursorIcon::Default,
             shaping_cache: crate::gui::shaping::ShapingCache::new(),
         }
     }
@@ -1611,18 +1608,17 @@ impl FreminalTerminalWidget {
 
                 // Update cursor icon from cached URL state.
                 // URL hover (pointing hand) takes priority over OSC 22 shape.
+                // Must be set unconditionally every frame because egui resets
+                // output.cursor_icon to Default at the start of each frame.
                 let new_icon = if cache.cached_hovered_url.is_some() {
                     CursorIcon::PointingHand
                 } else {
                     pointer_shape_to_cursor_icon(snap.pointer_shape)
                 };
 
-                if new_icon != cache.previous_cursor_icon {
-                    cache.previous_cursor_icon = new_icon;
-                    ui.ctx().output_mut(|output| {
-                        output.cursor_icon = new_icon;
-                    });
-                }
+                ui.ctx().output_mut(|output| {
+                    output.cursor_icon = new_icon;
+                });
 
                 // Ctrl+click (Cmd+click on macOS) opens the URL.
                 if let Some(url) = &cache.cached_hovered_url {
@@ -1644,24 +1640,18 @@ impl FreminalTerminalWidget {
                 cache.previous_hover_cell = None;
                 cache.cached_hovered_url = None;
                 let base_icon = pointer_shape_to_cursor_icon(snap.pointer_shape);
-                if cache.previous_cursor_icon != base_icon {
-                    cache.previous_cursor_icon = base_icon;
-                    ui.ctx().output_mut(|output| {
-                        output.cursor_icon = base_icon;
-                    });
-                }
+                ui.ctx().output_mut(|output| {
+                    output.cursor_icon = base_icon;
+                });
             }
         } else {
             // No URLs — apply OSC 22 shape (or default if none set).
             cache.previous_hover_cell = None;
             cache.cached_hovered_url = None;
             let base_icon = pointer_shape_to_cursor_icon(snap.pointer_shape);
-            if cache.previous_cursor_icon != base_icon {
-                cache.previous_cursor_icon = base_icon;
-                ui.ctx().output_mut(|output| {
-                    output.cursor_icon = base_icon;
-                });
-            }
+            ui.ctx().output_mut(|output| {
+                output.cursor_icon = base_icon;
+            });
         }
 
         // ── Drag-and-drop ────────────────────────────────────────────

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -13,7 +13,7 @@ use crate::gui::{
 
 use crossbeam_channel::{Receiver, Sender};
 use freminal_common::{
-    buffer_states::{tchar::TChar, url::Url},
+    buffer_states::{pointer_shape::PointerShape, tchar::TChar, url::Url},
     config::Config,
     themes::ThemePalette,
 };
@@ -1610,10 +1610,11 @@ impl FreminalTerminalWidget {
                 }
 
                 // Update cursor icon from cached URL state.
+                // URL hover (pointing hand) takes priority over OSC 22 shape.
                 let new_icon = if cache.cached_hovered_url.is_some() {
                     CursorIcon::PointingHand
                 } else {
-                    CursorIcon::Default
+                    pointer_shape_to_cursor_icon(snap.pointer_shape)
                 };
 
                 if new_icon != cache.previous_cursor_icon {
@@ -1639,24 +1640,26 @@ impl FreminalTerminalWidget {
                     }
                 }
             } else {
-                // Mouse left the terminal area.
+                // Mouse left the terminal area — fall back to OSC 22 shape.
                 cache.previous_hover_cell = None;
                 cache.cached_hovered_url = None;
-                if cache.previous_cursor_icon != CursorIcon::Default {
-                    cache.previous_cursor_icon = CursorIcon::Default;
+                let base_icon = pointer_shape_to_cursor_icon(snap.pointer_shape);
+                if cache.previous_cursor_icon != base_icon {
+                    cache.previous_cursor_icon = base_icon;
                     ui.ctx().output_mut(|output| {
-                        output.cursor_icon = CursorIcon::Default;
+                        output.cursor_icon = base_icon;
                     });
                 }
             }
         } else {
-            // No URLs — reset tracking state and ensure default cursor.
+            // No URLs — apply OSC 22 shape (or default if none set).
             cache.previous_hover_cell = None;
             cache.cached_hovered_url = None;
-            if cache.previous_cursor_icon != CursorIcon::Default {
-                cache.previous_cursor_icon = CursorIcon::Default;
+            let base_icon = pointer_shape_to_cursor_icon(snap.pointer_shape);
+            if cache.previous_cursor_icon != base_icon {
+                cache.previous_cursor_icon = base_icon;
                 ui.ctx().output_mut(|output| {
-                    output.cursor_icon = CursorIcon::Default;
+                    output.cursor_icon = base_icon;
                 });
             }
         }
@@ -1740,6 +1743,49 @@ impl FreminalTerminalWidget {
 /// POSIX shell-escape a file path for safe pasting into a terminal.
 ///
 /// Wraps the path in single quotes and escapes any embedded single quotes
+/// Convert a `PointerShape` (from `TerminalSnapshot`) to the corresponding
+/// `egui::CursorIcon`.
+///
+/// `PointerShape::Default` and any value that has no direct egui equivalent
+/// both produce `CursorIcon::Default`.
+const fn pointer_shape_to_cursor_icon(shape: PointerShape) -> CursorIcon {
+    match shape {
+        PointerShape::Default => CursorIcon::Default,
+        PointerShape::None => CursorIcon::None,
+        PointerShape::Text => CursorIcon::Text,
+        PointerShape::VerticalText => CursorIcon::VerticalText,
+        PointerShape::Pointer => CursorIcon::PointingHand,
+        PointerShape::ContextMenu => CursorIcon::ContextMenu,
+        PointerShape::Help => CursorIcon::Help,
+        PointerShape::Progress => CursorIcon::Progress,
+        PointerShape::Wait => CursorIcon::Wait,
+        PointerShape::Cell => CursorIcon::Cell,
+        PointerShape::Crosshair => CursorIcon::Crosshair,
+        PointerShape::Move => CursorIcon::Move,
+        PointerShape::NoDrop => CursorIcon::NoDrop,
+        PointerShape::NotAllowed => CursorIcon::NotAllowed,
+        PointerShape::Grab => CursorIcon::Grab,
+        PointerShape::Grabbing => CursorIcon::Grabbing,
+        PointerShape::Alias => CursorIcon::Alias,
+        PointerShape::Copy => CursorIcon::Copy,
+        PointerShape::AllScroll => CursorIcon::AllScroll,
+        PointerShape::ResizeHorizontal => CursorIcon::ResizeHorizontal,
+        PointerShape::ResizeVertical => CursorIcon::ResizeVertical,
+        PointerShape::ResizeNeSw => CursorIcon::ResizeNeSw,
+        PointerShape::ResizeNwSe => CursorIcon::ResizeNwSe,
+        PointerShape::ResizeEast => CursorIcon::ResizeEast,
+        PointerShape::ResizeSouthEast => CursorIcon::ResizeSouthEast,
+        PointerShape::ResizeSouth => CursorIcon::ResizeSouth,
+        PointerShape::ResizeSouthWest => CursorIcon::ResizeSouthWest,
+        PointerShape::ResizeWest => CursorIcon::ResizeWest,
+        PointerShape::ResizeNorthWest => CursorIcon::ResizeNorthWest,
+        PointerShape::ResizeNorth => CursorIcon::ResizeNorth,
+        PointerShape::ResizeNorthEast => CursorIcon::ResizeNorthEast,
+        PointerShape::ZoomIn => CursorIcon::ZoomIn,
+        PointerShape::ZoomOut => CursorIcon::ZoomOut,
+    }
+}
+
 /// with the `'\''` idiom.  The result is safe to paste into `sh`, `bash`,
 /// `zsh`, and `fish`.
 fn shell_escape_path(path: &std::path::Path) -> String {


### PR DESCRIPTION
## Summary

- **fix: remove incorrect cursor clamp in primary buffer `resize_height`** — `cursor.pos.y` is an absolute index into `rows[]`, not screen-relative; the clamp moved the cursor to the wrong row after SIGWINCH, causing shell redraws to overwrite content
- **fix: silence spurious warnings for known OSC sequences** — OSC 13/14/15/16/17/19/22/66 now have explicit `OscTarget` variants consumed at `trace!` level; `Mode::Theming(_)` moved to the silent pass-through arm
- **feat: implement OSC 22 pointer shape** — full data flow from `OSC 22;name ST` through parser, `TerminalHandler`, snapshot, to `egui::CursorIcon` mapping; fixed critical bug where egui reset cursor icon every frame
- **fix: preserve scrollback during soft-wrap in full-screen primary buffer** — `scroll_region_up_for_wrap()` used in-place rotation that destroyed the top visible row on each wrap; long soft-wrapped lines (e.g. 1539-char direnv export) lost ~10 rows of scrollback history

## Details

### Scrollback truncation (the big one)

Root cause: `insert_text()`'s wrap handling called `scroll_region_up_for_wrap()` → `scroll_slice_up()`, which does an in-place rotation within the visible window. The top visible row is overwritten rather than preserved in scrollback. Each soft-wrap iteration destroys one row. With ~12 wraps for a long direnv export line, ~12 rows of history are lost.

Fix: when at the bottom of a full-screen scroll region on the primary buffer, use `handle_lf`'s non-destructive strategy — push a new row at the bottom and advance the cursor. Old rows naturally become scrollback via `visible_window_start()`. Partial DECSTBM regions and alternate buffers retain the rotation behavior.

Extracted `advance_row_for_wrap()` helper to eliminate duplication between PRE-WRAP and POST-WRAP paths, also resolving clippy's `too_many_lines` lint.

### Test coverage

- 3 regression tests for scrollback truncation: full-screen primary soft-wrap, alt buffer (no scrollback growth), partial DECSTBM (rotation preserved)
- All existing tests pass (449 buffer + 350 GUI + all other crates)

### Files changed

| File | Change |
|------|--------|
| `freminal-buffer/src/buffer.rs` | Cursor clamp fix, `advance_row_for_wrap()` helper, scrollback fix, 3 regression tests |
| `freminal-buffer/src/terminal_handler/mod.rs` | OSC theming silent arm, `SetPointerShape` handling |
| `freminal-common/src/buffer_states/osc.rs` | 8 new `OscTarget` variants |
| `freminal-common/src/buffer_states/pointer_shape.rs` | New `PointerShape` enum (401 lines) |
| `freminal-common/src/buffer_states/mod.rs` | `pub mod pointer_shape` |
| `freminal-terminal-emulator/src/ansi_components/osc.rs` | `handle_osc_pointer_shape()`, match arms |
| `freminal-terminal-emulator/src/interface.rs` | `pointer_shape` in `build_snapshot()` |
| `freminal-terminal-emulator/src/snapshot.rs` | `pointer_shape: PointerShape` field |
| `freminal/src/gui/terminal/widget.rs` | `pointer_shape_to_cursor_icon()`, removed dead cache field |