### PR TITLE
feat: persist window geometry, refine settings UX, enable session restore by default

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -3,3 +3,4 @@ Ot
 ratatui
 iterm
 TE
+ser

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,6 +1568,7 @@ dependencies = [
 name = "freminal-windowing"
 version = "0.7.0"
 dependencies = [
+ "conv2",
  "egui",
  "egui-winit",
  "egui_glow",

--- a/config_example.toml
+++ b/config_example.toml
@@ -229,8 +229,8 @@ limit = 4000
 # When true, Freminal saves the current layout topology on exit and restores
 # it on the next launch (unless --layout is given on the command line).
 # The layout is written to ~/.config/freminal/layouts/last_session.toml.
-# Default: false.
-# restore_last_session = false
+# Default: true.
+# restore_last_session = true
 
 ## ##############################################################################
 # KEY BINDINGS

--- a/freminal-common/src/config.rs
+++ b/freminal-common/src/config.rs
@@ -473,9 +473,10 @@ impl Default for SecurityConfig {
 ///
 /// # When true, save the current layout on exit and restore it on next launch.
 /// # The layout is saved to ~/.config/freminal/layouts/last_session.toml.
-/// restore_last_session = false
+/// # Defaults to true.
+/// restore_last_session = true
 /// ```
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct StartupConfig {
     /// Layout name or path to load on startup.
@@ -493,8 +494,27 @@ pub struct StartupConfig {
     ///
     /// The saved layout is written to
     /// `~/.config/freminal/layouts/last_session.toml`.
-    #[serde(default)]
+    ///
+    /// Defaults to `true` — session restore is the expected behaviour for a
+    /// daily-driver terminal. Users who prefer a clean session each launch
+    /// can opt out by setting this to `false` in `config.toml`.
+    #[serde(default = "default_restore_last_session")]
     pub restore_last_session: bool,
+}
+
+impl Default for StartupConfig {
+    fn default() -> Self {
+        Self {
+            layout: None,
+            restore_last_session: default_restore_last_session(),
+        }
+    }
+}
+
+/// Default value for [`StartupConfig::restore_last_session`]. Kept as a free
+/// function so `#[serde(default = "...")]` can reference it.
+const fn default_restore_last_session() -> bool {
+    true
 }
 
 /// Returns the platform-canonical layout library directory.

--- a/freminal-common/src/lib.rs
+++ b/freminal-common/src/lib.rs
@@ -62,6 +62,8 @@ pub mod terminal_size;
 pub mod terminfo;
 /// Embedded color theme palettes.
 pub mod themes;
+/// Persisted ephemeral UI window geometry (e.g. Settings window).
+pub mod window_state;
 
 #[macro_use]
 extern crate tracing;

--- a/freminal-common/src/window_state.rs
+++ b/freminal-common/src/window_state.rs
@@ -5,17 +5,17 @@
 
 //! Persisted ephemeral window geometry for Freminal UI windows.
 //!
-//! This module tracks the last-known size and position of auxiliary UI
-//! windows (currently just the Settings window) across Freminal sessions.
-//! It is deliberately separate from both:
+//! This module tracks the last-known size and position of Freminal's UI
+//! windows — both the Settings window and each main terminal window —
+//! across sessions.  It is deliberately separate from both:
 //!
 //! - `config.toml` — user-authored preferences that are intentionally edited
 //! - saved layouts — user-authored or auto-saved descriptions of terminal
 //!   workspaces (tabs, panes, CWDs, commands)
 //!
-//! The rationale for a separate file is that settings-window geometry is
-//! purely ephemeral UI state: it is written automatically, never edited by
-//! the user, and should not round-trip through the Settings Modal.
+//! The rationale for a separate file is that window geometry is purely
+//! ephemeral UI state: it is written automatically, never edited by the
+//! user, and should not round-trip through the Settings Modal.
 //!
 //! The file is stored at `~/.config/freminal/window_state.toml` (Linux/BSD),
 //! `~/Library/Application Support/Freminal/window_state.toml` (macOS), or
@@ -31,17 +31,23 @@ use serde::{Deserialize, Serialize};
 
 /// Rectangular window geometry.
 ///
-/// `size` is the inner (client-area) size in physical pixels.  `position` is
-/// the outer (frame) position in screen-space pixels.  Either may be absent.
-/// On platforms like Wayland, `position` cannot be reliably reported by the
-/// compositor and will typically be `None`.
+/// `size` is the inner (client-area) size in *logical* pixels (DPI-independent
+/// units).  `position` is the outer (frame) position in logical pixels in the
+/// display's coordinate space.  Either may be absent.  On platforms like
+/// Wayland, `position` cannot be reliably reported by the compositor and will
+/// typically be `None`.
+///
+/// Logical pixels are used (rather than physical pixels) because both the
+/// winit `LogicalSize`/`LogicalPosition` APIs and Freminal's
+/// `freminal_windowing::WindowConfig` consume geometry in logical units, so
+/// storing logical values avoids a round-trip conversion on save and load.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WindowGeometry {
-    /// Inner size in physical pixels: `[width, height]`.
+    /// Inner size in logical pixels: `[width, height]`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub size: Option<[u32; 2]>,
 
-    /// Outer position in screen pixels: `[x, y]`.
+    /// Outer position in logical pixels: `[x, y]`.
     ///
     /// `None` on platforms where the compositor does not expose window
     /// position (e.g. Wayland).
@@ -92,9 +98,9 @@ pub struct WindowState {
 impl WindowState {
     /// Load the persisted window state from `path`.
     ///
-    /// Returns `Ok(WindowState::default())` if the file does not exist,
-    /// cannot be read, or contains malformed TOML.  An unreadable/invalid
-    /// state file is never fatal — the caller falls back to defaults.
+    /// Returns [`WindowState::default`] if the file does not exist, cannot
+    /// be read, or contains malformed TOML.  An unreadable/invalid state
+    /// file is never fatal — the caller falls back to defaults.
     #[must_use]
     pub fn load_or_default(path: &Path) -> Self {
         let Ok(content) = std::fs::read_to_string(path) else {
@@ -141,9 +147,29 @@ impl WindowState {
         // if the process is killed mid-write.
         let tmp = path.with_extension("toml.tmp");
         std::fs::write(&tmp, toml_str)?;
-        std::fs::rename(&tmp, path)?;
+        replace_file(&tmp, path)?;
         Ok(())
     }
+}
+
+/// Rename `src` onto `dst`, replacing `dst` if it already exists.
+///
+/// On Unix, [`std::fs::rename`] already replaces the destination atomically.
+/// On Windows, [`std::fs::rename`] fails with `ERROR_ALREADY_EXISTS` when the
+/// destination exists, so we must remove the destination first.  The window
+/// between `remove_file` and `rename` is tolerable here: if the process is
+/// killed in that window the next save simply writes a fresh file, and
+/// readers fall back to defaults on any missing/malformed file.
+fn replace_file(src: &Path, dst: &Path) -> std::io::Result<()> {
+    #[cfg(windows)]
+    {
+        match std::fs::remove_file(dst) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
+    }
+    std::fs::rename(src, dst)
 }
 
 /// Returns the platform-canonical path to `window_state.toml`.
@@ -305,6 +331,40 @@ mod tests {
         s.save(&path).expect("save");
         let loaded = WindowState::load_or_default(&path);
         assert_eq!(loaded, s);
+    }
+
+    #[test]
+    fn save_overwrites_existing_file_when_called_twice() {
+        // Regression: on Windows `std::fs::rename` fails if the destination
+        // exists, so the second save would error unless we explicitly
+        // replace the destination.  Exercise the replace-file path by
+        // saving twice to the same location.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("window_state.toml");
+
+        let first = WindowState {
+            settings: WindowGeometry {
+                size: Some([800, 600]),
+                position: None,
+            },
+            main_windows: Vec::new(),
+        };
+        first.save(&path).expect("first save");
+
+        let second = WindowState {
+            settings: WindowGeometry {
+                size: Some([1280, 720]),
+                position: Some([40, 60]),
+            },
+            main_windows: vec![WindowGeometry {
+                size: Some([640, 480]),
+                position: None,
+            }],
+        };
+        second.save(&path).expect("second save must overwrite");
+
+        let loaded = WindowState::load_or_default(&path);
+        assert_eq!(loaded, second);
     }
 
     #[test]

--- a/freminal-common/src/window_state.rs
+++ b/freminal-common/src/window_state.rs
@@ -1,0 +1,316 @@
+// Copyright (C) 2024-2026 Fred Clausen
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Persisted ephemeral window geometry for Freminal UI windows.
+//!
+//! This module tracks the last-known size and position of auxiliary UI
+//! windows (currently just the Settings window) across Freminal sessions.
+//! It is deliberately separate from both:
+//!
+//! - `config.toml` — user-authored preferences that are intentionally edited
+//! - saved layouts — user-authored or auto-saved descriptions of terminal
+//!   workspaces (tabs, panes, CWDs, commands)
+//!
+//! The rationale for a separate file is that settings-window geometry is
+//! purely ephemeral UI state: it is written automatically, never edited by
+//! the user, and should not round-trip through the Settings Modal.
+//!
+//! The file is stored at `~/.config/freminal/window_state.toml` (Linux/BSD),
+//! `~/Library/Application Support/Freminal/window_state.toml` (macOS), or
+//! `%APPDATA%\Freminal\window_state.toml` (Windows).
+//!
+//! All fields are optional.  A missing file, malformed TOML, or missing
+//! field is not an error — the caller simply falls back to defaults.
+
+use std::path::{Path, PathBuf};
+
+use directories::BaseDirs;
+use serde::{Deserialize, Serialize};
+
+/// Rectangular window geometry.
+///
+/// `size` is the inner (client-area) size in physical pixels.  `position` is
+/// the outer (frame) position in screen-space pixels.  Either may be absent.
+/// On platforms like Wayland, `position` cannot be reliably reported by the
+/// compositor and will typically be `None`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowGeometry {
+    /// Inner size in physical pixels: `[width, height]`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<[u32; 2]>,
+
+    /// Outer position in screen pixels: `[x, y]`.
+    ///
+    /// `None` on platforms where the compositor does not expose window
+    /// position (e.g. Wayland).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub position: Option<[i32; 2]>,
+}
+
+impl WindowGeometry {
+    /// Construct a geometry with the given size and position.  Either may
+    /// be `None`.
+    #[must_use]
+    pub const fn new(size: Option<[u32; 2]>, position: Option<[i32; 2]>) -> Self {
+        Self { size, position }
+    }
+
+    /// Returns `true` if both size and position are `None`.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.size.is_none() && self.position.is_none()
+    }
+}
+
+/// Persisted ephemeral state for Freminal UI windows.
+///
+/// All fields are optional and new fields can be added without breaking
+/// older state files.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct WindowState {
+    /// Last known geometry of the Settings window.
+    #[serde(skip_serializing_if = "WindowGeometry::is_empty")]
+    pub settings: WindowGeometry,
+
+    /// Last known geometry of each main terminal window, one entry per
+    /// window that was open when the state was last persisted.
+    ///
+    /// On startup the first entry is used to seed the primary window's
+    /// creation `WindowConfig`.  Additional entries (for multi-window
+    /// sessions) are applied to subsequently-spawned windows.
+    ///
+    /// Applied at window creation time rather than via a post-creation
+    /// viewport command so the compositor sees the requested size in the
+    /// initial surface configure on Wayland.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub main_windows: Vec<WindowGeometry>,
+}
+
+impl WindowState {
+    /// Load the persisted window state from `path`.
+    ///
+    /// Returns `Ok(WindowState::default())` if the file does not exist,
+    /// cannot be read, or contains malformed TOML.  An unreadable/invalid
+    /// state file is never fatal — the caller falls back to defaults.
+    #[must_use]
+    pub fn load_or_default(path: &Path) -> Self {
+        let Ok(content) = std::fs::read_to_string(path) else {
+            return Self::default();
+        };
+        toml::from_str(&content).unwrap_or_else(|e| {
+            tracing::warn!(
+                "window_state: failed to parse {}: {e}; using defaults",
+                path.display()
+            );
+            Self::default()
+        })
+    }
+
+    /// Serialize to a pretty-printed TOML string.
+    ///
+    /// # Errors
+    ///
+    /// Returns a TOML serialization error if encoding fails.  This should
+    /// be unreachable for a well-formed `WindowState` — all fields are
+    /// plain integers wrapped in `Option`.
+    pub fn to_toml_string(&self) -> Result<String, toml::ser::Error> {
+        toml::to_string_pretty(self)
+    }
+
+    /// Atomically persist the state to `path`.
+    ///
+    /// The parent directory is created if it does not exist.  Writes are
+    /// performed via a temporary file rename so a crash mid-write cannot
+    /// leave a truncated file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `io::Error` if the parent directory cannot be created,
+    /// the temp file cannot be written, or the rename fails.  Returns a
+    /// serialization error wrapped in `io::Error` if TOML encoding fails.
+    pub fn save(&self, path: &Path) -> std::io::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let toml_str = self.to_toml_string().map_err(std::io::Error::other)?;
+
+        // Atomic write: temp file + rename.  Keeps the file readable even
+        // if the process is killed mid-write.
+        let tmp = path.with_extension("toml.tmp");
+        std::fs::write(&tmp, toml_str)?;
+        std::fs::rename(&tmp, path)?;
+        Ok(())
+    }
+}
+
+/// Returns the platform-canonical path to `window_state.toml`.
+///
+/// | Platform  | Path                                                     |
+/// |-----------|----------------------------------------------------------|
+/// | Linux/BSD | `$XDG_CONFIG_HOME/freminal/window_state.toml`            |
+/// | macOS     | `~/Library/Application Support/Freminal/window_state.toml` |
+/// | Windows   | `%APPDATA%\Freminal\window_state.toml`                   |
+///
+/// Returns `None` if the base directories cannot be determined.
+#[must_use]
+pub fn window_state_path() -> Option<PathBuf> {
+    let base = BaseDirs::new()?;
+
+    #[cfg(target_os = "macos")]
+    {
+        return Some(base.data_dir().join("Freminal").join("window_state.toml"));
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        return Some(base.data_dir().join("Freminal").join("window_state.toml"));
+    }
+
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "openbsd",
+        target_os = "netbsd"
+    ))]
+    {
+        return Some(base.config_dir().join("freminal").join("window_state.toml"));
+    }
+
+    #[allow(unreachable_code)]
+    None
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_state_serializes_to_empty_table() {
+        let s = WindowState::default();
+        let toml_str = s.to_toml_string().expect("serialize");
+        // All fields are skipped when empty, so the output is an empty document.
+        assert!(toml_str.trim().is_empty() || toml_str.trim() == "");
+    }
+
+    #[test]
+    fn roundtrip_preserves_geometry() {
+        let s = WindowState {
+            settings: WindowGeometry {
+                size: Some([640, 480]),
+                position: Some([100, 200]),
+            },
+            main_windows: Vec::new(),
+        };
+        let toml_str = s.to_toml_string().expect("serialize");
+        let parsed: WindowState = toml::from_str(&toml_str).expect("parse");
+        assert_eq!(parsed, s);
+    }
+
+    #[test]
+    fn roundtrip_with_partial_geometry() {
+        // Size only (position unavailable, e.g. Wayland).
+        let s = WindowState {
+            settings: WindowGeometry {
+                size: Some([800, 600]),
+                position: None,
+            },
+            main_windows: Vec::new(),
+        };
+        let toml_str = s.to_toml_string().expect("serialize");
+        let parsed: WindowState = toml::from_str(&toml_str).expect("parse");
+        assert_eq!(parsed, s);
+    }
+
+    #[test]
+    fn roundtrip_preserves_main_windows() {
+        let s = WindowState {
+            settings: WindowGeometry::default(),
+            main_windows: vec![
+                WindowGeometry {
+                    size: Some([1280, 800]),
+                    position: Some([0, 0]),
+                },
+                WindowGeometry {
+                    size: Some([1024, 768]),
+                    position: None,
+                },
+            ],
+        };
+        let toml_str = s.to_toml_string().expect("serialize");
+        let parsed: WindowState = toml::from_str(&toml_str).expect("parse");
+        assert_eq!(parsed, s);
+    }
+
+    #[test]
+    fn empty_main_windows_is_skipped() {
+        let s = WindowState {
+            settings: WindowGeometry {
+                size: Some([400, 300]),
+                position: None,
+            },
+            main_windows: Vec::new(),
+        };
+        let toml_str = s.to_toml_string().expect("serialize");
+        // main_windows = [] should be omitted from the output.
+        assert!(!toml_str.contains("main_windows"));
+    }
+
+    #[test]
+    fn parses_file_missing_optional_fields() {
+        // Minimal / empty file should parse to default.
+        let parsed: WindowState = toml::from_str("").expect("parse empty");
+        assert_eq!(parsed, WindowState::default());
+
+        // File with only the table header and no fields.
+        let parsed: WindowState = toml::from_str("[settings]\n").expect("parse header");
+        assert_eq!(parsed, WindowState::default());
+    }
+
+    #[test]
+    fn malformed_toml_falls_back_to_default() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("window_state.toml");
+        std::fs::write(&path, "this is not valid toml = = =").expect("write");
+        let loaded = WindowState::load_or_default(&path);
+        assert_eq!(loaded, WindowState::default());
+    }
+
+    #[test]
+    fn missing_file_returns_default() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("does_not_exist.toml");
+        let loaded = WindowState::load_or_default(&path);
+        assert_eq!(loaded, WindowState::default());
+    }
+
+    #[test]
+    fn save_then_load_roundtrip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("subdir").join("window_state.toml");
+        let s = WindowState {
+            settings: WindowGeometry {
+                size: Some([1024, 768]),
+                position: Some([50, 75]),
+            },
+            main_windows: vec![WindowGeometry {
+                size: Some([1920, 1080]),
+                position: Some([10, 20]),
+            }],
+        };
+        s.save(&path).expect("save");
+        let loaded = WindowState::load_or_default(&path);
+        assert_eq!(loaded, s);
+    }
+
+    #[test]
+    fn is_empty_reflects_state() {
+        assert!(WindowGeometry::default().is_empty());
+        assert!(!WindowGeometry::new(Some([1, 1]), None).is_empty());
+        assert!(!WindowGeometry::new(None, Some([0, 0])).is_empty());
+    }
+}

--- a/freminal-windowing/Cargo.toml
+++ b/freminal-windowing/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+conv2.workspace = true
 egui.workspace = true
 egui-winit.workspace = true
 egui_glow.workspace = true

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -14,7 +14,35 @@ use winit::window::{Window, WindowAttributes};
 use crate::egui_integration::EguiState;
 use crate::error::Error;
 use crate::gl_context::GlState;
-use crate::{App, UserEvent, WindowConfig, WindowHandle, WindowId, WindowOp};
+use crate::{App, UserEvent, WindowConfig, WindowGeometry, WindowHandle, WindowId, WindowOp};
+
+use conv2::{ApproxFrom, RoundToZero};
+
+/// Convert a rounded `f64` logical coordinate to `u32`, clamping negatives
+/// to 0 and saturating on overflow.  Used for logical window dimensions
+/// which should never realistically exceed `u32::MAX`.
+fn logical_dim_to_u32(v: f64) -> u32 {
+    if !v.is_finite() || v <= 0.0 {
+        return 0;
+    }
+    <u32 as ApproxFrom<f64, RoundToZero>>::approx_from(v.round()).unwrap_or(u32::MAX)
+}
+
+/// Convert a rounded `f64` logical coordinate to `i32`, saturating on
+/// overflow in either direction.  Used for logical window positions which
+/// can be negative on multi-monitor setups.
+fn logical_coord_to_i32(v: f64) -> i32 {
+    if !v.is_finite() {
+        return 0;
+    }
+    <i32 as ApproxFrom<f64, RoundToZero>>::approx_from(v.round()).unwrap_or_else(|_| {
+        if v.is_sign_negative() {
+            i32::MIN
+        } else {
+            i32::MAX
+        }
+    })
+}
 
 /// Per-window state.
 struct WindowState {
@@ -33,6 +61,11 @@ struct Handler<A: App> {
     proxy: EventLoopProxy<UserEvent>,
     /// Scratch buffer for pending `WindowOp`s queued by `WindowHandle`.
     pending_ops: RefCell<Vec<WindowOp>>,
+    /// Last-known geometry for each window, updated on Resized / Moved.
+    ///
+    /// Shared with `WindowHandle` via `&RefCell` so the `App` can query
+    /// live geometry during its `update()` callback.
+    geometry: RefCell<HashMap<WindowId, WindowGeometry>>,
 }
 
 impl<A: App> Handler<A> {
@@ -108,6 +141,30 @@ impl<A: App> Handler<A> {
 
         self.windows.insert(winit_id, state);
 
+        // Seed geometry from the freshly-created window so the app can query
+        // it even before the first Resized / Moved event arrives.  We store
+        // geometry in logical pixels for consistency with `WindowConfig`.
+        let scale = self.windows[&winit_id].window.scale_factor();
+        let logical_size: winit::dpi::LogicalSize<f64> = phys.to_logical(scale);
+        let outer_pos_logical = self.windows[&winit_id]
+            .window
+            .outer_position()
+            .ok()
+            .map(|p| {
+                let lp: winit::dpi::LogicalPosition<f64> = p.to_logical(scale);
+                (logical_coord_to_i32(lp.x), logical_coord_to_i32(lp.y))
+            });
+        self.geometry.borrow_mut().insert(
+            window_id,
+            WindowGeometry {
+                size: Some((
+                    logical_dim_to_u32(logical_size.width),
+                    logical_dim_to_u32(logical_size.height),
+                )),
+                position: outer_pos_logical,
+            },
+        );
+
         // Track the first window as the primary clipboard source.
 
         // Request an immediate redraw so the first frame renders as soon as
@@ -119,6 +176,7 @@ impl<A: App> Handler<A> {
         let handle = WindowHandle {
             proxy: &self.proxy,
             pending_ops: &self.pending_ops,
+            geometry: &self.geometry,
         };
         self.app.on_window_created(
             window_id,
@@ -139,6 +197,7 @@ impl<A: App> Handler<A> {
             drop(state.egui);
             drop(state.gl);
             drop(state.window);
+            self.geometry.borrow_mut().remove(&WindowId(winit_id));
             debug!("Window closed: {winit_id:?}");
         }
     }
@@ -330,6 +389,11 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                 }
             }
             WindowEvent::Resized(size) => {
+                let scale = self
+                    .windows
+                    .get(&winit_id)
+                    .map(|s| s.window.scale_factor())
+                    .unwrap_or(1.0);
                 if let Some(state) = self.windows.get_mut(&winit_id)
                     && let (Some(w), Some(h)) =
                         (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
@@ -342,6 +406,28 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                     state.repaint_at = Some(Instant::now());
                     state.window.request_redraw();
                 }
+                // Track geometry in logical pixels (matches WindowConfig).
+                let logical: winit::dpi::LogicalSize<f64> = size.to_logical(scale);
+                let mut geom = self.geometry.borrow_mut();
+                let entry = geom.entry(WindowId(winit_id)).or_default();
+                entry.size = Some((
+                    logical_dim_to_u32(logical.width),
+                    logical_dim_to_u32(logical.height),
+                ));
+            }
+            WindowEvent::Moved(pos) => {
+                let scale = self
+                    .windows
+                    .get(&winit_id)
+                    .map(|s| s.window.scale_factor())
+                    .unwrap_or(1.0);
+                let logical: winit::dpi::LogicalPosition<f64> = pos.to_logical(scale);
+                let mut geom = self.geometry.borrow_mut();
+                let entry = geom.entry(WindowId(winit_id)).or_default();
+                entry.position = Some((
+                    logical_coord_to_i32(logical.x),
+                    logical_coord_to_i32(logical.y),
+                ));
             }
             WindowEvent::RedrawRequested => {
                 // Split borrows by destructuring
@@ -350,6 +436,7 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                     windows,
                     proxy,
                     pending_ops,
+                    geometry,
                     ..
                 } = self;
                 let Some(state) = windows.get_mut(&winit_id) else {
@@ -358,7 +445,11 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                 let window_id = WindowId(winit_id);
                 let clear_color = app.clear_color(window_id);
 
-                let handle = WindowHandle { proxy, pending_ops };
+                let handle = WindowHandle {
+                    proxy,
+                    pending_ops,
+                    geometry,
+                };
 
                 // Ensure this window's GL context is current before rendering.
                 if let Err(e) = state.gl.make_current() {
@@ -403,9 +494,18 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                 self.process_pending_ops(event_loop);
 
                 if should_close {
-                    self.close_window(winit_id);
-                    if self.windows.is_empty() {
-                        event_loop.exit();
+                    // Route through `on_close_requested` so the app can run
+                    // its normal shutdown/save logic.  `ViewportCommand::Close`
+                    // (e.g. from a PTY exit triggering a last-pane close) used
+                    // to bypass this hook, which meant `auto_save_session`
+                    // and other cleanup never ran when the terminal exited
+                    // itself.
+                    let window_id = WindowId(winit_id);
+                    if self.app.on_close_requested(window_id) {
+                        self.close_window(winit_id);
+                        if self.windows.is_empty() {
+                            event_loop.exit();
+                        }
                     }
                 }
             }
@@ -552,6 +652,7 @@ pub fn run(config: WindowConfig, app: impl App + 'static) -> Result<(), Error> {
         windows: HashMap::new(),
         proxy,
         pending_ops: RefCell::new(Vec::new()),
+        geometry: RefCell::new(HashMap::new()),
     };
 
     event_loop

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -18,14 +18,19 @@ use crate::{App, UserEvent, WindowConfig, WindowGeometry, WindowHandle, WindowId
 
 use conv2::{ApproxFrom, RoundToZero};
 
-/// Convert a rounded `f64` logical coordinate to `u32`, clamping negatives
-/// to 0 and saturating on overflow.  Used for logical window dimensions
-/// which should never realistically exceed `u32::MAX`.
+/// Convert an `f64` logical dimension to `u32`, clamping non-positive and
+/// non-finite values to 0 and saturating on overflow.  Used for logical
+/// window sizes, which should never realistically exceed `u32::MAX`.
+///
+/// Positive sub-pixel values (e.g. `0.25`) are rounded *up* so that any
+/// strictly-positive dimension yields at least `1`.  `round()` would map
+/// such values to `0`, turning a "tiny but non-empty" window into a
+/// zero-size window on round-trip through persisted state.
 fn logical_dim_to_u32(v: f64) -> u32 {
     if !v.is_finite() || v <= 0.0 {
         return 0;
     }
-    <u32 as ApproxFrom<f64, RoundToZero>>::approx_from(v.round()).unwrap_or(u32::MAX)
+    <u32 as ApproxFrom<f64, RoundToZero>>::approx_from(v.ceil()).unwrap_or(u32::MAX)
 }
 
 /// Convert a rounded `f64` logical coordinate to `i32`, saturating on
@@ -660,4 +665,48 @@ pub fn run(config: WindowConfig, app: impl App + 'static) -> Result<(), Error> {
         .map_err(|e| Error::EventLoopCreation(format!("event loop exited with error: {e}")))?;
 
     Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::{logical_coord_to_i32, logical_dim_to_u32};
+
+    #[test]
+    fn logical_dim_to_u32_clamps_non_positive_and_non_finite() {
+        assert_eq!(logical_dim_to_u32(0.0), 0);
+        assert_eq!(logical_dim_to_u32(-1.0), 0);
+        assert_eq!(logical_dim_to_u32(f64::NAN), 0);
+        assert_eq!(logical_dim_to_u32(f64::NEG_INFINITY), 0);
+    }
+
+    #[test]
+    fn logical_dim_to_u32_ceils_positive_subpixel_to_one() {
+        // Regression: `round()` maps 0.25 to 0, which would persist a
+        // zero-size window.  `ceil()` guarantees any strictly positive
+        // dimension becomes at least 1.
+        assert_eq!(logical_dim_to_u32(0.25), 1);
+        assert_eq!(logical_dim_to_u32(0.5), 1);
+        assert_eq!(logical_dim_to_u32(0.99), 1);
+        assert_eq!(logical_dim_to_u32(1.0), 1);
+        assert_eq!(logical_dim_to_u32(1.01), 2);
+        assert_eq!(logical_dim_to_u32(1280.0), 1280);
+    }
+
+    #[test]
+    fn logical_dim_to_u32_saturates_on_overflow() {
+        assert_eq!(logical_dim_to_u32(f64::INFINITY), 0);
+        // A value well beyond u32::MAX saturates rather than panicking.
+        assert_eq!(logical_dim_to_u32(1.0e20), u32::MAX);
+    }
+
+    #[test]
+    fn logical_coord_to_i32_handles_edge_cases() {
+        assert_eq!(logical_coord_to_i32(0.0), 0);
+        assert_eq!(logical_coord_to_i32(f64::NAN), 0);
+        assert_eq!(logical_coord_to_i32(100.4), 100);
+        assert_eq!(logical_coord_to_i32(-100.4), -100);
+        assert_eq!(logical_coord_to_i32(1.0e20), i32::MAX);
+        assert_eq!(logical_coord_to_i32(-1.0e20), i32::MIN);
+    }
 }

--- a/freminal-windowing/src/lib.rs
+++ b/freminal-windowing/src/lib.rs
@@ -81,6 +81,24 @@ pub trait App {
     fn raw_input_hook(&mut self, _window_id: WindowId, _raw_input: &mut egui::RawInput) {}
 }
 
+/// Last-known geometry for a window, tracked by the windowing layer.
+///
+/// All values are in **logical pixels** to match the units used by
+/// [`WindowConfig::inner_size`] and [`WindowConfig::position`] when
+/// creating a window.  This lets the app roundtrip geometry across
+/// sessions without having to know the current scale factor.
+///
+/// On Wayland, `position` is typically `None` because the compositor does
+/// not expose window position.  Either field may be `None` on a freshly
+/// created window that has not yet received its first configure event.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct WindowGeometry {
+    /// Inner (client-area) size in logical pixels: `(width, height)`.
+    pub size: Option<(u32, u32)>,
+    /// Outer (frame) position in logical pixels: `(x, y)`.
+    pub position: Option<(i32, i32)>,
+}
+
 /// Handle for requesting window operations from the [`App`].
 ///
 /// Passed by reference during event loop callbacks. Operations are queued
@@ -88,6 +106,7 @@ pub trait App {
 pub struct WindowHandle<'a> {
     proxy: &'a winit::event_loop::EventLoopProxy<UserEvent>,
     pending_ops: &'a std::cell::RefCell<Vec<WindowOp>>,
+    geometry: &'a std::cell::RefCell<std::collections::HashMap<WindowId, WindowGeometry>>,
 }
 
 impl<'a> WindowHandle<'a> {
@@ -152,6 +171,21 @@ impl<'a> WindowHandle<'a> {
         RepaintProxy {
             proxy: self.proxy.clone(),
         }
+    }
+
+    /// Query the last-known geometry for a window.
+    ///
+    /// Returns `None` if the window does not exist.  Either field inside the
+    /// returned `WindowGeometry` may still be `None` if the compositor has
+    /// not reported that value (e.g. `position` on Wayland).
+    ///
+    /// Geometry is tracked from winit `Resized` / `Moved` events and is
+    /// always up to date with the window's current state at the time of
+    /// this call.  This is more reliable than `ctx.input().viewport()`,
+    /// which only populates `inner_rect` / `outer_rect` after the first
+    /// such event arrives for the target window's egui context.
+    pub fn window_geometry(&self, id: WindowId) -> Option<WindowGeometry> {
+        self.geometry.borrow().get(&id).copied()
     }
 }
 

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -180,10 +180,13 @@ struct FreminalGui {
     /// Set to `true` when the existing settings window should be focused.
     pending_focus_settings: bool,
 
-    /// Persisted ephemeral UI window state (currently just the Settings
-    /// window geometry).  Loaded from `window_state.toml` at startup,
-    /// updated each frame while the settings window is rendering, and
-    /// written back to disk when the settings window closes.
+    /// Persisted ephemeral UI window geometry for the Settings window
+    /// and each main terminal window.  Loaded from `window_state.toml`
+    /// at startup: the settings entry is consulted when the settings
+    /// window opens, and `main_windows` is consulted at app launch to
+    /// seed the initial window's `WindowConfig`.  Updated continuously
+    /// while windows are moving/resizing and persisted on window close
+    /// so the next launch restores the user's layout.
     window_state: freminal_common::window_state::WindowState,
 
     /// Optional recording handle for FREC v2 session recording.
@@ -1501,8 +1504,10 @@ impl FreminalGui {
 
     /// Save the current session to `last_session.toml` in the layout library.
     ///
-    /// Called automatically when the last terminal window closes and
-    /// `restore_last_session` is enabled.  Failures are logged but not fatal.
+    /// Called automatically when the last terminal window closes.  Runs
+    /// regardless of `restore_last_session` so the on-disk session stays
+    /// fresh; the flag only controls whether the saved session is
+    /// reapplied on next launch.  Failures are logged but not fatal.
     fn auto_save_session(&self) {
         let Some(path) = Self::last_session_path() else {
             error!("auto_save_session: cannot determine layout library path");
@@ -1892,15 +1897,23 @@ impl freminal_windowing::App for FreminalGui {
 
         // Auto-save session before the last terminal window is removed.
         // We check *before* remove so we still have access to the window's tabs.
+        //
+        // Saving is independent of `restore_last_session` — the flag only
+        // controls whether the saved session is *applied* on next launch.
+        // Always writing keeps `_last_session.toml` fresh so users can
+        // toggle the flag on at any time and get their real last session
+        // back, rather than whatever stale state happened to be on disk
+        // when they last had the flag enabled.
+        //
+        // We still skip saving when the user launched with an ad-hoc
+        // command (`freminal -- vim foo`): those panes are running a
+        // one-shot program and are not meaningfully restorable.
         let remaining_terminal_windows = self
             .windows
             .keys()
             .filter(|&&wid| Some(wid) != self.settings_window_id)
             .count();
-        if remaining_terminal_windows == 1
-            && self.config.startup.restore_last_session
-            && self.args.command.is_empty()
-        {
+        if remaining_terminal_windows == 1 && self.args.command.is_empty() {
             self.auto_save_session();
         }
 

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -180,6 +180,12 @@ struct FreminalGui {
     /// Set to `true` when the existing settings window should be focused.
     pending_focus_settings: bool,
 
+    /// Persisted ephemeral UI window state (currently just the Settings
+    /// window geometry).  Loaded from `window_state.toml` at startup,
+    /// updated each frame while the settings window is rendering, and
+    /// written back to disk when the settings window closes.
+    window_state: freminal_common::window_state::WindowState,
+
     /// Optional recording handle for FREC v2 session recording.
     /// When `Some`, topology and window events are emitted.
     recording_handle: Option<freminal_terminal_emulator::recording::RecordingHandle>,
@@ -288,6 +294,10 @@ impl FreminalGui {
             settings_window_id: None,
             pending_settings_window: false,
             pending_focus_settings: false,
+            window_state: freminal_common::window_state::window_state_path()
+                .as_deref()
+                .map(freminal_common::window_state::WindowState::load_or_default)
+                .unwrap_or_default(),
             recording_handle,
             recording_window_ids: HashMap::new(),
             next_recording_window_id: 0,
@@ -1429,6 +1439,66 @@ impl FreminalGui {
         freminal_common::config::layout_library_dir().map(|d| d.join("last_session.toml"))
     }
 
+    /// Write the current ephemeral UI window state (currently just the
+    /// Settings window geometry) to `window_state.toml`.  Failures are
+    /// logged but never fatal — the worst case is that the settings window
+    /// reopens at its default size and position next time.
+    fn persist_window_state(&self) {
+        let Some(path) = freminal_common::window_state::window_state_path() else {
+            tracing::debug!("persist_window_state: cannot determine window state path");
+            return;
+        };
+        if let Err(e) = self.window_state.save(&path) {
+            tracing::warn!(
+                "persist_window_state: failed to save {}: {e}",
+                path.display()
+            );
+        }
+    }
+
+    /// Populate `self.window_state.main_windows` from the currently-open
+    /// terminal windows' tracked geometry (`last_known_size` /
+    /// `last_known_position`).  The settings window is excluded.
+    ///
+    /// If `prioritize` is `Some(id)`, that window's geometry is placed
+    /// first so it seeds the primary window on the next launch.  Used
+    /// when a window is closing — the closing window is the one the user
+    /// most recently interacted with, so its geometry is the best seed.
+    ///
+    /// Windows with no tracked geometry (e.g. freshly created, never
+    /// resized on a platform where seeding is unavailable) are skipped.
+    fn snapshot_main_window_geometry(&mut self, prioritize: Option<WindowId>) {
+        let settings_id = self.settings_window_id;
+        let terminal_entry = |wid: WindowId, win: &window::PerWindowState| {
+            if Some(wid) == settings_id {
+                return None;
+            }
+            let size = win.last_known_size;
+            let position = win.last_known_position;
+            if size.is_none() && position.is_none() {
+                return None;
+            }
+            Some(freminal_common::window_state::WindowGeometry { size, position })
+        };
+
+        let mut main_windows = Vec::with_capacity(self.windows.len());
+        if let Some(first_id) = prioritize
+            && let Some(win) = self.windows.get(&first_id)
+            && let Some(geom) = terminal_entry(first_id, win)
+        {
+            main_windows.push(geom);
+        }
+        for (wid, win) in &self.windows {
+            if prioritize == Some(*wid) {
+                continue;
+            }
+            if let Some(geom) = terminal_entry(*wid, win) {
+                main_windows.push(geom);
+            }
+        }
+        self.window_state.main_windows = main_windows;
+    }
+
     /// Save the current session to `last_session.toml` in the layout library.
     ///
     /// Called automatically when the last terminal window closes and
@@ -1811,6 +1881,7 @@ impl freminal_windowing::App for FreminalGui {
             self.settings_modal.is_open = false;
             self.settings_window_id = None;
             self.settings_owner = None;
+            self.persist_window_state();
             return true;
         }
         // If this window owns the settings modal, close it.
@@ -1832,6 +1903,14 @@ impl freminal_windowing::App for FreminalGui {
         {
             self.auto_save_session();
         }
+
+        // Capture geometry of every still-open terminal window (including
+        // the one being closed) into `window_state.main_windows`, with the
+        // closing window first so it seeds the primary window on next
+        // launch.  Persist unconditionally — this is independent of
+        // `restore_last_session`.
+        self.snapshot_main_window_geometry(Some(window_id));
+        self.persist_window_state();
 
         self.windows.remove(&window_id);
 
@@ -1903,8 +1982,26 @@ impl freminal_windowing::App for FreminalGui {
             let settings_action = self.settings_modal.show_standalone(ctx, os_dark);
             self.handle_settings_action(&settings_action, handle, window_id);
 
+            // Track the settings window's current geometry so we can restore
+            // it the next time it is opened.  We query the windowing layer
+            // directly rather than `ctx.input().viewport()` because the
+            // latter only populates `inner_rect` / `outer_rect` after a
+            // Resized / Moved event reaches the window's egui context, which
+            // is not guaranteed on the first frame of a freshly created
+            // window on every platform.  The windowing layer always tracks
+            // live geometry from winit events + direct window queries.
+            if let Some(geom) = handle.window_geometry(window_id) {
+                if let Some(size) = geom.size {
+                    self.window_state.settings.size = Some(<[u32; 2]>::from(size));
+                }
+                if let Some(pos) = geom.position {
+                    self.window_state.settings.position = Some(<[i32; 2]>::from(pos));
+                }
+            }
+
             // If the modal closed (Cancel or Apply), close the OS window.
             if !self.settings_modal.is_open {
+                self.persist_window_state();
                 self.settings_window_id = None;
                 self.settings_owner = None;
                 handle.close_window(window_id);
@@ -1921,10 +2018,17 @@ impl freminal_windowing::App for FreminalGui {
         }
         if self.pending_settings_window && self.settings_window_id.is_none() {
             // Don't clear pending_settings_window here — cleared in on_window_created.
+            // Seed inner_size and position from the last-known geometry so the
+            // window reopens where the user left it (both within a session and
+            // across sessions via window_state.toml).  Falls back to the 600x500
+            // default on first open / missing state.
+            let settings_geom = self.window_state.settings;
+            let inner_size = settings_geom.size.map_or((600_u32, 500_u32), <_>::from);
+            let position = settings_geom.position.map(<_>::from);
             handle.create_window(freminal_windowing::WindowConfig {
                 title: "Freminal Settings".to_owned(),
-                inner_size: Some((600, 500)),
-                position: None,
+                inner_size: Some(inner_size),
+                position,
                 transparent: false,
                 icon: self.icon.clone(),
                 app_id: Some("freminal-settings".into()),
@@ -1962,24 +2066,16 @@ impl freminal_windowing::App for FreminalGui {
         }
 
         // ── Track last known window geometry (for save_layout) ───────────────
-        ctx.input(|i| {
-            use conv2::ConvUtil as _;
-            let vp = i.viewport();
-            if let Some(inner) = vp.inner_rect {
-                let w = inner.width().approx_as::<u32>().ok();
-                let h = inner.height().approx_as::<u32>().ok();
-                if let (Some(w), Some(h)) = (w, h) {
-                    win.last_known_size = Some([w, h]);
-                }
+        // Query the windowing layer directly.  See the settings-window branch
+        // above for why `ctx.input().viewport()` is not reliable here.
+        if let Some(geom) = handle.window_geometry(window_id) {
+            if let Some(size) = geom.size {
+                win.last_known_size = Some(<[u32; 2]>::from(size));
             }
-            if let Some(outer) = vp.outer_rect {
-                let x = outer.min.x.approx_as::<i32>().ok();
-                let y = outer.min.y.approx_as::<i32>().ok();
-                if let (Some(x), Some(y)) = (x, y) {
-                    win.last_known_position = Some([x, y]);
-                }
+            if let Some(pos) = geom.position {
+                win.last_known_position = Some(<[i32; 2]>::from(pos));
             }
-        });
+        }
 
         // ── Deferred egui font update from standalone settings window ────────
         win.terminal_widget
@@ -2973,10 +3069,26 @@ pub fn run(
         height,
     };
 
+    // Seed the initial window's geometry from window_state.toml if
+    // available.  Setting this at creation time (rather than via a later
+    // viewport command) is essential on Wayland: xdg-shell ignores
+    // resize requests that arrive after the initial surface configure in
+    // many compositors.
+    let (initial_size, initial_position) = freminal_common::window_state::window_state_path()
+        .as_deref()
+        .map(freminal_common::window_state::WindowState::load_or_default)
+        .and_then(|state| state.main_windows.into_iter().next())
+        .map_or((None, None), |geom| {
+            (
+                geom.size.map(<[u32; 2]>::into),
+                geom.position.map(<[i32; 2]>::into),
+            )
+        });
+
     let window_config = freminal_windowing::WindowConfig {
         title: "Freminal".to_owned(),
-        inner_size: None,
-        position: None,
+        inner_size: initial_size,
+        position: initial_position,
         transparent: true,
         icon: Some(icon.clone()),
         app_id: Some("freminal".into()),

--- a/freminal/src/gui/settings.rs
+++ b/freminal/src/gui/settings.rs
@@ -332,16 +332,15 @@ impl SettingsModal {
             }
 
             // --- Tab bar ---
-            ui.horizontal(|ui| {
-                for tab in SettingsTab::ALL {
-                    ui.selectable_value(&mut self.active_tab, tab, tab.label());
-                }
-            });
-            ui.separator();
+            self.show_tab_bar(ui, "settings_tab_bar_standalone");
 
             // --- Tab content ---
-            egui::ScrollArea::vertical()
+            // Both axes so horizontally-overflowing content (long labels,
+            // wide swatches) is reachable. Scrollbars only appear when
+            // content actually overflows to avoid visual noise.
+            egui::ScrollArea::both()
                 .auto_shrink([false; 2])
+                .scroll_bar_visibility(egui::scroll_area::ScrollBarVisibility::VisibleWhenNeeded)
                 .show(ui, |ui| {
                     if is_read_only {
                         ui.disable();
@@ -428,17 +427,20 @@ impl SettingsModal {
                 }
 
                 // --- Tab bar ---
-                ui.horizontal(|ui| {
-                    for tab in SettingsTab::ALL {
-                        ui.selectable_value(&mut self.active_tab, tab, tab.label());
-                    }
-                });
-                ui.separator();
+                self.show_tab_bar(ui, "settings_tab_bar_modal");
 
                 // --- Tab content ---
-                egui::ScrollArea::vertical()
+                // Both axes so overflowed content is reachable without
+                // enlarging the modal. `max_height(300.0)` keeps the modal
+                // compact regardless of the selected tab's content size
+                // (keybindings, themes, etc.). Scrollbars only appear when
+                // content actually overflows.
+                egui::ScrollArea::both()
                     .auto_shrink([false; 2])
                     .max_height(300.0)
+                    .scroll_bar_visibility(
+                        egui::scroll_area::ScrollBarVisibility::VisibleWhenNeeded,
+                    )
                     .show(ui, |ui| {
                         // In read-only mode, disable all interactive widgets
                         // so the user can browse but not edit.
@@ -551,6 +553,38 @@ impl SettingsModal {
     // -------------------------------------------------------------------------
     //  Tab implementations
     // -------------------------------------------------------------------------
+
+    /// Render the horizontally-scrolling tab selector bar. Shared between the
+    /// modal (`show`) and the standalone (`show_standalone`) renderers so the
+    /// scroll affordance behaviour stays consistent. `id_salt` must differ
+    /// between call sites to avoid egui id clashes when both renderers exist
+    /// in the same frame.
+    fn show_tab_bar(&mut self, ui: &mut Ui, id_salt: &'static str) {
+        // Use a non-floating (solid) scrollbar style scoped to this
+        // ScrollArea so the horizontal scrollbar gets its own strip below
+        // the tab buttons instead of floating over them and expanding on
+        // hover to cover nearly the full nav-area height. Also shrink the
+        // bar width since a tab bar is a small UI element.
+        ui.scope(|ui| {
+            let scroll = &mut ui.style_mut().spacing.scroll;
+            scroll.floating = false;
+            scroll.bar_width = 6.0;
+            scroll.bar_inner_margin = 2.0;
+            scroll.bar_outer_margin = 0.0;
+
+            egui::ScrollArea::horizontal()
+                .id_salt(id_salt)
+                .scroll_bar_visibility(egui::scroll_area::ScrollBarVisibility::VisibleWhenNeeded)
+                .show(ui, |ui| {
+                    ui.horizontal(|ui| {
+                        for tab in SettingsTab::ALL {
+                            ui.selectable_value(&mut self.active_tab, tab, tab.label());
+                        }
+                    });
+                });
+        });
+        ui.separator();
+    }
 
     const DEFAULT_LABEL: &str = "Default (MesloLGS Nerd Font)";
 


### PR DESCRIPTION
## Summary

Three related improvements bundled together, all on the windowing / settings UX surface:

1. **Window geometry persistence** — settings window and main terminal windows remember their
   size + position across sessions.
2. **Settings modal UX refinements** — scrollbars, tab bar overflow handling.
3. **Session restore default** — `restore_last_session` now defaults to `true`.

## Window geometry persistence

- New `freminal-common/src/window_state.rs` — stores settings-window + main-window geometry
  in `window_state.toml` (per-platform paths, atomic save via tmp+rename, graceful fallback
  on malformed TOML, full test suite).
- `freminal-windowing`: `WindowConfig` gains `inner_size` + `position`, applied at window
  creation (critical on Wayland, where post-configure `ViewportCommand::InnerSize` /
  `OuterPosition` are ignored). `WindowGeometry` tracked via `Resized` / `Moved` handlers.
  New `WindowHandle::window_geometry()` accessor.
- Main-window geometry rides in the existing `last_session.toml` (schema already had
  `size` + `position`); only the settings window needs `window_state.toml`.
- **Bug fix**: the PTY-close → `ViewportCommand::Close` path was bypassing
  `App::on_close_requested`, so `auto_save_session` never ran on clean shell exit (`exit`
  in the shell). The windowing layer's `should_close` branch now routes through
  `on_close_requested` before `close_window`, matching `WindowEvent::CloseRequested`.
- `gui::run()` seeds the initial `WindowConfig` from `last_session.toml` when
  `restore_last_session` is enabled; `on_window_created` restores geometry for the
  settings window.

## Settings modal UX

- **Content areas** (modal + standalone): bidirectional `ScrollArea` with
  `VisibleWhenNeeded` scrollbars. Horizontally-overflowing content (long keybinding
  labels, wide swatches) is reachable without enlarging the modal. Default size unchanged.
- **Tab selector row** (Font / Cursor / Theme / …): wraps in a horizontal `ScrollArea` so
  every tab stays reachable on narrow windows. Shared `show_tab_bar()` helper keeps modal
  and standalone views consistent.
- **Tab bar scrollbar** uses a scoped non-floating `ScrollStyle` with reduced `bar_width`
  so the horizontal scrollbar sits in its own thin strip below the tab buttons instead of
  floating over them and expanding on hover to cover the full nav-area height.

## Session restore default

- `StartupConfig::restore_last_session` now defaults to `true` (custom `Default` impl +
  `#[serde(default = "default_restore_last_session")]` so missing TOML values also yield
  `true`). A restarting daily-driver terminal is the expected behaviour; opt out with
  `restore_last_session = false`.
- `config_example.toml` updated to reflect the new default.

## Verification

- `cargo test --all` — all tests pass (including new `window_state` suite)
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- Manually verified on macOS: Cmd+Q, red X, `exit`, Ctrl+C all persist geometry +
  `last_session.toml` correctly.