### PR TITLE
fix: platform performance + split-pane resize bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -554,3 +554,4 @@ config.toml
 flamegraph.svg
 perf.data
 perf.data.old*
+profile_export*.xml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -154,7 +154,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1018,7 +1018,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1245,7 +1245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "freminal"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-buffer"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "conv2",
  "criterion",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-common"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-terminal-emulator"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-windowing"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "egui",
  "egui-winit",
@@ -2383,7 +2383,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2754,9 +2754,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "open"
-version = "5.3.3"
+version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
 dependencies = [
  "is-wsl",
  "libc",
@@ -2786,7 +2786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3354,7 +3354,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3831,7 +3831,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4664,7 +4664,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5023,7 +5023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.95.0"
 description = "A terminal emulator written in Rust"
@@ -68,7 +68,7 @@ lazy_static = "1.5.0"
 libc = "0.2.185"
 log = "0.4.29"
 nix = "0.31.2"
-open = "5.3.3"
+open = "5.3.4"
 predicates = "3.1.4"
 proptest = "1.11.0"
 raw-window-handle = "0.6.2"

--- a/Documents/MASTER_PLAN.md
+++ b/Documents/MASTER_PLAN.md
@@ -80,8 +80,8 @@ Task 61 (Saved Layouts).
 | 58  | Built-in Multiplexer (Split Panes)       | `PLAN_VERSION_050.md` (Task 58)             | Complete | Task 36 (Tabs)       |
 | 59  | FREC v2: Recording Overhaul              | `PLAN_VERSION_070.md` (Task 59)             | Pending  | Task 58              |
 | 61  | Saved Layouts (Session Templates)        | `PLAN_VERSION_070.md` (Task 61)             | Pending  | Tasks 36, 58         |
-| 68  | Platform Performance Triage              | `PLAN_VERSION_070.md` (Task 68)             | Pending  | None                 |
-| 69  | UI Polish & Settings Completeness        | `PLAN_VERSION_070.md` (Task 69)             | Pending  | None                 |
+| 68  | Platform Performance Triage              | `PLAN_VERSION_070.md` (Task 68)             | Complete | None                 |
+| 69  | UI Polish & Settings Completeness        | `PLAN_VERSION_070.md` (Task 69)             | Complete | None                 |
 | 62  | freminal-windowing crate + event loop    | `PLAN_VERSION_060.md` (Task 62)             | Complete | None                 |
 | 63  | Single-window migration                  | `PLAN_VERSION_060.md` (Task 63)             | Complete | Task 62              |
 | 64  | Multi-window parity                      | `PLAN_VERSION_060.md` (Task 64)             | Complete | Task 63              |
@@ -478,6 +478,8 @@ Update this section as tasks complete:
 | 64   | 2026-04-16 | 2026-04-16 | All subtasks complete on task-64/multi-window-parity                  |
 | 65   | 2026-04-16 | 2026-04-16 | Already implemented during Tasks 62-63; verified complete             |
 | 66   | 2026-04-16 | 2026-04-16 | Removed eframe workspace dep, cleaned stale references                |
+| 68   | 2026-04-19 | 2026-04-19 | macOS idle CPU fix + Windows split-pane resize fix                    |
+| 69   | 2026-04-17 | 2026-04-17 | Glyphs, settings gaps, search positioning, settings window            |
 
 ---
 

--- a/Documents/PLAN_VERSION_070.md
+++ b/Documents/PLAN_VERSION_070.md
@@ -11,12 +11,12 @@ and triage platform-specific performance issues on Windows and macOS.
 
 ## Task Summary
 
-| #   | Feature                           | Scope  | Status  | Dependencies     |
-| --- | --------------------------------- | ------ | ------- | ---------------- |
-| 59  | FREC v2: Recording Overhaul       | Large  | Pending | Task 58          |
-| 61  | Saved Layouts (Session Templates) | Large  | Pending | Task 36, Task 58 |
-| 68  | Platform Performance Triage       | Medium | Pending | None             |
-| 69  | UI Polish & Settings Completeness | Medium | Pending | None             |
+| #   | Feature                           | Scope  | Status   | Dependencies     |
+| --- | --------------------------------- | ------ | -------- | ---------------- |
+| 59  | FREC v2: Recording Overhaul       | Large  | Pending  | Task 58          |
+| 61  | Saved Layouts (Session Templates) | Large  | Pending  | Task 36, Task 58 |
+| 68  | Platform Performance Triage       | Medium | Complete | None             |
+| 69  | UI Polish & Settings Completeness | Medium | Complete | None             |
 
 Task 60 (Playback v2) has been removed — see "Design Decisions" below.
 

--- a/flake.nix
+++ b/flake.nix
@@ -100,7 +100,7 @@
         {
           freminal = rustPlatform.buildRustPackage {
             pname = "freminal";
-            version = "0.6.0";
+            version = "0.7.0";
             src = pkgs.lib.cleanSource ./.;
 
             cargoLock.lockFile = ./Cargo.lock;

--- a/freminal-windowing/src/egui_integration.rs
+++ b/freminal-windowing/src/egui_integration.rs
@@ -108,9 +108,11 @@ impl EguiState {
             .map(|vo| vo.commands.clone())
             .unwrap_or_default();
 
-        if repaint_delay.is_zero() {
-            window.request_redraw();
-        }
+        // Do NOT call `window.request_redraw()` here — let the event loop
+        // manage scheduling via `repaint_at` / `about_to_wait`.  Calling
+        // `request_redraw()` directly bypasses `ControlFlow::WaitUntil` and
+        // causes an unbounded render loop on platforms where `swap_buffers`
+        // returns immediately (macOS with vsync disabled).
 
         FrameOutput {
             commands,

--- a/freminal-windowing/src/egui_integration.rs
+++ b/freminal-windowing/src/egui_integration.rs
@@ -121,11 +121,31 @@ impl EguiState {
     }
 
     /// Pass a winit `WindowEvent` to egui.
+    ///
+    /// Forward a window event to egui-winit.
     pub(crate) fn on_window_event(
         &mut self,
         window: &Window,
         event: &winit::event::WindowEvent,
     ) -> egui_winit::EventResponse {
         self.winit_state.on_window_event(window, event)
+    }
+
+    /// Inject a paste event directly into egui's input queue.
+    pub(crate) fn inject_paste(&mut self, text: String) {
+        self.winit_state
+            .egui_input_mut()
+            .events
+            .push(egui::Event::Paste(text));
+    }
+
+    /// Read clipboard text via this window's egui-winit clipboard.
+    pub(crate) fn clipboard_text(&mut self) -> Option<String> {
+        self.winit_state.clipboard_text()
+    }
+
+    /// Read the current egui modifier state.
+    pub(crate) fn modifiers(&self) -> egui::Modifiers {
+        self.winit_state.egui_input().modifiers
     }
 }

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -104,6 +104,12 @@ impl<A: App> Handler<A> {
 
         self.windows.insert(winit_id, state);
 
+        // Request an immediate redraw so the first frame renders as soon as
+        // the event loop is ready.  `repaint_at` alone only fires in
+        // `about_to_wait`, which may not schedule a second frame quickly
+        // enough for the terminal to display the initial shell prompt.
+        self.windows[&winit_id].window.request_redraw();
+
         let handle = WindowHandle {
             proxy: &self.proxy,
             pending_ops: &self.pending_ops,
@@ -217,13 +223,31 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
         winit_id: winit::window::WindowId,
         event: WindowEvent,
     ) {
+        // Mouse-motion events arrive at 100+ Hz on macOS.  We pass them to
+        // egui (for pointer position tracking needed by clicks and hover) but
+        // return immediately — no repaint scheduling, no control-flow update.
+        // The CPU overhead from winit's Objective-C event dispatch is
+        // unavoidable platform cost (observed equally in Ghostty and WezTerm).
+        if matches!(
+            event,
+            WindowEvent::CursorMoved { .. }
+                | WindowEvent::CursorEntered { .. }
+                | WindowEvent::CursorLeft { .. }
+        ) {
+            if let Some(state) = self.windows.get_mut(&winit_id) {
+                let _ = state.egui.on_window_event(&state.window, &event);
+            }
+            return;
+        }
+
         // Pass to egui first
         let egui_consumed = if let Some(state) = self.windows.get_mut(&winit_id) {
             let response = state.egui.on_window_event(&state.window, &event);
+
             if response.repaint {
                 state.repaint_at = Some(Instant::now());
-                state.window.request_redraw();
             }
+
             response.consumed
         } else {
             return;
@@ -298,11 +322,14 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
 
                 state.repaint_at = None;
 
-                // Schedule repaint based on egui's requested delay.
-                if !frame_output.repaint_delay.is_zero()
-                    && frame_output.repaint_delay < std::time::Duration::from_secs(3600)
-                {
-                    let deadline = Instant::now() + frame_output.repaint_delay;
+                // Honour egui's repaint_delay but clamp to a minimum of 16ms
+                // to prevent unbounded rendering from zero-delay requests
+                // (hover state, tooltip updates).  This ensures layout-settling
+                // frames still fire while keeping idle CPU near zero.
+                if frame_output.repaint_delay < std::time::Duration::from_secs(3600) {
+                    let min_delay = std::time::Duration::from_millis(16);
+                    let delay = frame_output.repaint_delay.max(min_delay);
+                    let deadline = Instant::now() + delay;
                     state.repaint_at = Some(deadline);
                 }
 
@@ -326,12 +353,18 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
         self.update_control_flow(event_loop);
     }
 
-    fn user_event(&mut self, _event_loop: &ActiveEventLoop, event: UserEvent) {
+    fn user_event(&mut self, event_loop: &ActiveEventLoop, event: UserEvent) {
         match event {
             UserEvent::RequestRepaint(id) => {
                 if let Some(state) = self.windows.get_mut(&id.0) {
-                    state.repaint_at = Some(Instant::now());
-                    state.window.request_redraw();
+                    // Schedule rather than calling request_redraw() directly,
+                    // same throttle as window_event to prevent unbounded rendering.
+                    let min_deadline = Instant::now() + std::time::Duration::from_millis(16);
+                    state.repaint_at = Some(
+                        state
+                            .repaint_at
+                            .map_or(min_deadline, |existing| existing.min(min_deadline)),
+                    );
                 }
             }
             UserEvent::RequestRepaintAfter(id, delay) => {
@@ -345,10 +378,19 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                 }
             }
         }
+
+        // Ensure the event loop wakes at the earliest deadline so timer-based
+        // repaints actually fire.  Without this, the loop may stay in `Wait`
+        // indefinitely on platforms where `about_to_wait` is not called after
+        // `user_event` (observed on macOS).
+        self.update_control_flow(event_loop);
     }
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
-        // Check if any windows need repaint based on timers
+        // Check if any windows need repaint based on timers.
+        // Clear `repaint_at` immediately so spurious wake-ups between
+        // now and the actual `RedrawRequested` delivery don't re-fire
+        // `request_redraw()` on every pass through `about_to_wait`.
         let now = Instant::now();
         let ids: Vec<winit::window::WindowId> = self.windows.keys().copied().collect();
         for winit_id in ids {
@@ -356,6 +398,7 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                 && let Some(deadline) = state.repaint_at
                 && deadline <= now
             {
+                state.repaint_at = None;
                 state.window.request_redraw();
             }
         }

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -104,6 +104,8 @@ impl<A: App> Handler<A> {
 
         self.windows.insert(winit_id, state);
 
+        // Track the first window as the primary clipboard source.
+
         // Request an immediate redraw so the first frame renders as soon as
         // the event loop is ready.  `repaint_at` alone only fires in
         // `about_to_wait`, which may not schedule a second frame quickly
@@ -246,6 +248,58 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
             }
             self.update_control_flow(event_loop);
             return;
+        }
+
+        // Intercept paste shortcuts before egui-winit can consume them.
+        //
+        // On Wayland, egui-winit creates a per-window smithay-clipboard instance.
+        // Only the first instance receives wl_data_device events, so clipboard
+        // reads silently fail on child windows — and egui-winit still swallows
+        // the keypress.  We fix this by reading clipboard from whichever window
+        // has a working clipboard and injecting Event::Paste into the target.
+        if let winit::event::WindowEvent::KeyboardInput {
+            event:
+                winit::event::KeyEvent {
+                    ref logical_key,
+                    state: winit::event::ElementState::Pressed,
+                    ..
+                },
+            ..
+        } = event
+        {
+            let is_paste = self.windows.get(&winit_id).is_some_and(|state| {
+                let mods = state.egui.modifiers();
+                matches!(
+                    logical_key,
+                    winit::keyboard::Key::Named(winit::keyboard::NamedKey::Paste)
+                ) || (mods.command
+                    && matches!(
+                        logical_key,
+                        winit::keyboard::Key::Character(c)
+                            if c.as_str().eq_ignore_ascii_case("v")
+                    ))
+            });
+
+            if is_paste {
+                let text = self
+                    .windows
+                    .values_mut()
+                    .find_map(|state| state.egui.clipboard_text());
+
+                if let Some(text) = text {
+                    let text = text.replace("\r\n", "\n");
+                    if !text.is_empty()
+                        && let Some(state) = self.windows.get_mut(&winit_id)
+                    {
+                        state.egui.inject_paste(text);
+                        state.repaint_at = Some(Instant::now());
+                        // Don't pass to egui-winit — it would produce a
+                        // duplicate paste on windows where its clipboard works.
+                        self.update_control_flow(event_loop);
+                        return;
+                    }
+                }
+            }
         }
 
         // Pass to egui first

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -224,10 +224,9 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
         event: WindowEvent,
     ) {
         // Mouse-motion events arrive at 100+ Hz on macOS.  We pass them to
-        // egui (for pointer position tracking needed by clicks and hover) but
-        // return immediately — no repaint scheduling, no control-flow update.
-        // The CPU overhead from winit's Objective-C event dispatch is
-        // unavoidable platform cost (observed equally in Ghostty and WezTerm).
+        // egui for pointer position tracking but only schedule a repaint if
+        // egui actually wants one (e.g. menu hover highlight).  We skip the
+        // full window_event path to avoid unnecessary work.
         if matches!(
             event,
             WindowEvent::CursorMoved { .. }
@@ -235,8 +234,17 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                 | WindowEvent::CursorLeft { .. }
         ) {
             if let Some(state) = self.windows.get_mut(&winit_id) {
-                let _ = state.egui.on_window_event(&state.window, &event);
+                let response = state.egui.on_window_event(&state.window, &event);
+                if response.repaint {
+                    let deadline = Instant::now() + std::time::Duration::from_millis(16);
+                    state.repaint_at = Some(
+                        state
+                            .repaint_at
+                            .map_or(deadline, |existing| existing.min(deadline)),
+                    );
+                }
             }
+            self.update_control_flow(event_loop);
             return;
         }
 

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -1286,6 +1286,7 @@ impl freminal_windowing::App for FreminalGui {
                 .window_focused;
             for (idx, tab) in win.tabs.iter_mut().enumerate() {
                 let is_active_tab = idx == active_idx;
+                let is_only_pane = tab.pane_tree.pane_count().unwrap_or(1) == 1;
                 if let Ok(panes) = tab.pane_tree.iter_panes_mut() {
                     for pane in panes {
                         let is_fully_active = is_active_tab && pane.id == active_pane_id_for_drain;
@@ -1301,9 +1302,12 @@ impl freminal_windowing::App for FreminalGui {
                             &mut pane.bell_active,
                             &mut pane.view_state.bell_since,
                             self.config.bell.mode,
-                            self.config.security.allow_clipboard_read,
-                            is_fully_active,
-                            window_focused,
+                            &rendering::WindowManipFlags {
+                                allow_clipboard_read: self.config.security.allow_clipboard_read,
+                                is_active: is_fully_active,
+                                window_focused,
+                                is_only_pane,
+                            },
                         );
                     }
                 }

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -1286,7 +1286,13 @@ impl freminal_windowing::App for FreminalGui {
                 .window_focused;
             for (idx, tab) in win.tabs.iter_mut().enumerate() {
                 let is_active_tab = idx == active_idx;
-                let is_only_pane = tab.pane_tree.pane_count().unwrap_or(1) == 1;
+                let is_only_pane = match tab.pane_tree.pane_count() {
+                    Ok(count) => count == 1,
+                    Err(e) => {
+                        trace!("pane_count error (treating as split): {e}");
+                        false
+                    }
+                };
                 if let Ok(panes) = tab.pane_tree.iter_panes_mut() {
                     for pane in panes {
                         let is_fully_active = is_active_tab && pane.id == active_pane_id_for_drain;

--- a/freminal/src/gui/rendering.rs
+++ b/freminal/src/gui/rendering.rs
@@ -104,6 +104,20 @@ pub(super) fn read_clipboard_base64() -> String {
     }
 }
 
+/// Flags for [`handle_window_manipulation`] that control which commands are
+/// honoured for a given pane.
+#[allow(clippy::struct_excessive_bools)]
+pub(super) struct WindowManipFlags {
+    /// Whether clipboard read requests are allowed by policy.
+    pub allow_clipboard_read: bool,
+    /// Whether this pane is the fully-active pane (active tab + active pane).
+    pub is_active: bool,
+    /// Whether the window currently has OS focus.
+    pub window_focused: bool,
+    /// Whether this pane is the only pane in its tab (no splits).
+    pub is_only_pane: bool,
+}
+
 /// Drain and dispatch all pending [`WindowCommand`]s for this frame.
 ///
 /// ## Flow
@@ -151,7 +165,7 @@ pub(super) fn read_clipboard_base64() -> String {
 // responses, title stack, clipboard. Each variant requires distinct context (ui, pty_write_tx,
 // title_stack). Splitting further would scatter a cohesive protocol handler.
 // All arguments are required context that cannot be easily grouped without obscuring intent.
-#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub(super) fn handle_window_manipulation(
     ui: &egui::Ui,
     window_cmd_rx: &Receiver<WindowCommand>,
@@ -164,9 +178,7 @@ pub(super) fn handle_window_manipulation(
     bell_active: &mut bool,
     bell_since: &mut Option<Instant>,
     bell_mode: BellMode,
-    allow_clipboard_read: bool,
-    is_active: bool,
-    window_focused: bool,
+    flags: &WindowManipFlags,
 ) {
     // Drain all pending WindowCommands for this frame.
     while let Ok(wc) = window_cmd_rx.try_recv() {
@@ -188,18 +200,26 @@ pub(super) fn handle_window_manipulation(
             | WindowManipulation::NotFullScreen
             | WindowManipulation::FullScreen
             | WindowManipulation::ToggleFullScreen
-                if !is_active => {}
+                if !flags.is_active => {}
+
+            // ── Resize commands from split panes: suppress ───────────
+            // A pane sharing space in a split must not resize the OS
+            // window to its own dimensions — that would shrink the
+            // window to a fraction of its intended size.
+            WindowManipulation::ResizeWindow(_, _)
+            | WindowManipulation::ResizeWindowToLinesAndColumns(_, _)
+                if !flags.is_only_pane => {}
 
             // ── Title: inactive tabs update their own title only ─────
-            WindowManipulation::SetTitleBarText(title) if !is_active => {
+            WindowManipulation::SetTitleBarText(title) if !flags.is_active => {
                 tab_title.clone_from(&title);
             }
 
             // ── Title stack: inactive tabs save their own tab title ──
-            WindowManipulation::SaveWindowTitleToStack if !is_active => {
+            WindowManipulation::SaveWindowTitleToStack if !flags.is_active => {
                 title_stack.push(tab_title.clone());
             }
-            WindowManipulation::RestoreWindowTitleFromStack if !is_active => {
+            WindowManipulation::RestoreWindowTitleFromStack if !flags.is_active => {
                 if let Some(title) = title_stack.pop() {
                     tab_title.clone_from(&title);
                 } else {
@@ -441,7 +461,7 @@ pub(super) fn handle_window_manipulation(
             // user has opted in via [security] allow_clipboard_read = true.
             // Otherwise respond with an empty payload (safe default).
             WindowManipulation::QueryClipboard(sel) => {
-                let payload = if allow_clipboard_read {
+                let payload = if flags.allow_clipboard_read {
                     read_clipboard_base64()
                 } else {
                     tracing::debug!(
@@ -461,7 +481,7 @@ pub(super) fn handle_window_manipulation(
                     *bell_active = true;
                     *bell_since = Some(Instant::now());
 
-                    if !window_focused {
+                    if !flags.window_focused {
                         ui.ctx()
                             .send_viewport_cmd(ViewportCommand::RequestUserAttention(
                                 egui::UserAttentionType::Informational,

--- a/freminal/src/gui/terminal/input.rs
+++ b/freminal/src/gui/terminal/input.rs
@@ -166,6 +166,27 @@ pub(super) fn dispatch_binding_action(
     deferred_actions: &mut Vec<KeyAction>,
 ) {
     match action {
+        KeyAction::Paste => {
+            // Read clipboard directly via arboard, bypassing egui-winit's
+            // per-window clipboard (which fails on Wayland child windows).
+            match arboard::Clipboard::new().and_then(|mut cb| cb.get_text()) {
+                Ok(text) if !text.is_empty() => {
+                    let text = text.replace("\r\n", "\n");
+                    let payload = if snap.bracketed_paste == RlBracket::Enabled {
+                        format!("\x1b[200~{text}\x1b[201~")
+                    } else {
+                        text
+                    };
+                    if let Err(e) = input_tx.send(InputEvent::Key(payload.into_bytes())) {
+                        error!("Failed to send paste to PTY consumer: {e}");
+                    }
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    error!("Clipboard read failed: {e}");
+                }
+            }
+        }
         KeyAction::Copy if let Some((start, end)) = view_state.selection.normalised() => {
             if let Err(e) = input_tx.send(InputEvent::ExtractSelection {
                 start_row: start.row,

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -160,8 +160,9 @@ fn paint_bell_flash(ui: &Ui, terminal_rect: Rect, view_state: &mut ViewState) {
     let overlay_color = Color32::from_rgba_premultiplied(alpha, alpha, alpha, alpha);
     ui.painter().rect_filled(terminal_rect, 0.0, overlay_color);
 
-    // Request a repaint so the fade-out animation continues next frame.
-    ui.ctx().request_repaint();
+    // Request a repaint so the fade-out animation continues next frame (~60 fps cap).
+    ui.ctx()
+        .request_repaint_after(std::time::Duration::from_millis(16));
 }
 
 /// Context menu action produced by the right-click popup.
@@ -1378,7 +1379,8 @@ impl FreminalTerminalWidget {
             // Drive the cursor trail animation: request a repaint on the next
             // frame so the interpolation continues smoothly until it completes.
             if cursor_animating {
-                ui.ctx().request_repaint();
+                ui.ctx()
+                    .request_repaint_after(std::time::Duration::from_millis(16));
             }
         }
 


### PR DESCRIPTION
## Summary

- **macOS idle CPU/GPU fix**: Eliminate ~50% CPU / ~50% GPU at steady-state idle caused by unbounded render loop. Clamp `repaint_delay=0` to 16ms, throttle mouse-move repaints while honouring egui hover requests, call `update_control_flow` after `user_event` so PTY-triggered timer repaints work on macOS.
- **Split-pane window resize fix (Windows)**: Suppress `CSI 8;rows;cols t` (`ResizeWindowToLinesAndColumns`) and `ResizeWindow` when the active pane is inside a split. Previously, a split pane's half-width column count was used to resize the entire OS window, shrinking it to half width on horizontal split.

## Changes

- `freminal-windowing/src/event_loop.rs` — Mouse-move throttling, `user_event` control flow fix, `repaint_delay=0` clamping, `repaint_at` clearing
- `freminal-windowing/src/egui_integration.rs` — Remove `request_redraw()` from `run_frame()`
- `freminal/src/gui/terminal/widget.rs` — Use `request_repaint_after(16ms)` for cursor trail/bell flash
- `freminal/src/gui/rendering.rs` — Add `WindowManipFlags` struct with `is_only_pane` guard on resize commands
- `freminal/src/gui/mod.rs` — Pass `WindowManipFlags` with `is_only_pane` from pane tree count