### PR TITLE
fix: deploy improvements — version string, RPM, macOS codesigning & .app bundle

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -189,29 +189,16 @@ jobs:
       - name: Bundle .app
         run: cargo bundle --release -p freminal
 
-      # temporarily disable code sign. Yes, I know it breaks installability
-      # - name: Code sign
-      #   if: env.MACOS_CERTIFICATE != ''
-      #   env:
-      #     MACOS_CERTIFICATE_PWD: ${{ secrets.MAOS_CERTIFICATE_PWD }}
-      #     MACOS_CODESIGN_IDENTITY: ${{ secrets.MACOS_CERTIFICATE }}
-      #   uses: toitlang/action-macos-sign-notarize@v1.2.0
-      #   with:
-      #     certificate: ${{ secrets.MACOS_CERTIFICATE }}
-      #     certificate-password: ${{ secrets.MAOS_CERTIFICATE_PWD }}
-      #     username: ${{ secrets.APPLE_ID_USERNAME }}
-      #     password: ${{ secrets.APPLE_ID_PASSWORD }}
-      #     apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
-      #     app-path: target/release/bundle/osx/Freminal.app
-      # the stupid cert pwd env var is not named properly in github. Nvm, just use the wrong name and it will work.
-      # run: |
-      #   echo "$MACOS_CERTIFICATE" | base64 -d > certificate.p12
-      #   security create-keychain -p build build.keychain
-      #   security default-keychain -s build.keychain
-      #   security unlock-keychain -p build build.keychain
-      #   security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
-      #   security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k build build.keychain
-      #   /usr/bin/codesign --force -s "$MACOS_CODESIGN_IDENTITY" target/release/bundle/osx/*.app -v
+      - name: Codesign and notarize .app
+        if: env.MACOS_CERTIFICATE != ''
+        uses: toitlang/action-macos-sign-notarize@v1.3.0
+        with:
+          certificate: ${{ secrets.MACOS_CERTIFICATE }}
+          certificate-password: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          username: ${{ secrets.APPLE_ID_USERNAME }}
+          password: ${{ secrets.APPLE_ID_PASSWORD }}
+          apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
+          app-path: target/release/bundle/osx/Freminal.app
 
       - name: Extract version
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -189,6 +189,12 @@ jobs:
       - name: Bundle .app
         run: cargo bundle --release -p freminal
 
+      # The signing action zips the app-path as-is, preserving directory
+      # structure.  Apple requires the .app at the zip root, so we copy
+      # it to a flat location first.
+      - name: Stage .app for signing
+        run: cp -R target/release/bundle/osx/Freminal.app ./Freminal.app
+
       - name: Codesign and notarize .app
         if: env.MACOS_CERTIFICATE != ''
         uses: toitlang/action-macos-sign-notarize@v1.3.0
@@ -198,7 +204,7 @@ jobs:
           username: ${{ secrets.APPLE_ID_USERNAME }}
           password: ${{ secrets.APPLE_ID_PASSWORD }}
           apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
-          app-path: target/release/bundle/osx/Freminal.app
+          app-path: Freminal.app
           entitlements-path: assets/macos/entitlements.plist
 
       - name: Fetch notarization log (debug)
@@ -235,9 +241,7 @@ jobs:
       - name: Rename artifacts
         run: |
           mkdir -p dist
-          cd target/release/bundle/osx
-          zip -r "../../../../dist/freminal-${VERSION}-macos-arm64.app.zip" *.app
-          cd ../../../..
+          zip -r "dist/freminal-${VERSION}-macos-arm64.app.zip" Freminal.app
           cp target/release/freminal "dist/freminal-${VERSION}-macos-arm64"
 
       - name: Upload artifacts

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -201,6 +201,28 @@ jobs:
           app-path: target/release/bundle/osx/Freminal.app
           entitlements-path: assets/macos/entitlements.plist
 
+      - name: Fetch notarization log (debug)
+        if: always() && env.MACOS_CERTIFICATE != ''
+        run: |
+          # Find the most recent notarization submission and print its log.
+          # This is invaluable when notarization returns "Invalid".
+          xcrun notarytool history \
+            --apple-id "${{ secrets.APPLE_ID_USERNAME }}" \
+            --password "${{ secrets.APPLE_ID_PASSWORD }}" \
+            --team-id "${{ secrets.APPLE_TEAM_ID }}" | head -20
+
+          SUBMISSION_ID=$(xcrun notarytool history \
+            --apple-id "${{ secrets.APPLE_ID_USERNAME }}" \
+            --password "${{ secrets.APPLE_ID_PASSWORD }}" \
+            --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+            --output-format json | python3 -c "import sys,json; print(json.load(sys.stdin)['history'][0]['id'])")
+
+          echo "Latest submission: $SUBMISSION_ID"
+          xcrun notarytool log "$SUBMISSION_ID" \
+            --apple-id "${{ secrets.APPLE_ID_USERNAME }}" \
+            --password "${{ secrets.APPLE_ID_PASSWORD }}" \
+            --team-id "${{ secrets.APPLE_TEAM_ID }}"
+
       - name: Extract version
         run: |
           if [[ "$GITHUB_REF_NAME" == v* ]]; then

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,11 +30,14 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
-      - name: Install cargo-bundle
-        run: cargo install cargo-bundle
+      - name: Install cargo-bundle and cargo-generate-rpm
+        run: cargo install cargo-bundle cargo-generate-rpm
 
       - name: Bundle .deb package and build release binary
         run: cargo bundle --release -p freminal
+
+      - name: Generate RPM package
+        run: cargo generate-rpm -p freminal
 
       - name: Extract version
         run: |
@@ -50,6 +53,7 @@ jobs:
           cp target/release/freminal "dist/freminal-${VERSION}-linux-amd64"
           cp target/release/bundle/deb/*.deb "dist/freminal-${VERSION}-linux-amd64.deb"
           cp target/release/bundle/appimage/*.AppImage "dist/freminal-${VERSION}-linux-amd64.AppImage"
+          cp target/generate-rpm/*.rpm "dist/freminal-${VERSION}-linux-amd64.rpm"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -76,11 +80,14 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
-      - name: Install cargo-bundle
-        run: cargo install cargo-bundle
+      - name: Install cargo-bundle and cargo-generate-rpm
+        run: cargo install cargo-bundle cargo-generate-rpm
 
       - name: Bundle .deb package and build release binary
         run: cargo bundle --release -p freminal
+
+      - name: Generate RPM package
+        run: cargo generate-rpm -p freminal
 
       - name: Extract version
         run: |
@@ -96,6 +103,7 @@ jobs:
           cp target/release/freminal "dist/freminal-${VERSION}-linux-arm64"
           cp target/release/bundle/deb/*.deb "dist/freminal-${VERSION}-linux-arm64.deb"
           cp target/release/bundle/appimage/*.AppImage "dist/freminal-${VERSION}-linux-arm64.AppImage"
+          cp target/generate-rpm/*.rpm "dist/freminal-${VERSION}-linux-arm64.rpm"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -189,45 +189,117 @@ jobs:
       - name: Bundle .app
         run: cargo bundle --release -p freminal
 
-      # The signing action zips the app-path as-is, preserving directory
-      # structure.  Apple requires the .app at the zip root, so we copy
-      # it to a flat location first.
+      # Stage the .app at the repo root for a clean zip path.
       - name: Stage .app for signing
-        run: cp -R target/release/bundle/osx/Freminal.app ./Freminal.app
+        run: |
+          cp -R target/release/bundle/osx/Freminal.app ./Freminal.app
+          echo "::group::Staged .app structure"
+          find Freminal.app -type f | head -50
+          echo "::endgroup::"
+          echo "::group::Info.plist contents"
+          cat Freminal.app/Contents/Info.plist
+          echo "::endgroup::"
+          echo "::group::Binary file info"
+          file Freminal.app/Contents/MacOS/freminal
+          ls -lh Freminal.app/Contents/MacOS/freminal
+          echo "::endgroup::"
 
-      - name: Codesign and notarize .app
+      # We handle codesigning and notarization manually instead of using
+      # toitlang/action-macos-sign-notarize because that action's zip step
+      # is not recursive, producing an empty archive that Apple rejects.
+      - name: Import signing certificate
         if: env.MACOS_CERTIFICATE != ''
-        uses: toitlang/action-macos-sign-notarize@v1.3.0
+        uses: apple-actions/import-codesign-certs@b610f78488812c1e56b20e6df63ec42d833f2d14 # v6.0.0
         with:
-          certificate: ${{ secrets.MACOS_CERTIFICATE }}
-          certificate-password: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-          username: ${{ secrets.APPLE_ID_USERNAME }}
-          password: ${{ secrets.APPLE_ID_PASSWORD }}
-          apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
-          app-path: Freminal.app
-          entitlements-path: assets/macos/entitlements.plist
+          p12-file-base64: ${{ secrets.MACOS_CERTIFICATE }}
+          p12-password: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+
+      - name: List signing identities
+        if: env.MACOS_CERTIFICATE != ''
+        run: |
+          echo "::group::Available signing identities"
+          security find-identity -v -p codesigning
+          echo "::endgroup::"
+
+      - name: Codesign .app
+        if: env.MACOS_CERTIFICATE != ''
+        run: |
+          echo "::group::Entitlements file"
+          cat assets/macos/entitlements.plist
+          echo "::endgroup::"
+
+          echo "Signing with team ID: ${{ secrets.APPLE_TEAM_ID }}"
+          codesign --force --deep --sign "${{ secrets.APPLE_TEAM_ID }}" \
+            --entitlements assets/macos/entitlements.plist \
+            --options=runtime \
+            --verbose=4 \
+            Freminal.app
+
+          echo "::group::Signature details"
+          codesign -dvvv Freminal.app
+          echo "::endgroup::"
+
+          echo "::group::Signature verification"
+          codesign --verify --strict --verbose=4 Freminal.app
+          echo "::endgroup::"
+
+          echo "::group::Embedded entitlements"
+          codesign -d --entitlements - Freminal.app || true
+          echo "::endgroup::"
+
+      - name: Notarize .app
+        if: env.MACOS_CERTIFICATE != ''
+        run: |
+          # Create a proper recursive zip for notarization
+          ditto -c -k --keepParent Freminal.app Freminal.zip
+          echo "Zip size: $(ls -lh Freminal.zip | awk '{print $5}')"
+          echo "Zip contents:"
+          zipinfo -1 Freminal.zip | head -30
+
+          echo "::group::Submitting to Apple notarization service"
+          xcrun notarytool submit Freminal.zip \
+            --wait \
+            --apple-id "${{ secrets.APPLE_ID_USERNAME }}" \
+            --password "${{ secrets.APPLE_ID_PASSWORD }}" \
+            --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+            --verbose
+          echo "::endgroup::"
+
+          echo "::group::Stapling notarization ticket"
+          xcrun stapler staple -v Freminal.app
+          echo "::endgroup::"
+
+          echo "::group::Final verification (spctl)"
+          spctl --assess --type exec --verbose=4 Freminal.app || true
+          echo "::endgroup::"
 
       - name: Fetch notarization log (debug)
-        if: always() && env.MACOS_CERTIFICATE != ''
+        if: failure() && env.MACOS_CERTIFICATE != ''
         run: |
-          # Find the most recent notarization submission and print its log.
-          # This is invaluable when notarization returns "Invalid".
+          echo "::group::Notarization history"
           xcrun notarytool history \
             --apple-id "${{ secrets.APPLE_ID_USERNAME }}" \
             --password "${{ secrets.APPLE_ID_PASSWORD }}" \
-            --team-id "${{ secrets.APPLE_TEAM_ID }}" | head -20
+            --team-id "${{ secrets.APPLE_TEAM_ID }}" || true
+          echo "::endgroup::"
 
           SUBMISSION_ID=$(xcrun notarytool history \
             --apple-id "${{ secrets.APPLE_ID_USERNAME }}" \
             --password "${{ secrets.APPLE_ID_PASSWORD }}" \
             --team-id "${{ secrets.APPLE_TEAM_ID }}" \
-            --output-format json | python3 -c "import sys,json; print(json.load(sys.stdin)['history'][0]['id'])")
+            --output-format json | python3 -c "import sys,json; print(json.load(sys.stdin)['history'][0]['id'])" 2>/dev/null) || true
 
-          echo "Latest submission: $SUBMISSION_ID"
-          xcrun notarytool log "$SUBMISSION_ID" \
-            --apple-id "${{ secrets.APPLE_ID_USERNAME }}" \
-            --password "${{ secrets.APPLE_ID_PASSWORD }}" \
-            --team-id "${{ secrets.APPLE_TEAM_ID }}"
+          if [ -n "$SUBMISSION_ID" ]; then
+            echo "Latest submission: $SUBMISSION_ID"
+            echo "::group::Notarization log"
+            xcrun notarytool log "$SUBMISSION_ID" \
+              --apple-id "${{ secrets.APPLE_ID_USERNAME }}" \
+              --password "${{ secrets.APPLE_ID_PASSWORD }}" \
+              --team-id "${{ secrets.APPLE_TEAM_ID }}" || true
+            echo "::endgroup::"
+          else
+            echo "Could not retrieve submission ID from history"
+          fi
 
       - name: Extract version
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -199,6 +199,7 @@ jobs:
           password: ${{ secrets.APPLE_ID_PASSWORD }}
           apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
           app-path: target/release/bundle/osx/Freminal.app
+          entitlements-path: assets/macos/entitlements.plist
 
       - name: Extract version
         run: |

--- a/assets/macos/entitlements.plist
+++ b/assets/macos/entitlements.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Required for GPU-accelerated rendering (glow/OpenGL). -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+
+  <!-- Required for OpenGL drivers that allocate executable memory. -->
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+
+  <!-- Required to load third-party dylibs (e.g. system OpenGL, libGL). -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/flake.nix
+++ b/flake.nix
@@ -108,23 +108,83 @@
             nativeBuildInputs = [
               pkgs.pkg-config
               pkgs.makeWrapper
+            ]
+            ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
               pkgs.copyDesktopItems
             ];
 
             buildInputs = runtimeLibs;
 
-            desktopItems = [
+            desktopItems = pkgs.lib.optionals pkgs.stdenv.isLinux [
               desktopItem
             ];
 
-            postInstall = ''
-              wrapProgram $out/bin/freminal \
-                --prefix LD_LIBRARY_PATH : ${runtimeLibPath}
+            postInstall =
+              if pkgs.stdenv.isDarwin then
+                ''
+                                    # Create a macOS .app bundle so Freminal appears in
+                                    # Finder / Spotlight / Launchpad.
+                                    mkdir -p "$out/Applications"
+                                    OUT_APP="$out/Applications/Freminal.app/Contents"
+                                    mkdir -p "$OUT_APP/MacOS" "$OUT_APP/Resources"
 
-              # optional, once you have icons in the repo:
-              install -Dm644 assets/icon.png \
-                $out/share/icons/hicolor/256x256/apps/freminal.png
-            '';
+                                    # macOS only recognises an app bundle if the real binary
+                                    # lives inside it.  Move the binary in, then create a
+                                    # symlink back to $out/bin/ so CLI usage still works.
+                                    mv "$out/bin/freminal" "$OUT_APP/MacOS/freminal"
+                                    ln -s "$OUT_APP/MacOS/freminal" "$out/bin/freminal"
+
+                                    # Write Info.plist
+                                    cat > "$OUT_APP/Info.plist" << 'PLIST'
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+                    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+                  <plist version="1.0">
+                  <dict>
+                    <key>CFBundleName</key>
+                    <string>Freminal</string>
+                    <key>CFBundleDisplayName</key>
+                    <string>Freminal</string>
+                    <key>CFBundleIdentifier</key>
+                    <string>io.github.fredclausen.freminal</string>
+                    <key>CFBundleVersion</key>
+                    <string>0.6.0</string>
+                    <key>CFBundleShortVersionString</key>
+                    <string>0.6.0</string>
+                    <key>CFBundleExecutable</key>
+                    <string>freminal</string>
+                    <key>CFBundleIconFile</key>
+                    <string>freminal</string>
+                    <key>CFBundlePackageType</key>
+                    <string>APPL</string>
+                    <key>LSMinimumSystemVersion</key>
+                    <string>13.0</string>
+                    <key>NSHighResolutionCapable</key>
+                    <true/>
+                  </dict>
+                  </plist>
+                  PLIST
+
+                                    # Icon — generate .icns from PNG via iconutil if available,
+                                    # otherwise copy raw PNG (still works, just single-resolution).
+                                    mkdir -p "$OUT_APP/Resources/freminal.iconset"
+                                    cp assets/icon.png "$OUT_APP/Resources/freminal.iconset/icon_256x256.png"
+                                    if command -v iconutil &>/dev/null; then
+                                      iconutil -c icns -o "$OUT_APP/Resources/freminal.icns" \
+                                        "$OUT_APP/Resources/freminal.iconset"
+                                    else
+                                      cp assets/icon.png "$OUT_APP/Resources/freminal.icns"
+                                    fi
+                                    rm -rf "$OUT_APP/Resources/freminal.iconset"
+                ''
+              else
+                ''
+                  wrapProgram $out/bin/freminal \
+                    --prefix LD_LIBRARY_PATH : ${runtimeLibPath}
+
+                  install -Dm644 assets/icon.png \
+                    $out/share/icons/hicolor/256x256/apps/freminal.png
+                '';
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -245,11 +245,11 @@
                 pkgs.vttest
                 pkgs.markdownlint-cli2
                 pkgs.cargo-flamegraph
-                pkgs.perf
               ]
               ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
                 pkgs.cargo-llvm-cov
                 pkgs.cachix
+                pkgs.perf
               ];
 
               # Extra dev packages provided by mkCheck (includes rustToolchain)

--- a/freminal-terminal-emulator/build.rs
+++ b/freminal-terminal-emulator/build.rs
@@ -25,6 +25,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .add_instructions(&si)?
         .emit()?;
 
+    // Emit VERGEN_GIT_DESCRIBE via the `git` CLI.  This avoids pulling in a
+    // heavy git-library dependency (vergen v9 requires vergen-gix/vergen-git2
+    // for git info).  The describe output looks like "v0.6.0-42-gabc1234" or
+    // just "v0.6.0" when exactly on a tag.  Falls back to the short SHA if
+    // `git describe` fails (e.g. shallow clone with no tags).
+    let git_describe = Command::new("git")
+        .args(["describe", "--tags", "--always", "--dirty"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_owned())
+        .unwrap_or_else(|| "unknown".to_owned());
+    println!("cargo:rustc-env=VERGEN_GIT_DESCRIBE={git_describe}");
+
     rebuild_terminfo()?;
 
     Ok(())

--- a/freminal-terminal-emulator/src/io/pty.rs
+++ b/freminal-terminal-emulator/src/io/pty.rs
@@ -240,9 +240,9 @@ pub fn run_terminal(
 
     // get the version of freminal
     let version = format!(
-        "{}-{}",
+        "{} ({})",
         env!("CARGO_PKG_VERSION"),
-        env!("VERGEN_BUILD_TIMESTAMP")
+        env!("VERGEN_GIT_DESCRIBE")
     );
     cmd.env("TERM_PROGRAM", "freminal");
     cmd.env("TERM_PROGRAM_VERSION", version);

--- a/freminal/Cargo.toml
+++ b/freminal/Cargo.toml
@@ -17,7 +17,7 @@ name = "Freminal"
 identifier = "io.github.fredclausen.freminal"
 copyright = "Copyright (c) 2024-2026 Fred Clausen"
 category = "Developer Tools"
-icon = ["../assets/icon.png"]
+icon = ["assets/icon.png"]
 short_description = "A terminal emulator written in Rust"
 long_description = """
 Freminal is a terminal emulator written in Rust, designed to provide a fast, efficient, and customizable terminal experience. It leverages modern Rust libraries and technologies to deliver a robust and user-friendly interface for developers and power users.

--- a/freminal/Cargo.toml
+++ b/freminal/Cargo.toml
@@ -17,6 +17,7 @@ name = "Freminal"
 identifier = "io.github.fredclausen.freminal"
 copyright = "Copyright (c) 2024-2026 Fred Clausen"
 category = "Developer Tools"
+icon = ["../assets/icon.png"]
 short_description = "A terminal emulator written in Rust"
 long_description = """
 Freminal is a terminal emulator written in Rust, designed to provide a fast, efficient, and customizable terminal experience. It leverages modern Rust libraries and technologies to deliver a robust and user-friendly interface for developers and power users.

--- a/freminal/Cargo.toml
+++ b/freminal/Cargo.toml
@@ -65,3 +65,8 @@ criterion.workspace = true
 default = []
 playback = ["freminal-terminal-emulator/playback"]
 validation = []
+
+[package.metadata.generate-rpm]
+assets = [
+    { source = "target/release/freminal", dest = "/usr/bin/freminal", mode = "755" },
+]

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -535,5 +535,18 @@ in
     xdg.configFile."freminal/config.toml" = {
       source = tomlFormat.generate "freminal-config" configAttrset;
     };
+
+    # On macOS, symlink the .app bundle into ~/Applications so that
+    # Finder, Spotlight, and Launchpad can discover Freminal.
+    home.activation.linkFreminalApp = lib.mkIf pkgs.stdenv.isDarwin (
+      lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        app_src="${cfg.package}/Applications/Freminal.app"
+        app_dst="$HOME/Applications/Freminal.app"
+        if [ -e "$app_src" ]; then
+          $DRY_RUN_CMD rm -rf "$app_dst"
+          $DRY_RUN_CMD cp -RL "$app_src" "$app_dst"
+        fi
+      ''
+    );
   };
 }


### PR DESCRIPTION
## Summary

- **Version string fix**: Replaced `VERGEN_BUILD_TIMESTAMP` (broken by Nix's `SOURCE_DATE_EPOCH=315532800`) with `VERGEN_GIT_DESCRIBE` via `git describe --tags --always --dirty` in build.rs
- **RPM packaging**: Added `cargo-generate-rpm` metadata to `freminal/Cargo.toml` and RPM build steps to both Linux jobs in deploy.yaml
- **macOS .app codesigning & notarization**: Replaced broken `toitlang/action-macos-sign-notarize` (its zip step isn't recursive, producing empty archives Apple rejects) with manual `codesign` + `ditto` + `xcrun notarytool` pipeline, with hardened runtime entitlements for GPU/OpenGL
- **macOS .app bundle in Nix**: Platform-conditional `postInstall` in flake.nix creates a proper `.app` bundle on Darwin; HM module copies it to `~/Applications/` for Spotlight indexing
- **App icon**: Wired `assets/icon.png` into cargo-bundle config

## Files changed

- `.github/workflows/deploy.yaml` — RPM steps, manual codesign/notarize pipeline with debug logging
- `assets/macos/entitlements.plist` — GPU entitlements for hardened runtime
- `flake.nix` — Darwin .app bundle creation, iconutil integration
- `nix/home-manager-module.nix` — Darwin activation hook for ~/Applications
- `freminal-terminal-emulator/build.rs` — git describe emission
- `freminal-terminal-emulator/src/io/pty.rs` — version string format
- `freminal/Cargo.toml` — cargo-generate-rpm metadata, bundle icon