### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+permissions:
+  contents: read
+  packages: read
+
 on:
   pull_request:
   merge_group:


### PR DESCRIPTION
Potential fix for [https://github.com/fredsystems/freminal/security/code-scanning/16](https://github.com/fredsystems/freminal/security/code-scanning/16)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the **workflow root** (top-level, alongside `name`, `on`, `concurrency`, `jobs`) so it applies to all jobs unless overridden.  
The safest minimal non-breaking setting for this workflow is:

- `contents: read` (needed for checkout)
- `packages: read` (commonly safe for dependency/package reads; aligns with GitHub’s recommended read-only baseline)

This addresses the CodeQL finding without changing existing behavior. No imports, methods, or extra definitions are needed (YAML workflow config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
