### PR TITLE
MSRV 1.95.0 bump, reflow cursor fix, version renumbering

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Freminal — Copilot Instructions
 
-Freminal is a Rust terminal emulator (Edition 2024, MSRV 1.92.0) using egui/glow
+Freminal is a Rust terminal emulator (Edition 2024, MSRV 1.95.0) using egui/glow
 for rendering. It is a Cargo workspace with five crates.
 
 ## Architecture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, ubuntu-24.04-arm]
-        # We target 1.92.0 because it is the minimum supported version of Rust. If that build fails, or we rely on language features
-        # added in later versions, we'll have to bump the minimum version of rust.
-        toolchain: ["1.92.0", "stable", "nightly"]
+        # We target the MSRV (currently 1.95.0, matching stable) plus nightly.
+        # When stable advances beyond MSRV, add the explicit MSRV version back to avoid double-compiling.
+        toolchain: ["stable", "nightly"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -671,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3083,9 +3083,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -4344,9 +4344,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "serde_core",
 ]
@@ -4706,9 +4706,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
  "core-foundation 0.10.1",
  "jni",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default-members = [
 [workspace.package]
 version = "0.5.0"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version = "1.95.0"
 description = "A terminal emulator written in Rust"
 documentation = "https://github.com/fredsystems/freminal/README.md"
 readme = "README.md"
@@ -35,7 +35,7 @@ arc-swap = "1.9.1"
 assert_cmd = "2.2.0"
 bitflags = "2.11.1"
 cargo_metadata = "0.23.1"
-clap = { version = "4.6.0", features = ["derive"] }
+clap = { version = "4.6.1", features = ["derive"] }
 clap-cargo = { version = "0.18.3", features = ["cargo_metadata"] }
 clap-verbosity-flag = "3.0.4"
 color-eyre = "0.6.5"

--- a/Documents/FUTURE_PLANS.md
+++ b/Documents/FUTURE_PLANS.md
@@ -11,7 +11,7 @@ For scoped, versioned work see:
 - `PLAN_VERSION_030.md` — v0.3.0 (Daily Driver)
 - `PLAN_VERSION_040.md` — v0.4.0 (Search & Protocol)
 - `PLAN_VERSION_050.md` — v0.5.0 (Multi-Instance & Visual)
-- `PLAN_VERSION_060.md` — v0.6.0 (Replay & Layouts)
+- `PLAN_VERSION_060.md` — v0.6.0 (Foundation / eframe Replacement)
 
 ### Severity Ratings
 
@@ -187,5 +187,5 @@ a project website at `freminal.dev`. Separate repository.
 - B.1 (Remote Mux) remains deferred — local muxing is now Task 58 in v0.5.0.
 - B.2, B.3, B.7, and B.8 are deferred pending design decisions — not rejected.
 - A.2 (Split Panes) is subsumed by Task 58 (Built-in Multiplexer) in v0.5.0.
-- Task 56 (Session Restore) is subsumed by Task 61 (Saved Layouts) in v0.6.0.
+- Task 56 (Session Restore) is subsumed by Task 61 (Saved Layouts) in v0.7.0.
 - Category C items remain tracked in `MASTER_PLAN.md` with their existing plan documents.

--- a/Documents/MASTER_PLAN.md
+++ b/Documents/MASTER_PLAN.md
@@ -333,7 +333,9 @@ layout into new tab). Large scope (11 subtasks).
 ## Recommended Execution Order
 
 The following reflects the actual execution state: Tasks 1-17, 20-35, and 53-58 are complete.
-The remaining tasks are ordered as follows.
+The remaining tasks are ordered as follows. Note: v0.7.0 (eframe replacement) is executed
+**before** v0.6.0 (replay & layouts) so that v0.6.0 work targets the final windowing
+architecture.
 
 ### Phase 7 — Update Mechanism
 
@@ -353,22 +355,11 @@ These tasks are defined in `PLAN_VERSION_050.md`. All tasks are complete.
 - **Task 57** — Render Loop Optimization — Complete
 - **Task 58** — Built-in Multiplexer / Split Panes — Complete
 
-### v0.6.0 — Replay & Layouts
-
-These tasks are defined in `PLAN_VERSION_060.md`. Task 56 (Session Restore) has been moved
-here and subsumed by Task 61 (Saved Layouts).
-
-- **Task 59** — FREC v2: Multi-Pane Recording (depends on Tasks 32, 58)
-- **Task 60** — Playback v2: Multi-Pane Replay (depends on Task 59)
-- **Task 61** — Saved Layouts / Session Templates (depends on Tasks 36, 58; subsumes Task 56)
-
-Tasks 59 and 61 can start in parallel (independent of each other). Task 60 starts after
-Task 59 is complete.
-
 ### v0.7.0 — Foundation (eframe Replacement)
 
 These tasks are defined in `PLAN_VERSION_070.md`. Replaces eframe with direct
-winit + glutin + egui integration in a new `freminal-windowing` crate.
+winit + glutin + egui integration in a new `freminal-windowing` crate. **Executed before
+v0.6.0** so that replay/layout work builds on the final windowing architecture.
 
 - **Task 62** — freminal-windowing crate + event loop (independent, new crate)
 - **Task 63** — Single-window migration (depends on Task 62)
@@ -378,17 +369,30 @@ winit + glutin + egui integration in a new `freminal-windowing` crate.
 
 Task 62 can start any time. Tasks 64 and 65 can run in parallel after Task 63.
 
+### v0.6.0 — Replay & Layouts
+
+These tasks are defined in `PLAN_VERSION_060.md`. Task 56 (Session Restore) has been moved
+here and subsumed by Task 61 (Saved Layouts). **Executed after v0.7.0** so that replay and
+layout features target the final windowing architecture (no eframe).
+
+- **Task 59** — FREC v2: Multi-Pane Recording (depends on Tasks 32, 58)
+- **Task 60** — Playback v2: Multi-Pane Replay (depends on Task 59)
+- **Task 61** — Saved Layouts / Session Templates (depends on Tasks 36, 58; subsumes Task 56)
+
+Tasks 59 and 61 can start in parallel (independent of each other). Task 60 starts after
+Task 59 is complete.
+
 ```text
 Complete:     Tasks 1-17, 20-35, 53-55, 57-58
               │
 Phase 7:      ├── Task 18 (Update Client) ──┤
               ├── Task 19 (Update Service)   ┤ (parallel, separate repo)
               │
-v0.6.0:       ├── Task 59 (FREC v2 Format) ──► Task 60 (Playback v2)
-              ├── Task 61 (Saved Layouts)      [parallel with 59]
-              │
 v0.7.0:       ├── Task 62 (windowing crate) ──► Task 63 (single-window) ──┬──► Task 64 (multi-window) ──► Task 66 (cleanup)
               │                                                            └──► Task 65 (frame pacing)
+              │
+v0.6.0:       ├── Task 59 (FREC v2 Format) ──► Task 60 (Playback v2)
+              ├── Task 61 (Saved Layouts)      [parallel with 59]
 ```
 
 ---

--- a/Documents/MASTER_PLAN.md
+++ b/Documents/MASTER_PLAN.md
@@ -17,12 +17,12 @@ and plan document maintenance rules.
 | v0.3.0  | Daily Driver            | `PLAN_VERSION_030.md` | 36–44 | Active   |
 | v0.4.0  | Search & Protocol       | `PLAN_VERSION_040.md` | 45–52 | Complete |
 | v0.5.0  | Multi-Instance & Visual | `PLAN_VERSION_050.md` | 53–58 | Complete |
-| v0.6.0  | Replay & Layouts        | `PLAN_VERSION_060.md` | 59–61 | Pending  |
-| v0.7.0  | Foundation              | `PLAN_VERSION_070.md` | 62–66 | Pending  |
+| v0.6.0  | Foundation              | `PLAN_VERSION_060.md` | 62–66 | Pending  |
+| v0.7.0  | Replay & Layouts        | `PLAN_VERSION_070.md` | 59–61 | Pending  |
 
 See `FUTURE_PLANS.md` for deferred features not yet assigned to a version (B.1, B.2, B.3,
 B.7, B.8) and remaining Category C housekeeping (Tasks 18, 19). A.2 (Split Panes) has been
-subsumed by Task 58. Task 56 (Session Restore) has been moved to v0.6.0 and subsumed by
+subsumed by Task 58. Task 56 (Session Restore) has been moved to v0.7.0 and subsumed by
 Task 61 (Saved Layouts).
 
 ---
@@ -78,14 +78,14 @@ Task 61 (Saved Layouts).
 | 35  | Kitty Keyboard Protocol                  | `PLAN_35_KITTY_KEYBOARD_PROTOCOL.md`        | Complete | None                 |
 | 53  | Multiple Windows                         | `PLAN_VERSION_050.md` (Task 53)             | Complete | Task 36 (Tabs)       |
 | 58  | Built-in Multiplexer (Split Panes)       | `PLAN_VERSION_050.md` (Task 58)             | Complete | Task 36 (Tabs)       |
-| 59  | FREC v2: Multi-Pane Recording            | `PLAN_VERSION_060.md` (Task 59)             | Pending  | Tasks 32, 58         |
-| 60  | Playback v2: Multi-Pane Replay           | `PLAN_VERSION_060.md` (Task 60)             | Pending  | Task 59              |
-| 61  | Saved Layouts (Session Templates)        | `PLAN_VERSION_060.md` (Task 61)             | Pending  | Tasks 36, 58         |
-| 62  | freminal-windowing crate + event loop    | `PLAN_VERSION_070.md` (Task 62)             | Pending  | None                 |
-| 63  | Single-window migration                  | `PLAN_VERSION_070.md` (Task 63)             | Pending  | Task 62              |
-| 64  | Multi-window parity                      | `PLAN_VERSION_070.md` (Task 64)             | Pending  | Task 63              |
-| 65  | Frame pacing + idle optimization         | `PLAN_VERSION_070.md` (Task 65)             | Pending  | Task 63              |
-| 66  | Cleanup + eframe removal                 | `PLAN_VERSION_070.md` (Task 66)             | Pending  | Task 64              |
+| 59  | FREC v2: Multi-Pane Recording            | `PLAN_VERSION_070.md` (Task 59)             | Pending  | Tasks 32, 58         |
+| 60  | Playback v2: Multi-Pane Replay           | `PLAN_VERSION_070.md` (Task 60)             | Pending  | Task 59              |
+| 61  | Saved Layouts (Session Templates)        | `PLAN_VERSION_070.md` (Task 61)             | Pending  | Tasks 36, 58         |
+| 62  | freminal-windowing crate + event loop    | `PLAN_VERSION_060.md` (Task 62)             | Pending  | None                 |
+| 63  | Single-window migration                  | `PLAN_VERSION_060.md` (Task 63)             | Pending  | Task 62              |
+| 64  | Multi-window parity                      | `PLAN_VERSION_060.md` (Task 64)             | Pending  | Task 63              |
+| 65  | Frame pacing + idle optimization         | `PLAN_VERSION_060.md` (Task 65)             | Pending  | Task 63              |
+| 66  | Cleanup + eframe removal                 | `PLAN_VERSION_060.md` (Task 66)             | Pending  | Task 64              |
 
 ---
 
@@ -333,33 +333,13 @@ layout into new tab). Large scope (11 subtasks).
 ## Recommended Execution Order
 
 The following reflects the actual execution state: Tasks 1-17, 20-35, and 53-58 are complete.
-The remaining tasks are ordered as follows. Note: v0.7.0 (eframe replacement) is executed
-**before** v0.6.0 (replay & layouts) so that v0.6.0 work targets the final windowing
-architecture.
+The remaining tasks are ordered as follows.
 
-### Phase 7 — Update Mechanism
+### v0.6.0 — Foundation (eframe Replacement)
 
-Task 18 depends on Tasks 2, 3, and 16 (all complete). Task 19 is independent
-and can be developed in a separate repo in parallel with Task 18.
-
-- **Task 18** — Client-Side Update Mechanism (unblocked by Tasks 2 + 3 + 16)
-- **Task 19** — Update Service & Website (independent, separate repo; shares API contract with 18)
-
-### v0.5.0 — Multi-Instance, Visual & Muxing
-
-These tasks are defined in `PLAN_VERSION_050.md`. All tasks are complete.
-
-- **Task 53** — Multiple Windows — Complete
-- **Task 54** — Background Images — Complete
-- **Task 55** — Custom Shaders — Complete
-- **Task 57** — Render Loop Optimization — Complete
-- **Task 58** — Built-in Multiplexer / Split Panes — Complete
-
-### v0.7.0 — Foundation (eframe Replacement)
-
-These tasks are defined in `PLAN_VERSION_070.md`. Replaces eframe with direct
-winit + glutin + egui integration in a new `freminal-windowing` crate. **Executed before
-v0.6.0** so that replay/layout work builds on the final windowing architecture.
+These tasks are defined in `PLAN_VERSION_060.md`. Replaces eframe with direct
+winit + glutin + egui integration in a new `freminal-windowing` crate. Executed first
+so that v0.7.0 replay/layout work builds on the final windowing architecture.
 
 - **Task 62** — freminal-windowing crate + event loop (independent, new crate)
 - **Task 63** — Single-window migration (depends on Task 62)
@@ -369,10 +349,10 @@ v0.6.0** so that replay/layout work builds on the final windowing architecture.
 
 Task 62 can start any time. Tasks 64 and 65 can run in parallel after Task 63.
 
-### v0.6.0 — Replay & Layouts
+### v0.7.0 — Replay & Layouts
 
-These tasks are defined in `PLAN_VERSION_060.md`. Task 56 (Session Restore) has been moved
-here and subsumed by Task 61 (Saved Layouts). **Executed after v0.7.0** so that replay and
+These tasks are defined in `PLAN_VERSION_070.md`. Task 56 (Session Restore) has been moved
+here and subsumed by Task 61 (Saved Layouts). Executed after v0.6.0 so that replay and
 layout features target the final windowing architecture (no eframe).
 
 - **Task 59** — FREC v2: Multi-Pane Recording (depends on Tasks 32, 58)
@@ -388,10 +368,10 @@ Complete:     Tasks 1-17, 20-35, 53-55, 57-58
 Phase 7:      ├── Task 18 (Update Client) ──┤
               ├── Task 19 (Update Service)   ┤ (parallel, separate repo)
               │
-v0.7.0:       ├── Task 62 (windowing crate) ──► Task 63 (single-window) ──┬──► Task 64 (multi-window) ──► Task 66 (cleanup)
+v0.6.0:       ├── Task 62 (windowing crate) ──► Task 63 (single-window) ──┬──► Task 64 (multi-window) ──► Task 66 (cleanup)
               │                                                            └──► Task 65 (frame pacing)
               │
-v0.6.0:       ├── Task 59 (FREC v2 Format) ──► Task 60 (Playback v2)
+v0.7.0:       ├── Task 59 (FREC v2 Format) ──► Task 60 (Playback v2)
               ├── Task 61 (Saved Layouts)      [parallel with 59]
 ```
 
@@ -507,8 +487,8 @@ Update this section as tasks complete:
 - `Documents/PLAN_VERSION_030.md` — v0.3.0 "Daily Driver" roadmap (Tasks 36–44)
 - `Documents/PLAN_VERSION_040.md` — v0.4.0 "Search & Protocol" roadmap (Tasks 45–52)
 - `Documents/PLAN_VERSION_050.md` — v0.5.0 "Multi-Instance & Visual" roadmap (Tasks 53–56)
-- `Documents/PLAN_VERSION_060.md` — v0.6.0 "Replay & Layouts" roadmap (Tasks 59–61)
-- `Documents/PLAN_VERSION_070.md` — v0.7.0 "Foundation" roadmap (Tasks 62–66)
+- `Documents/PLAN_VERSION_060.md` — v0.6.0 "Foundation" roadmap (Tasks 62–66)
+- `Documents/PLAN_VERSION_070.md` — v0.7.0 "Replay & Layouts" roadmap (Tasks 59–61)
 - `Documents/PLAN_18_UPDATE_MECHANISM.md` — Client-side update mechanism (pending)
 - `Documents/PLAN_19_UPDATE_SERVICE_AND_WEBSITE.md` — Update service and website (pending)
 - `config_example.toml` — Current config format

--- a/Documents/PLAN_VERSION_050.md
+++ b/Documents/PLAN_VERSION_050.md
@@ -17,10 +17,10 @@ images, and user-provided custom shaders for post-processing effects.
 | 57  | Render Loop Optimization | Medium | Complete |
 | 58  | Built-in Multiplexer     | Large  | Complete |
 
-**Note:** Task 56 (Session Restore / Startup Commands) has been moved to v0.6.0 where it is
+**Note:** Task 56 (Session Restore / Startup Commands) has been moved to v0.7.0 where it is
 subsumed by Task 61 (Saved Layouts), which provides a superset of the original scope including
 multi-tab/multi-pane layout definitions, variable substitution, and a layout library. See
-`PLAN_VERSION_060.md`.
+`PLAN_VERSION_070.md`.
 
 ---
 
@@ -301,7 +301,7 @@ terminal (brief overlay or title bar message), and fall back to direct rendering
 
 ## Task 56 — Session Restore / Startup Commands
 
-**Status: Moved to v0.6.0.** Subsumed by Task 61 (Saved Layouts) in `PLAN_VERSION_060.md`,
+**Status: Moved to v0.7.0.** Subsumed by Task 61 (Saved Layouts) in `PLAN_VERSION_070.md`,
 which provides a superset of this task's scope: multi-tab/multi-pane layout definitions with
 variable substitution, a layout library, save/restore, and auto-restore on startup.
 
@@ -905,7 +905,7 @@ Adding thread ownership of the tree would require synchronization with no perfor
 Task 53 (Multiple Windows) ── builds on tabs (Task 36, v0.3.0)
 Task 54 (Background Images) ── extends background_opacity (Task 34, complete)
 Task 55 (Custom Shaders) ── extends the GL renderer (Task 1, complete)
-Task 56 (Session Restore) ── MOVED to v0.6.0, subsumed by Task 61 (Saved Layouts)
+Task 56 (Session Restore) ── MOVED to v0.7.0, subsumed by Task 61 (Saved Layouts)
 Task 57 (Render Loop Opt) ── independent; complete
 Task 58 (Built-in Muxing) ── builds on tabs (Task 36, v0.3.0); subsumes A.2
 

--- a/Documents/PLAN_VERSION_060.md
+++ b/Documents/PLAN_VERSION_060.md
@@ -1,866 +1,593 @@
-# PLAN_VERSION_060.md — v0.6.0 "Replay & Layouts"
+# PLAN_VERSION_060.md — v0.6.0 "Foundation"
 
 ## Goal
 
-Transform Freminal's recording/playback system from a single-stream byte dump into a full
-session reconstruction engine, and introduce a layout system that lets users define, save,
-and restore complete multi-tab, multi-pane workspace configurations.
+Replace eframe with a direct winit + glutin + egui integration, giving Freminal full control
+over the event loop, GL context lifecycle, frame pacing, and multi-window management. This
+eliminates five documented eframe workarounds, enables true event-driven rendering (zero CPU
+at idle), and removes the root-viewport coupling that forces the "Close All Windows?"
+confirmation dialog. The new windowing layer lives in a dedicated workspace crate
+(`freminal-windowing`) that encapsulates all platform windowing, GL context management, and
+egui integration — keeping the `freminal` binary crate focused on terminal-specific GUI logic.
 
 ---
 
 ## Task Summary
 
-| #   | Feature                           | Scope | Status  | Dependencies     |
-| --- | --------------------------------- | ----- | ------- | ---------------- |
-| 59  | FREC v2: Multi-Pane Recording     | Large | Pending | Task 32, Task 58 |
-| 60  | Playback v2: Multi-Pane Replay    | Large | Pending | Task 59          |
-| 61  | Saved Layouts (Session Templates) | Large | Pending | Task 36, Task 58 |
+| #   | Feature                               | Scope  | Status  | Dependencies |
+| --- | ------------------------------------- | ------ | ------- | ------------ |
+| 62  | freminal-windowing crate + event loop | Large  | Pending | None         |
+| 63  | Single-window migration               | Large  | Pending | Task 62      |
+| 64  | Multi-window parity                   | Large  | Pending | Task 63      |
+| 65  | Frame pacing + idle optimization      | Medium | Pending | Task 63      |
+| 66  | Cleanup + eframe removal              | Medium | Pending | Task 64      |
 
 ---
 
-## Task 59 — FREC v2: Multi-Pane Recording Format
+## Crate: freminal-windowing
 
-### 59 Overview
+A new workspace member that owns the platform windowing abstraction. Everything below the
+`freminal` crate's terminal GUI logic and above the OS lives here.
 
-The current FREC v1 format is a flat sequence of timestamped PTY read chunks — no metadata,
-no terminal dimensions, no input recording, and no awareness of tabs or panes. It was designed
-for a single-emulator world. With tabs (Task 36) and split panes (Task 58) now in place, the
-format is fundamentally inadequate: it cannot record multi-pane sessions at all, and even for
-single-pane sessions it loses critical information (window size, user input, resize events).
+### Responsibilities
 
-FREC v2 is a complete redesign. The goals:
+- winit `EventLoop` creation and `ApplicationHandler` implementation
+- GL context creation and management via glutin + glutin-winit
+- egui input translation via egui-winit
+- egui rendering via egui_glow (chrome: menus, modals, dialogs)
+- Window lifecycle: create, destroy, resize, focus, minimize, close
+- Frame pacing: render only on demand, proper Wayland `pre_present_notify()`
+- Multi-window management: peer windows with independent GL contexts
 
-1. **Per-stream isolation.** Each pane's PTY output is recorded independently — no byte
-   interleaving. A recording of a 4-pane session contains 4 distinct output streams.
-2. **Bidirectional capture.** Every byte Freminal sends TO the PTY (keyboard input, paste,
-   bracketed paste sequences, report responses) is recorded per-pane. This is not replayed
-   during playback — it exists purely for diagnostics ("what did the user type to produce
-   this state?").
-3. **Topology events.** Tab create/close, pane split/close, focus changes, and zoom
-   toggle are recorded as timestamped events. Combined with the per-pane streams, this
-   allows exact reconstruction of Freminal's state at any point in time.
-4. **Size tracking.** Initial window dimensions and every resize event (both window-level
-   and per-pane) are recorded, so playback can reconstruct the correct terminal geometry.
-5. **Rich metadata.** Recording version, Freminal version, initial tab/pane topology,
-   per-pane dimensions, TERM value, scrollback limit, shell, CWD at recording start.
-6. **Seekability.** A frame index table at the end of the file enables random access and
-   backward seeking without scanning the entire file.
+### What It Does NOT Own
 
-### 59 Format Design
+- Terminal emulation (freminal-terminal-emulator)
+- Buffer model (freminal-buffer)
+- Custom terminal renderer (stays in freminal — the GL shaders, glyph atlas, vertex builder)
+- Application-level state (tabs, panes, config, keybindings)
+- PTY I/O
 
-#### File Structure
-
-```text
-┌─────────────────────────────────────────────────────┐
-│ File Header                                          │
-│   Magic: b"FREC"  (4 bytes)                          │
-│   Version: 0x02   (1 byte)                           │
-│   Flags: u32 LE   (4 bytes, reserved — e.g. compression) │
-│   Metadata Length: u32 LE                             │
-│   Metadata: MessagePack / bincode blob                │
-├─────────────────────────────────────────────────────┤
-│ Event Stream (sequential, variable-length records)    │
-│   Record 0: { timestamp_us, event_type, pane_id, ... }│
-│   Record 1: ...                                       │
-│   ...                                                 │
-│   Record N: ...                                       │
-├─────────────────────────────────────────────────────┤
-│ Seek Index (written at finalization)                  │
-│   Index entry count: u64 LE                           │
-│   Per entry: { timestamp_us: u64, file_offset: u64 }  │
-│   Index interval: every ~1 second of recording time   │
-├─────────────────────────────────────────────────────┤
-│ Footer                                               │
-│   Seek index offset: u64 LE (byte offset of index)   │
-│   Total duration: u64 LE (microseconds)               │
-│   Total events: u64 LE                                │
-│   Magic: b"FREC" (4 bytes, for reverse scanning)      │
-└─────────────────────────────────────────────────────┘
-```
-
-#### Metadata Block
-
-Serialized as a structured binary format (MessagePack or bincode — decided during
-implementation based on dependency weight). Contains:
+### Public API Surface (Sketch)
 
 ```rust
-struct RecordingMetadata {
-    freminal_version: String,       // e.g. "0.6.0"
-    created_at: u64,                // Unix epoch seconds
-    term: String,                   // e.g. "xterm-256color"
-    initial_window_size: (u32, u32), // pixels
-    initial_topology: TopologySnapshot, // full tab/pane tree at recording start
-    scrollback_limit: u32,
+/// The application trait that `freminal` implements instead of `eframe::App`.
+pub trait App {
+    /// Called once per window per frame, only when a redraw is needed.
+    /// `gl` is the window's GL context; `ctx` is the egui context for this window.
+    fn update(&mut self, window_id: WindowId, ctx: &egui::Context, gl: &glow::Context);
+
+    /// Called when a window is created.  Returns initial egui configuration.
+    fn on_window_created(&mut self, window_id: WindowId, ctx: &egui::Context);
+
+    /// Called when a window close is requested.  Return `false` to cancel.
+    fn on_close_requested(&mut self, window_id: WindowId) -> bool;
+
+    /// GL clear color for the given window (supports transparency).
+    fn clear_color(&self, window_id: WindowId) -> [f32; 4];
 }
 
-struct TopologySnapshot {
-    tabs: Vec<TabSnapshot>,
-    active_tab: TabId,
+/// Opaque window identifier (wraps winit::window::WindowId).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct WindowId(winit::window::WindowId);
+
+/// Configuration for creating a new window.
+pub struct WindowConfig {
+    pub title: String,
+    pub inner_size: Option<(u32, u32)>,
+    pub transparent: bool,
+    pub icon: Option<egui::IconData>,
+    pub app_id: Option<String>,
 }
 
-struct TabSnapshot {
-    id: TabId,
-    pane_tree: PaneTreeSnapshot,
-    active_pane: PaneId,
-    zoomed_pane: Option<PaneId>,
+/// Handle passed to the App for requesting window operations.
+pub struct WindowHandle<'a> { /* ... */ }
+
+impl<'a> WindowHandle<'a> {
+    pub fn create_window(&self, config: WindowConfig);
+    pub fn close_window(&self, id: WindowId);
+    pub fn request_repaint(&self, id: WindowId);
+    pub fn request_repaint_after(&self, id: WindowId, delay: Duration);
+    pub fn set_title(&self, id: WindowId, title: &str);
+    pub fn set_visible(&self, id: WindowId, visible: bool);
+    pub fn set_minimized(&self, id: WindowId, minimized: bool);
 }
 
-struct PaneTreeSnapshot {
-    // Mirrors PaneTree enum but with serializable IDs and metadata
-    node: PaneNodeSnapshot,
-}
-
-enum PaneNodeSnapshot {
-    Leaf {
-        pane_id: PaneId,
-        cols: u32,
-        rows: u32,
-        cwd: Option<String>,
-        shell: Option<String>,
-        title: String,
-    },
-    Split {
-        direction: SplitDirection,
-        ratio: f32,
-        first: Box<PaneNodeSnapshot>,
-        second: Box<PaneNodeSnapshot>,
-    },
-}
+/// Entry point — replaces `eframe::run_native()`.
+pub fn run(config: WindowConfig, app: impl App + 'static) -> Result<(), Error>;
 ```
 
-#### Event Types
+This is a sketch, not a contract. The API will be refined during implementation. The key
+design principle: `freminal-windowing` owns the event loop and GL contexts; the `freminal`
+crate owns everything terminal-specific.
 
-Each event record in the stream has a common header:
+### Dependencies
 
-```text
-[0..8]   u64 LE   timestamp_us (elapsed from recording start)
-[8]      u8       event_type
-[9..13]  u32 LE   payload_length
-[13..]   payload  (event_type-specific)
-```
+The implementing agent MUST use the most recent stable versions of all crates at the time of
+implementation. The versions listed below are the latest stable as of 2026-04-15 and serve as
+a **minimum floor**, not a pin:
 
-Event types:
+| Crate               | Minimum Version | Purpose                                    |
+| ------------------- | --------------- | ------------------------------------------ |
+| `winit`             | 0.30.13         | Window creation, event loop                |
+| `glutin`            | 0.32.3          | OpenGL context creation (EGL/WGL/GLX/CGL)  |
+| `glutin-winit`      | 0.5.0           | glutin-to-winit integration bridge         |
+| `egui`              | 0.34.1          | Immediate-mode UI (menus, modals, dialogs) |
+| `egui-winit`        | 0.34.1          | winit event to egui RawInput translation   |
+| `egui_glow`         | 0.34.1          | egui rendering via glow (chrome only)      |
+| `glow`              | 0.17.0          | OpenGL function loader and bindings        |
+| `raw-window-handle` | 0.6.2           | Window handle interop (glutin / winit)     |
+| `tracing`           | (workspace)     | Structured logging                         |
+| `thiserror`         | (workspace)     | Error types                                |
+| `conv2`             | (workspace)     | Numeric conversions (per agents.md)        |
 
-| Type ID | Name         | Payload                                                                          |
-| ------- | ------------ | -------------------------------------------------------------------------------- |
-| 0x01    | PtyOutput    | pane_id: u32, data: [u8]                                                         |
-| 0x02    | PtyInput     | pane_id: u32, data: [u8]                                                         |
-| 0x03    | PaneResize   | pane_id: u32, cols: u32, rows: u32                                               |
-| 0x04    | WindowResize | width_px: u32, height_px: u32                                                    |
-| 0x05    | TabCreate    | tab_id: u32, pane_id: u32, cols: u32, rows: u32                                  |
-| 0x06    | TabClose     | tab_id: u32                                                                      |
-| 0x07    | PaneSplit    | parent_pane: u32, new_pane: u32, direction: u8, ratio: f32, cols: u32, rows: u32 |
-| 0x08    | PaneClose    | pane_id: u32                                                                     |
-| 0x09    | FocusChange  | tab_id: u32, pane_id: u32                                                        |
-| 0x0A    | ZoomToggle   | tab_id: u32, pane_id: u32, zoomed: u8                                            |
-| 0x0B    | TabSwitch    | tab_id: u32                                                                      |
-| 0x0C    | ThemeChange  | theme_name: String (length-prefixed)                                             |
+**IMPORTANT:** At implementation time, the agent MUST run `cargo search <crate>` for each
+dependency to verify the latest stable version and use that version, not the floor listed here.
+If a new major version of `winit` (0.31+) or `egui` (0.35+) has been released stable, the
+agent must evaluate compatibility and use the latest stable if feasible.
 
-**PtyOutput (0x01)** is the primary data event — equivalent to v1 frames but tagged with a
-pane ID. **PtyInput (0x02)** records what Freminal sent to the PTY — keyboard input, paste
-content, report responses. This is write-only (diagnostics) and is skipped during normal
-playback.
-
-#### Backward Compatibility
-
-- Files starting with `b"FREC" 0x01` are v1 and handled by the existing parser.
-- Files starting with `b"FREC" 0x02` are v2 and handled by the new parser.
-- `parse_recording()` dispatches on the version byte.
-- The `--with-playback-file` flag accepts both formats. v1 files play back in single-pane
-  mode exactly as today.
-
-### 59 Subtasks
-
-1. **59.1 — Define FREC v2 format types**
-   Create the Rust types for the v2 format: `RecordingMetadataV2`, `RecordingEvent`,
-   `EventType` enum, `TopologySnapshot`, `PaneNodeSnapshot`, `SeekIndexEntry`. Place in
-   `freminal-terminal-emulator/src/recording.rs` (or a new `recording/` module directory
-   if the file grows too large). All types must be serializable. Choose and justify the
-   serialization format (MessagePack via `rmp-serde`, bincode, or raw manual encoding).
-   Add unit tests for round-trip serialization of all types.
-
-2. **59.2 — v2 file writer: header and metadata**
-   Implement `write_header_v2()` that writes the magic, version, flags, and serialized
-   metadata block. The writer takes a `RecordingMetadataV2` (constructed from the current
-   `TabManager` topology at recording start). Unit tests: write + read back, verify
-   metadata fields survive the round trip.
-
-3. **59.3 — v2 file writer: event stream**
-   Implement `write_event()` that appends a single event record to the file. Called from
-   the PTY reader thread (for PtyOutput/PtyInput) and the GUI thread (for topology and
-   resize events). Use a channel to funnel events from multiple threads to a single writer
-   thread (avoids interleaving and file locking). Unit tests: write a sequence of events,
-   read back, verify ordering and content.
-
-4. **59.4 — v2 file writer: seek index and footer**
-   On recording stop (or application exit), the writer thread computes the seek index
-   (one entry per ~1 second of recording time, or per N events), writes it, and writes
-   the footer with the index offset, total duration, and event count. Implement graceful
-   finalization on both clean exit and SIGTERM/crash (write what we have). Unit tests:
-   verify index entries point to correct file offsets, verify footer fields.
-
-5. **59.5 — v2 file parser**
-   Implement `parse_recording_v2()` that reads the header, metadata, and loads the event
-   stream. Two modes: full load (all events into memory, for small files) and indexed
-   streaming (use the seek index for random access, for large files). The indexed mode
-   reads events on demand by seeking to the nearest index entry. Dispatch from the existing
-   `parse_recording()` based on version byte. Unit tests: parse files written by 59.2–59.4,
-   verify all fields. Test backward compat: v1 files still parse correctly.
-
-6. **59.6 — Hook PTY output recording**
-   In the PTY reader thread (`pty.rs`), replace the v1 `write_frame()` call with
-   `write_event(PtyOutput { pane_id, data })`. Each pane's PTY reader knows its pane ID
-   (threaded through at spawn time). This is the minimal change to start producing v2 files.
-
-7. **59.7 — Hook PTY input recording**
-   Every byte sent TO the PTY (keyboard input via `PtyWrite::Write`, paste via
-   `PtyWrite::Write`, resize via `PtyWrite::Resize`, and report responses) is captured as
-   a `PtyInput` event. The input channel already passes through a known point — tap it
-   there. `PtyWrite::Resize` additionally generates a `PaneResize` event.
-
-8. **59.8 — Hook topology events**
-   In the GUI thread, emit topology events when:
-   - A tab is created (`TabCreate`) or closed (`TabClose`)
-   - A pane is split (`PaneSplit`) or closed (`PaneClose`)
-   - Focus changes (`FocusChange`)
-   - Zoom toggles (`ZoomToggle`)
-   - The active tab switches (`TabSwitch`)
-   - The window resizes (`WindowResize`)
-     These are sent through the event channel to the writer thread.
-
-9. **59.9 — Recording CLI and config updates**
-   Update `--recording-path` to produce v2 files by default. Add `--recording-format v1|v2`
-   flag for backward compatibility. Update `config_example.toml` if any config-level
-   recording options are added. Update the `playback` feature flag gating to cover the
-   new types.
-
-10. **59.10 — Tests and integration**
-    End-to-end test: start a headless multi-pane session, feed input, split panes, resize,
-    close panes, stop recording. Parse the resulting file and verify: correct event ordering,
-    per-pane data isolation (no interleaving), topology events at correct timestamps, seek
-    index validity. Test v1 backward compatibility. Test graceful finalization on abrupt stop.
-
-### 59 Primary Files
-
-- `freminal-terminal-emulator/src/recording.rs` (or `recording/` module — format types, writer, parser)
-- `freminal-terminal-emulator/src/io/pty.rs` (PTY output and input hooks)
-- `freminal/src/gui/mod.rs` (topology event emission)
-- `freminal/src/gui/panes/mod.rs` (pane ID threading)
-- `freminal/src/gui/tabs.rs` (tab lifecycle events)
-- `freminal-common/src/args.rs` (CLI flag updates)
-
-### 59 Design Decisions
-
-1. **Single writer thread via channel.** Events from multiple PTY reader threads and the
-   GUI thread are funneled through a bounded crossbeam channel to a dedicated writer thread.
-   This avoids file-level locking, guarantees chronological ordering (events are timestamped
-   at the source and sorted if needed), and keeps I/O off the hot paths.
-
-2. **Seek index at file end.** Writing the index at finalization (rather than maintaining it
-   inline) simplifies the writer — it just appends events sequentially. The footer's index
-   offset allows the parser to jump straight to the index. Crash resilience: if the file is
-   not finalized (crash before footer), the parser falls back to sequential scanning.
-
-3. **PtyInput is write-only.** Input events are never replayed during playback — they exist
-   for diagnostic reconstruction. This means the playback engine can skip them entirely,
-   and the recording overhead of capturing input is negligible (input volume is tiny compared
-   to output).
-
-4. **Topology snapshots, not diffs.** The metadata block stores the full initial topology.
-   Subsequent topology changes are recorded as discrete events (split, close, etc.). The
-   playback engine reconstructs the topology by applying events sequentially from the initial
-   snapshot. This is simpler and more debuggable than differential encoding.
+**The `eframe` dependency is NOT removed until Task 66.** Tasks 62–65 add the new crate
+alongside eframe so that the migration can be verified incrementally.
 
 ---
 
-## Task 60 — Playback v2: Multi-Pane Replay with Size Adaptation
+## Task 62 — freminal-windowing Crate + Event Loop
 
-### 60 Overview
+### 62 Overview
 
-The current playback engine (`freminal/src/playback.rs`) drives a single headless
-`TerminalEmulator`, feeding it frames sequentially. It cannot:
+Create the `freminal-windowing` workspace crate with a working event loop, GL context, and
+egui integration for a single window. This is the foundation — no terminal rendering, no
+migration of `freminal` code. The deliverable is a crate that can open a window, run an egui
+frame, and paint it via glow, verified by a minimal example binary.
 
-- Replay multi-pane or multi-tab sessions
-- Handle window size mismatch between recording and playback
-- Seek backward or jump to arbitrary positions
-- Isolate a single pane's stream
+### 62 Subtasks
 
-Task 60 rebuilds the playback engine to consume FREC v2 files, reconstruct the full tab/pane
-topology, and introduce size adaptation strategies for tiling WM users who cannot freely
-resize their window.
+1. **62.1 — Scaffold the crate**
+   Create `freminal-windowing/Cargo.toml` with workspace dependencies. Create `src/lib.rs`
+   with the public API types (`App` trait, `WindowId`, `WindowConfig`, `run()`). Add the
+   crate to the workspace `members` list in the root `Cargo.toml`. Ensure `cargo check --all`
+   passes with the new empty crate.
 
-### 60 Design
+2. **62.2 — winit event loop**
+   Implement the winit 0.30 `ApplicationHandler` trait. Create an `EventLoop`, open a single
+   window via `ActiveEventLoop::create_window()`. Handle `Resumed`, `Suspended`,
+   `WindowEvent::RedrawRequested`, `WindowEvent::CloseRequested`, `WindowEvent::Resized`,
+   and `AboutToWait`. The `ApplicationHandler` holds application state and dispatches to the
+   `App` trait.
 
-#### Multi-Pane Reconstruction
+3. **62.3 — GL context via glutin**
+   On `Resumed`, create a glutin `Display` (EGL on Linux/Wayland, WGL on Windows, CGL on
+   macOS) via `glutin-winit::DisplayBuilder`. Select an OpenGL config with RGBA8 + alpha
+   (for transparency support). Create a `Surface` and `PossiblyCurrentContext`. Create a
+   `glow::Context` from the GL loader function. Handle `Suspended` by destroying the surface
+   (required on Android, good practice elsewhere).
 
-The playback engine creates a headless `TerminalEmulator` per pane (just as live mode does).
-On startup, it reads the `TopologySnapshot` from the FREC v2 metadata and constructs the
-initial tab/pane tree:
+4. **62.4 — egui integration**
+   Create an `egui::Context`. Create an `egui_winit::State` for input translation. Create an
+   `egui_glow::Painter` for rendering. On each `RedrawRequested`:
+   - `state.take_egui_input(&window)` → `RawInput`
+   - `ctx.run(raw_input, |ctx| app.update(...))` → `FullOutput`
+   - `state.handle_platform_output(&window, full_output.platform_output)`
+   - `painter.paint_and_update_textures(...)` with the shapes and textures delta
+   - `window.pre_present_notify()` then `surface.swap_buffers(&context)`
 
-```text
-1. Read metadata.initial_topology
-2. For each tab:
-   a. For each leaf pane in the tree: create TerminalEmulator::new_headless(cols, rows)
-   b. Construct the PaneTree (mirrors the recorded topology)
-   c. Set active_pane and zoomed_pane from the snapshot
-3. Publish initial snapshots for all panes
-```
+5. **62.5 — Frame pacing**
+   Implement demand-driven rendering: only call `window.request_redraw()` when egui reports
+   `needs_repaint`. Expose `request_repaint()` and `request_repaint_after(delay)` through the
+   `WindowHandle` API. Use a timer (winit `ControlFlow::WaitUntil`) to wake the event loop
+   for delayed repaints. Verify: with no UI interaction, CPU usage is zero.
 
-As topology events arrive during playback (TabCreate, PaneSplit, PaneClose, etc.), the engine
-modifies the tab/pane tree accordingly — creating or destroying emulators as needed.
+6. **62.6 — Transparency support**
+   When `WindowConfig::transparent` is true, configure the glutin surface with alpha, set
+   `window_attributes.with_transparent(true)`, and clear with `[0, 0, 0, 0]` before each
+   frame. Verify: window background is see-through on a supported compositor.
 
-PtyOutput events are routed to the correct emulator by `pane_id`. PtyInput events are skipped
-(logged to a diagnostic sidebar if one is ever added, but not fed to emulators).
+7. **62.7 — Error handling**
+   Define a `freminal_windowing::Error` enum covering: event loop creation failure, GL context
+   creation failure, surface creation failure, window creation failure. All public APIs return
+   `Result<T, Error>`. No panics in production code.
 
-#### Size Adaptation
+8. **62.8 — Example binary + tests**
+   Create `freminal-windowing/examples/hello.rs` — a minimal app that opens a window, shows
+   an egui label "Hello from freminal-windowing", and exits on close. Unit tests for
+   `WindowId`, `WindowConfig`, error types. The example is not a production artifact — it
+   exists for verification and can be removed later.
 
-The recording captures the exact terminal dimensions at every point. The playback window may
-be a different size — especially on tiling WMs where the user cannot resize freely. Three
-strategies, selectable via a toolbar toggle:
+### 62 Primary Files
 
-**1. Letterbox (default):**
-Render each pane at its _recorded_ dimensions. If the playback window is larger, pad with
-background color. If smaller, scroll/clip. This guarantees pixel-perfect fidelity — the
-terminal content is identical to what was recorded. The pane tree layout uses the recorded
-split ratios applied to the recorded window size, then the entire layout is centered in the
-actual window.
+- `freminal-windowing/Cargo.toml` (new crate manifest)
+- `freminal-windowing/src/lib.rs` (public API, re-exports)
+- `freminal-windowing/src/event_loop.rs` (ApplicationHandler, event dispatch)
+- `freminal-windowing/src/gl_context.rs` (glutin setup, surface management)
+- `freminal-windowing/src/egui_integration.rs` (egui_winit + egui_glow wiring)
+- `freminal-windowing/src/error.rs` (error types)
+- `freminal-windowing/examples/hello.rs` (verification example)
+- `Cargo.toml` (workspace member addition)
 
-**2. Reflow:**
-Create each headless emulator at the _playback_ window dimensions (or the pane's proportional
-share of the playback window). The same byte stream is fed, but the terminal re-wraps content
-to fit the new width. This changes line breaks and may alter visual layout, but is more
-readable when the size mismatch is large. Resize events in the recording are translated
-proportionally.
+### 62 Design Decisions
 
-**3. Scale:**
-Render at the recorded dimensions (like letterbox) but scale the output to fill the playback
-window. Preserves layout fidelity while using available space. May look fuzzy if scaling up
-significantly. Implemented via an intermediate framebuffer rendered at recorded size, then
-scaled to the display rect (leveraging the existing custom GL renderer).
+1. **Separate crate, not inline in `freminal`.** The windowing layer is a reusable abstraction
+   that encapsulates platform-specific complexity. Keeping it in a separate crate enforces a
+   clean API boundary, makes it testable in isolation, and follows the existing workspace
+   pattern (`freminal-buffer`, `freminal-common`, `freminal-terminal-emulator`).
 
-**Default: Letterbox.** It is the only mode that guarantees the playback is visually identical
-to the recording. The user can switch modes during playback via the toolbar.
+2. **winit 0.30 `ApplicationHandler` trait, not the deprecated `EventLoop::run()` closure.**
+   winit 0.30 deprecated the closure-based event loop in favor of the trait-based
+   `ApplicationHandler`. The trait-based approach is cleaner (proper struct methods instead of
+   a giant closure) and is the only supported path forward in winit 0.31+.
 
-#### Seek and Rewind
+3. **One `egui::Context` per window (not shared).** eframe shares one `Context` across all
+   viewports. This causes the root-viewport coupling problem. With independent contexts, each
+   window is a peer with its own egui state. The cost is that egui `Memory` (widget state like
+   scroll offsets, text cursor positions) is per-window, which is correct behavior anyway.
 
-The FREC v2 seek index enables jumping to arbitrary positions:
-
-**Forward seek:** Skip events until the target timestamp. Feed PtyOutput events to emulators
-in fast-forward (no timing delays). Apply topology events normally.
-
-**Backward seek / rewind:** Terminal emulators are not reversible — you cannot "undo" bytes
-fed to them. To seek backward:
-
-1. Find the nearest seek index entry at or before the target timestamp.
-2. Reset all emulators to their initial state (or the state at the index entry — see
-   checkpoint strategy below).
-3. Replay all events from that point to the target timestamp in fast-forward.
-
-**Checkpoint strategy (optimization):** During forward playback, periodically snapshot the
-full emulator state (every ~5 seconds or at each seek index entry). Store these snapshots
-in memory. When seeking backward, find the nearest checkpoint before the target and replay
-from there instead of from the beginning. Memory budget: cap at ~100 checkpoints (each
-snapshot is a few hundred KB), evicting the oldest when the cap is reached.
-
-#### Per-Pane Solo Mode
-
-The playback toolbar offers a pane selector. When a pane is "soloed," only that pane's
-PtyOutput events are fed to its emulator and rendered. Other panes are paused (their events
-are skipped). This is useful for focusing on one pane's output in a busy multi-pane recording.
-Unsoloing resumes all panes from the current timestamp (events that were skipped are not
-replayed — the other panes jump to their state at the current time via fast-forward).
-
-#### Playback Toolbar Updates
-
-The current toolbar has: mode selector (Instant/RealTime/FrameStep), play/pause, frame
-counter. v2 adds:
-
-- **Timeline scrubber:** drag to seek to any timestamp. Shows total duration and current
-  position.
-- **Size mode toggle:** Letterbox / Reflow / Scale.
-- **Pane selector:** dropdown or clickable pane labels for solo mode.
-- **Speed control:** 0.5x, 1x, 2x, 4x, 8x playback speed (multiplier on inter-frame delays).
-- **Diagnostic toggle:** show/hide PtyInput events in a side panel (stretch goal).
-
-### 60 Subtasks
-
-1. **60.1 — Multi-emulator playback engine**
-   Refactor `run_playback_thread` (or replace it) to manage multiple headless
-   `TerminalEmulator` instances, one per pane. Read the `TopologySnapshot` from the v2
-   metadata and construct the initial emulator set. Route `PtyOutput` events by pane ID.
-   Handle topology events (create/destroy emulators as panes split/close). Publish per-pane
-   snapshots via per-pane `ArcSwap`. Fall back to single-emulator mode for v1 files.
-
-2. **60.2 — Playback tab/pane tree reconstruction**
-   On playback start, construct a `TabManager` with the recorded topology. The GUI renders
-   tabs and panes using the same layout code as live mode. Topology events during playback
-   modify the tree (split, close, tab create/close). The GUI must handle dynamic topology
-   changes during playback just as it does in live mode.
-
-3. **60.3 — Letterbox size adaptation**
-   Implement the letterbox strategy: each pane's emulator runs at its recorded dimensions
-   regardless of the playback window size. The layout engine uses recorded dimensions for
-   the pane tree, centers the result in the available window, and pads with background color.
-   If the playback window is smaller than the recorded layout, clip or add scrollbars to the
-   outer frame (not per-pane — the entire layout scrolls as a unit).
-
-4. **60.4 — Reflow size adaptation**
-   Implement the reflow strategy: each pane's emulator is created at the playback window's
-   proportional dimensions. Resize events in the recording are translated proportionally.
-   The pane tree uses the playback window dimensions with recorded split ratios.
-
-5. **60.5 — Scale size adaptation**
-   Implement the scale strategy: render the terminal layout at recorded dimensions into an
-   offscreen framebuffer (FBO), then draw a single textured quad scaled to fill the playback
-   window. This leverages the existing GL renderer. If Task 55 (Custom Shaders) is complete,
-   the scale pass is just another post-processing step. If not, a minimal FBO + blit shader
-   is needed (subset of 55.1).
-
-6. **60.6 — Forward seek**
-   Implement seek-forward: given a target timestamp, skip events and feed them to emulators
-   in fast-forward (no timing delays). Update the timeline scrubber position. Handle topology
-   events during fast-forward.
-
-7. **60.7 — Backward seek with checkpoints**
-   Implement the checkpoint system: during forward playback, snapshot emulator state at
-   regular intervals. On backward seek, find the nearest checkpoint, restore emulator state,
-   and fast-forward to the target. Cap checkpoint memory at a configurable budget. If no
-   checkpoint exists (e.g., seeking to near the beginning), reset to initial state and
-   replay from the start.
-
-8. **60.8 — Per-pane solo mode**
-   Add pane solo/unsolo to the playback toolbar. When soloed, only the selected pane's
-   PtyOutput events are processed. Other panes freeze at their current state. Unsoloing
-   fast-forwards the unsoloed panes to the current timestamp.
-
-9. **60.9 — Speed control**
-   Add speed multiplier to the playback toolbar (0.5x, 1x, 2x, 4x, 8x). The multiplier
-   divides inter-frame delays in RealTime mode. In Instant mode, speed is already infinite.
-   In FrameStep mode, speed is irrelevant.
-
-10. **60.10 — Timeline scrubber UI**
-    Add a horizontal scrubber bar to the playback toolbar showing total duration and current
-    position. Clicking/dragging seeks to the target timestamp (using 60.6/60.7). Show
-    timestamps in human-readable format (MM:SS or HH:MM:SS).
-
-11. **60.11 — v1 backward compatibility**
-    Ensure v1 FREC files continue to play back correctly. The v1 path remains single-pane,
-    forward-only, with the existing playback modes. The new toolbar features (seek, speed,
-    size mode) gracefully degrade: seek is not available (no index), size mode uses letterbox
-    at the default 80x24, speed control works normally.
-
-12. **60.12 — Tests and integration**
-    End-to-end test: record a multi-pane session (using 59.10's test infrastructure), play
-    it back, verify: pane topology matches, per-pane content matches frame-by-frame, seek
-    forward/backward produces correct state, size adaptation modes render without crashes.
-    Test v1 backward compatibility. Benchmark: measure playback throughput for large
-    recordings (e.g., 1M events).
-
-### 60 Primary Files
-
-- `freminal/src/playback.rs` (rebuilt playback engine)
-- `freminal/src/gui/mod.rs` (playback toolbar updates, multi-pane playback rendering)
-- `freminal/src/gui/tabs.rs` (playback tab/pane tree construction)
-- `freminal/src/gui/panes/mod.rs` (playback-mode pane management)
-- `freminal/src/gui/terminal/widget.rs` (size adaptation rendering)
-- `freminal/src/gui/renderer/gpu.rs` (FBO for scale mode, if Task 55 not done)
-- `freminal/src/main.rs` (v2 playback startup path)
-
-### 60 Design Decisions
-
-1. **Letterbox as default.** A tiling WM user cannot resize freely. Reflow changes the
-   content layout. Scale can be fuzzy. Letterbox is the only mode that guarantees the
-   playback is visually identical to the recording, regardless of window size. The user
-   can switch to reflow or scale if they prefer readability over fidelity.
-
-2. **Checkpoints for backward seek.** Terminal emulators are state machines with no reverse
-   operation. The alternative to checkpoints is replaying from the beginning on every
-   backward seek, which is O(N) in recording length. Checkpoints make it O(checkpoint_interval).
-   The memory cost is bounded by the checkpoint cap.
-
-3. **Per-pane solo is skip-based, not filter-based.** Solo mode skips events for non-soloed
-   panes rather than filtering them out of the event stream. This means the timeline stays
-   consistent (the scrubber position reflects real recording time, not just the soloed pane's
-   activity). Unsoloing requires fast-forward to sync the other panes.
-
-4. **Speed control as delay multiplier.** The simplest correct approach. 2x speed = half the
-   inter-frame delay. This preserves relative timing between events (a burst of output still
-   looks like a burst, just faster). The alternative — frame batching — would change the
-   visual cadence.
+4. **GL context per window.** Each window gets its own glutin `Surface` +
+   `PossiblyCurrentContext`. This avoids the need for context switching (`make_current`) on
+   every frame and enables future per-window vsync.
 
 ---
 
-## Task 61 — Saved Layouts (Session Templates)
-
-### 61 Overview
-
-A layout is a complete description of a Freminal workspace: how many tabs, how each tab's
-panes are arranged, and what runs in each pane. Layouts enable:
-
-- **Startup configuration:** launch Freminal with a predefined multi-tab, multi-pane
-  workspace tailored to a project
-- **Save current state:** capture the running session's topology, working directories, and
-  programs into a reusable layout file
-- **Layout library:** a collection of named layouts in `~/.config/freminal/layouts/`,
-  selectable from the menu or Settings Modal
-- **Partial application:** load a layout into a new tab without replacing the entire session
-- **Auto-restore:** optionally save the layout on exit and restore it on next launch
-
-This task subsumes and expands Task 56 (Session Restore / Startup Commands), which was limited
-to flat tab lists with no pane tree support.
-
-### 61 Design
-
-#### Layout File Format
-
-Layouts are TOML files. TOML's nesting is limited, but for tree structures we use a
-flattened representation with explicit parent references. The format is human-readable
-and hand-editable — a key design goal.
-
-```toml
-# ~/.config/freminal/layouts/dev.toml
-
-[layout]
-name = "Development"
-description = "Standard dev workspace: editor, server, logs"
-
-# Variables — can be overridden from CLI: freminal --layout dev.toml ~/projects/myapp
-# $1, $2, etc. are positional args. Named vars use ${VAR_NAME}.
-[layout.variables]
-project_dir = "~/projects/default"  # default value, overridden by $1 if provided
-
-# --- Tab definitions ---
-
-[[tabs]]
-title = "Editor"
-active = true  # this tab is focused on launch
-
-  # Pane tree for this tab. The tree is defined as a flat list of nodes.
-  # Each node has an "id" (local to this tab) and optionally a "parent" + "position".
-  # The root node has no parent.
-
-  [[tabs.panes]]
-  id = "root"
-  split = "vertical"   # "vertical" (left/right) or "horizontal" (top/bottom)
-  ratio = 0.65
-
-  [[tabs.panes]]
-  id = "editor"
-  parent = "root"
-  position = "first"   # "first" (left/top) or "second" (right/bottom)
-  directory = "${project_dir}"
-  command = "nvim ."
-  active = true         # this pane has focus within the tab
-
-  [[tabs.panes]]
-  id = "sidebar"
-  parent = "root"
-  position = "second"
-  split = "horizontal"
-  ratio = 0.5
-
-  [[tabs.panes]]
-  id = "terminal"
-  parent = "sidebar"
-  position = "first"
-  directory = "${project_dir}"
-
-  [[tabs.panes]]
-  id = "git"
-  parent = "sidebar"
-  position = "second"
-  directory = "${project_dir}"
-  command = "lazygit"
-
-[[tabs]]
-title = "Server"
-
-  [[tabs.panes]]
-  id = "server"
-  directory = "${project_dir}"
-  command = "cargo watch -x run"
-
-[[tabs]]
-title = "Logs"
-
-  [[tabs.panes]]
-  id = "logs"
-  directory = "/var/log"
-  command = "tail -f syslog"
-```
-
-#### Pane Node Properties
-
-Each `[[tabs.panes]]` entry is either a **split node** (has `split` and `ratio`) or a
-**leaf node** (has no `split`). Leaf nodes represent actual terminal panes.
+## Task 63 — Single-Window Migration
+
+### 63 Overview
+
+Migrate the `freminal` binary from eframe to `freminal-windowing` for the single-window case.
+After this task, Freminal opens and runs using the new event loop with full feature parity
+for a single window. eframe remains as a dependency (not yet removed) but is no longer called.
+
+### 63 Subtasks
+
+1. **63.1 — Implement the `App` trait in `freminal`**
+   Create a new `impl freminal_windowing::App for FreminalApp` (or adapt `FreminalGui`).
+   The `update()` method should contain the same logic as the current `eframe::App::ui()`
+   body. The `on_close_requested()` method replaces the `close_requested` + `CancelClose`
+   intercept.
+
+2. **63.2 — Replace `eframe::run_native()` with `freminal_windowing::run()`**
+   In `main.rs`, replace the eframe launch code with the new entry point. Translate
+   `NativeOptions` to `WindowConfig`. Remove the `raw_input_hook` override (no longer needed).
+   Remove the `clear_color` hook (controlled directly via the `App` trait method).
+
+3. **63.3 — Migrate PaintCallback to direct GL calls**
+   The current custom renderer is wrapped in `egui_glow::CallbackFn` closures. With
+   `freminal-windowing`, the `App::update()` method receives the `glow::Context` directly.
+   Restructure the render pipeline: egui paints chrome first (via `egui_glow::Painter`), then
+   the custom terminal renderer draws directly to the framebuffer. This eliminates the
+   `PaintCallback` indirection and the `painter.intermediate_fbo()` restore requirement.
+
+4. **63.4 — Migrate repaint requests**
+   Replace `ui.ctx().request_repaint()` and `ui.ctx().request_repaint_after(delay)` with
+   `WindowHandle::request_repaint()` and `WindowHandle::request_repaint_after()`. Update the
+   PTY consumer thread to use the new repaint mechanism (it currently holds an
+   `Arc<OnceLock<egui::Context>>` and calls `ctx.request_repaint_after`).
+
+5. **63.5 — Migrate ViewportCommand calls**
+   Replace all `ui.ctx().send_viewport_cmd(ViewportCommand::*)` calls with direct
+   `WindowHandle` method calls (`set_title`, `close_window`, `set_minimized`, etc.). Remove
+   the `last_window_title` caching workaround (no longer needed — direct winit calls don't
+   trigger repaint loops).
+
+6. **63.6 — Migrate `eframe::egui::*` imports**
+   Mechanical find-replace: all `eframe::egui::*` imports become `egui::*`. All
+   `eframe::glow::*` imports become `glow::*`. All `eframe::egui_glow::*` imports become
+   `egui_glow::*`. This is a large but trivial diff.
+
+7. **63.7 — Verification + benchmarks**
+   Run the full verification suite. Run render loop benchmarks before and after. Verify:
+   single window opens, terminal works, tabs work, panes work, settings modal works, menu bar
+   works, search works, background images work, custom shaders work, background opacity works.
+   Verify on Wayland: no hang on hidden workspace (the vsync bug is gone).
+
+### 63 Primary Files
+
+- `freminal/src/main.rs` (launch code replacement)
+- `freminal/src/gui/mod.rs` (App trait impl, removal of eframe hooks)
+- `freminal/src/gui/terminal/widget.rs` (PaintCallback removal)
+- `freminal/src/gui/window.rs` (secondary window code — deferred to Task 64)
+- `freminal/src/gui/rendering.rs` (direct GL rendering)
+- `freminal/src/gui/pty.rs` (repaint mechanism)
+- `freminal/Cargo.toml` (add `freminal-windowing` dep)
+
+### 63 Design Decisions
+
+1. **Render order: egui chrome first, then terminal GL.** Currently the terminal renderer
+   runs inside a `PaintCallback` embedded in egui's paint list. With direct control, we paint
+   egui's chrome (menu bar, settings modal, tab bar) first via `egui_glow::Painter`, then
+   render the terminal content directly via our custom shaders. The terminal occupies a known
+   pixel rect (from egui layout), so the custom renderer clips to that rect. This eliminates
+   the intermediate FBO restore dance.
+
+2. **Keep eframe as a dependency during migration.** Tasks 62–65 are incremental. eframe is
+   not removed until Task 66. This allows bisecting if something breaks.
+
+---
+
+## Task 64 — Multi-Window Parity
+
+### 64 Overview
+
+Extend `freminal-windowing` to support multiple windows and migrate the multi-window code from
+the current eframe deferred-viewport approach. After this task, `Ctrl+Shift+N` opens a new
+peer window with its own GL context, and closing any window closes only that window.
+
+### 64 Subtasks
+
+1. **64.1 — Multi-window support in freminal-windowing**
+   Extend the `ApplicationHandler` to manage a `HashMap<WindowId, WindowState>` where
+   `WindowState` holds the `Window`, `Surface`, `PossiblyCurrentContext`, `egui::Context`,
+   `egui_winit::State`, and `egui_glow::Painter` for each window. `WindowHandle::create_window()`
+   inserts a new entry. Events are dispatched to the correct window by `winit::window::WindowId`.
+
+2. **64.2 — Peer window model**
+   All windows are equal peers. There is no root window. Closing any window closes only that
+   window and its resources. Closing the last window exits the process. The `App` trait's
+   `on_close_requested()` receives the `WindowId` and the app decides whether to allow it
+   (e.g., confirm if the window has running processes). This eliminates the confirmation
+   dialog for root-window close.
+
+3. **64.3 — Migrate secondary window code**
+   Replace the `show_viewport_deferred` approach in `gui/window.rs` with
+   `WindowHandle::create_window()`. Remove `SecondaryWindowState`, the per-frame
+   re-registration loop, the pruning loop, and the `closing_all` flag. Each window calls
+   `App::update()` independently with its own `WindowId`.
+
+4. **64.4 — Shared resources**
+   Resources that are shared across windows (`Config`, `FontManager`, `PaneIdGenerator`)
+   continue to use `Arc<Mutex<>>`. Per-window resources (`TabManager`, `PaneTree`, channels,
+   `WindowPostRenderer`) move into a per-window state struct owned by the `App`.
 
-| Field       | Type   | Required | Description                                          |
-| ----------- | ------ | -------- | ---------------------------------------------------- |
-| `id`        | String | Yes      | Unique within the tab (for parent references)        |
-| `parent`    | String | No       | ID of the parent split node (absent for root)        |
-| `position`  | String | No       | "first" or "second" within the parent split          |
-| `split`     | String | No       | "vertical" or "horizontal" — makes this a split node |
-| `ratio`     | Float  | No       | Split ratio (0.0-1.0), default 0.5                   |
-| `directory` | String | No       | Working directory (supports `~` and variables)       |
-| `command`   | String | No       | Command to run after shell starts                    |
-| `shell`     | String | No       | Override the default shell for this pane             |
-| `env`       | Table  | No       | Extra environment variables: `env = { FOO = "bar" }` |
-| `title`     | String | No       | Initial pane title (before shell OSC overrides)      |
-| `active`    | Bool   | No       | If true, this pane/tab has focus on launch           |
-
-A tab with a single pane omits `parent`, `position`, and `split` — just one `[[tabs.panes]]`
-entry with the leaf properties.
-
-#### Variable Substitution
-
-Layouts support variable substitution for reusability across projects:
-
-- **Positional args:** `$1`, `$2`, etc. from `freminal --layout dev.toml ~/projects/myapp`
-  (where `~/projects/myapp` is `$1`)
-- **Named variables:** `${VAR_NAME}` references `[layout.variables]` defaults, overridable
-  via `--var NAME=VALUE`
-- **Environment variables:** `$ENV{HOME}`, `$ENV{USER}` for system env vars
-- **Tilde expansion:** `~` is expanded to `$HOME` in `directory` fields
-
-This means one layout file works across multiple projects:
-
-```sh
-freminal --layout dev.toml ~/projects/frontend
-freminal --layout dev.toml ~/projects/backend
-```
-
-#### Save Current Layout
-
-"Save Layout" captures the running session:
-
-- Tab count and order
-- Per-tab pane tree structure (split directions, ratios)
-- Per-pane working directory (read from `/proc/<pid>/cwd` on Linux)
-- Per-pane foreground process (read from `/proc/<pid>/cmdline` on Linux — best-effort,
-  may be empty or show the shell)
-- Per-pane title (current OSC title)
-
-The output is a valid layout TOML file. Directories are written as absolute paths; the user
-can edit the file to use variables afterward.
-
-**Platform note:** CWD and process detection via `/proc` is Linux-specific. On other
-platforms (if Freminal is ever ported), these fields are omitted and the saved layout
-captures topology only.
-
-#### Layout Application Modes
-
-Layouts can be applied in three ways:
-
-1. **Startup (replace):** `freminal --layout dev.toml` or `startup.layout = "dev"` in
-   config. Creates the workspace from scratch on launch. This is the primary use case.
-
-2. **On-demand replace:** Menu bar > "Layouts" > "Load Layout..." replaces the current
-   session with the selected layout. Prompts for confirmation ("This will close all
-   current tabs.").
-
-3. **On-demand append:** Menu bar > "Layouts" > "Load Layout in New Tab..." creates the
-   layout's tabs as additional tabs in the current session. Useful for "I want my dev
-   layout alongside my existing work."
-
-#### Auto-Save and Restore
-
-```toml
-[startup]
-# Save the current layout on exit and restore it on next launch.
-# The layout is saved to ~/.config/freminal/layouts/_last_session.toml
-restore_last_session = false
-```
-
-When enabled, Freminal saves the current layout to `_last_session.toml` on clean exit.
-On next launch (if no `--layout` flag is given), it restores from this file. This captures
-topology and CWDs but not running programs (since those have exited).
-
-#### Layout Library
-
-Layouts in `~/.config/freminal/layouts/` are discovered automatically. The menu bar shows
-them under "Layouts" with their `layout.name` field. The Settings Modal's "Layouts" tab
-(new tab) lists all discovered layouts with name, description, and a preview of the
-topology.
-
-### 61 Subtasks
-
-1. **61.1 — Layout file format and parser**
-   Define the `Layout`, `LayoutTab`, `LayoutPane`, `LayoutVariables` types. Implement
-   TOML parsing with validation: detect orphan nodes (parent references a non-existent ID),
-   multiple roots, cycles, missing position on non-root nodes. Implement variable
-   substitution (`$1`, `${name}`, `$ENV{...}`, `~`). Unit tests: parse valid layouts,
-   reject malformed ones, verify variable substitution.
-
-2. **61.2 — Layout application engine**
-   Given a parsed `Layout`, create the tab/pane tree using `spawn_pty_tab` for each leaf
-   pane. Pass `directory` to PTY creation (set CWD before exec). Queue `command` for
-   injection after shell ready (reuse the startup command injection mechanism). Set initial
-   titles. Set active tab and active pane per the layout spec.
-
-3. **61.3 — Startup command injection**
-   Implement command injection: after a pane's shell is ready (detect via a short delay or
-   by watching for the first prompt), send the `command` string as PTY input followed by
-   a newline. Handle the "no command" case (just open a shell). This is the core of the
-   original Task 56.3.
-
-4. **61.4 — Shell and environment overrides**
-   Support per-pane `shell` override (use this shell instead of the default). Support
-   per-pane `env` table (set additional environment variables on the PTY child process).
-   Requires extending `spawn_pty_tab` to accept optional shell and env overrides.
-
-5. **61.5 — CLI integration: `--layout` and `--var`**
-   Add `--layout <path_or_name>` flag: if a path, load directly; if a name, search
-   `~/.config/freminal/layouts/<name>.toml`. Add `--var NAME=VALUE` (repeatable) for
-   variable overrides. Positional args after the layout path become `$1`, `$2`, etc.
-   Update arg parsing and config precedence.
-
-6. **61.6 — Save current layout**
-   Implement "Save Layout" that captures the current session topology into a `Layout`
-   struct and serializes it to TOML. Read CWDs via `/proc/<pid>/cwd`. Read foreground
-   processes via `/proc/<pid>/cmdline` (best-effort). Write to a user-chosen path
-   (file dialog or prompt). Unit tests: round-trip save/load produces equivalent topology.
-
-7. **61.7 — Layout library discovery**
-   Scan `~/.config/freminal/layouts/` for `.toml` files on startup and when the directory
-   changes. Parse each file's `[layout]` section (name, description) without fully parsing
-   the tree. Make the list available to the GUI for the menu and Settings Modal.
-
-8. **61.8 — Menu bar integration**
-   Add "Layouts" menu to the menu bar with:
-   - "Load Layout..." (file picker, replace mode)
-   - "Load Layout in New Tab..." (file picker, append mode)
-   - "Save Current Layout..." (save dialog)
-   - Separator
-   - List of discovered layouts from the library (click to load in replace mode)
-     Add `KeyAction::LoadLayout` and `KeyAction::SaveLayout` to keybindings.
-
-9. **61.9 — Auto-save and restore**
-   Implement `startup.restore_last_session`: on exit, save to `_last_session.toml`. On
-   startup (if no `--layout` and `restore_last_session = true`), load from
-   `_last_session.toml`. The saved layout includes topology and CWDs but not commands
-   (since processes have exited — just open shells in the saved directories).
-
-10. **61.10 — Config and settings integration**
-    Add `[startup]` section to config: `layout`, `restore_last_session`. Add a "Layouts"
-    tab to the Settings Modal showing discovered layouts with previews. Update
-    `config_example.toml` and home-manager module.
-
-11. **61.11 — Tests and integration**
-    End-to-end: write a layout file, launch with `--layout`, verify correct tab/pane
-    topology, correct CWDs, correct command injection. Test variable substitution with
-    CLI overrides. Test save/load round-trip. Test auto-restore. Test malformed layouts
-    produce clear error messages. Test partial application (append mode).
-
-### 61 Primary Files
-
-- `freminal-common/src/config.rs` (`StartupConfig`, `LayoutConfig`)
-- `freminal-common/src/layout.rs` (new — layout types, parser, variable substitution)
-- `freminal/src/gui/mod.rs` (layout application, menu integration)
-- `freminal/src/gui/tabs.rs` (layout-driven tab creation)
-- `freminal/src/gui/panes/mod.rs` (layout-driven pane tree construction)
-- `freminal/src/main.rs` (startup layout loading)
-- `freminal-common/src/args.rs` (`--layout`, `--var` flags)
-- `freminal-common/src/keybindings.rs` (layout key actions)
-- `config_example.toml`
-- `nix/home-manager-module.nix`
-
-### 61 Design Decisions
-
-1. **TOML over JSON.** Consistent with the existing config format. TOML's nesting limitations
-   are overcome by the flat node list with parent references — this is more readable than
-   deeply nested inline tables would be, and allows the user to define nodes in any order.
-
-2. **Flat node list with parent references.** A tree can be represented in TOML either as
-   deeply nested inline tables (ugly, hard to edit) or as a flat list with explicit
-   relationships. The flat approach is how many configuration systems handle tree structures
-   (e.g., Terraform resources, Kubernetes manifests). Each node is self-contained and
-   easy to add/remove.
-
-3. **Variables for reusability.** Without variables, layouts are project-specific (hardcoded
-   paths). Variables make a single layout file work across projects. The `$1` positional
-   convention is familiar from shell scripting.
-
-4. **Save captures topology + CWD, not running programs.** We cannot reliably restart an
-   arbitrary program the user was running. Saving CWDs means the user gets shells in the
-   right directories, which covers 90% of the restore value. If `command` was specified
-   in the original layout, the saved layout preserves it — but the "detected" foreground
-   process from `/proc` is stored as a comment, not as an auto-run command, to avoid
-   surprising behavior.
-
-5. **Subsumes Task 56 entirely.** Task 56's `[startup.tabs]` flat list is a strict subset
-   of the layout system. Rather than implementing both, Task 61 provides a superset that
-   handles both simple (`[[tabs]]` with one pane each) and complex (multi-tab, multi-pane,
-   variables) cases. The `[startup]` config section is unified under the layout system.
+5. **64.5 — Tests**
+   Unit tests for the multi-window manager: create window, close window, close last window
+   exits, event dispatch to correct window. Integration: open two windows, verify independent
+   tab/pane management, close one, verify the other continues.
+
+### 64 Primary Files
+
+- `freminal-windowing/src/event_loop.rs` (multi-window dispatch)
+- `freminal-windowing/src/lib.rs` (WindowHandle API extensions)
+- `freminal/src/gui/mod.rs` (per-window state management)
+- `freminal/src/gui/window.rs` (replacement of deferred viewport code)
+- `freminal/src/gui/actions.rs` (close_or_hide_root → close_window)
+
+### 64 Design Decisions
+
+1. **No root window.** The fundamental architectural improvement. Every window is a peer.
+   Closing the last window triggers `ControlFlow::Exit`. This eliminates the entire class of
+   bugs around root-viewport coupling.
+
+2. **One `egui::Context` per window.** Each window has its own egui state. This means the
+   settings modal is per-window (not shared). If the user opens settings in Window A, Window B
+   is unaffected. This is simpler and more correct than the shared `Arc<AtomicBool>` mutual
+   exclusion approach.
+
+### 64 Known Bug: Child Window Initial Spawn Truncation
+
+**Must verify fixed / fix during this task.** Under eframe, child windows spawned via
+`show_viewport_deferred` start their PTY at the hardcoded 100×100 default size. The shell
+and any startup programs (e.g. fastfetch) format output for 100 columns using CUP (absolute
+cursor positioning) during the gap before the first deferred-viewport frame fires a resize.
+When the real resize arrives (e.g. 61×34 on a tiling WM), reflow garbles the CUP-positioned
+layout. The root window doesn't have this issue because eframe's synchronous initialization
+fires the first frame/resize before the shell does significant work.
+
+The fix in v0.6.0 is architectural: with peer windows and `on_window_created()`, the window
+size is known before PTY creation. `spawn_pty_tab()` should accept initial dimensions from
+the actual window geometry instead of using hardcoded defaults. **Additionally**, there may
+be a deeper buffer/reflow bug — verify that CUP-positioned content survives resize correctly
+even when the initial size is correct.
+
+---
+
+## Task 65 — Frame Pacing + Idle Optimization
+
+### 65 Overview
+
+With the custom event loop in place, implement true event-driven rendering. The goal: zero CPU
+usage when the terminal is idle with a steady cursor, and minimal wakeups when only the cursor
+blink timer is active.
+
+### 65 Subtasks
+
+1. **65.1 — Demand-driven rendering**
+   Each window tracks whether it needs a repaint via a dirty flag. The PTY consumer thread
+   sets the flag and calls `request_repaint()`. Keyboard/mouse input sets the flag. The cursor
+   blink timer calls `request_repaint_after(500ms)`. If the flag is not set when
+   `RedrawRequested` fires, skip the frame entirely (just return from the handler without
+   calling `ctx.run()` or `swap_buffers()`).
+
+2. **65.2 — Proper Wayland frame pacing**
+   Call `window.pre_present_notify()` before `surface.swap_buffers()`. This activates winit's
+   Wayland frame-callback pacing, preventing the compositor hang on hidden workspaces. Remove
+   the `vsync = false` workaround. Test: move Freminal to a hidden workspace, verify no hang
+   and no CPU spin.
+
+3. **65.3 — Per-window repaint timers**
+   Each window maintains its own next-repaint-at timestamp. The event loop's `ControlFlow` is
+   set to `WaitUntil(earliest_deadline)` across all windows. Only the window whose deadline
+   has passed receives a `request_redraw()`. Other windows sleep.
+
+4. **65.4 — Idle power measurement**
+   Measure and document idle CPU usage in three scenarios:
+   - Terminal idle, steady cursor (expect ~0%)
+   - Terminal idle, blinking cursor (expect ~0.1%, waking every 500ms)
+   - Active PTY output (expect proportional to output rate, capped at ~120 FPS per window)
+     Compare against the eframe baseline. Include in the completion report.
+
+### 65 Primary Files
+
+- `freminal-windowing/src/event_loop.rs` (frame pacing, dirty tracking, timer management)
+- `freminal/src/gui/pty.rs` (repaint request path)
+- `freminal/src/gui/mod.rs` (dirty flag integration)
+
+### 65 Design Decisions
+
+1. **Skip-frame on clean.** If nothing has changed, don't call `ctx.run()`. This is the
+   single biggest idle power win. eframe always calls `update()` on `RedrawRequested` even
+   if the frame will be identical.
+
+2. **`WaitUntil` instead of `Poll`.** winit's `ControlFlow::WaitUntil` suspends the thread
+   until the deadline or an OS event, whichever comes first. This is strictly better than
+   `Poll` (which spins) or `Wait` (which doesn't support timers).
+
+---
+
+## Task 66 — Cleanup + eframe Removal
+
+### 66 Overview
+
+Remove the `eframe` dependency entirely. Clean up any remaining eframe artifacts, dead code,
+and transitional scaffolding.
+
+### 66 Subtasks
+
+1. **66.1 — Remove eframe from Cargo.toml**
+   Remove `eframe` from the workspace `[dependencies]` and from `freminal/Cargo.toml`. Add
+   `egui`, `egui-winit`, `egui_glow`, `glow`, `winit`, `glutin`, `glutin-winit` as direct
+   workspace dependencies if not already present (they may already be there from Task 62).
+
+2. **66.2 — Remove eframe re-export paths**
+   Any remaining `eframe::egui::*`, `eframe::glow::*`, or `eframe::egui_glow::*` import
+   paths are replaced with direct crate imports. This should already be done by Task 63.6
+   but verify completeness.
+
+3. **66.3 — Remove dead workarounds**
+   Remove the following code that exists solely to work around eframe limitations:
+   - `raw_input_hook` method (no longer exists after Task 63)
+   - `clear_color` hook (no longer exists after Task 63)
+   - `last_window_title` caching (no longer needed after Task 63.5)
+   - `closing_all` flag and confirmation dialog (no longer needed after Task 64.2)
+   - `show_close_confirmation` flag
+   - `vsync = false` workaround and associated comments
+   - `predicted_dt = 0.0` override and associated comments
+
+4. **66.4 — Update documentation**
+   Update `agents.md` architecture section to reflect the new windowing layer. Update
+   `DESIGN_DECISIONS.md` with the eframe removal rationale. Update `config_example.toml` if
+   any config keys changed.
+
+5. **66.5 — Final verification**
+   Full verification suite. Render loop benchmarks before and after (expect improvement from
+   eliminated callback indirection). Manual testing on Linux/Wayland, Linux/X11. Verify all
+   features work: tabs, panes, split, multiple windows, search, background images, custom
+   shaders, background opacity, settings modal, theming, clipboard, drag-and-drop, bell,
+   cursor trail, blinking text, Kitty keyboard protocol.
+
+### 66 Primary Files
+
+- `Cargo.toml` (workspace dependency changes)
+- `freminal/Cargo.toml` (eframe removal)
+- `freminal/src/gui/mod.rs` (dead workaround removal)
+- `agents.md` (architecture update)
+- `Documents/DESIGN_DECISIONS.md` (new decision entry)
 
 ---
 
 ## Dependency Graph
 
 ```text
-Task 32 (Playback Feature Flag) ──► Task 59 (FREC v2 Format)
-Task 58 (Built-in Muxing) ──────► Task 59 (FREC v2 Format)
-                                     │
-                                     ▼
-                                  Task 60 (Playback v2)
-
-Task 36 (Tabs) ──► Task 61 (Saved Layouts)
-Task 58 (Built-in Muxing) ──► Task 61 (Saved Layouts)
-
-Task 55 (Custom Shaders) ─ ─ ► Task 60.5 (Scale mode — soft dependency, can use minimal FBO)
-
-Tasks 59 and 61 are independent of each other.
-Task 60 depends on Task 59 (needs v2 format to replay).
-Task 61 can start before, during, or after Task 59/60.
-```
-
-**Recommended order:**
-
-1. Tasks 59 and 61 can start in parallel (independent).
-2. Task 60 starts after Task 59 is complete.
-3. Within Task 60, subtask 60.5 (Scale mode) benefits from Task 55 (Custom Shaders) if
-   complete, but can be implemented with a minimal FBO otherwise.
-
-```text
-v0.6.0 Execution:
-  ┌── Task 59 (FREC v2 Format) ──► Task 60 (Playback v2)
+Task 62 (freminal-windowing crate)
   │
-  └── Task 61 (Saved Layouts)      [parallel with 59, independent]
+  ▼
+Task 63 (Single-window migration)
+  │
+  ├──────────────────┐
+  ▼                  ▼
+Task 64            Task 65
+(Multi-window)     (Frame pacing)
+  │
+  ▼
+Task 66 (Cleanup + eframe removal)
 ```
+
+**Recommended order:** 62 → 63 → 64 ∥ 65 → 66
+
+Tasks 64 and 65 can run in parallel after Task 63 — they touch different code (multi-window
+lifecycle vs. frame pacing/timers). Task 66 must be last.
 
 ---
 
 ## Cross-Cutting Concerns
 
-### Recording + Layouts Interaction
+### Crate Dependency Boundaries
 
-Task 59 (recording) captures topology events. Task 61 (layouts) defines topology. When
-recording starts, the initial topology snapshot in the FREC v2 metadata IS effectively a
-layout. This means:
+`freminal-windowing` must NOT depend on any other freminal crate. It is a general-purpose
+windowing layer. The dependency flows one way:
 
-- A recording's initial state can be exported as a layout file (diagnostic utility).
-- A layout file can be used to set up the initial state for a recording session.
-
-This interaction is a future enhancement, not a v0.6.0 requirement, but the format designs
-should not preclude it.
-
-### Config Schema Extensions
-
-Task 61 extends the config with `[startup]` fields:
-
-```toml
-[startup]
-layout = "dev"                    # name or path of layout to load on startup
-restore_last_session = false      # auto-save/restore
+```text
+freminal ──► freminal-windowing
+freminal ──► freminal-terminal-emulator ──► freminal-buffer ──► freminal-common
 ```
 
-This must be propagated to `config.rs`, `config_example.toml`, the home-manager module, and
-the Settings Modal.
+`freminal-windowing` depends only on external crates (winit, glutin, egui, glow, etc.) and
+standard library types.
 
-### Feature Flag Scope
+### Custom Renderer Integration
 
-Tasks 59 and 60 are gated behind the `playback` feature flag (extending the existing gating
-from Task 32). Task 61 (layouts) is NOT feature-gated — it is always available, as it is a
-core workflow feature independent of recording/playback.
+The terminal renderer (`freminal/src/gui/renderer/`) currently uses `egui_glow::CallbackFn`
+to inject GL calls into egui's paint pipeline. After migration:
+
+- The renderer receives `&glow::Context` directly from the `App::update()` signature
+- No more `PaintCallback` wrapping
+- No more `painter.intermediate_fbo()` restore
+- The render order is explicit: egui chrome → terminal content (or vice versa, with proper
+  depth/stencil management)
+
+The renderer itself (`gpu.rs`, `vertex.rs`, shader code) is unchanged — only the call site
+changes.
+
+### PTY Thread Repaint Path
+
+Currently, PTY consumer threads hold `Arc<OnceLock<egui::Context>>` and call
+`ctx.request_repaint_after(Duration::from_millis(8))`. After migration, they need a
+thread-safe repaint handle from `freminal-windowing`. Options:
+
+1. **Channel-based:** PTY thread sends a "repaint window X" message to the event loop thread
+   via `crossbeam-channel`. The event loop calls `window.request_redraw()`.
+2. **`EventLoopProxy`:** winit provides `EventLoopProxy::send_event()` for cross-thread
+   wakeups. The PTY thread holds a clone of the proxy and sends a custom user event.
+
+Option 2 is preferred — `EventLoopProxy` is the canonical winit mechanism for cross-thread
+wakeups and avoids adding a channel.
+
+### Config Schema
+
+No config schema changes are expected. The windowing layer is transparent to the user.
+`background_opacity`, `vsync` (if exposed), and window-related settings continue to work
+through the same config paths.
+
+### Platform Testing
+
+The migration is platform-sensitive. The following must be tested:
+
+- **Linux/Wayland:** Primary target. Verify no compositor hang, proper frame pacing,
+  transparency, multi-window.
+- **Linux/X11:** Verify GL context creation (GLX or EGL), transparency, multi-window.
+- **macOS:** Verify CGL context, Retina scaling, transparency. (If no macOS CI, document
+  as untested and request manual verification.)
+- **Windows:** Verify WGL context, DPI scaling, transparency. (Same caveat.)
+
+### Benchmark Impact
+
+The migration should improve render loop benchmarks by eliminating:
+
+- `PaintCallback` closure allocation and dispatch
+- egui intermediate FBO management
+- `predicted_dt` scheduling overhead
+
+Agents must capture before/after numbers for all render loop benchmarks:
+
+- `freminal/benches/render_loop_bench.rs` — all benchmarks
+
+---
+
+## Risk Assessment
+
+| Risk                                                  | Likelihood | Impact | Mitigation                                                                 |
+| ----------------------------------------------------- | ---------- | ------ | -------------------------------------------------------------------------- |
+| GL context creation fails on exotic drivers           | Medium     | High   | glutin handles driver fallbacks; test on Mesa, NVIDIA proprietary, and AMD |
+| winit 0.31 goes stable mid-task, breaking 0.30 API    | Low        | Medium | Pin to 0.30.x during migration; upgrade to 0.31 as a follow-up             |
+| egui 0.35 releases mid-task with breaking changes     | Low        | Medium | Pin to 0.34.x during migration; upgrade as a follow-up                     |
+| PaintCallback removal breaks custom shader pipeline   | Medium     | Medium | Task 63.3 is dedicated to this; thorough testing of all shader features    |
+| Wayland compositor differences (GNOME vs Sway vs KDE) | Medium     | Low    | Test on at least two compositors                                           |
 
 ---
 
@@ -872,5 +599,5 @@ Per `agents.md`, each task is complete when:
 2. `cargo test --all` passes
 3. `cargo clippy --all-targets --all-features -- -D warnings` passes
 4. `cargo-machete` passes
-5. Benchmarks show no unexplained regressions for render/buffer changes
-6. Config schema additions propagated to config.rs, config_example.toml, home-manager, settings
+5. Benchmarks show no unexplained regressions for render changes
+6. Plan document updated with completion status and notes

--- a/Documents/PLAN_VERSION_070.md
+++ b/Documents/PLAN_VERSION_070.md
@@ -359,6 +359,22 @@ peer window with its own GL context, and closing any window closes only that win
    is unaffected. This is simpler and more correct than the shared `Arc<AtomicBool>` mutual
    exclusion approach.
 
+### 64 Known Bug: Child Window Initial Spawn Truncation
+
+**Must verify fixed / fix during this task.** Under eframe, child windows spawned via
+`show_viewport_deferred` start their PTY at the hardcoded 100×100 default size. The shell
+and any startup programs (e.g. fastfetch) format output for 100 columns using CUP (absolute
+cursor positioning) during the gap before the first deferred-viewport frame fires a resize.
+When the real resize arrives (e.g. 61×34 on a tiling WM), reflow garbles the CUP-positioned
+layout. The root window doesn't have this issue because eframe's synchronous initialization
+fires the first frame/resize before the shell does significant work.
+
+The fix in v0.7.0 is architectural: with peer windows and `on_window_created()`, the window
+size is known before PTY creation. `spawn_pty_tab()` should accept initial dimensions from
+the actual window geometry instead of using hardcoded defaults. **Additionally**, there may
+be a deeper buffer/reflow bug — verify that CUP-positioned content survives resize correctly
+even when the initial size is correct.
+
 ---
 
 ## Task 65 — Frame Pacing + Idle Optimization

--- a/Documents/PLAN_VERSION_070.md
+++ b/Documents/PLAN_VERSION_070.md
@@ -1,593 +1,866 @@
-# PLAN_VERSION_070.md — v0.7.0 "Foundation"
+# PLAN_VERSION_070.md — v0.7.0 "Replay & Layouts"
 
 ## Goal
 
-Replace eframe with a direct winit + glutin + egui integration, giving Freminal full control
-over the event loop, GL context lifecycle, frame pacing, and multi-window management. This
-eliminates five documented eframe workarounds, enables true event-driven rendering (zero CPU
-at idle), and removes the root-viewport coupling that forces the "Close All Windows?"
-confirmation dialog. The new windowing layer lives in a dedicated workspace crate
-(`freminal-windowing`) that encapsulates all platform windowing, GL context management, and
-egui integration — keeping the `freminal` binary crate focused on terminal-specific GUI logic.
+Transform Freminal's recording/playback system from a single-stream byte dump into a full
+session reconstruction engine, and introduce a layout system that lets users define, save,
+and restore complete multi-tab, multi-pane workspace configurations.
 
 ---
 
 ## Task Summary
 
-| #   | Feature                               | Scope  | Status  | Dependencies |
-| --- | ------------------------------------- | ------ | ------- | ------------ |
-| 62  | freminal-windowing crate + event loop | Large  | Pending | None         |
-| 63  | Single-window migration               | Large  | Pending | Task 62      |
-| 64  | Multi-window parity                   | Large  | Pending | Task 63      |
-| 65  | Frame pacing + idle optimization      | Medium | Pending | Task 63      |
-| 66  | Cleanup + eframe removal              | Medium | Pending | Task 64      |
+| #   | Feature                           | Scope | Status  | Dependencies     |
+| --- | --------------------------------- | ----- | ------- | ---------------- |
+| 59  | FREC v2: Multi-Pane Recording     | Large | Pending | Task 32, Task 58 |
+| 60  | Playback v2: Multi-Pane Replay    | Large | Pending | Task 59          |
+| 61  | Saved Layouts (Session Templates) | Large | Pending | Task 36, Task 58 |
 
 ---
 
-## Crate: freminal-windowing
+## Task 59 — FREC v2: Multi-Pane Recording Format
 
-A new workspace member that owns the platform windowing abstraction. Everything below the
-`freminal` crate's terminal GUI logic and above the OS lives here.
+### 59 Overview
 
-### Responsibilities
+The current FREC v1 format is a flat sequence of timestamped PTY read chunks — no metadata,
+no terminal dimensions, no input recording, and no awareness of tabs or panes. It was designed
+for a single-emulator world. With tabs (Task 36) and split panes (Task 58) now in place, the
+format is fundamentally inadequate: it cannot record multi-pane sessions at all, and even for
+single-pane sessions it loses critical information (window size, user input, resize events).
 
-- winit `EventLoop` creation and `ApplicationHandler` implementation
-- GL context creation and management via glutin + glutin-winit
-- egui input translation via egui-winit
-- egui rendering via egui_glow (chrome: menus, modals, dialogs)
-- Window lifecycle: create, destroy, resize, focus, minimize, close
-- Frame pacing: render only on demand, proper Wayland `pre_present_notify()`
-- Multi-window management: peer windows with independent GL contexts
+FREC v2 is a complete redesign. The goals:
 
-### What It Does NOT Own
+1. **Per-stream isolation.** Each pane's PTY output is recorded independently — no byte
+   interleaving. A recording of a 4-pane session contains 4 distinct output streams.
+2. **Bidirectional capture.** Every byte Freminal sends TO the PTY (keyboard input, paste,
+   bracketed paste sequences, report responses) is recorded per-pane. This is not replayed
+   during playback — it exists purely for diagnostics ("what did the user type to produce
+   this state?").
+3. **Topology events.** Tab create/close, pane split/close, focus changes, and zoom
+   toggle are recorded as timestamped events. Combined with the per-pane streams, this
+   allows exact reconstruction of Freminal's state at any point in time.
+4. **Size tracking.** Initial window dimensions and every resize event (both window-level
+   and per-pane) are recorded, so playback can reconstruct the correct terminal geometry.
+5. **Rich metadata.** Recording version, Freminal version, initial tab/pane topology,
+   per-pane dimensions, TERM value, scrollback limit, shell, CWD at recording start.
+6. **Seekability.** A frame index table at the end of the file enables random access and
+   backward seeking without scanning the entire file.
 
-- Terminal emulation (freminal-terminal-emulator)
-- Buffer model (freminal-buffer)
-- Custom terminal renderer (stays in freminal — the GL shaders, glyph atlas, vertex builder)
-- Application-level state (tabs, panes, config, keybindings)
-- PTY I/O
+### 59 Format Design
 
-### Public API Surface (Sketch)
+#### File Structure
 
-```rust
-/// The application trait that `freminal` implements instead of `eframe::App`.
-pub trait App {
-    /// Called once per window per frame, only when a redraw is needed.
-    /// `gl` is the window's GL context; `ctx` is the egui context for this window.
-    fn update(&mut self, window_id: WindowId, ctx: &egui::Context, gl: &glow::Context);
-
-    /// Called when a window is created.  Returns initial egui configuration.
-    fn on_window_created(&mut self, window_id: WindowId, ctx: &egui::Context);
-
-    /// Called when a window close is requested.  Return `false` to cancel.
-    fn on_close_requested(&mut self, window_id: WindowId) -> bool;
-
-    /// GL clear color for the given window (supports transparency).
-    fn clear_color(&self, window_id: WindowId) -> [f32; 4];
-}
-
-/// Opaque window identifier (wraps winit::window::WindowId).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct WindowId(winit::window::WindowId);
-
-/// Configuration for creating a new window.
-pub struct WindowConfig {
-    pub title: String,
-    pub inner_size: Option<(u32, u32)>,
-    pub transparent: bool,
-    pub icon: Option<egui::IconData>,
-    pub app_id: Option<String>,
-}
-
-/// Handle passed to the App for requesting window operations.
-pub struct WindowHandle<'a> { /* ... */ }
-
-impl<'a> WindowHandle<'a> {
-    pub fn create_window(&self, config: WindowConfig);
-    pub fn close_window(&self, id: WindowId);
-    pub fn request_repaint(&self, id: WindowId);
-    pub fn request_repaint_after(&self, id: WindowId, delay: Duration);
-    pub fn set_title(&self, id: WindowId, title: &str);
-    pub fn set_visible(&self, id: WindowId, visible: bool);
-    pub fn set_minimized(&self, id: WindowId, minimized: bool);
-}
-
-/// Entry point — replaces `eframe::run_native()`.
-pub fn run(config: WindowConfig, app: impl App + 'static) -> Result<(), Error>;
+```text
+┌─────────────────────────────────────────────────────┐
+│ File Header                                          │
+│   Magic: b"FREC"  (4 bytes)                          │
+│   Version: 0x02   (1 byte)                           │
+│   Flags: u32 LE   (4 bytes, reserved — e.g. compression) │
+│   Metadata Length: u32 LE                             │
+│   Metadata: MessagePack / bincode blob                │
+├─────────────────────────────────────────────────────┤
+│ Event Stream (sequential, variable-length records)    │
+│   Record 0: { timestamp_us, event_type, pane_id, ... }│
+│   Record 1: ...                                       │
+│   ...                                                 │
+│   Record N: ...                                       │
+├─────────────────────────────────────────────────────┤
+│ Seek Index (written at finalization)                  │
+│   Index entry count: u64 LE                           │
+│   Per entry: { timestamp_us: u64, file_offset: u64 }  │
+│   Index interval: every ~1 second of recording time   │
+├─────────────────────────────────────────────────────┤
+│ Footer                                               │
+│   Seek index offset: u64 LE (byte offset of index)   │
+│   Total duration: u64 LE (microseconds)               │
+│   Total events: u64 LE                                │
+│   Magic: b"FREC" (4 bytes, for reverse scanning)      │
+└─────────────────────────────────────────────────────┘
 ```
 
-This is a sketch, not a contract. The API will be refined during implementation. The key
-design principle: `freminal-windowing` owns the event loop and GL contexts; the `freminal`
-crate owns everything terminal-specific.
+#### Metadata Block
 
-### Dependencies
+Serialized as a structured binary format (MessagePack or bincode — decided during
+implementation based on dependency weight). Contains:
 
-The implementing agent MUST use the most recent stable versions of all crates at the time of
-implementation. The versions listed below are the latest stable as of 2026-04-15 and serve as
-a **minimum floor**, not a pin:
+```rust
+struct RecordingMetadata {
+    freminal_version: String,       // e.g. "0.6.0"
+    created_at: u64,                // Unix epoch seconds
+    term: String,                   // e.g. "xterm-256color"
+    initial_window_size: (u32, u32), // pixels
+    initial_topology: TopologySnapshot, // full tab/pane tree at recording start
+    scrollback_limit: u32,
+}
 
-| Crate               | Minimum Version | Purpose                                    |
-| ------------------- | --------------- | ------------------------------------------ |
-| `winit`             | 0.30.13         | Window creation, event loop                |
-| `glutin`            | 0.32.3          | OpenGL context creation (EGL/WGL/GLX/CGL)  |
-| `glutin-winit`      | 0.5.0           | glutin-to-winit integration bridge         |
-| `egui`              | 0.34.1          | Immediate-mode UI (menus, modals, dialogs) |
-| `egui-winit`        | 0.34.1          | winit event to egui RawInput translation   |
-| `egui_glow`         | 0.34.1          | egui rendering via glow (chrome only)      |
-| `glow`              | 0.17.0          | OpenGL function loader and bindings        |
-| `raw-window-handle` | 0.6.2           | Window handle interop (glutin / winit)     |
-| `tracing`           | (workspace)     | Structured logging                         |
-| `thiserror`         | (workspace)     | Error types                                |
-| `conv2`             | (workspace)     | Numeric conversions (per agents.md)        |
+struct TopologySnapshot {
+    tabs: Vec<TabSnapshot>,
+    active_tab: TabId,
+}
 
-**IMPORTANT:** At implementation time, the agent MUST run `cargo search <crate>` for each
-dependency to verify the latest stable version and use that version, not the floor listed here.
-If a new major version of `winit` (0.31+) or `egui` (0.35+) has been released stable, the
-agent must evaluate compatibility and use the latest stable if feasible.
+struct TabSnapshot {
+    id: TabId,
+    pane_tree: PaneTreeSnapshot,
+    active_pane: PaneId,
+    zoomed_pane: Option<PaneId>,
+}
 
-**The `eframe` dependency is NOT removed until Task 66.** Tasks 62–65 add the new crate
-alongside eframe so that the migration can be verified incrementally.
+struct PaneTreeSnapshot {
+    // Mirrors PaneTree enum but with serializable IDs and metadata
+    node: PaneNodeSnapshot,
+}
 
----
+enum PaneNodeSnapshot {
+    Leaf {
+        pane_id: PaneId,
+        cols: u32,
+        rows: u32,
+        cwd: Option<String>,
+        shell: Option<String>,
+        title: String,
+    },
+    Split {
+        direction: SplitDirection,
+        ratio: f32,
+        first: Box<PaneNodeSnapshot>,
+        second: Box<PaneNodeSnapshot>,
+    },
+}
+```
 
-## Task 62 — freminal-windowing Crate + Event Loop
+#### Event Types
 
-### 62 Overview
+Each event record in the stream has a common header:
 
-Create the `freminal-windowing` workspace crate with a working event loop, GL context, and
-egui integration for a single window. This is the foundation — no terminal rendering, no
-migration of `freminal` code. The deliverable is a crate that can open a window, run an egui
-frame, and paint it via glow, verified by a minimal example binary.
+```text
+[0..8]   u64 LE   timestamp_us (elapsed from recording start)
+[8]      u8       event_type
+[9..13]  u32 LE   payload_length
+[13..]   payload  (event_type-specific)
+```
 
-### 62 Subtasks
+Event types:
 
-1. **62.1 — Scaffold the crate**
-   Create `freminal-windowing/Cargo.toml` with workspace dependencies. Create `src/lib.rs`
-   with the public API types (`App` trait, `WindowId`, `WindowConfig`, `run()`). Add the
-   crate to the workspace `members` list in the root `Cargo.toml`. Ensure `cargo check --all`
-   passes with the new empty crate.
+| Type ID | Name         | Payload                                                                          |
+| ------- | ------------ | -------------------------------------------------------------------------------- |
+| 0x01    | PtyOutput    | pane_id: u32, data: [u8]                                                         |
+| 0x02    | PtyInput     | pane_id: u32, data: [u8]                                                         |
+| 0x03    | PaneResize   | pane_id: u32, cols: u32, rows: u32                                               |
+| 0x04    | WindowResize | width_px: u32, height_px: u32                                                    |
+| 0x05    | TabCreate    | tab_id: u32, pane_id: u32, cols: u32, rows: u32                                  |
+| 0x06    | TabClose     | tab_id: u32                                                                      |
+| 0x07    | PaneSplit    | parent_pane: u32, new_pane: u32, direction: u8, ratio: f32, cols: u32, rows: u32 |
+| 0x08    | PaneClose    | pane_id: u32                                                                     |
+| 0x09    | FocusChange  | tab_id: u32, pane_id: u32                                                        |
+| 0x0A    | ZoomToggle   | tab_id: u32, pane_id: u32, zoomed: u8                                            |
+| 0x0B    | TabSwitch    | tab_id: u32                                                                      |
+| 0x0C    | ThemeChange  | theme_name: String (length-prefixed)                                             |
 
-2. **62.2 — winit event loop**
-   Implement the winit 0.30 `ApplicationHandler` trait. Create an `EventLoop`, open a single
-   window via `ActiveEventLoop::create_window()`. Handle `Resumed`, `Suspended`,
-   `WindowEvent::RedrawRequested`, `WindowEvent::CloseRequested`, `WindowEvent::Resized`,
-   and `AboutToWait`. The `ApplicationHandler` holds application state and dispatches to the
-   `App` trait.
+**PtyOutput (0x01)** is the primary data event — equivalent to v1 frames but tagged with a
+pane ID. **PtyInput (0x02)** records what Freminal sent to the PTY — keyboard input, paste
+content, report responses. This is write-only (diagnostics) and is skipped during normal
+playback.
 
-3. **62.3 — GL context via glutin**
-   On `Resumed`, create a glutin `Display` (EGL on Linux/Wayland, WGL on Windows, CGL on
-   macOS) via `glutin-winit::DisplayBuilder`. Select an OpenGL config with RGBA8 + alpha
-   (for transparency support). Create a `Surface` and `PossiblyCurrentContext`. Create a
-   `glow::Context` from the GL loader function. Handle `Suspended` by destroying the surface
-   (required on Android, good practice elsewhere).
+#### Backward Compatibility
 
-4. **62.4 — egui integration**
-   Create an `egui::Context`. Create an `egui_winit::State` for input translation. Create an
-   `egui_glow::Painter` for rendering. On each `RedrawRequested`:
-   - `state.take_egui_input(&window)` → `RawInput`
-   - `ctx.run(raw_input, |ctx| app.update(...))` → `FullOutput`
-   - `state.handle_platform_output(&window, full_output.platform_output)`
-   - `painter.paint_and_update_textures(...)` with the shapes and textures delta
-   - `window.pre_present_notify()` then `surface.swap_buffers(&context)`
+- Files starting with `b"FREC" 0x01` are v1 and handled by the existing parser.
+- Files starting with `b"FREC" 0x02` are v2 and handled by the new parser.
+- `parse_recording()` dispatches on the version byte.
+- The `--with-playback-file` flag accepts both formats. v1 files play back in single-pane
+  mode exactly as today.
 
-5. **62.5 — Frame pacing**
-   Implement demand-driven rendering: only call `window.request_redraw()` when egui reports
-   `needs_repaint`. Expose `request_repaint()` and `request_repaint_after(delay)` through the
-   `WindowHandle` API. Use a timer (winit `ControlFlow::WaitUntil`) to wake the event loop
-   for delayed repaints. Verify: with no UI interaction, CPU usage is zero.
+### 59 Subtasks
 
-6. **62.6 — Transparency support**
-   When `WindowConfig::transparent` is true, configure the glutin surface with alpha, set
-   `window_attributes.with_transparent(true)`, and clear with `[0, 0, 0, 0]` before each
-   frame. Verify: window background is see-through on a supported compositor.
+1. **59.1 — Define FREC v2 format types**
+   Create the Rust types for the v2 format: `RecordingMetadataV2`, `RecordingEvent`,
+   `EventType` enum, `TopologySnapshot`, `PaneNodeSnapshot`, `SeekIndexEntry`. Place in
+   `freminal-terminal-emulator/src/recording.rs` (or a new `recording/` module directory
+   if the file grows too large). All types must be serializable. Choose and justify the
+   serialization format (MessagePack via `rmp-serde`, bincode, or raw manual encoding).
+   Add unit tests for round-trip serialization of all types.
 
-7. **62.7 — Error handling**
-   Define a `freminal_windowing::Error` enum covering: event loop creation failure, GL context
-   creation failure, surface creation failure, window creation failure. All public APIs return
-   `Result<T, Error>`. No panics in production code.
+2. **59.2 — v2 file writer: header and metadata**
+   Implement `write_header_v2()` that writes the magic, version, flags, and serialized
+   metadata block. The writer takes a `RecordingMetadataV2` (constructed from the current
+   `TabManager` topology at recording start). Unit tests: write + read back, verify
+   metadata fields survive the round trip.
 
-8. **62.8 — Example binary + tests**
-   Create `freminal-windowing/examples/hello.rs` — a minimal app that opens a window, shows
-   an egui label "Hello from freminal-windowing", and exits on close. Unit tests for
-   `WindowId`, `WindowConfig`, error types. The example is not a production artifact — it
-   exists for verification and can be removed later.
+3. **59.3 — v2 file writer: event stream**
+   Implement `write_event()` that appends a single event record to the file. Called from
+   the PTY reader thread (for PtyOutput/PtyInput) and the GUI thread (for topology and
+   resize events). Use a channel to funnel events from multiple threads to a single writer
+   thread (avoids interleaving and file locking). Unit tests: write a sequence of events,
+   read back, verify ordering and content.
 
-### 62 Primary Files
+4. **59.4 — v2 file writer: seek index and footer**
+   On recording stop (or application exit), the writer thread computes the seek index
+   (one entry per ~1 second of recording time, or per N events), writes it, and writes
+   the footer with the index offset, total duration, and event count. Implement graceful
+   finalization on both clean exit and SIGTERM/crash (write what we have). Unit tests:
+   verify index entries point to correct file offsets, verify footer fields.
 
-- `freminal-windowing/Cargo.toml` (new crate manifest)
-- `freminal-windowing/src/lib.rs` (public API, re-exports)
-- `freminal-windowing/src/event_loop.rs` (ApplicationHandler, event dispatch)
-- `freminal-windowing/src/gl_context.rs` (glutin setup, surface management)
-- `freminal-windowing/src/egui_integration.rs` (egui_winit + egui_glow wiring)
-- `freminal-windowing/src/error.rs` (error types)
-- `freminal-windowing/examples/hello.rs` (verification example)
-- `Cargo.toml` (workspace member addition)
+5. **59.5 — v2 file parser**
+   Implement `parse_recording_v2()` that reads the header, metadata, and loads the event
+   stream. Two modes: full load (all events into memory, for small files) and indexed
+   streaming (use the seek index for random access, for large files). The indexed mode
+   reads events on demand by seeking to the nearest index entry. Dispatch from the existing
+   `parse_recording()` based on version byte. Unit tests: parse files written by 59.2–59.4,
+   verify all fields. Test backward compat: v1 files still parse correctly.
 
-### 62 Design Decisions
+6. **59.6 — Hook PTY output recording**
+   In the PTY reader thread (`pty.rs`), replace the v1 `write_frame()` call with
+   `write_event(PtyOutput { pane_id, data })`. Each pane's PTY reader knows its pane ID
+   (threaded through at spawn time). This is the minimal change to start producing v2 files.
 
-1. **Separate crate, not inline in `freminal`.** The windowing layer is a reusable abstraction
-   that encapsulates platform-specific complexity. Keeping it in a separate crate enforces a
-   clean API boundary, makes it testable in isolation, and follows the existing workspace
-   pattern (`freminal-buffer`, `freminal-common`, `freminal-terminal-emulator`).
+7. **59.7 — Hook PTY input recording**
+   Every byte sent TO the PTY (keyboard input via `PtyWrite::Write`, paste via
+   `PtyWrite::Write`, resize via `PtyWrite::Resize`, and report responses) is captured as
+   a `PtyInput` event. The input channel already passes through a known point — tap it
+   there. `PtyWrite::Resize` additionally generates a `PaneResize` event.
 
-2. **winit 0.30 `ApplicationHandler` trait, not the deprecated `EventLoop::run()` closure.**
-   winit 0.30 deprecated the closure-based event loop in favor of the trait-based
-   `ApplicationHandler`. The trait-based approach is cleaner (proper struct methods instead of
-   a giant closure) and is the only supported path forward in winit 0.31+.
+8. **59.8 — Hook topology events**
+   In the GUI thread, emit topology events when:
+   - A tab is created (`TabCreate`) or closed (`TabClose`)
+   - A pane is split (`PaneSplit`) or closed (`PaneClose`)
+   - Focus changes (`FocusChange`)
+   - Zoom toggles (`ZoomToggle`)
+   - The active tab switches (`TabSwitch`)
+   - The window resizes (`WindowResize`)
+     These are sent through the event channel to the writer thread.
 
-3. **One `egui::Context` per window (not shared).** eframe shares one `Context` across all
-   viewports. This causes the root-viewport coupling problem. With independent contexts, each
-   window is a peer with its own egui state. The cost is that egui `Memory` (widget state like
-   scroll offsets, text cursor positions) is per-window, which is correct behavior anyway.
+9. **59.9 — Recording CLI and config updates**
+   Update `--recording-path` to produce v2 files by default. Add `--recording-format v1|v2`
+   flag for backward compatibility. Update `config_example.toml` if any config-level
+   recording options are added. Update the `playback` feature flag gating to cover the
+   new types.
 
-4. **GL context per window.** Each window gets its own glutin `Surface` +
-   `PossiblyCurrentContext`. This avoids the need for context switching (`make_current`) on
-   every frame and enables future per-window vsync.
+10. **59.10 — Tests and integration**
+    End-to-end test: start a headless multi-pane session, feed input, split panes, resize,
+    close panes, stop recording. Parse the resulting file and verify: correct event ordering,
+    per-pane data isolation (no interleaving), topology events at correct timestamps, seek
+    index validity. Test v1 backward compatibility. Test graceful finalization on abrupt stop.
 
----
+### 59 Primary Files
 
-## Task 63 — Single-Window Migration
+- `freminal-terminal-emulator/src/recording.rs` (or `recording/` module — format types, writer, parser)
+- `freminal-terminal-emulator/src/io/pty.rs` (PTY output and input hooks)
+- `freminal/src/gui/mod.rs` (topology event emission)
+- `freminal/src/gui/panes/mod.rs` (pane ID threading)
+- `freminal/src/gui/tabs.rs` (tab lifecycle events)
+- `freminal-common/src/args.rs` (CLI flag updates)
 
-### 63 Overview
+### 59 Design Decisions
 
-Migrate the `freminal` binary from eframe to `freminal-windowing` for the single-window case.
-After this task, Freminal opens and runs using the new event loop with full feature parity
-for a single window. eframe remains as a dependency (not yet removed) but is no longer called.
+1. **Single writer thread via channel.** Events from multiple PTY reader threads and the
+   GUI thread are funneled through a bounded crossbeam channel to a dedicated writer thread.
+   This avoids file-level locking, guarantees chronological ordering (events are timestamped
+   at the source and sorted if needed), and keeps I/O off the hot paths.
 
-### 63 Subtasks
+2. **Seek index at file end.** Writing the index at finalization (rather than maintaining it
+   inline) simplifies the writer — it just appends events sequentially. The footer's index
+   offset allows the parser to jump straight to the index. Crash resilience: if the file is
+   not finalized (crash before footer), the parser falls back to sequential scanning.
 
-1. **63.1 — Implement the `App` trait in `freminal`**
-   Create a new `impl freminal_windowing::App for FreminalApp` (or adapt `FreminalGui`).
-   The `update()` method should contain the same logic as the current `eframe::App::ui()`
-   body. The `on_close_requested()` method replaces the `close_requested` + `CancelClose`
-   intercept.
+3. **PtyInput is write-only.** Input events are never replayed during playback — they exist
+   for diagnostic reconstruction. This means the playback engine can skip them entirely,
+   and the recording overhead of capturing input is negligible (input volume is tiny compared
+   to output).
 
-2. **63.2 — Replace `eframe::run_native()` with `freminal_windowing::run()`**
-   In `main.rs`, replace the eframe launch code with the new entry point. Translate
-   `NativeOptions` to `WindowConfig`. Remove the `raw_input_hook` override (no longer needed).
-   Remove the `clear_color` hook (controlled directly via the `App` trait method).
-
-3. **63.3 — Migrate PaintCallback to direct GL calls**
-   The current custom renderer is wrapped in `egui_glow::CallbackFn` closures. With
-   `freminal-windowing`, the `App::update()` method receives the `glow::Context` directly.
-   Restructure the render pipeline: egui paints chrome first (via `egui_glow::Painter`), then
-   the custom terminal renderer draws directly to the framebuffer. This eliminates the
-   `PaintCallback` indirection and the `painter.intermediate_fbo()` restore requirement.
-
-4. **63.4 — Migrate repaint requests**
-   Replace `ui.ctx().request_repaint()` and `ui.ctx().request_repaint_after(delay)` with
-   `WindowHandle::request_repaint()` and `WindowHandle::request_repaint_after()`. Update the
-   PTY consumer thread to use the new repaint mechanism (it currently holds an
-   `Arc<OnceLock<egui::Context>>` and calls `ctx.request_repaint_after`).
-
-5. **63.5 — Migrate ViewportCommand calls**
-   Replace all `ui.ctx().send_viewport_cmd(ViewportCommand::*)` calls with direct
-   `WindowHandle` method calls (`set_title`, `close_window`, `set_minimized`, etc.). Remove
-   the `last_window_title` caching workaround (no longer needed — direct winit calls don't
-   trigger repaint loops).
-
-6. **63.6 — Migrate `eframe::egui::*` imports**
-   Mechanical find-replace: all `eframe::egui::*` imports become `egui::*`. All
-   `eframe::glow::*` imports become `glow::*`. All `eframe::egui_glow::*` imports become
-   `egui_glow::*`. This is a large but trivial diff.
-
-7. **63.7 — Verification + benchmarks**
-   Run the full verification suite. Run render loop benchmarks before and after. Verify:
-   single window opens, terminal works, tabs work, panes work, settings modal works, menu bar
-   works, search works, background images work, custom shaders work, background opacity works.
-   Verify on Wayland: no hang on hidden workspace (the vsync bug is gone).
-
-### 63 Primary Files
-
-- `freminal/src/main.rs` (launch code replacement)
-- `freminal/src/gui/mod.rs` (App trait impl, removal of eframe hooks)
-- `freminal/src/gui/terminal/widget.rs` (PaintCallback removal)
-- `freminal/src/gui/window.rs` (secondary window code — deferred to Task 64)
-- `freminal/src/gui/rendering.rs` (direct GL rendering)
-- `freminal/src/gui/pty.rs` (repaint mechanism)
-- `freminal/Cargo.toml` (add `freminal-windowing` dep)
-
-### 63 Design Decisions
-
-1. **Render order: egui chrome first, then terminal GL.** Currently the terminal renderer
-   runs inside a `PaintCallback` embedded in egui's paint list. With direct control, we paint
-   egui's chrome (menu bar, settings modal, tab bar) first via `egui_glow::Painter`, then
-   render the terminal content directly via our custom shaders. The terminal occupies a known
-   pixel rect (from egui layout), so the custom renderer clips to that rect. This eliminates
-   the intermediate FBO restore dance.
-
-2. **Keep eframe as a dependency during migration.** Tasks 62–65 are incremental. eframe is
-   not removed until Task 66. This allows bisecting if something breaks.
+4. **Topology snapshots, not diffs.** The metadata block stores the full initial topology.
+   Subsequent topology changes are recorded as discrete events (split, close, etc.). The
+   playback engine reconstructs the topology by applying events sequentially from the initial
+   snapshot. This is simpler and more debuggable than differential encoding.
 
 ---
 
-## Task 64 — Multi-Window Parity
+## Task 60 — Playback v2: Multi-Pane Replay with Size Adaptation
 
-### 64 Overview
+### 60 Overview
 
-Extend `freminal-windowing` to support multiple windows and migrate the multi-window code from
-the current eframe deferred-viewport approach. After this task, `Ctrl+Shift+N` opens a new
-peer window with its own GL context, and closing any window closes only that window.
+The current playback engine (`freminal/src/playback.rs`) drives a single headless
+`TerminalEmulator`, feeding it frames sequentially. It cannot:
 
-### 64 Subtasks
+- Replay multi-pane or multi-tab sessions
+- Handle window size mismatch between recording and playback
+- Seek backward or jump to arbitrary positions
+- Isolate a single pane's stream
 
-1. **64.1 — Multi-window support in freminal-windowing**
-   Extend the `ApplicationHandler` to manage a `HashMap<WindowId, WindowState>` where
-   `WindowState` holds the `Window`, `Surface`, `PossiblyCurrentContext`, `egui::Context`,
-   `egui_winit::State`, and `egui_glow::Painter` for each window. `WindowHandle::create_window()`
-   inserts a new entry. Events are dispatched to the correct window by `winit::window::WindowId`.
+Task 60 rebuilds the playback engine to consume FREC v2 files, reconstruct the full tab/pane
+topology, and introduce size adaptation strategies for tiling WM users who cannot freely
+resize their window.
 
-2. **64.2 — Peer window model**
-   All windows are equal peers. There is no root window. Closing any window closes only that
-   window and its resources. Closing the last window exits the process. The `App` trait's
-   `on_close_requested()` receives the `WindowId` and the app decides whether to allow it
-   (e.g., confirm if the window has running processes). This eliminates the confirmation
-   dialog for root-window close.
+### 60 Design
 
-3. **64.3 — Migrate secondary window code**
-   Replace the `show_viewport_deferred` approach in `gui/window.rs` with
-   `WindowHandle::create_window()`. Remove `SecondaryWindowState`, the per-frame
-   re-registration loop, the pruning loop, and the `closing_all` flag. Each window calls
-   `App::update()` independently with its own `WindowId`.
+#### Multi-Pane Reconstruction
 
-4. **64.4 — Shared resources**
-   Resources that are shared across windows (`Config`, `FontManager`, `PaneIdGenerator`)
-   continue to use `Arc<Mutex<>>`. Per-window resources (`TabManager`, `PaneTree`, channels,
-   `WindowPostRenderer`) move into a per-window state struct owned by the `App`.
+The playback engine creates a headless `TerminalEmulator` per pane (just as live mode does).
+On startup, it reads the `TopologySnapshot` from the FREC v2 metadata and constructs the
+initial tab/pane tree:
 
-5. **64.5 — Tests**
-   Unit tests for the multi-window manager: create window, close window, close last window
-   exits, event dispatch to correct window. Integration: open two windows, verify independent
-   tab/pane management, close one, verify the other continues.
+```text
+1. Read metadata.initial_topology
+2. For each tab:
+   a. For each leaf pane in the tree: create TerminalEmulator::new_headless(cols, rows)
+   b. Construct the PaneTree (mirrors the recorded topology)
+   c. Set active_pane and zoomed_pane from the snapshot
+3. Publish initial snapshots for all panes
+```
 
-### 64 Primary Files
+As topology events arrive during playback (TabCreate, PaneSplit, PaneClose, etc.), the engine
+modifies the tab/pane tree accordingly — creating or destroying emulators as needed.
 
-- `freminal-windowing/src/event_loop.rs` (multi-window dispatch)
-- `freminal-windowing/src/lib.rs` (WindowHandle API extensions)
-- `freminal/src/gui/mod.rs` (per-window state management)
-- `freminal/src/gui/window.rs` (replacement of deferred viewport code)
-- `freminal/src/gui/actions.rs` (close_or_hide_root → close_window)
+PtyOutput events are routed to the correct emulator by `pane_id`. PtyInput events are skipped
+(logged to a diagnostic sidebar if one is ever added, but not fed to emulators).
 
-### 64 Design Decisions
+#### Size Adaptation
 
-1. **No root window.** The fundamental architectural improvement. Every window is a peer.
-   Closing the last window triggers `ControlFlow::Exit`. This eliminates the entire class of
-   bugs around root-viewport coupling.
+The recording captures the exact terminal dimensions at every point. The playback window may
+be a different size — especially on tiling WMs where the user cannot resize freely. Three
+strategies, selectable via a toolbar toggle:
 
-2. **One `egui::Context` per window.** Each window has its own egui state. This means the
-   settings modal is per-window (not shared). If the user opens settings in Window A, Window B
-   is unaffected. This is simpler and more correct than the shared `Arc<AtomicBool>` mutual
-   exclusion approach.
+**1. Letterbox (default):**
+Render each pane at its _recorded_ dimensions. If the playback window is larger, pad with
+background color. If smaller, scroll/clip. This guarantees pixel-perfect fidelity — the
+terminal content is identical to what was recorded. The pane tree layout uses the recorded
+split ratios applied to the recorded window size, then the entire layout is centered in the
+actual window.
 
-### 64 Known Bug: Child Window Initial Spawn Truncation
+**2. Reflow:**
+Create each headless emulator at the _playback_ window dimensions (or the pane's proportional
+share of the playback window). The same byte stream is fed, but the terminal re-wraps content
+to fit the new width. This changes line breaks and may alter visual layout, but is more
+readable when the size mismatch is large. Resize events in the recording are translated
+proportionally.
 
-**Must verify fixed / fix during this task.** Under eframe, child windows spawned via
-`show_viewport_deferred` start their PTY at the hardcoded 100×100 default size. The shell
-and any startup programs (e.g. fastfetch) format output for 100 columns using CUP (absolute
-cursor positioning) during the gap before the first deferred-viewport frame fires a resize.
-When the real resize arrives (e.g. 61×34 on a tiling WM), reflow garbles the CUP-positioned
-layout. The root window doesn't have this issue because eframe's synchronous initialization
-fires the first frame/resize before the shell does significant work.
+**3. Scale:**
+Render at the recorded dimensions (like letterbox) but scale the output to fill the playback
+window. Preserves layout fidelity while using available space. May look fuzzy if scaling up
+significantly. Implemented via an intermediate framebuffer rendered at recorded size, then
+scaled to the display rect (leveraging the existing custom GL renderer).
 
-The fix in v0.7.0 is architectural: with peer windows and `on_window_created()`, the window
-size is known before PTY creation. `spawn_pty_tab()` should accept initial dimensions from
-the actual window geometry instead of using hardcoded defaults. **Additionally**, there may
-be a deeper buffer/reflow bug — verify that CUP-positioned content survives resize correctly
-even when the initial size is correct.
+**Default: Letterbox.** It is the only mode that guarantees the playback is visually identical
+to the recording. The user can switch modes during playback via the toolbar.
+
+#### Seek and Rewind
+
+The FREC v2 seek index enables jumping to arbitrary positions:
+
+**Forward seek:** Skip events until the target timestamp. Feed PtyOutput events to emulators
+in fast-forward (no timing delays). Apply topology events normally.
+
+**Backward seek / rewind:** Terminal emulators are not reversible — you cannot "undo" bytes
+fed to them. To seek backward:
+
+1. Find the nearest seek index entry at or before the target timestamp.
+2. Reset all emulators to their initial state (or the state at the index entry — see
+   checkpoint strategy below).
+3. Replay all events from that point to the target timestamp in fast-forward.
+
+**Checkpoint strategy (optimization):** During forward playback, periodically snapshot the
+full emulator state (every ~5 seconds or at each seek index entry). Store these snapshots
+in memory. When seeking backward, find the nearest checkpoint before the target and replay
+from there instead of from the beginning. Memory budget: cap at ~100 checkpoints (each
+snapshot is a few hundred KB), evicting the oldest when the cap is reached.
+
+#### Per-Pane Solo Mode
+
+The playback toolbar offers a pane selector. When a pane is "soloed," only that pane's
+PtyOutput events are fed to its emulator and rendered. Other panes are paused (their events
+are skipped). This is useful for focusing on one pane's output in a busy multi-pane recording.
+Unsoloing resumes all panes from the current timestamp (events that were skipped are not
+replayed — the other panes jump to their state at the current time via fast-forward).
+
+#### Playback Toolbar Updates
+
+The current toolbar has: mode selector (Instant/RealTime/FrameStep), play/pause, frame
+counter. v2 adds:
+
+- **Timeline scrubber:** drag to seek to any timestamp. Shows total duration and current
+  position.
+- **Size mode toggle:** Letterbox / Reflow / Scale.
+- **Pane selector:** dropdown or clickable pane labels for solo mode.
+- **Speed control:** 0.5x, 1x, 2x, 4x, 8x playback speed (multiplier on inter-frame delays).
+- **Diagnostic toggle:** show/hide PtyInput events in a side panel (stretch goal).
+
+### 60 Subtasks
+
+1. **60.1 — Multi-emulator playback engine**
+   Refactor `run_playback_thread` (or replace it) to manage multiple headless
+   `TerminalEmulator` instances, one per pane. Read the `TopologySnapshot` from the v2
+   metadata and construct the initial emulator set. Route `PtyOutput` events by pane ID.
+   Handle topology events (create/destroy emulators as panes split/close). Publish per-pane
+   snapshots via per-pane `ArcSwap`. Fall back to single-emulator mode for v1 files.
+
+2. **60.2 — Playback tab/pane tree reconstruction**
+   On playback start, construct a `TabManager` with the recorded topology. The GUI renders
+   tabs and panes using the same layout code as live mode. Topology events during playback
+   modify the tree (split, close, tab create/close). The GUI must handle dynamic topology
+   changes during playback just as it does in live mode.
+
+3. **60.3 — Letterbox size adaptation**
+   Implement the letterbox strategy: each pane's emulator runs at its recorded dimensions
+   regardless of the playback window size. The layout engine uses recorded dimensions for
+   the pane tree, centers the result in the available window, and pads with background color.
+   If the playback window is smaller than the recorded layout, clip or add scrollbars to the
+   outer frame (not per-pane — the entire layout scrolls as a unit).
+
+4. **60.4 — Reflow size adaptation**
+   Implement the reflow strategy: each pane's emulator is created at the playback window's
+   proportional dimensions. Resize events in the recording are translated proportionally.
+   The pane tree uses the playback window dimensions with recorded split ratios.
+
+5. **60.5 — Scale size adaptation**
+   Implement the scale strategy: render the terminal layout at recorded dimensions into an
+   offscreen framebuffer (FBO), then draw a single textured quad scaled to fill the playback
+   window. This leverages the existing GL renderer. If Task 55 (Custom Shaders) is complete,
+   the scale pass is just another post-processing step. If not, a minimal FBO + blit shader
+   is needed (subset of 55.1).
+
+6. **60.6 — Forward seek**
+   Implement seek-forward: given a target timestamp, skip events and feed them to emulators
+   in fast-forward (no timing delays). Update the timeline scrubber position. Handle topology
+   events during fast-forward.
+
+7. **60.7 — Backward seek with checkpoints**
+   Implement the checkpoint system: during forward playback, snapshot emulator state at
+   regular intervals. On backward seek, find the nearest checkpoint, restore emulator state,
+   and fast-forward to the target. Cap checkpoint memory at a configurable budget. If no
+   checkpoint exists (e.g., seeking to near the beginning), reset to initial state and
+   replay from the start.
+
+8. **60.8 — Per-pane solo mode**
+   Add pane solo/unsolo to the playback toolbar. When soloed, only the selected pane's
+   PtyOutput events are processed. Other panes freeze at their current state. Unsoloing
+   fast-forwards the unsoloed panes to the current timestamp.
+
+9. **60.9 — Speed control**
+   Add speed multiplier to the playback toolbar (0.5x, 1x, 2x, 4x, 8x). The multiplier
+   divides inter-frame delays in RealTime mode. In Instant mode, speed is already infinite.
+   In FrameStep mode, speed is irrelevant.
+
+10. **60.10 — Timeline scrubber UI**
+    Add a horizontal scrubber bar to the playback toolbar showing total duration and current
+    position. Clicking/dragging seeks to the target timestamp (using 60.6/60.7). Show
+    timestamps in human-readable format (MM:SS or HH:MM:SS).
+
+11. **60.11 — v1 backward compatibility**
+    Ensure v1 FREC files continue to play back correctly. The v1 path remains single-pane,
+    forward-only, with the existing playback modes. The new toolbar features (seek, speed,
+    size mode) gracefully degrade: seek is not available (no index), size mode uses letterbox
+    at the default 80x24, speed control works normally.
+
+12. **60.12 — Tests and integration**
+    End-to-end test: record a multi-pane session (using 59.10's test infrastructure), play
+    it back, verify: pane topology matches, per-pane content matches frame-by-frame, seek
+    forward/backward produces correct state, size adaptation modes render without crashes.
+    Test v1 backward compatibility. Benchmark: measure playback throughput for large
+    recordings (e.g., 1M events).
+
+### 60 Primary Files
+
+- `freminal/src/playback.rs` (rebuilt playback engine)
+- `freminal/src/gui/mod.rs` (playback toolbar updates, multi-pane playback rendering)
+- `freminal/src/gui/tabs.rs` (playback tab/pane tree construction)
+- `freminal/src/gui/panes/mod.rs` (playback-mode pane management)
+- `freminal/src/gui/terminal/widget.rs` (size adaptation rendering)
+- `freminal/src/gui/renderer/gpu.rs` (FBO for scale mode, if Task 55 not done)
+- `freminal/src/main.rs` (v2 playback startup path)
+
+### 60 Design Decisions
+
+1. **Letterbox as default.** A tiling WM user cannot resize freely. Reflow changes the
+   content layout. Scale can be fuzzy. Letterbox is the only mode that guarantees the
+   playback is visually identical to the recording, regardless of window size. The user
+   can switch to reflow or scale if they prefer readability over fidelity.
+
+2. **Checkpoints for backward seek.** Terminal emulators are state machines with no reverse
+   operation. The alternative to checkpoints is replaying from the beginning on every
+   backward seek, which is O(N) in recording length. Checkpoints make it O(checkpoint_interval).
+   The memory cost is bounded by the checkpoint cap.
+
+3. **Per-pane solo is skip-based, not filter-based.** Solo mode skips events for non-soloed
+   panes rather than filtering them out of the event stream. This means the timeline stays
+   consistent (the scrubber position reflects real recording time, not just the soloed pane's
+   activity). Unsoloing requires fast-forward to sync the other panes.
+
+4. **Speed control as delay multiplier.** The simplest correct approach. 2x speed = half the
+   inter-frame delay. This preserves relative timing between events (a burst of output still
+   looks like a burst, just faster). The alternative — frame batching — would change the
+   visual cadence.
 
 ---
 
-## Task 65 — Frame Pacing + Idle Optimization
+## Task 61 — Saved Layouts (Session Templates)
 
-### 65 Overview
+### 61 Overview
 
-With the custom event loop in place, implement true event-driven rendering. The goal: zero CPU
-usage when the terminal is idle with a steady cursor, and minimal wakeups when only the cursor
-blink timer is active.
+A layout is a complete description of a Freminal workspace: how many tabs, how each tab's
+panes are arranged, and what runs in each pane. Layouts enable:
 
-### 65 Subtasks
+- **Startup configuration:** launch Freminal with a predefined multi-tab, multi-pane
+  workspace tailored to a project
+- **Save current state:** capture the running session's topology, working directories, and
+  programs into a reusable layout file
+- **Layout library:** a collection of named layouts in `~/.config/freminal/layouts/`,
+  selectable from the menu or Settings Modal
+- **Partial application:** load a layout into a new tab without replacing the entire session
+- **Auto-restore:** optionally save the layout on exit and restore it on next launch
 
-1. **65.1 — Demand-driven rendering**
-   Each window tracks whether it needs a repaint via a dirty flag. The PTY consumer thread
-   sets the flag and calls `request_repaint()`. Keyboard/mouse input sets the flag. The cursor
-   blink timer calls `request_repaint_after(500ms)`. If the flag is not set when
-   `RedrawRequested` fires, skip the frame entirely (just return from the handler without
-   calling `ctx.run()` or `swap_buffers()`).
+This task subsumes and expands Task 56 (Session Restore / Startup Commands), which was limited
+to flat tab lists with no pane tree support.
 
-2. **65.2 — Proper Wayland frame pacing**
-   Call `window.pre_present_notify()` before `surface.swap_buffers()`. This activates winit's
-   Wayland frame-callback pacing, preventing the compositor hang on hidden workspaces. Remove
-   the `vsync = false` workaround. Test: move Freminal to a hidden workspace, verify no hang
-   and no CPU spin.
+### 61 Design
 
-3. **65.3 — Per-window repaint timers**
-   Each window maintains its own next-repaint-at timestamp. The event loop's `ControlFlow` is
-   set to `WaitUntil(earliest_deadline)` across all windows. Only the window whose deadline
-   has passed receives a `request_redraw()`. Other windows sleep.
+#### Layout File Format
 
-4. **65.4 — Idle power measurement**
-   Measure and document idle CPU usage in three scenarios:
-   - Terminal idle, steady cursor (expect ~0%)
-   - Terminal idle, blinking cursor (expect ~0.1%, waking every 500ms)
-   - Active PTY output (expect proportional to output rate, capped at ~120 FPS per window)
-     Compare against the eframe baseline. Include in the completion report.
+Layouts are TOML files. TOML's nesting is limited, but for tree structures we use a
+flattened representation with explicit parent references. The format is human-readable
+and hand-editable — a key design goal.
 
-### 65 Primary Files
+```toml
+# ~/.config/freminal/layouts/dev.toml
 
-- `freminal-windowing/src/event_loop.rs` (frame pacing, dirty tracking, timer management)
-- `freminal/src/gui/pty.rs` (repaint request path)
-- `freminal/src/gui/mod.rs` (dirty flag integration)
+[layout]
+name = "Development"
+description = "Standard dev workspace: editor, server, logs"
 
-### 65 Design Decisions
+# Variables — can be overridden from CLI: freminal --layout dev.toml ~/projects/myapp
+# $1, $2, etc. are positional args. Named vars use ${VAR_NAME}.
+[layout.variables]
+project_dir = "~/projects/default"  # default value, overridden by $1 if provided
 
-1. **Skip-frame on clean.** If nothing has changed, don't call `ctx.run()`. This is the
-   single biggest idle power win. eframe always calls `update()` on `RedrawRequested` even
-   if the frame will be identical.
+# --- Tab definitions ---
 
-2. **`WaitUntil` instead of `Poll`.** winit's `ControlFlow::WaitUntil` suspends the thread
-   until the deadline or an OS event, whichever comes first. This is strictly better than
-   `Poll` (which spins) or `Wait` (which doesn't support timers).
+[[tabs]]
+title = "Editor"
+active = true  # this tab is focused on launch
 
----
+  # Pane tree for this tab. The tree is defined as a flat list of nodes.
+  # Each node has an "id" (local to this tab) and optionally a "parent" + "position".
+  # The root node has no parent.
 
-## Task 66 — Cleanup + eframe Removal
+  [[tabs.panes]]
+  id = "root"
+  split = "vertical"   # "vertical" (left/right) or "horizontal" (top/bottom)
+  ratio = 0.65
 
-### 66 Overview
+  [[tabs.panes]]
+  id = "editor"
+  parent = "root"
+  position = "first"   # "first" (left/top) or "second" (right/bottom)
+  directory = "${project_dir}"
+  command = "nvim ."
+  active = true         # this pane has focus within the tab
 
-Remove the `eframe` dependency entirely. Clean up any remaining eframe artifacts, dead code,
-and transitional scaffolding.
+  [[tabs.panes]]
+  id = "sidebar"
+  parent = "root"
+  position = "second"
+  split = "horizontal"
+  ratio = 0.5
 
-### 66 Subtasks
+  [[tabs.panes]]
+  id = "terminal"
+  parent = "sidebar"
+  position = "first"
+  directory = "${project_dir}"
 
-1. **66.1 — Remove eframe from Cargo.toml**
-   Remove `eframe` from the workspace `[dependencies]` and from `freminal/Cargo.toml`. Add
-   `egui`, `egui-winit`, `egui_glow`, `glow`, `winit`, `glutin`, `glutin-winit` as direct
-   workspace dependencies if not already present (they may already be there from Task 62).
+  [[tabs.panes]]
+  id = "git"
+  parent = "sidebar"
+  position = "second"
+  directory = "${project_dir}"
+  command = "lazygit"
 
-2. **66.2 — Remove eframe re-export paths**
-   Any remaining `eframe::egui::*`, `eframe::glow::*`, or `eframe::egui_glow::*` import
-   paths are replaced with direct crate imports. This should already be done by Task 63.6
-   but verify completeness.
+[[tabs]]
+title = "Server"
 
-3. **66.3 — Remove dead workarounds**
-   Remove the following code that exists solely to work around eframe limitations:
-   - `raw_input_hook` method (no longer exists after Task 63)
-   - `clear_color` hook (no longer exists after Task 63)
-   - `last_window_title` caching (no longer needed after Task 63.5)
-   - `closing_all` flag and confirmation dialog (no longer needed after Task 64.2)
-   - `show_close_confirmation` flag
-   - `vsync = false` workaround and associated comments
-   - `predicted_dt = 0.0` override and associated comments
+  [[tabs.panes]]
+  id = "server"
+  directory = "${project_dir}"
+  command = "cargo watch -x run"
 
-4. **66.4 — Update documentation**
-   Update `agents.md` architecture section to reflect the new windowing layer. Update
-   `DESIGN_DECISIONS.md` with the eframe removal rationale. Update `config_example.toml` if
-   any config keys changed.
+[[tabs]]
+title = "Logs"
 
-5. **66.5 — Final verification**
-   Full verification suite. Render loop benchmarks before and after (expect improvement from
-   eliminated callback indirection). Manual testing on Linux/Wayland, Linux/X11. Verify all
-   features work: tabs, panes, split, multiple windows, search, background images, custom
-   shaders, background opacity, settings modal, theming, clipboard, drag-and-drop, bell,
-   cursor trail, blinking text, Kitty keyboard protocol.
+  [[tabs.panes]]
+  id = "logs"
+  directory = "/var/log"
+  command = "tail -f syslog"
+```
 
-### 66 Primary Files
+#### Pane Node Properties
 
-- `Cargo.toml` (workspace dependency changes)
-- `freminal/Cargo.toml` (eframe removal)
-- `freminal/src/gui/mod.rs` (dead workaround removal)
-- `agents.md` (architecture update)
-- `Documents/DESIGN_DECISIONS.md` (new decision entry)
+Each `[[tabs.panes]]` entry is either a **split node** (has `split` and `ratio`) or a
+**leaf node** (has no `split`). Leaf nodes represent actual terminal panes.
+
+| Field       | Type   | Required | Description                                          |
+| ----------- | ------ | -------- | ---------------------------------------------------- |
+| `id`        | String | Yes      | Unique within the tab (for parent references)        |
+| `parent`    | String | No       | ID of the parent split node (absent for root)        |
+| `position`  | String | No       | "first" or "second" within the parent split          |
+| `split`     | String | No       | "vertical" or "horizontal" — makes this a split node |
+| `ratio`     | Float  | No       | Split ratio (0.0-1.0), default 0.5                   |
+| `directory` | String | No       | Working directory (supports `~` and variables)       |
+| `command`   | String | No       | Command to run after shell starts                    |
+| `shell`     | String | No       | Override the default shell for this pane             |
+| `env`       | Table  | No       | Extra environment variables: `env = { FOO = "bar" }` |
+| `title`     | String | No       | Initial pane title (before shell OSC overrides)      |
+| `active`    | Bool   | No       | If true, this pane/tab has focus on launch           |
+
+A tab with a single pane omits `parent`, `position`, and `split` — just one `[[tabs.panes]]`
+entry with the leaf properties.
+
+#### Variable Substitution
+
+Layouts support variable substitution for reusability across projects:
+
+- **Positional args:** `$1`, `$2`, etc. from `freminal --layout dev.toml ~/projects/myapp`
+  (where `~/projects/myapp` is `$1`)
+- **Named variables:** `${VAR_NAME}` references `[layout.variables]` defaults, overridable
+  via `--var NAME=VALUE`
+- **Environment variables:** `$ENV{HOME}`, `$ENV{USER}` for system env vars
+- **Tilde expansion:** `~` is expanded to `$HOME` in `directory` fields
+
+This means one layout file works across multiple projects:
+
+```sh
+freminal --layout dev.toml ~/projects/frontend
+freminal --layout dev.toml ~/projects/backend
+```
+
+#### Save Current Layout
+
+"Save Layout" captures the running session:
+
+- Tab count and order
+- Per-tab pane tree structure (split directions, ratios)
+- Per-pane working directory (read from `/proc/<pid>/cwd` on Linux)
+- Per-pane foreground process (read from `/proc/<pid>/cmdline` on Linux — best-effort,
+  may be empty or show the shell)
+- Per-pane title (current OSC title)
+
+The output is a valid layout TOML file. Directories are written as absolute paths; the user
+can edit the file to use variables afterward.
+
+**Platform note:** CWD and process detection via `/proc` is Linux-specific. On other
+platforms (if Freminal is ever ported), these fields are omitted and the saved layout
+captures topology only.
+
+#### Layout Application Modes
+
+Layouts can be applied in three ways:
+
+1. **Startup (replace):** `freminal --layout dev.toml` or `startup.layout = "dev"` in
+   config. Creates the workspace from scratch on launch. This is the primary use case.
+
+2. **On-demand replace:** Menu bar > "Layouts" > "Load Layout..." replaces the current
+   session with the selected layout. Prompts for confirmation ("This will close all
+   current tabs.").
+
+3. **On-demand append:** Menu bar > "Layouts" > "Load Layout in New Tab..." creates the
+   layout's tabs as additional tabs in the current session. Useful for "I want my dev
+   layout alongside my existing work."
+
+#### Auto-Save and Restore
+
+```toml
+[startup]
+# Save the current layout on exit and restore it on next launch.
+# The layout is saved to ~/.config/freminal/layouts/_last_session.toml
+restore_last_session = false
+```
+
+When enabled, Freminal saves the current layout to `_last_session.toml` on clean exit.
+On next launch (if no `--layout` flag is given), it restores from this file. This captures
+topology and CWDs but not running programs (since those have exited).
+
+#### Layout Library
+
+Layouts in `~/.config/freminal/layouts/` are discovered automatically. The menu bar shows
+them under "Layouts" with their `layout.name` field. The Settings Modal's "Layouts" tab
+(new tab) lists all discovered layouts with name, description, and a preview of the
+topology.
+
+### 61 Subtasks
+
+1. **61.1 — Layout file format and parser**
+   Define the `Layout`, `LayoutTab`, `LayoutPane`, `LayoutVariables` types. Implement
+   TOML parsing with validation: detect orphan nodes (parent references a non-existent ID),
+   multiple roots, cycles, missing position on non-root nodes. Implement variable
+   substitution (`$1`, `${name}`, `$ENV{...}`, `~`). Unit tests: parse valid layouts,
+   reject malformed ones, verify variable substitution.
+
+2. **61.2 — Layout application engine**
+   Given a parsed `Layout`, create the tab/pane tree using `spawn_pty_tab` for each leaf
+   pane. Pass `directory` to PTY creation (set CWD before exec). Queue `command` for
+   injection after shell ready (reuse the startup command injection mechanism). Set initial
+   titles. Set active tab and active pane per the layout spec.
+
+3. **61.3 — Startup command injection**
+   Implement command injection: after a pane's shell is ready (detect via a short delay or
+   by watching for the first prompt), send the `command` string as PTY input followed by
+   a newline. Handle the "no command" case (just open a shell). This is the core of the
+   original Task 56.3.
+
+4. **61.4 — Shell and environment overrides**
+   Support per-pane `shell` override (use this shell instead of the default). Support
+   per-pane `env` table (set additional environment variables on the PTY child process).
+   Requires extending `spawn_pty_tab` to accept optional shell and env overrides.
+
+5. **61.5 — CLI integration: `--layout` and `--var`**
+   Add `--layout <path_or_name>` flag: if a path, load directly; if a name, search
+   `~/.config/freminal/layouts/<name>.toml`. Add `--var NAME=VALUE` (repeatable) for
+   variable overrides. Positional args after the layout path become `$1`, `$2`, etc.
+   Update arg parsing and config precedence.
+
+6. **61.6 — Save current layout**
+   Implement "Save Layout" that captures the current session topology into a `Layout`
+   struct and serializes it to TOML. Read CWDs via `/proc/<pid>/cwd`. Read foreground
+   processes via `/proc/<pid>/cmdline` (best-effort). Write to a user-chosen path
+   (file dialog or prompt). Unit tests: round-trip save/load produces equivalent topology.
+
+7. **61.7 — Layout library discovery**
+   Scan `~/.config/freminal/layouts/` for `.toml` files on startup and when the directory
+   changes. Parse each file's `[layout]` section (name, description) without fully parsing
+   the tree. Make the list available to the GUI for the menu and Settings Modal.
+
+8. **61.8 — Menu bar integration**
+   Add "Layouts" menu to the menu bar with:
+   - "Load Layout..." (file picker, replace mode)
+   - "Load Layout in New Tab..." (file picker, append mode)
+   - "Save Current Layout..." (save dialog)
+   - Separator
+   - List of discovered layouts from the library (click to load in replace mode)
+     Add `KeyAction::LoadLayout` and `KeyAction::SaveLayout` to keybindings.
+
+9. **61.9 — Auto-save and restore**
+   Implement `startup.restore_last_session`: on exit, save to `_last_session.toml`. On
+   startup (if no `--layout` and `restore_last_session = true`), load from
+   `_last_session.toml`. The saved layout includes topology and CWDs but not commands
+   (since processes have exited — just open shells in the saved directories).
+
+10. **61.10 — Config and settings integration**
+    Add `[startup]` section to config: `layout`, `restore_last_session`. Add a "Layouts"
+    tab to the Settings Modal showing discovered layouts with previews. Update
+    `config_example.toml` and home-manager module.
+
+11. **61.11 — Tests and integration**
+    End-to-end: write a layout file, launch with `--layout`, verify correct tab/pane
+    topology, correct CWDs, correct command injection. Test variable substitution with
+    CLI overrides. Test save/load round-trip. Test auto-restore. Test malformed layouts
+    produce clear error messages. Test partial application (append mode).
+
+### 61 Primary Files
+
+- `freminal-common/src/config.rs` (`StartupConfig`, `LayoutConfig`)
+- `freminal-common/src/layout.rs` (new — layout types, parser, variable substitution)
+- `freminal/src/gui/mod.rs` (layout application, menu integration)
+- `freminal/src/gui/tabs.rs` (layout-driven tab creation)
+- `freminal/src/gui/panes/mod.rs` (layout-driven pane tree construction)
+- `freminal/src/main.rs` (startup layout loading)
+- `freminal-common/src/args.rs` (`--layout`, `--var` flags)
+- `freminal-common/src/keybindings.rs` (layout key actions)
+- `config_example.toml`
+- `nix/home-manager-module.nix`
+
+### 61 Design Decisions
+
+1. **TOML over JSON.** Consistent with the existing config format. TOML's nesting limitations
+   are overcome by the flat node list with parent references — this is more readable than
+   deeply nested inline tables would be, and allows the user to define nodes in any order.
+
+2. **Flat node list with parent references.** A tree can be represented in TOML either as
+   deeply nested inline tables (ugly, hard to edit) or as a flat list with explicit
+   relationships. The flat approach is how many configuration systems handle tree structures
+   (e.g., Terraform resources, Kubernetes manifests). Each node is self-contained and
+   easy to add/remove.
+
+3. **Variables for reusability.** Without variables, layouts are project-specific (hardcoded
+   paths). Variables make a single layout file work across projects. The `$1` positional
+   convention is familiar from shell scripting.
+
+4. **Save captures topology + CWD, not running programs.** We cannot reliably restart an
+   arbitrary program the user was running. Saving CWDs means the user gets shells in the
+   right directories, which covers 90% of the restore value. If `command` was specified
+   in the original layout, the saved layout preserves it — but the "detected" foreground
+   process from `/proc` is stored as a comment, not as an auto-run command, to avoid
+   surprising behavior.
+
+5. **Subsumes Task 56 entirely.** Task 56's `[startup.tabs]` flat list is a strict subset
+   of the layout system. Rather than implementing both, Task 61 provides a superset that
+   handles both simple (`[[tabs]]` with one pane each) and complex (multi-tab, multi-pane,
+   variables) cases. The `[startup]` config section is unified under the layout system.
 
 ---
 
 ## Dependency Graph
 
 ```text
-Task 62 (freminal-windowing crate)
-  │
-  ▼
-Task 63 (Single-window migration)
-  │
-  ├──────────────────┐
-  ▼                  ▼
-Task 64            Task 65
-(Multi-window)     (Frame pacing)
-  │
-  ▼
-Task 66 (Cleanup + eframe removal)
+Task 32 (Playback Feature Flag) ──► Task 59 (FREC v2 Format)
+Task 58 (Built-in Muxing) ──────► Task 59 (FREC v2 Format)
+                                     │
+                                     ▼
+                                  Task 60 (Playback v2)
+
+Task 36 (Tabs) ──► Task 61 (Saved Layouts)
+Task 58 (Built-in Muxing) ──► Task 61 (Saved Layouts)
+
+Task 55 (Custom Shaders) ─ ─ ► Task 60.5 (Scale mode — soft dependency, can use minimal FBO)
+
+Tasks 59 and 61 are independent of each other.
+Task 60 depends on Task 59 (needs v2 format to replay).
+Task 61 can start before, during, or after Task 59/60.
 ```
 
-**Recommended order:** 62 → 63 → 64 ∥ 65 → 66
+**Recommended order:**
 
-Tasks 64 and 65 can run in parallel after Task 63 — they touch different code (multi-window
-lifecycle vs. frame pacing/timers). Task 66 must be last.
+1. Tasks 59 and 61 can start in parallel (independent).
+2. Task 60 starts after Task 59 is complete.
+3. Within Task 60, subtask 60.5 (Scale mode) benefits from Task 55 (Custom Shaders) if
+   complete, but can be implemented with a minimal FBO otherwise.
+
+```text
+v0.7.0 Execution:
+  ┌── Task 59 (FREC v2 Format) ──► Task 60 (Playback v2)
+  │
+  └── Task 61 (Saved Layouts)      [parallel with 59, independent]
+```
 
 ---
 
 ## Cross-Cutting Concerns
 
-### Crate Dependency Boundaries
+### Recording + Layouts Interaction
 
-`freminal-windowing` must NOT depend on any other freminal crate. It is a general-purpose
-windowing layer. The dependency flows one way:
+Task 59 (recording) captures topology events. Task 61 (layouts) defines topology. When
+recording starts, the initial topology snapshot in the FREC v2 metadata IS effectively a
+layout. This means:
 
-```text
-freminal ──► freminal-windowing
-freminal ──► freminal-terminal-emulator ──► freminal-buffer ──► freminal-common
+- A recording's initial state can be exported as a layout file (diagnostic utility).
+- A layout file can be used to set up the initial state for a recording session.
+
+This interaction is a future enhancement, not a v0.7.0 requirement, but the format designs
+should not preclude it.
+
+### Config Schema Extensions
+
+Task 61 extends the config with `[startup]` fields:
+
+```toml
+[startup]
+layout = "dev"                    # name or path of layout to load on startup
+restore_last_session = false      # auto-save/restore
 ```
 
-`freminal-windowing` depends only on external crates (winit, glutin, egui, glow, etc.) and
-standard library types.
+This must be propagated to `config.rs`, `config_example.toml`, the home-manager module, and
+the Settings Modal.
 
-### Custom Renderer Integration
+### Feature Flag Scope
 
-The terminal renderer (`freminal/src/gui/renderer/`) currently uses `egui_glow::CallbackFn`
-to inject GL calls into egui's paint pipeline. After migration:
-
-- The renderer receives `&glow::Context` directly from the `App::update()` signature
-- No more `PaintCallback` wrapping
-- No more `painter.intermediate_fbo()` restore
-- The render order is explicit: egui chrome → terminal content (or vice versa, with proper
-  depth/stencil management)
-
-The renderer itself (`gpu.rs`, `vertex.rs`, shader code) is unchanged — only the call site
-changes.
-
-### PTY Thread Repaint Path
-
-Currently, PTY consumer threads hold `Arc<OnceLock<egui::Context>>` and call
-`ctx.request_repaint_after(Duration::from_millis(8))`. After migration, they need a
-thread-safe repaint handle from `freminal-windowing`. Options:
-
-1. **Channel-based:** PTY thread sends a "repaint window X" message to the event loop thread
-   via `crossbeam-channel`. The event loop calls `window.request_redraw()`.
-2. **`EventLoopProxy`:** winit provides `EventLoopProxy::send_event()` for cross-thread
-   wakeups. The PTY thread holds a clone of the proxy and sends a custom user event.
-
-Option 2 is preferred — `EventLoopProxy` is the canonical winit mechanism for cross-thread
-wakeups and avoids adding a channel.
-
-### Config Schema
-
-No config schema changes are expected. The windowing layer is transparent to the user.
-`background_opacity`, `vsync` (if exposed), and window-related settings continue to work
-through the same config paths.
-
-### Platform Testing
-
-The migration is platform-sensitive. The following must be tested:
-
-- **Linux/Wayland:** Primary target. Verify no compositor hang, proper frame pacing,
-  transparency, multi-window.
-- **Linux/X11:** Verify GL context creation (GLX or EGL), transparency, multi-window.
-- **macOS:** Verify CGL context, Retina scaling, transparency. (If no macOS CI, document
-  as untested and request manual verification.)
-- **Windows:** Verify WGL context, DPI scaling, transparency. (Same caveat.)
-
-### Benchmark Impact
-
-The migration should improve render loop benchmarks by eliminating:
-
-- `PaintCallback` closure allocation and dispatch
-- egui intermediate FBO management
-- `predicted_dt` scheduling overhead
-
-Agents must capture before/after numbers for all render loop benchmarks:
-
-- `freminal/benches/render_loop_bench.rs` — all benchmarks
-
----
-
-## Risk Assessment
-
-| Risk                                                  | Likelihood | Impact | Mitigation                                                                 |
-| ----------------------------------------------------- | ---------- | ------ | -------------------------------------------------------------------------- |
-| GL context creation fails on exotic drivers           | Medium     | High   | glutin handles driver fallbacks; test on Mesa, NVIDIA proprietary, and AMD |
-| winit 0.31 goes stable mid-task, breaking 0.30 API    | Low        | Medium | Pin to 0.30.x during migration; upgrade to 0.31 as a follow-up             |
-| egui 0.35 releases mid-task with breaking changes     | Low        | Medium | Pin to 0.34.x during migration; upgrade as a follow-up                     |
-| PaintCallback removal breaks custom shader pipeline   | Medium     | Medium | Task 63.3 is dedicated to this; thorough testing of all shader features    |
-| Wayland compositor differences (GNOME vs Sway vs KDE) | Medium     | Low    | Test on at least two compositors                                           |
+Tasks 59 and 60 are gated behind the `playback` feature flag (extending the existing gating
+from Task 32). Task 61 (layouts) is NOT feature-gated — it is always available, as it is a
+core workflow feature independent of recording/playback.
 
 ---
 
@@ -599,5 +872,5 @@ Per `agents.md`, each task is complete when:
 2. `cargo test --all` passes
 3. `cargo clippy --all-targets --all-features -- -D warnings` passes
 4. `cargo-machete` passes
-5. Benchmarks show no unexplained regressions for render changes
-6. Plan document updated with completion status and notes
+5. Benchmarks show no unexplained regressions for render/buffer changes
+6. Config schema additions propagated to config.rs, config_example.toml, home-manager, settings

--- a/agents.md
+++ b/agents.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Freminal is a modern terminal emulator written in Rust (Edition 2024, MSRV 1.92.0). It targets
+Freminal is a modern terminal emulator written in Rust (Edition 2024, MSRV 1.95.0). It targets
 deep ANSI/DEC/xterm escape sequence compatibility, sub-millisecond frame times, and pixel-perfect
 rendering via egui/glow.
 

--- a/flake.lock
+++ b/flake.lock
@@ -97,11 +97,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1776180412,
-        "narHash": "sha256-i/rUOrl2y7f1pHjkKC2VZlltHEpyj76osI6Ad5xaINc=",
+        "lastModified": 1776356478,
+        "narHash": "sha256-F8tgeptiO/pEewoVR94GGQCCoaEUKTCin5XHITqkwgM=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "d48771750f19b0b0b74d6d1029cacb073c84f3d9",
+        "rev": "bd6364c9469a46d993e3877ee847f091cbe0916a",
         "type": "github"
       },
       "original": {
@@ -159,11 +159,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1776136407,
-        "narHash": "sha256-Cp8XrVLGruSDBTRs8L4LmvaEcd76tHHU9esLk7Ysa4E=",
+        "lastModified": 1776350315,
+        "narHash": "sha256-ijD4bgb5Iyap9F3MX73vLAZF/SYu+q7Gd7Ux4cbfCWw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "753568957a87312ed599cba5699e67126eded6c0",
+        "rev": "62e3b8aedabc240e5b0cc9fae003bc9edfebbc9b",
         "type": "github"
       },
       "original": {

--- a/freminal-buffer/src/buffer.rs
+++ b/freminal-buffer/src/buffer.rs
@@ -963,18 +963,37 @@ impl Buffer {
             return;
         }
 
+        let old_cursor_y = self.cursor.pos.y;
+        let old_cursor_x = self.cursor.pos.x;
+
         // Take ownership of the old rows
         let old_rows = std::mem::take(&mut self.rows);
 
-        // 1) Group rows into logical lines based on RowJoin
+        // 1) Group rows into logical lines based on RowJoin.
+        //    While grouping, identify which logical line contains the cursor
+        //    and compute the cursor's flat cell offset within that line.
         let mut logical_lines: Vec<Vec<Row>> = Vec::new();
         let mut current_line: Vec<Row> = Vec::new();
 
-        for row in old_rows {
+        let mut cursor_logical_line: Option<usize> = None;
+        let mut cursor_flat_offset: usize = 0;
+
+        for (old_row_idx, row) in old_rows.into_iter().enumerate() {
             if row.join == RowJoin::NewLogicalLine && !current_line.is_empty() {
                 logical_lines.push(current_line);
                 current_line = Vec::new();
             }
+
+            if old_row_idx == old_cursor_y {
+                cursor_logical_line = Some(logical_lines.len());
+                // Flat offset = cells from preceding rows in this logical line + cursor X.
+                cursor_flat_offset = current_line
+                    .iter()
+                    .map(|r| r.get_characters().len())
+                    .sum::<usize>()
+                    + old_cursor_x;
+            }
+
             current_line.push(row);
         }
         if !current_line.is_empty() {
@@ -983,16 +1002,22 @@ impl Buffer {
 
         // 2) For each logical line, flatten its cells and re-wrap
         let mut new_rows: Vec<Row> = Vec::new();
+        let mut new_cursor_y: Option<usize> = None;
+        let mut new_cursor_x: Option<usize> = None;
 
-        for line in logical_lines {
+        for (line_idx, line) in logical_lines.into_iter().enumerate() {
             // Determine origin for the first row of this logical line.
             let first_origin = line.first().map_or(RowOrigin::HardBreak, |r| r.origin);
+            let is_cursor_line = cursor_logical_line == Some(line_idx);
 
             // Flatten all rows in this logical line into a single Vec<Cell>
             let mut flat_cells: Vec<Cell> = Vec::new();
             for row in &line {
                 flat_cells.extend(row.get_characters().iter().cloned());
             }
+
+            // Record where this logical line's new rows start (for cursor mapping).
+            let line_start_idx = new_rows.len();
 
             if flat_cells.is_empty() {
                 // Empty logical line → keep a single empty row
@@ -1001,6 +1026,10 @@ impl Buffer {
                     first_origin,
                     RowJoin::NewLogicalLine,
                 ));
+                if is_cursor_line {
+                    new_cursor_y = Some(new_rows.len() - 1);
+                    new_cursor_x = Some(old_cursor_x.min(new_width.saturating_sub(1)));
+                }
                 continue;
             }
 
@@ -1093,6 +1122,31 @@ impl Buffer {
 
                 new_rows.push(Row::from_cells(new_width, origin, join, cur_cells));
             }
+
+            // If this logical line contains the cursor, map the old cursor
+            // position to the correct new row and column.
+            if is_cursor_line {
+                let mut flat_col: usize = 0;
+                let mut found = false;
+                for (i, new_row) in new_rows[line_start_idx..].iter().enumerate() {
+                    let row_cells = new_row.get_characters().len();
+                    if flat_col + row_cells > cursor_flat_offset {
+                        new_cursor_y = Some(line_start_idx + i);
+                        new_cursor_x = Some(cursor_flat_offset - flat_col);
+                        found = true;
+                        break;
+                    }
+                    flat_col += row_cells;
+                }
+                if !found {
+                    // Cursor is past the end of content (in blank space).
+                    // Place it on the last row of this logical line.
+                    let last_row_idx = new_rows.len() - 1;
+                    let last_row_len = new_rows[last_row_idx].get_characters().len();
+                    new_cursor_y = Some(last_row_idx);
+                    new_cursor_x = Some(cursor_flat_offset.saturating_sub(flat_col) + last_row_len);
+                }
+            }
         }
 
         // 3) Install the new rows and update width
@@ -1106,20 +1160,19 @@ impl Buffer {
         // merged cells.
         self.image_cell_count = self.rows.iter().map(Row::count_image_cells).sum();
 
-        // 4) Ensure cursor is in bounds (scroll_offset is always reset to 0 by the
-        //    caller after a reflow — returned from set_size).
-        if self.cursor.pos.y >= self.rows.len() {
+        // 4) Remap cursor position based on reflow tracking.
+        if let (Some(cy), Some(cx)) = (new_cursor_y, new_cursor_x) {
+            self.cursor.pos.y = cy.min(self.rows.len().saturating_sub(1));
+            self.cursor.pos.x = cx.min(self.width.saturating_sub(1));
+        } else if self.cursor.pos.y >= self.rows.len() {
             if self.rows.is_empty() {
                 self.cursor.pos.y = 0;
             } else {
                 self.cursor.pos.y = self.rows.len() - 1;
             }
             self.cursor.pos.x = 0;
-        } else {
-            // Clamp X to the new width
-            if self.cursor.pos.x >= self.width {
-                self.cursor.pos.x = self.width.saturating_sub(1);
-            }
+        } else if self.cursor.pos.x >= self.width {
+            self.cursor.pos.x = self.width.saturating_sub(1);
         }
     }
 
@@ -8038,6 +8091,76 @@ mod reflow_to_width_tests {
         let row1 = cell_str(&buf, 1);
         assert!(row0.starts_with("AAAA"), "row0: {row0}");
         assert!(row1.starts_with("BBBB"), "row1: {row1}");
+    }
+
+    // Test 10: cursor Y is remapped when lines before cursor wrap to more rows
+    #[test]
+    fn reflow_remaps_cursor_y_on_narrow() {
+        let mut buf = Buffer::new(10, 5);
+        // Row 0: "ABCDEFGHIJ" (10 chars, fills full width)
+        buf.insert_text(&t("ABCDEFGHIJ"));
+        buf.handle_lf();
+        buf.cursor.pos.x = 0;
+        // Row 1: "XY" (cursor is here)
+        buf.insert_text(&t("XY"));
+
+        // Cursor should be at row 1
+        assert_eq!(buf.cursor.pos.y, 1);
+        assert_eq!(buf.cursor.pos.x, 2);
+
+        // Reflow to width 5: "ABCDEFGHIJ" splits into 2 rows, "XY" stays 1 row
+        // Row 0: "ABCDE"
+        // Row 1: "FGHIJ"
+        // Row 2: "XY"
+        buf.reflow_to_width(5);
+
+        assert_eq!(buf.rows.len(), 3);
+        assert_eq!(
+            buf.cursor.pos.y, 2,
+            "cursor should move to row 2 (was row 1 before reflow)"
+        );
+        assert_eq!(buf.cursor.pos.x, 2, "cursor X should be preserved");
+    }
+
+    // Test 11: cursor on a row that itself wraps — cursor X remapped to new row
+    #[test]
+    fn reflow_remaps_cursor_on_wrapping_row() {
+        let mut buf = Buffer::new(10, 5);
+        // Row 0: "ABCDEFGHIJ" — cursor at col 7
+        buf.insert_text(&t("ABCDEFGHIJ"));
+        buf.cursor.pos.x = 7;
+        buf.cursor.pos.y = 0;
+
+        // Reflow to width 5:
+        // Row 0: "ABCDE"
+        // Row 1: "FGHIJ" — old col 7 maps to flat offset 7, row 1 col 2
+        buf.reflow_to_width(5);
+
+        assert_eq!(buf.rows.len(), 2);
+        assert_eq!(
+            buf.cursor.pos.y, 1,
+            "cursor should be on row 1 (second half)"
+        );
+        assert_eq!(buf.cursor.pos.x, 2, "cursor should be at col 2 in new row");
+    }
+
+    // Test 12: cursor past end of content (in blank space) is preserved
+    #[test]
+    fn reflow_cursor_in_blank_space() {
+        let mut buf = Buffer::new(10, 5);
+        // Row 0: "AB" (2 cells), cursor at col 8 (in blank space)
+        buf.insert_text(&t("AB"));
+        buf.cursor.pos.x = 8;
+        buf.cursor.pos.y = 0;
+
+        // Reflow to width 5: "AB" fits in one row, cursor was at col 8
+        // flat_offset = 8, but flat_cells.len() = 2
+        // Cursor should land on row 0 at col 8 (past content but still valid)
+        buf.reflow_to_width(5);
+
+        assert_eq!(buf.cursor.pos.y, 0);
+        // Cursor X should be clamped to new_width - 1 = 4
+        assert_eq!(buf.cursor.pos.x, 4);
     }
 }
 

--- a/freminal-buffer/src/terminal_handler/graphics_kitty.rs
+++ b/freminal-buffer/src/terminal_handler/graphics_kitty.rs
@@ -665,22 +665,26 @@ impl TerminalHandler {
                 self.buffer.image_store_mut().clear();
                 self.virtual_placements.clear();
             }
-            KittyDeleteTarget::ById | KittyDeleteTarget::ByIdCursorOrAfter => {
-                if let Some(image_id) = cmd.control.image_id {
-                    let id = u64::from(image_id);
-                    tracing::debug!("Kitty graphics: deleting image id={id}");
-                    self.buffer.clear_image_placements_by_id(id);
-                    self.buffer.image_store_mut().remove(id);
-                    self.virtual_placements
-                        .retain(|&(img_id, _), _| img_id != id);
-                }
+            KittyDeleteTarget::ById | KittyDeleteTarget::ByIdCursorOrAfter
+                if let Some(image_id) = cmd.control.image_id =>
+            {
+                let id = u64::from(image_id);
+                tracing::debug!("Kitty graphics: deleting image id={id}");
+                self.buffer.clear_image_placements_by_id(id);
+                self.buffer.image_store_mut().remove(id);
+                self.virtual_placements
+                    .retain(|&(img_id, _), _| img_id != id);
             }
-            KittyDeleteTarget::ByNumber | KittyDeleteTarget::ByNumberCursorOrAfter => {
-                if let Some(number) = cmd.control.image_number {
-                    tracing::debug!("Kitty graphics: deleting image number={number}");
-                    self.buffer.clear_image_placements_by_number(number);
-                }
+            KittyDeleteTarget::ByNumber | KittyDeleteTarget::ByNumberCursorOrAfter
+                if let Some(number) = cmd.control.image_number =>
+            {
+                tracing::debug!("Kitty graphics: deleting image number={number}");
+                self.buffer.clear_image_placements_by_number(number);
             }
+            KittyDeleteTarget::ById
+            | KittyDeleteTarget::ByIdCursorOrAfter
+            | KittyDeleteTarget::ByNumber
+            | KittyDeleteTarget::ByNumberCursorOrAfter => {}
             KittyDeleteTarget::AtCursor => {
                 tracing::debug!("Kitty graphics: deleting images at cursor");
                 self.buffer.clear_image_placements_at_cursor();

--- a/freminal-buffer/src/terminal_handler/mod.rs
+++ b/freminal-buffer/src/terminal_handler/mod.rs
@@ -1675,15 +1675,15 @@ impl TerminalHandler {
             }
             TerminalOutput::Mode(mode) => match mode {
                 Mode::XtExtscrn(XtExtscrn::Alternate)
-                | Mode::AltScreen47(AltScreen47::Alternate) => {
-                    if self.allow_alt_screen == AllowAltScreen::Allow {
-                        self.handle_enter_alternate();
-                    }
+                | Mode::AltScreen47(AltScreen47::Alternate)
+                    if self.allow_alt_screen == AllowAltScreen::Allow =>
+                {
+                    self.handle_enter_alternate();
                 }
-                Mode::XtExtscrn(XtExtscrn::Primary) | Mode::AltScreen47(AltScreen47::Primary) => {
-                    if self.allow_alt_screen == AllowAltScreen::Allow {
-                        self.handle_leave_alternate();
-                    }
+                Mode::XtExtscrn(XtExtscrn::Primary) | Mode::AltScreen47(AltScreen47::Primary)
+                    if self.allow_alt_screen == AllowAltScreen::Allow =>
+                {
+                    self.handle_leave_alternate();
                 }
                 Mode::SaveCursor1048(SaveCursor1048::Save) => self.handle_save_cursor(),
                 Mode::SaveCursor1048(SaveCursor1048::Restore) => self.handle_restore_cursor(),
@@ -1771,28 +1771,28 @@ impl TerminalHandler {
                     };
                     self.write_to_pty(&Decom::OriginMode.report(Some(mode)));
                 }
-                Mode::Deccolm(Deccolm::Column132) => {
-                    if self.allow_column_mode_switch == AllowColumnModeSwitch::AllowColumnModeSwitch
-                    {
-                        // Save the current width so CSI?3l can restore it
-                        // instead of hardcoding 80.
-                        if self.pre_deccolm_width.is_none() {
-                            self.pre_deccolm_width = Some(self.buffer.terminal_width());
-                        }
-                        self.buffer.set_column_mode(132);
-                        self.send_pty_resize(132);
+                Mode::Deccolm(Deccolm::Column132)
+                    if self.allow_column_mode_switch
+                        == AllowColumnModeSwitch::AllowColumnModeSwitch =>
+                {
+                    // Save the current width so CSI?3l can restore it
+                    // instead of hardcoding 80.
+                    if self.pre_deccolm_width.is_none() {
+                        self.pre_deccolm_width = Some(self.buffer.terminal_width());
                     }
+                    self.buffer.set_column_mode(132);
+                    self.send_pty_resize(132);
                 }
-                Mode::Deccolm(Deccolm::Column80) => {
-                    if self.allow_column_mode_switch == AllowColumnModeSwitch::AllowColumnModeSwitch
-                    {
-                        // Restore the pre-DECCOLM width (falls back to 80 if
-                        // no prior width was saved — e.g. CSI?3l without a
-                        // preceding CSI?3h).
-                        let restore_width = self.pre_deccolm_width.take().unwrap_or(80);
-                        self.buffer.set_column_mode(restore_width);
-                        self.send_pty_resize(restore_width);
-                    }
+                Mode::Deccolm(Deccolm::Column80)
+                    if self.allow_column_mode_switch
+                        == AllowColumnModeSwitch::AllowColumnModeSwitch =>
+                {
+                    // Restore the pre-DECCOLM width (falls back to 80 if
+                    // no prior width was saved — e.g. CSI?3l without a
+                    // preceding CSI?3h).
+                    let restore_width = self.pre_deccolm_width.take().unwrap_or(80);
+                    self.buffer.set_column_mode(restore_width);
+                    self.send_pty_resize(restore_width);
                 }
                 Mode::Deccolm(Deccolm::Query) => {
                     // Report current column mode: 132 if width == 132, else 80.
@@ -1951,7 +1951,13 @@ impl TerminalHandler {
                 // noise from the catch-all.
                 // GraphemeClustering Set/Reset are also silently accepted
                 // here — Freminal does grapheme clustering unconditionally.
-                Mode::Decckm(_)
+                // XtExtscrn/AltScreen47 Alternate/Primary without allow_alt_screen
+                // permission, and Deccolm Column132/Column80 without
+                // allow_column_mode_switch permission, are also silently ignored.
+                Mode::XtExtscrn(XtExtscrn::Alternate | XtExtscrn::Primary)
+                | Mode::AltScreen47(AltScreen47::Alternate | AltScreen47::Primary)
+                | Mode::Deccolm(Deccolm::Column132 | Deccolm::Column80)
+                | Mode::Decckm(_)
                 | Mode::BracketedPaste(_)
                 | Mode::MouseMode(_)
                 | Mode::MouseEncodingMode(_)

--- a/freminal-common/src/buffer_states/tchar.rs
+++ b/freminal-common/src/buffer_states/tchar.rs
@@ -64,9 +64,7 @@ impl TChar {
             Self::Utf8(buf, len) => {
                 let bytes = &buf[..*len as usize];
                 // Try to interpret as UTF-8; fallback to width 1 for invalid sequences
-                std::str::from_utf8(bytes)
-                    .map(unicode_width::UnicodeWidthStr::width)
-                    .unwrap_or(1)
+                std::str::from_utf8(bytes).map_or(1, unicode_width::UnicodeWidthStr::width)
             }
         }
     }

--- a/freminal-terminal-emulator/src/interface.rs
+++ b/freminal-terminal-emulator/src/interface.rs
@@ -738,14 +738,15 @@ impl TerminalEmulator {
                     // First snapshot with DontDraw active — start the clock.
                     self.dont_draw_entered_at = Some(Instant::now());
                 }
-                Some(entered_at) => {
-                    if entered_at.elapsed() >= Duration::from_millis(SYNC_UPDATES_TIMEOUT_MS) {
-                        // Timeout expired — reset to Draw so the next snapshot
-                        // carries skip_draw = false, and clear the timer.
-                        self.internal.modes.synchronized_updates = SynchronizedUpdates::Draw;
-                        self.dont_draw_entered_at = None;
-                    }
+                Some(entered_at)
+                    if entered_at.elapsed() >= Duration::from_millis(SYNC_UPDATES_TIMEOUT_MS) =>
+                {
+                    // Timeout expired — reset to Draw so the next snapshot
+                    // carries skip_draw = false, and clear the timer.
+                    self.internal.modes.synchronized_updates = SynchronizedUpdates::Draw;
+                    self.dont_draw_entered_at = None;
                 }
+                Some(_) => {}
             }
         } else {
             // Mode is Draw (or Query) — clear stale timer state.

--- a/freminal-terminal-emulator/src/io/pty.rs
+++ b/freminal-terminal-emulator/src/io/pty.rs
@@ -150,11 +150,10 @@ fn process_pty_write(
     msg: &PtyWrite,
 ) {
     match msg {
-        PtyWrite::Write(data) => {
-            if let Err(e) = writer.write_all(data) {
-                error!("Failed to write to pty: {e}");
-            }
+        PtyWrite::Write(data) if let Err(e) = writer.write_all(data) => {
+            error!("Failed to write to pty: {e}");
         }
+        PtyWrite::Write(_) => {}
         PtyWrite::Resize(size) => {
             let size: PtySize = match pty_size_from_terminal_size(size) {
                 Ok(size) => size,

--- a/freminal/src/gui/actions.rs
+++ b/freminal/src/gui/actions.rs
@@ -161,21 +161,18 @@ impl super::FreminalGui {
         use freminal_common::keybindings::KeyAction;
 
         match action {
-            KeyAction::OpenSettings => {
-                if !self.settings_modal.is_open {
-                    let families = self.terminal_widget.monospace_families();
-                    self.settings_modal
-                        .open(&self.config, families, self.os_dark_mode);
-                    self.settings_modal
-                        .set_base_font_defs(self.terminal_widget.base_font_defs().clone());
-                }
+            KeyAction::OpenSettings if !self.settings_modal.is_open => {
+                let families = self.terminal_widget.monospace_families();
+                self.settings_modal
+                    .open(&self.config, families, self.os_dark_mode);
+                self.settings_modal
+                    .set_base_font_defs(self.terminal_widget.base_font_defs().clone());
             }
             KeyAction::NewTab => self.spawn_new_tab(),
-            KeyAction::CloseTab => {
-                if let Err(e) = self.tabs.close_active_tab() {
-                    trace!("Cannot close tab: {e}");
-                }
+            KeyAction::CloseTab if let Err(e) = self.tabs.close_active_tab() => {
+                trace!("Cannot close tab: {e}");
             }
+            KeyAction::OpenSettings | KeyAction::CloseTab => {}
             KeyAction::NextTab => {
                 self.tabs.next_tab();
                 self.tabs.active_tab_mut().active_pane_mut().bell_active = false;

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -1382,13 +1382,17 @@ impl eframe::App for FreminalGui {
                             // Process any pending shader change.
                             if let Some(pending_shader) = wpr.pending_shader.take() {
                                 match pending_shader {
-                                    Some(src) => {
-                                        if let Err(e) =
-                                            wpr.update_shader(gl, &src, vp.width_px, vp.height_px)
-                                        {
-                                            error!("Shader compilation failed: {e}");
-                                        }
+                                    Some(src)
+                                        if let Err(e) = wpr.update_shader(
+                                            gl,
+                                            &src,
+                                            vp.width_px,
+                                            vp.height_px,
+                                        ) =>
+                                    {
+                                        error!("Shader compilation failed: {e}");
                                     }
+                                    Some(_) => {}
                                     None => wpr.clear_shader(gl),
                                 }
                             }
@@ -1681,45 +1685,43 @@ impl eframe::App for FreminalGui {
                     }
                 }
             }
-            SettingsAction::PreviewTheme(ref slug) => {
-                if let Some(theme) = freminal_common::themes::by_slug(slug) {
-                    if let Err(e) = self
-                        .tabs
-                        .active_tab()
-                        .active_pane()
-                        .input_tx
-                        .send(InputEvent::ThemeChange(theme))
-                    {
-                        error!("Failed to send theme preview to PTY thread: {e}");
-                    }
-                    rendering::update_egui_theme(
-                        ui.ctx(),
-                        theme,
-                        self.config.ui.background_opacity,
-                    );
+            SettingsAction::PreviewTheme(ref slug)
+                if let Some(theme) = freminal_common::themes::by_slug(slug) =>
+            {
+                if let Err(e) = self
+                    .tabs
+                    .active_tab()
+                    .active_pane()
+                    .input_tx
+                    .send(InputEvent::ThemeChange(theme))
+                {
+                    error!("Failed to send theme preview to PTY thread: {e}");
                 }
+                rendering::update_egui_theme(ui.ctx(), theme, self.config.ui.background_opacity);
             }
-            SettingsAction::RevertTheme(ref slug, original_opacity) => {
-                if let Some(theme) = freminal_common::themes::by_slug(slug) {
-                    if let Err(e) = self
-                        .tabs
-                        .active_tab()
-                        .active_pane()
-                        .input_tx
-                        .send(InputEvent::ThemeChange(theme))
-                    {
-                        error!("Failed to send theme revert to PTY thread: {e}");
-                    }
-                    // Restore opacity first so update_egui_theme uses the
-                    // correct value for panel_fill.
-                    self.config.ui.background_opacity = original_opacity;
-                    rendering::update_egui_theme(ui.ctx(), theme, original_opacity);
+            SettingsAction::RevertTheme(ref slug, original_opacity)
+                if let Some(theme) = freminal_common::themes::by_slug(slug) =>
+            {
+                if let Err(e) = self
+                    .tabs
+                    .active_tab()
+                    .active_pane()
+                    .input_tx
+                    .send(InputEvent::ThemeChange(theme))
+                {
+                    error!("Failed to send theme revert to PTY thread: {e}");
                 }
+                // Restore opacity first so update_egui_theme uses the
+                // correct value for panel_fill.
+                self.config.ui.background_opacity = original_opacity;
+                rendering::update_egui_theme(ui.ctx(), theme, original_opacity);
             }
+            SettingsAction::RevertTheme(_, _)
+            | SettingsAction::PreviewTheme(_)
+            | SettingsAction::None => {}
             SettingsAction::PreviewOpacity(opacity) | SettingsAction::RevertOpacity(opacity) => {
                 self.config.ui.background_opacity = opacity;
             }
-            SettingsAction::None => {}
         }
 
         let elapsed = now.elapsed();

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -590,6 +590,17 @@ impl eframe::App for FreminalGui {
                 live.push((vid, state));
             }
             self.secondary_windows = live;
+
+            // Ensure every secondary (deferred) viewport gets a repaint
+            // whenever the root window repaints.  Without this, compositor-
+            // initiated resizes on tiling Wayland go unnoticed because the
+            // deferred closure only runs as part of the root frame — if no
+            // explicit repaint is requested for the child viewport, eframe
+            // may skip it, leaving the GL framebuffer stretched at the old
+            // size until the user interacts with the child window.
+            for (vid, _) in &self.secondary_windows {
+                ctx.request_repaint_of(*vid);
+            }
         }
 
         // Collect `pending_new_window` requests from secondary windows and

--- a/freminal/src/gui/pty.rs
+++ b/freminal/src/gui/pty.rs
@@ -210,11 +210,10 @@ fn spawn_pty_consumer_thread(
                 Ok(InputEvent::Resize(w, h, pw, ph)) => {
                     emulator.handle_resize_event(w, h, pw, ph);
                 }
-                Ok(InputEvent::Key(bytes)) => {
-                    if let Err(e) = emulator.write_raw_bytes(&bytes) {
-                        error!("Failed to forward key bytes to PTY: {e}");
-                    }
+                Ok(InputEvent::Key(bytes)) if let Err(e) = emulator.write_raw_bytes(&bytes) => {
+                    error!("Failed to forward key bytes to PTY: {e}");
                 }
+                Ok(InputEvent::Key(_)) => {}
                 Ok(InputEvent::FocusChange(focused)) => {
                     emulator.internal.send_focus_event(focused);
                 }

--- a/freminal/src/gui/renderer/vertex.rs
+++ b/freminal/src/gui/renderer/vertex.rs
@@ -585,16 +585,8 @@ pub fn build_image_verts(
 
     for (cell_idx, placement) in placements.iter().enumerate() {
         let Some(p) = placement else { continue };
-        let col = if term_width == 0 {
-            0
-        } else {
-            cell_idx % term_width
-        };
-        let row = if term_width == 0 {
-            0
-        } else {
-            cell_idx / term_width
-        };
+        let col = cell_idx.checked_rem(term_width).unwrap_or(0);
+        let row = cell_idx.checked_div(term_width).unwrap_or(0);
 
         let x0 = gl_f32(col) * gl_f32_u32(cell_width);
         let y0 = gl_f32(row) * gl_f32_u32(cell_height);

--- a/freminal/src/gui/terminal/input.rs
+++ b/freminal/src/gui/terminal/input.rs
@@ -166,19 +166,17 @@ pub(super) fn dispatch_binding_action(
     deferred_actions: &mut Vec<KeyAction>,
 ) {
     match action {
-        KeyAction::Copy => {
-            if let Some((start, end)) = view_state.selection.normalised() {
-                if let Err(e) = input_tx.send(InputEvent::ExtractSelection {
-                    start_row: start.row,
-                    start_col: start.col,
-                    end_row: end.row,
-                    end_col: end.col,
-                    is_block: view_state.selection.is_block,
-                }) {
-                    error!("Failed to send ExtractSelection to PTY consumer: {e}");
-                } else {
-                    *clipboard_pending = true;
-                }
+        KeyAction::Copy if let Some((start, end)) = view_state.selection.normalised() => {
+            if let Err(e) = input_tx.send(InputEvent::ExtractSelection {
+                start_row: start.row,
+                start_col: start.col,
+                end_row: end.row,
+                end_col: end.col,
+                is_block: view_state.selection.is_block,
+            }) {
+                error!("Failed to send ExtractSelection to PTY consumer: {e}");
+            } else {
+                *clipboard_pending = true;
             }
         }
         KeyAction::ScrollPageUp => {
@@ -211,12 +209,10 @@ pub(super) fn dispatch_binding_action(
                 }
             }
         }
-        KeyAction::ScrollToBottom => {
-            if view_state.scroll_offset != 0 {
-                view_state.scroll_offset = 0;
-                if let Err(e) = input_tx.send(InputEvent::ScrollOffset(0)) {
-                    error!("Failed to send scroll offset to PTY consumer: {e}");
-                }
+        KeyAction::ScrollToBottom if view_state.scroll_offset != 0 => {
+            view_state.scroll_offset = 0;
+            if let Err(e) = input_tx.send(InputEvent::ScrollOffset(0)) {
+                error!("Failed to send scroll offset to PTY consumer: {e}");
             }
         }
         KeyAction::ScrollLineUp => {
@@ -792,25 +788,24 @@ pub(super) fn write_input_to_terminal(
             // LIMITATION (egui#3653): egui unifies numpad and main-row keys.
             // Application keypad mode cannot distinguish them until egui exposes
             // separate key variants.
-            Event::Text(text) => {
-                if repeat_characters == Decarm::RepeatKey || previous_key.is_none() {
-                    collect_text(text)
-                } else {
-                    continue;
-                }
+            Event::Text(text)
+                if repeat_characters == Decarm::RepeatKey || previous_key.is_none() =>
+            {
+                collect_text(text)
             }
+            Event::Text(_) => continue,
             Event::Key {
                 key: Key::Enter,
                 pressed: true,
                 modifiers,
                 ..
-            } => {
-                if modifiers.is_none() {
-                    [TerminalInput::Enter].as_ref().into()
-                } else {
-                    continue;
-                }
-            }
+            } if modifiers.is_none() => [TerminalInput::Enter].as_ref().into(),
+            #[allow(clippy::match_same_arms)] // Semantically distinct from Event::Text(_) above
+            Event::Key {
+                key: Key::Enter,
+                pressed: true,
+                ..
+            } => continue,
             // https://github.com/emilk/egui/issues/3653
             // egui-winit intercepts Ctrl+C and Ctrl+X at the platform layer and converts them
             // to Event::Copy and Event::Cut respectively, before they can reach us as

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -370,25 +370,24 @@ fn dispatch_context_menu_action(
     };
 
     match action {
-        ContextMenuAction::Copy => {
-            if let Some((start, end)) = view_state.selection.normalised() {
-                if let Err(e) = input_tx.send(InputEvent::ExtractSelection {
-                    start_row: start.row,
-                    start_col: start.col,
-                    end_row: end.row,
-                    end_col: end.col,
-                    is_block: view_state.selection.is_block,
-                }) {
-                    error!("Context menu: failed to send ExtractSelection: {e}");
-                } else if let Ok(text) =
-                    clipboard_rx.recv_timeout(std::time::Duration::from_millis(100))
-                    && !text.is_empty()
-                {
-                    ui.ctx().copy_text(text);
-                    view_state.selection.clear();
-                }
+        ContextMenuAction::Copy if let Some((start, end)) = view_state.selection.normalised() => {
+            if let Err(e) = input_tx.send(InputEvent::ExtractSelection {
+                start_row: start.row,
+                start_col: start.col,
+                end_row: end.row,
+                end_col: end.col,
+                is_block: view_state.selection.is_block,
+            }) {
+                error!("Context menu: failed to send ExtractSelection: {e}");
+            } else if let Ok(text) =
+                clipboard_rx.recv_timeout(std::time::Duration::from_millis(100))
+                && !text.is_empty()
+            {
+                ui.ctx().copy_text(text);
+                view_state.selection.clear();
             }
         }
+        ContextMenuAction::Copy => {}
         ContextMenuAction::Paste => {
             // Ask the platform to inject an Event::Paste on the next frame.
             // egui-winit reads the system clipboard internally and delivers
@@ -1409,11 +1408,12 @@ impl FreminalTerminalWidget {
                 // the config-apply path (these need a GL context).
                 if let Some(pending) = rs.pending_bg_image.take() {
                     match pending {
-                        PendingGpuOp::Load(ref path) => {
-                            if let Err(e) = rs.renderer.update_background_image(gl, path) {
-                                error!("Failed to load background image: {e}");
-                            }
+                        PendingGpuOp::Load(ref path)
+                            if let Err(e) = rs.renderer.update_background_image(gl, path) =>
+                        {
+                            error!("Failed to load background image: {e}");
                         }
+                        PendingGpuOp::Load(_) => {}
                         PendingGpuOp::Clear => rs.renderer.clear_background_image(gl),
                     }
                 }

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -1158,13 +1158,13 @@ pub(super) fn run_secondary_window_frame(win: &mut SecondaryWindowState, ui: &mu
                         // Process any pending shader change.
                         if let Some(pending_shader) = wpr.pending_shader.take() {
                             match pending_shader {
-                                Some(src) => {
+                                Some(src)
                                     if let Err(e) =
-                                        wpr.update_shader(gl, &src, vp.width_px, vp.height_px)
-                                    {
-                                        error!("Secondary window: shader compilation failed: {e}");
-                                    }
+                                        wpr.update_shader(gl, &src, vp.width_px, vp.height_px) =>
+                                {
+                                    error!("Secondary window: shader compilation failed: {e}");
                                 }
+                                Some(_) => {}
                                 None => wpr.clear_shader(gl),
                             }
                         }

--- a/freminal/src/playback.rs
+++ b/freminal/src/playback.rs
@@ -338,30 +338,28 @@ fn handle_playback_command(
                 }
             }
         }
-        PlaybackCommand::Pause => {
-            if let PlaybackState::RealTimePlaying { play_start, .. } = state {
-                *state = PlaybackState::RealTimePaused {
-                    elapsed_at_pause: play_start.elapsed(),
-                };
-            }
-            // Pause in other states is a no-op.
+        PlaybackCommand::Pause if let PlaybackState::RealTimePlaying { play_start, .. } = state => {
+            *state = PlaybackState::RealTimePaused {
+                elapsed_at_pause: play_start.elapsed(),
+            };
         }
-        PlaybackCommand::NextFrame => {
+        PlaybackCommand::NextFrame
             if matches!(
                 state,
                 PlaybackState::FrameStepWaiting | PlaybackState::WaitingForPlay
             ) && *mode == PlaybackMode::FrameStepping
-                && *current_frame < frames.len()
-            {
-                emulator.handle_incoming_data(&frames[*current_frame].data);
-                *current_frame += 1;
-                *state = if *current_frame >= frames.len() {
-                    PlaybackState::Complete
-                } else {
-                    PlaybackState::FrameStepWaiting
-                };
-            }
+                && *current_frame < frames.len() =>
+        {
+            emulator.handle_incoming_data(&frames[*current_frame].data);
+            *current_frame += 1;
+            *state = if *current_frame >= frames.len() {
+                PlaybackState::Complete
+            } else {
+                PlaybackState::FrameStepWaiting
+            };
         }
+        // Pause in other states is a no-op. NextFrame in non-steppable states is a no-op.
+        PlaybackCommand::Pause | PlaybackCommand::NextFrame => {}
     }
 }
 


### PR DESCRIPTION
## Summary

- Bump MSRV to 1.95.0, fix 3 new clippy lints, adopt 19 if-let guard refactors across 11 files
- Fix cursor position getting lost during `reflow_to_width` — cursor is now tracked through logical line grouping and mapped to the correct row/column after re-wrapping (3 new tests)
- Request repaint of child viewports on root frame to fix GL stretch on tiling WM resize
- Renumber v0.6.0 (Foundation/eframe replacement) and v0.7.0 (Replay & Layouts) so release versions are sequential with execution order
- Document child window initial spawn truncation as a known eframe limitation to fix in v0.6.0 Task 64