### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   merge_group:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/fredsystems/freminal/security/code-scanning/24](https://github.com/fredsystems/freminal/security/code-scanning/24)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token scopes by default.

Best single fix (without changing functionality): insert

- `permissions:`
- `  contents: read`

near the top of the workflow (after triggers is a common placement). This satisfies checkout/read needs and prevents unintended broader token rights if repository/org defaults change. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
