### PR TITLE
fix: clip alt-screen row cells on shrink to prevent stale right-edge artifact

### DIFF
--- a/freminal-buffer/src/buffer.rs
+++ b/freminal-buffer/src/buffer.rs
@@ -875,6 +875,14 @@ impl Buffer {
         if width_changed {
             for (i, row) in self.rows.iter_mut().enumerate() {
                 row.set_max_width(new_width);
+                // On the alternate screen (which skips reflow) a shrink leaves
+                // stale cells beyond the new width in row.cells.  flatten_row
+                // iterates row.cells directly, so those stale cells would leak
+                // into the snapshot and render as a strip of old content at
+                // the right edge of the viewport.  `truncate_cells_to_width`
+                // is a no-op when cells.len() <= new_width, so it is safe to
+                // call unconditionally (including on grow).
+                row.truncate_cells_to_width(new_width);
                 row.dirty = true;
                 self.row_cache[i] = None;
             }

--- a/freminal-buffer/src/row.rs
+++ b/freminal-buffer/src/row.rs
@@ -192,6 +192,36 @@ impl Row {
         self.width = new_width;
     }
 
+    /// Clip the physical cell storage to `new_width` columns.
+    ///
+    /// Used by [`Buffer::set_size`] when shrinking the alternate screen (which
+    /// must not reflow).  Without this, rows retain cells beyond the new width
+    /// and [`Buffer::flatten_row`] emits them — the snapshot then contains
+    /// rows wider than `term_width`, producing a stale strip of glyphs/
+    /// backgrounds at the right edge of the viewport after a shrink.
+    ///
+    /// If a wide-glyph head sits at column `new_width - 1` its continuation
+    /// cell at column `new_width` would be orphaned, so the head is converted
+    /// to a blank using the head's own format tag (preserving background).
+    pub fn truncate_cells_to_width(&mut self, new_width: usize) {
+        if self.cells.len() <= new_width {
+            return;
+        }
+
+        // Guard against splitting a wide glyph at the boundary.  If the cell
+        // at new_width is a continuation, its head sits at new_width - 1 and
+        // must become a blank (keep its format so BCE background survives).
+        if new_width > 0
+            && let Some(boundary_cell) = self.cells.get(new_width)
+            && boundary_cell.is_continuation()
+        {
+            let head_tag = self.cells[new_width - 1].tag().clone();
+            self.cells[new_width - 1] = Cell::blank_with_tag(head_tag);
+        }
+
+        self.cells.truncate(new_width);
+    }
+
     /// How many cells are currently occupied.
     #[must_use]
     pub fn get_row_width(&self) -> usize {
@@ -920,6 +950,64 @@ mod tests {
         assert_eq!(row.max_width(), 80);
         row.set_max_width(40);
         assert_eq!(row.max_width(), 40);
+    }
+
+    // -----------------------------------------------------------------------
+    // truncate_cells_to_width
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn truncate_cells_to_width_drops_cells_beyond_new_width() {
+        let mut row = Row::new(10);
+        let text: Vec<TChar> = b"abcdefghij".iter().map(|b| TChar::Ascii(*b)).collect();
+        row.insert_text(0, &text, &FormatTag::default());
+        assert_eq!(row.get_characters().len(), 10);
+
+        row.set_max_width(5);
+        row.truncate_cells_to_width(5);
+
+        assert_eq!(row.get_characters().len(), 5);
+        assert_eq!(row.max_width(), 5);
+    }
+
+    #[test]
+    fn truncate_cells_to_width_noop_when_already_within_bounds() {
+        let mut row = Row::new(10);
+        let text: Vec<TChar> = b"abc".iter().map(|b| TChar::Ascii(*b)).collect();
+        row.insert_text(0, &text, &FormatTag::default());
+        let before = row.get_characters().len();
+
+        // new_width >= cells.len() — nothing to truncate
+        row.truncate_cells_to_width(20);
+
+        assert_eq!(row.get_characters().len(), before);
+    }
+
+    #[test]
+    fn truncate_cells_to_width_handles_wide_glyph_at_boundary() {
+        // A wide glyph whose head sits at `new_width - 1` would leave an
+        // orphan continuation at `new_width` after truncation.  The head
+        // must be replaced with a blank so the row stays well-formed.
+        let mut row = Row::new(10);
+
+        // Build: 'a' at col 0, wide CJK glyph (head at col 1, continuation at col 2), 'b' at col 3.
+        row.cells_mut_push(Cell::new(TChar::Ascii(b'a'), FormatTag::default()));
+        row.cells_mut_push(Cell::new(TChar::from('中'), FormatTag::default()));
+        row.cells_mut_push(Cell::wide_continuation());
+        row.cells_mut_push(Cell::new(TChar::Ascii(b'b'), FormatTag::default()));
+        for _ in 4..10 {
+            row.cells_mut_push(Cell::blank_with_tag(FormatTag::default()));
+        }
+        assert!(row.get_characters()[1].is_head());
+        assert!(row.get_characters()[2].is_continuation());
+
+        // Truncate to 2 cols: the continuation at col 2 is cut, so the head
+        // at col 1 must become a blank.
+        row.truncate_cells_to_width(2);
+
+        assert_eq!(row.get_characters().len(), 2);
+        assert!(!row.get_characters()[1].is_head());
+        assert!(!row.get_characters()[1].is_continuation());
     }
 
     // -----------------------------------------------------------------------

--- a/freminal-buffer/src/row.rs
+++ b/freminal-buffer/src/row.rs
@@ -220,6 +220,10 @@ impl Row {
         }
 
         self.cells.truncate(new_width);
+        // We mutated `cells` (and possibly cell content at `new_width - 1`),
+        // so invalidate the Buffer's row cache. Matches every other mutator
+        // in this file.
+        self.dirty = true;
     }
 
     /// How many cells are currently occupied.
@@ -1008,6 +1012,36 @@ mod tests {
         assert_eq!(row.get_characters().len(), 2);
         assert!(!row.get_characters()[1].is_head());
         assert!(!row.get_characters()[1].is_continuation());
+    }
+
+    #[test]
+    fn truncate_cells_to_width_marks_row_dirty_when_it_mutates() {
+        let mut row = Row::new(10);
+        let text: Vec<TChar> = b"abcdefghij".iter().map(|b| TChar::Ascii(*b)).collect();
+        row.insert_text(0, &text, &FormatTag::default());
+
+        // Clear the dirty flag so we can assert the mutation re-sets it.
+        row.dirty = false;
+        row.truncate_cells_to_width(5);
+        assert!(
+            row.dirty,
+            "truncate_cells_to_width must mark the row dirty so the Buffer's row cache is invalidated"
+        );
+    }
+
+    #[test]
+    fn truncate_cells_to_width_does_not_mark_row_dirty_on_noop() {
+        let mut row = Row::new(10);
+        let text: Vec<TChar> = b"abc".iter().map(|b| TChar::Ascii(*b)).collect();
+        row.insert_text(0, &text, &FormatTag::default());
+
+        row.dirty = false;
+        // new_width >= cells.len() — no mutation should happen.
+        row.truncate_cells_to_width(20);
+        assert!(
+            !row.dirty,
+            "truncate_cells_to_width must not flip the dirty flag when there is nothing to truncate"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -675,6 +675,15 @@ pub struct PaneRenderCache {
     pub(crate) shaping_cache: crate::gui::shaping::ShapingCache,
     /// Whether the user is currently dragging the scrollbar thumb.
     pub(super) scrollbar_dragging: bool,
+    /// Terminal width (columns) from the last full vertex rebuild.  When this
+    /// changes (window resize), the cell-instance VBOs still contain vertices
+    /// for the old column count; drawing them into a smaller viewport leaves
+    /// stale glyph slivers in the right-edge slop region.  We force a full
+    /// rebuild whenever the dimensions change.
+    pub(super) previous_term_width: usize,
+    /// Terminal height (rows) from the last full vertex rebuild.  See
+    /// `previous_term_width` for rationale.
+    pub(super) previous_term_height: usize,
 }
 
 impl PaneRenderCache {
@@ -703,6 +712,8 @@ impl PaneRenderCache {
             hover_snap_ptr: 0,
             shaping_cache: crate::gui::shaping::ShapingCache::new(),
             scrollbar_dragging: false,
+            previous_term_width: 0,
+            previous_term_height: 0,
         }
     }
 
@@ -1170,8 +1181,17 @@ impl FreminalTerminalWidget {
             let theme_changed = cache
                 .previous_theme
                 .is_none_or(|prev| !std::ptr::eq(prev, snap.theme));
+            // Detect terminal grid resize (cols or rows changed).  The cell
+            // background and foreground instance VBOs hold per-cell vertices
+            // that encode column indices and pixel positions based on the
+            // terminal width at build time; drawing them into a viewport sized
+            // for a different column count leaves stale glyph slivers at the
+            // right edge.  Force a full rebuild on resize.
+            let dims_changed = snap.term_width != cache.previous_term_width
+                || snap.term_height != cache.previous_term_height;
             let content_changed = snap.content_changed
                 || theme_changed
+                || dims_changed
                 || cache
                     .last_rendered_visible
                     .as_ref()
@@ -1474,6 +1494,8 @@ impl FreminalTerminalWidget {
                 cache.previous_text_blink_fast_visible = view_state.text_blink_fast_visible;
                 cache.previous_search_match_count = search_match_count;
                 cache.previous_search_current_match = search_current_match;
+                cache.previous_term_width = snap.term_width;
+                cache.previous_term_height = snap.term_height;
             }
             // If neither path applies (content unchanged, cursor unchanged,
             // selection unchanged, buffers not empty) we simply re-draw the


### PR DESCRIPTION
## Summary

Fixes a right-edge rendering artifact on the alternate screen when the terminal is shrunk
(e.g. opencode and other TUIs showed a ~6-8 px sliver of stale glyphs/backgrounds after resize).

## Root cause

`Buffer::set_size` on the alternate screen updated `row.max_width` but left `row.cells` at
the old length. `flatten_row` iterates `row.cells` directly, so a shrink from e.g. 253→125
cols leaked 253-wide row contents into the snapshot; the renderer then drew quads past the
new viewport edge.

## Changes

- **`Row::truncate_cells_to_width`** — trims `row.cells` to the new width and safely handles
  wide-glyph split at the new boundary (orphaned head cell becomes a blank, preserving its
  format tag so BCE background survives).
- **`Buffer::set_size`** — calls `truncate_cells_to_width` for every row on width change.
  No-op when cells already fit, so safe on grow too.
- **`PaneRenderCache`** — tracks previous term dimensions and forces a full vertex rebuild
  when they change. Cell-instance VBOs encode column indices / pixel positions for the
  terminal width at build time, and drawing them into a differently sized viewport would
  produce a similar class of right-edge artifact.

## Tests

3 new unit tests for `truncate_cells_to_width`:
- basic clipping
- no-op when already within bounds
- wide-glyph boundary handling

## Verification

- `cargo test --all` — all tests pass
- `cargo clippy --all-targets --all-features -- -D warnings` — clean