### PR TITLE
Task 73: Command-block gutters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
 dependencies = [
  "android-properties",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cc",
  "jni",
  "libc",
@@ -352,9 +352,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -368,7 +368,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -394,9 +394,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -424,6 +424,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -478,7 +503,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "log",
  "polling",
  "rustix 0.38.44",
@@ -492,7 +517,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "polling",
  "rustix 1.1.4",
  "slab",
@@ -564,9 +589,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -921,9 +946,9 @@ checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -931,11 +956,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -945,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -961,37 +985,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
- "syn",
 ]
 
 [[package]]
@@ -1033,15 +1026,15 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1089,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "ecolor"
-version = "0.34.2"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f6cc0cb3b84a21232c468db972ebcddd34decbf1ff02cdebffd807c13bbd81"
+checksum = "a05fbfa222ffb51989d5ccf33e5f7aebfcf96c5023413856b0c3618a7f79896e"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1100,13 +1093,13 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.34.2"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbe28ac1a9c0761319aafb9ad37737720cc49d99c13a4a6b990768fa01ffe67"
+checksum = "42112be0ae157289312b92b3dfaf20e911b5a3c4c65d4aab0e7c47fbc0ce16e3"
 dependencies = [
  "accesskit",
  "ahash",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "emath",
  "epaint",
  "log",
@@ -1120,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.34.2"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e97625c2fe0fadc8b92ec690fbf515e15e2efd67ca50e063ad3302ec8ee626"
+checksum = "967c5b323625d46d46a59b5daba3fef742248d27693cc18972458619858c4239"
 dependencies = [
  "arboard",
  "bytemuck",
@@ -1141,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.34.2"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6caa4eca47cc2358e2c5ae60843a94118e338f87099c6af4170e6e968e8d77cb"
+checksum = "62b652957fa7e1ab01e8fecbfbf4e35f6e43a53fa98af8a562b50d5403cd44b9"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1157,15 +1150,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "emath"
-version = "0.34.2"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a74fbbf7501c430b89df62d102b6bfa02162faaf3e155512c677c9d20f5708d1"
+checksum = "b53f0d33a479321da6b0caa71366c9f67e8a2c149762d90bdc0d16e601ee8ecb"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1205,9 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.34.2"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b452e348c2758115288802ca25f86ee286ce2cfae6643711ce116662311310"
+checksum = "6675898a291ec212fc3df04f537d177fce8496120244590e6359dcaa4c25da79"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1228,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.34.2"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1644e25dbe3d663fd9c2a4181772c64b23361e377e550c10422ecc3a7de1c3c2"
+checksum = "f8970033a4282a7bcf899b38b5ed3a58b732fe093d03785d58648515d8d309da"
 
 [[package]]
 name = "equivalent"
@@ -1459,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "freminal"
-version = "0.9.0-beta.1"
+version = "0.9.0-beta.2"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1481,7 +1474,7 @@ dependencies = [
  "rustc-hash",
  "rustybuzz",
  "swash",
- "sysinfo 0.39.2",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -1492,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-buffer"
-version = "0.9.0-beta.1"
+version = "0.9.0-beta.2"
 dependencies = [
  "conv2",
  "criterion",
@@ -1505,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-common"
-version = "0.9.0-beta.1"
+version = "0.9.0-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1526,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-terminal-emulator"
-version = "0.9.0-beta.1"
+version = "0.9.0-beta.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1552,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-windowing"
-version = "0.9.0-beta.1"
+version = "0.9.0-beta.2"
 dependencies = [
  "conv2",
  "egui",
@@ -1675,7 +1668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1759,7 +1752,7 @@ version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg_aliases",
  "cgl",
  "dispatch2",
@@ -2082,7 +2075,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2138,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2191,7 +2184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2202,14 +2195,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "libc",
  "plain",
- "redox_syscall 0.7.5",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -2247,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "matchers"
@@ -2262,9 +2255,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
@@ -2310,7 +2303,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -2340,7 +2333,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2378,9 +2371,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -2453,7 +2446,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2 0.5.2",
@@ -2469,7 +2462,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2482,7 +2475,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -2506,7 +2499,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -2518,7 +2511,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2 0.6.4",
 ]
@@ -2529,7 +2522,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -2572,7 +2565,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "dispatch",
  "libc",
@@ -2585,7 +2578,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -2606,7 +2599,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -2629,10 +2622,21 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2641,7 +2645,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -2664,7 +2668,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "objc2 0.5.2",
  "objc2-cloud-kit",
@@ -2685,7 +2689,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -2708,7 +2712,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -2761,9 +2765,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a570f6bca41d29acb2139229a7c873ec99bc9a313bd10804081d89bfac8ff329"
+checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
 dependencies = [
  "libc",
  "libredox",
@@ -2830,7 +2834,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2941,7 +2945,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2976,7 +2980,7 @@ name = "portable-pty"
 version = "0.9.1"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "downcast-rs 2.0.2",
  "filedescriptor",
  "futures",
@@ -3089,7 +3093,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -3237,16 +3241,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3314,7 +3318,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "once_cell",
  "serde",
  "serde_derive",
@@ -3355,7 +3359,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3368,7 +3372,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -3399,7 +3403,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "core_maths",
  "log",
@@ -3493,9 +3497,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3568,9 +3572,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sigchld"
@@ -3665,7 +3669,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "calloop 0.13.0",
  "calloop-wayland-source 0.3.0",
  "cursor-icon",
@@ -3690,7 +3694,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "calloop 0.14.4",
  "calloop-wayland-source 0.4.1",
  "cursor-icon",
@@ -3816,37 +3820,24 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.37.2"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.61.3",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.39.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14311e7e9a03114cd4b65eedd54e8fed2945e17f08586ae97ef53bc0669f9581"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows 0.62.2",
+ "objc2-open-directory",
+ "windows",
 ]
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -3874,9 +3865,9 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-log"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f46bf474f0a4afebf92f076d54fd5e63423d9438b8c278a3d2ccb0f47f7cdb3"
+checksum = "9b9c218384242b5c89b68303ab6f6fc53a312d923f0c14dc6bb860c6aeee40f1"
 dependencies = [
  "env_logger",
  "test-log-macros",
@@ -3885,9 +3876,9 @@ dependencies = [
 
 [[package]]
 name = "test-log-core"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d4d41320b48bc4a211a9021678fcc0c99569b594ea31c93735b8e517102b4c"
+checksum = "c26ef8b00e4d382e59f6a8ddb3cd790b3a5bb29f21a358a9a69ea2f29f13f27b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3896,9 +3887,9 @@ dependencies = [
 
 [[package]]
 name = "test-log-macros"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9beb9249a81e430dffd42400a49019bcf548444f1968ff23080a625de0d4d320"
+checksum = "944ad38adcbb71eaa682c56bceeb079e4ca82b4b3edc2a0fde5cb297b77dac8d"
 dependencies = [
  "syn",
  "test-log-core",
@@ -4086,9 +4077,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -4250,9 +4241,9 @@ checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -4292,9 +4283,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "serde_core",
 ]
@@ -4333,29 +4324,27 @@ dependencies = [
 
 [[package]]
 name = "vergen"
-version = "9.1.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
+checksum = "7bdf18a54cf91b4d98a8e8b67f6321606539fbcdcac02536286ad1de37b53fd2"
 dependencies = [
  "anyhow",
- "cargo_metadata",
- "derive_builder",
- "regex",
+ "bon",
  "rustc_version",
  "rustversion",
- "sysinfo 0.37.2",
+ "sysinfo",
  "time",
  "vergen-lib",
 ]
 
 [[package]]
 name = "vergen-lib"
-version = "9.1.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
+checksum = "910e8471e27130bbc019e9bfa6bda16dfc4c6dd7c5d0793da70a9256caeae984"
 dependencies = [
  "anyhow",
- "derive_builder",
+ "bon",
  "rustversion",
 ]
 
@@ -4410,9 +4399,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4423,9 +4412,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4433,9 +4422,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4443,9 +4432,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4456,9 +4445,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -4491,7 +4480,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4517,7 +4506,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
@@ -4529,7 +4518,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -4551,7 +4540,7 @@ version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -4563,7 +4552,7 @@ version = "20250721.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -4576,7 +4565,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -4589,7 +4578,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -4602,7 +4591,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -4634,9 +4623,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4707,36 +4696,14 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections 0.2.0",
- "windows-core 0.61.2",
- "windows-future 0.2.1",
- "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -4745,20 +4712,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4769,20 +4723,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading 0.1.0",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -4791,9 +4734,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4820,25 +4763,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-numerics"
@@ -4846,17 +4773,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -4865,16 +4783,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -4883,7 +4792,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4919,7 +4828,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4944,7 +4853,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -4957,20 +4866,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5078,7 +4978,7 @@ dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "bytemuck",
  "calloop 0.13.0",
@@ -5204,7 +5104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",
@@ -5294,7 +5194,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dlib",
  "log",
  "once_cell",
@@ -5337,9 +5237,9 @@ checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5366,18 +5266,18 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.9.0-beta.1"
+version = "0.9.0-beta.2"
 edition = "2024"
 rust-version = "1.95.0"
 description = "A terminal emulator written in Rust"
@@ -34,7 +34,7 @@ anyhow = "1.0.102"
 arboard = "3.6.1"
 arc-swap = "1.9.1"
 assert_cmd = "2.2.2"
-bitflags = "2.11.1"
+bitflags = "2.13.0"
 cargo_metadata = "0.23.1"
 clap = { version = "4.6.1", features = ["derive"] }
 clap-cargo = { version = "0.18.3", features = ["cargo_metadata"] }
@@ -46,27 +46,19 @@ crossbeam-channel = "0.5.15"
 directories = "6.0.0"
 downcast-rs = "2.0.2"
 duct = "1.1.1"
-egui = { version = "0.34.2", default-features = false, features = [
-  "default_fonts",
-  "persistence",
-] }
-egui_glow = { version = "0.34.2", default-features = false }
-egui-winit = "0.34.1"
+egui = { version = "0.34.3", default-features = false, features = ["default_fonts", "persistence"] }
+egui_glow = { version = "0.34.3", default-features = false }
+egui-winit = "0.34.3"
 filedescriptor = "0.8.3"
 fontdb = "0.23.0"
 futures = "0.3.32"
 glow = "0.17.0"
 glutin = "0.32.3"
 glutin-winit = "0.5.0"
-image = { version = "0.25.10", default-features = false, features = [
-  "gif",
-  "jpeg",
-  "png",
-  "webp",
-] }
+image = { version = "0.25.10", default-features = false, features = ["gif", "jpeg", "png", "webp"] }
 lazy_static = "1.5.0"
 libc = "0.2.186"
-log = "0.4.29"
+log = "0.4.32"
 nix = "0.31.3"
 open = "5.3.5"
 predicates = "3.1.4"
@@ -84,25 +76,20 @@ shared_library = "0.1.9"
 shell-words = "1.1.1"
 smol = "2.0.2"
 swash = "0.2.7"
+sysinfo = { version = "0.39.3", default-features = false, features = ["system"] }
 sys-locale = "0.3.2"
-sysinfo = { version = "0.39.2", default-features = false, features = [
-  "system",
-] }
-tar = "0.4.45"
+tar = "0.4.46"
 tempfile = "3.27.0"
-test-log = { version = "0.2.19", features = ["trace"] }
+test-log = { version = "0.2.21", features = ["trace"] }
 thiserror = "2.0.18"
 toml = "1.1.2"
 tracing = "0.1.44"
 tracing-appender = "0.2.4"
 tracing-log = "0.2.0"
-tracing-subscriber = { version = "0.3.23", features = [
-  "env-filter",
-  "parking_lot",
-] }
-unicode-segmentation = "1.13.2"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter", "parking_lot"] }
+unicode-segmentation = "1.13.3"
 unicode-width = "0.2.2"
-vergen = { version = "9.1.0", features = ["build", "cargo", "rustc", "si"] }
+vergen = { version = "10.0.0", features = ["build", "cargo", "rustc", "si"] }
 winapi = "0.3.9"
 winit = { version = "0.30.13", features = ["rwh_06"] }
 winreg = "0.56.0"

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -2037,7 +2037,7 @@ warnings`, `cargo machete`, `cargo fmt --check` all clean.
 - `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
 warnings`, `cargo machete`, `cargo fmt --check` all clean.
 
-#### 73.5 — Move hover trigger from buffer to gutter
+#### 73.5 — Move hover trigger from buffer to gutter ✅
 
 **Scope:** `freminal/src/gui/mouse.rs`, `freminal/src/gui/renderer/`
 (whichever module currently owns the 72.12 hover overlay), and the view-
@@ -2071,6 +2071,34 @@ block-related.
 **Verification:** Update or replace the 72.12 hover unit tests. New
 integration test: hovering output cells does not set
 `hovered_block_id`; hovering gutter rows belonging to a block does.
+
+**Completion notes (2026-06-08):**
+
+- **Minimal change thanks to 73.3.** 73.3 had already added the gutter as a
+  hover trigger _alongside_ the 72.12 cell trigger inside
+  `compute_command_block_hover_rows`. 73.5 simply deletes the cell-hover
+  branch (`else if terminal_rect.contains(...)`), leaving the gutter strip
+  as the sole surface. The tint rendering (25%-alpha row range across the
+  cell grid) is unchanged — only the trigger surface moved.
+- **Disabled states.** Hover returns `None` when the feature is off, the
+  alternate screen is active, there are no blocks, OR the gutter is off
+  (`gutter_inset <= 0.0`, which is the case for `gutter = "off"`). The
+  unused `logical_cell_w` parameter was dropped.
+- **No view-state field.** There is no stored `hovered_block_id`; hover is
+  recomputed per frame as a local (`command_block_hover_rows`), gated by
+  the `hover_changed` cache term from 73.3. The plan's "does not set
+  `hovered_block_id`" is expressed as "returns `None`".
+- **Mouse-reporting safety** is inherited: the gutter is outside
+  `terminal_rect`, so DEC mouse modes never see gutter hover.
+- **Tests:** new `gutter_hover_trigger_tests` module —
+  `hovering_gutter_row_tints_the_block` (gutter -> `Some(range)`),
+  `hovering_output_cell_does_not_tint` (the regression: cell -> `None`),
+  `gutter_off_disables_hover`, and `no_pointer_no_tint`. Built on
+  `TerminalSnapshot::empty()` + `ViewState::new()` + a no-fold `RowMap`, so
+  no GUI/GL context is needed. No prior 72.12 hover unit test existed to
+  retire (the cell trigger was inline render-path code).
+- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
+warnings`, `cargo machete`, `cargo fmt --check` all clean.
 
 #### 73.6 — Move command-duration label into the gutter
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -1809,7 +1809,7 @@ block-highlight overlay.
 
 ### 73 Subtasks
 
-#### 73.1 — `ThemePalette` gutter colors
+#### 73.1 — `ThemePalette` gutter colors ✅
 
 **Scope:** `freminal-common/src/themes.rs` (or wherever `ThemePalette` lives).
 
@@ -1827,6 +1827,33 @@ block-highlight overlay.
 **Verification:** Round-trip TOML test. The themes count test (mentioned in
 `PLAN_33_WEZTERM_GHOSTTY_PALETTES.md` history) does not need updating —
 existing themes default to None and use the fallback.
+
+**Completion notes (2026-06-08):**
+
+- **Color-type deviation from the pseudocode:** `ThemePalette` colors are
+  `(u8, u8, u8)` tuples, NOT `egui::Color32` (that type lives in the
+  `freminal` GUI crate and cannot be referenced from `freminal-common`).
+  The three new fields are therefore `Option<(u8, u8, u8)>`. The
+  `freminal/src/gui/colors.rs` helpers convert tuples to `Color32` /
+  `[f32; 4]` at the GUI call sites, so a later subtask (73.2) wraps the
+  resolved tuple there.
+- **No TOML round-trip test (deviation):** `ThemePalette` has no serde
+  derives — it is never serialized to/from TOML; only theme _slugs_ are
+  stored in config. The plan's "Round-trip TOML test" is therefore not
+  applicable to `ThemePalette`. Coverage is instead: a test asserting all
+  27 shipped themes default the three overrides to `None`, plus resolver
+  tests for fallback, override-preference, and exit-code-independence.
+- `gutter_color_for(status)` is a `const fn` method on `ThemePalette`.
+  Fallbacks: Success → `ansi[2]` (green), Failure → `ansi[1]` (red),
+  Running → `ansi[3]` (yellow). `CommandStatus::Unknown` has no dedicated
+  override field and resolves to `ansi[7]` (white).
+- All 27 `const ThemePalette` literals updated to add
+  `gutter_success/failure/running: None` (mechanical, via a verified
+  exact-match pass; the `ansi: [ … ],` close is the last field on every
+  literal so the insertion point was unambiguous).
+- 4 new unit tests in `themes::tests`. `cargo test --all`,
+  `cargo clippy --all-targets --all-features -- -D warnings`, and
+  `cargo machete` all clean workspace-wide.
 
 #### 73.2 — Render the gutter column
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -2008,7 +2008,7 @@ terminal_rect.min.x)`) before `write_input_to_terminal`. Gutter positions
 - `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
 warnings`, `cargo machete`, `cargo fmt --check` all clean.
 
-#### 73.4 — Settings UI: gutter toggle
+#### 73.4 — Settings UI: gutter toggle ✅
 
 **Scope:** `freminal/src/gui/settings.rs` / `settings_dispatch.rs`.
 
@@ -2016,6 +2016,26 @@ warnings`, `cargo machete`, `cargo fmt --check` all clean.
   position (`Left` / `Off`).
 
 **Verification:** Toggle persists via TOML round-trip.
+
+**Completion notes (2026-06-08):**
+
+- Added a "Status gutter" `ComboBox` (`Left` / `Off`) to the Command Blocks
+  section of the **Shell Integration** settings tab (where 72.5
+  consolidated the command-block settings), below the duration threshold.
+  Mirrors the existing `tab_bar_position` dropdown pattern with a
+  `gutter_position_label` helper.
+- **No `settings_dispatch.rs` change needed.** On Apply the dispatch
+  already replaces the whole live config (`self.config = new_cfg`), and
+  `app_impl` reads `command_blocks.gutter.total_inset_px()` every frame, so
+  toggling takes effect immediately — switching to `Off` zeroes the inset,
+  which flows through the normal resize path (wider PTY column count, strip
+  hidden). Same "takes effect on next render" model 72.5 documented.
+- **Tests:** `gutter_position_labels` (label helper) and
+  `gutter_setting_persists_through_draft_apply` (modal surfaces and mutates
+  the field). The TOML round-trip is already covered by the
+  `freminal-common` config test added in 73.2.
+- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
+warnings`, `cargo machete`, `cargo fmt --check` all clean.
 
 #### 73.5 — Move hover trigger from buffer to gutter
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -2112,7 +2112,7 @@ duration-formatting unit test from 72.12 still applies; add a placement
 test (the label coordinate is computed against the block's last on-screen
 row, not its first row).
 
-#### 73.7 — Investigate spurious long duration for instant commands
+#### 73.7 — Investigate spurious long duration for instant commands ✅
 
 **Scope:** Investigation first; fix scope determined by findings.
 Likely surfaces: `CommandBlock::started_at` / `finished_at`
@@ -2173,6 +2173,47 @@ either absent (below threshold) or correctly reporting milliseconds.
 duration computation, not the gutter rendering. Schedule it early in
 Task 73 so the fix is in place before 73.6 moves the label into the
 gutter, otherwise the bug just relocates with the label.
+
+**Completion notes (2026-06-08):**
+
+- **Root cause: timing semantics, not units.** Hypothesis 1 (unit/format
+  mismatch) was ruled out — `duration()` used correct `SystemTime`
+  arithmetic and the formatter truncates whole seconds correctly.
+  Hypothesis 2 was the cause, in its "wrong window" form: `started_at` is
+  stamped at `OSC 133 A` (prompt start) and `finished_at` at `OSC 133 D`,
+  so `duration() = D - A` **included the time the user spent typing the
+  command and reading the previous output at the prompt**. An instant `ls`
+  preceded by a 30 s pause reported ~30 s. The fid correlation itself
+  (72.8c) was correct — no off-by-one.
+- **Fix.** Added `executed_at: Option<SystemTime>` to `CommandBlock`,
+  stamped in `Buffer::mark_output_start_row` (`OSC 133 C`, command-execution
+  start). `CommandBlock::duration()` now measures `finished_at -
+executed_at` (true runtime C->D), falling back to `started_at` only when
+  no `C` was received. The in-buffer duration-overlay renderer was also
+  fixed: it computed `finished_at.duration_since(started_at)` directly
+  (the D-A bug) and now calls `block.duration()`.
+- **No FREC/snapshot serialization concern.** `CommandBlock` rides the
+  snapshot as `Arc<[CommandBlock]>` (cloned), so the new field propagates
+  automatically; FREC v2 captures the OSC byte stream, not the struct.
+- **No escape-sequence-doc change.** OSC 133 C parsing/support is
+  unchanged (still ✅); only internal timing semantics changed, and the
+  coverage row makes no duration claim.
+- **Tests:** `duration_measures_from_executed_at_not_started_at` (the
+  regression: 30 s prompt-wait + 5 ms command -> 5 ms),
+  `duration_falls_back_to_started_at_when_executed_at_missing`,
+  `duration_clock_skew_against_executed_at_is_none`, and
+  `mark_output_start_row_stamps_executed_at` (buffer-level: `OSC 133 C`
+  stamps `executed_at`). Five `CommandBlock` test-literal sites updated
+  for the new field. A handler-level wall-clock-delta integration test was
+  not added because `executed_at` uses real `SystemTime::now()` and cannot
+  assert a deterministic delta without sleeping; the deterministic unit
+  tests cover the C->D semantics fully.
+- **Benchmark:** `command_block_record_10k` ~895 µs (vs ~863 µs documented
+  baseline) — within machine variance; the one-field struct growth and the
+  `C`-path `SystemTime::now()` (not exercised by this bench) cause no
+  regression.
+- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
+warnings`, `cargo machete`, `cargo fmt --check` all clean.
 
 ### 73 Open Questions Resolved
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -1855,10 +1855,7 @@ existing themes default to None and use the fallback.
   `cargo clippy --all-targets --all-features -- -D warnings`, and
   `cargo machete` all clean workspace-wide.
 
-#### 73.2 — Render the gutter column
-
-**Scope:** `freminal/src/gui/renderer/` (whichever pass draws the terminal
-cell background — likely a glow shader / atlas layer).
+#### 73.2 — Render the gutter column ✅
 
 - Add a config knob `[command_blocks] gutter = "left" | "off"` (default
   `"left"`).
@@ -1872,6 +1869,74 @@ cell background — likely a glow shader / atlas layer).
 
 **Verification:** Visual verification via a recorded `.frec` of a typical
 session. Benchmark: `render_loop_bench` should not regress > 15%.
+
+**Completion notes (2026-06-08):**
+
+- **Single-source-of-truth inset (the column-count correctness rule).**
+  The reserved left inset is computed once per frame in `app_impl.rs`
+  (`gutter_inset_logical = gutter.total_inset_px() / ppp`, zeroed when
+  the feature is disabled) and consumed by BOTH the PTY column-count
+  computation (`pane_content_width = content_rect.width() - inset`) AND
+  the renderer (`terminal_rect.min.x += inset`). Because both derive
+  from the identical inset, the column count reported to the PTY always
+  equals the rendered cell-grid width — no drift, no wrapping/cursor
+  desync. The widget consumes `snap.term_width` (the value `app_impl`
+  sent), never re-deriving columns from its own rect.
+- **Renderer scope.** The plan guessed `freminal/src/gui/renderer/`. In
+  practice the gutter is drawn in `terminal/widget.rs` via egui's
+  painter (`rect_filled` per visible row), not in the glow vertex
+  builders. The `PaintCallback` rect was changed from `ui.max_rect()`
+  (full pane) to `terminal_rect` (full pane minus inset) so the GL
+  viewport origin clears the gutter and column 0 does not render under
+  the strip.
+- **Strip width vs. inset (padding gap).** Per mid-task feedback, the
+  4px painted strip would otherwise sit flush against the first glyph.
+  Split into two constants in `freminal-common/src/config.rs`:
+  `COMMAND_BLOCK_GUTTER_WIDTH_PX = 4.0` (painted strip) and
+  `COMMAND_BLOCK_GUTTER_PADDING_PX = 4.0` (blank gap).
+  `GutterPosition::total_inset_px()` (= strip + padding = 8px) is the
+  shared inset; `width_px()` (= 4px) is the painted strip only. Layout:
+  `[0–4px] status strip` → `[4–8px] padding` → `[8px+] glyphs`.
+- **Config.** Added `[command_blocks] gutter = "left" | "off"`
+  (`GutterPosition` enum, kebab-case serde, default `Left`) and the
+  `config_example.toml` entry. Disabling `command_blocks.enabled` zeroes
+  the inset entirely (no gutter, full width).
+- **Row → color mapping** factored into the pure, unit-tested
+  `gutter_status_for_row(blocks, row, running_extent)` in
+  `gui/command_blocks.rs`. A running block (no `end_row`) extends to the
+  last visible row so the live prompt shows a full yellow bar; on
+  overlap the last-emitted block wins. Fold placeholders are colored by
+  the folded block's status at half alpha. Status colors come from
+  `ThemePalette::gutter_color_for` (73.1): green/red/yellow/white.
+- **Alternate screen.** The gutter is suppressed on the alternate screen
+  (same rationale as the earlier overlay fix — stored blocks describe
+  primary-screen rows).
+- **Mouse.** Because `terminal_rect.min.x` shifted right, gutter pixels
+  fall outside `terminal_rect`, so terminal mouse-event forwarding and
+  hover already ignore the strip; `encode_egui_mouse_pos_as_usize`
+  saturates `x < origin` to column 0. Gutter click/hover interception is
+  73.3.
+- **Tests:** 5 `gutter_status_for_row` tests (containment, inclusivity,
+  exit-code → status, running-extent, overlap), 3 config tests
+  (default, kebab-case serialization, `total_inset_px` padding),
+  extended the 72.5 round-trip test with the `gutter` field.
+- **Benchmark (`render_loop_bench`, 15% budget):** the vertex-builder
+  passes are untouched by the gutter (it's egui-painter-side); measured
+  for regression safety:
+
+  | Benchmark                              | Before   | After    | Change        |
+  | -------------------------------------- | -------- | -------- | ------------- |
+  | instanced_bg/build_bg_instances/80x24  | 75.7 ns  | 73.2 ns  | -1.0% (noise) |
+  | instanced_bg/build_bg_instances/200x50 | 136.6 ns | 129.8 ns | -5.7%         |
+  | instanced_fg/build_fg_instances/80x24  | 422.8 µs | 388.1 µs | -5.3%         |
+  | instanced_fg/build_fg_instances/200x50 | 464.2 µs | 474.5 µs | -0.8% (noise) |
+
+- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
+warnings`, `cargo machete`, `cargo fmt --check` all clean.
+- **Open follow-up (not blocking):** `CommandStatus::Unknown` resolves
+  to normal white (`ansi[7]`); the plan text said "gray". Could map to
+  `ansi[8]` (bright-black/gray) if a grayer neutral is preferred —
+  deferred pending user preference.
 
 #### 73.3 — Gutter click and hover
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -1938,7 +1938,7 @@ warnings`, `cargo machete`, `cargo fmt --check` all clean.
   `ansi[8]` (bright-black/gray) if a grayer neutral is preferred —
   deferred pending user preference.
 
-#### 73.3 — Gutter click and hover
+#### 73.3 — Gutter click and hover ✅
 
 **Scope:** `freminal/src/gui/mouse.rs`, `terminal/widget.rs`.
 
@@ -1952,6 +1952,61 @@ warnings`, `cargo machete`, `cargo fmt --check` all clean.
 
 **Verification:** Integration test using egui's test harness for mouse
 events.
+
+**Completion notes (2026-06-08):**
+
+- **Click interception.** A gutter pre-check in `widget.rs::show()` (modeled
+  on the existing scrollbar pre-check) intercepts a primary press whose
+  position falls in the inset region (`pos.x ∈ [pane.min.x,
+terminal_rect.min.x)`) before `write_input_to_terminal`. Gutter positions
+  are already outside `terminal_rect`, so they would otherwise be dropped
+  entirely (no fold, no focus). The press maps `y → rendered row → buffer
+  row → block` via a fresh fold-aware `RowMap`
+  (`gutter_block_id_at_pos`). A finished block toggles its fold
+  (`view_state.toggle_fold`); a running block is a no-op fold. Either way
+  the pane is focused (`left_mouse_button_pressed`), since the gutter is
+  outside the rect that normally sets that flag.
+- **Foldability guard** factored into the pure, tested
+  `command_blocks::block_is_foldable` (finished blocks only), mirroring the
+  `FoldPreviousCommand` "completed block" guard.
+- **Hover hit-test** shares `command_blocks::gutter_block_for_row`
+  (a `gutter_status_for_row` refactor that returns the block, not just the
+  status). The gutter trigger is added _alongside_ the existing 72.12
+  cell-hover trigger; 73.5 retires the cell trigger.
+- **Hit zone** is the whole inset (4px strip + 4px padding), a more
+  forgiving target than the 4px strip alone.
+- **Two-part hover-live fix (the subtle one).** Getting the gutter hover
+  tint to appear/clear on bare pointer motion required two independent
+  fixes, both necessary:
+  1. **Waking a frame.** The windowing cursor-move fast path
+     (`freminal-windowing/event_loop.rs`, Task 65/68 idle-CPU
+     optimization) only schedules a repaint when egui reports `repaint`,
+     i.e. when an egui-tracked interactive region's hover state changes.
+     The terminal hover tint is painted by our own GL pass, not an egui
+     widget, so a bare move never woke a frame. Registering the gutter as
+     a `Sense::click()` region makes egui report `repaint` on enter/leave,
+     waking the frame (and giving the hand cursor).
+  2. **Rebuilding the VBO.** The hover tint is baked into the background
+     instance buffer, which was only rebuilt on
+     content/selection/search/blink changes. A hover-only change reused
+     stale vertices and showed nothing. Added a `hover_changed` term
+     (tracked via `cache.previous_command_block_hover_rows`) to both the
+     cursor-only fast-path exclusion and the full-rebuild trigger. The
+     hover-row computation was hoisted into
+     `compute_command_block_hover_rows` and run _before_ the rebuild
+     decision so `hover_changed` is known in time.
+- **Mouse-reporting safety.** Gutter positions are outside `terminal_rect`,
+  so `terminal_rect.contains` already excludes them from terminal mouse-
+  event forwarding and selection; DEC mouse modes never see gutter
+  hover/clicks.
+- **Tests:** added `gutter_block_for_row` and `block_is_foldable` unit
+  tests (finished foldable, running not, containment, returns block). No
+  egui-harness integration test was added — the repo has no egui_kittest
+  harness; the click/hover logic is covered by the pure helper tests, and
+  the wiring was verified manually with debug instrumentation across the
+  appear/track/clear lifecycle.
+- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
+warnings`, `cargo machete`, `cargo fmt --check` all clean.
 
 #### 73.4 — Settings UI: gutter toggle
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -2100,7 +2100,7 @@ integration test: hovering output cells does not set
 - `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
 warnings`, `cargo machete`, `cargo fmt --check` all clean.
 
-#### 73.6 — Move command-duration label into the gutter
+#### 73.6 — Move command-duration label into the gutter ✅
 
 **Scope:** Same renderer module as 73.2 (the gutter draw pass) and the
 duration-formatting helper introduced in 72.12.
@@ -2139,6 +2139,40 @@ label belongs there.
 duration-formatting unit test from 72.12 still applies; add a placement
 test (the label coordinate is computed against the block's last on-screen
 row, not its first row).
+
+**Completion notes (2026-06-08):**
+
+- **Option (a) chosen** (floating layer, keep the gutter thin). The label
+  is drawn as an egui-painter text layer just inside the cell grid
+  (`terminal_rect.min.x + 2px`, left-aligned, ~60% alpha), overlaying the
+  first cells of the block's last visible row. The gutter stays 4px; no
+  `gutter_width_px` config was added.
+- **Last-visible-row anchor.** Relocated from 72.12's first-row placement
+  (which scrolled off immediately) to the block's last on-screen row via
+  the pure, tested `duration_label_anchor_row(block, win_start, win_end,
+running_extent)` — clamps to the viewport bottom when the block extends
+  below, returns `None` when the block is entirely off-screen, and uses
+  `running_extent` for running blocks.
+- **Gating.** Requires the gutter to be present (`gutter_inset > 0`), so a
+  `gutter = "off"` config also hides the label (no anchor). Threshold
+  gating unchanged; running blocks have no `duration()` and are skipped;
+  suppressed on the alternate screen. Uses `block.duration()` (the 73.7
+  C->D fix), so values are correct.
+- **Tests:** five `duration_label_anchor_row` cases (last-not-first,
+  clamp-to-viewport, above/below viewport -> `None`, running-block ->
+  `running_extent`).
+- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
+warnings`, `cargo machete`, `cargo fmt --check` all clean. No
+  `render_loop_bench` regression (label is egui-painter-side, no
+  vertex-builder change).
+
+**Shell-integration follow-up (committed separately):** visual testing of
+73.6 in bash surfaced that bash never emitted `OSC 133 C` under freminal's
+`bash --posix` launch (bash-preexec's preexec dispatch is dead in that
+mode), so bash durations showed prompt-to-prompt. Fixed in
+`shell-integration/bash/freminal-init.bash` by emitting C from a
+re-armed DEBUG trap; shell-integration bumped to v4. zsh/fish were
+unaffected.
 
 #### 73.7 — Investigate spurious long duration for instant commands ✅
 

--- a/config_example.toml
+++ b/config_example.toml
@@ -263,6 +263,13 @@ limit = 4000
 # Default: 2.0.
 # duration_threshold_secs = 2.0
 
+# Where the per-command status gutter is drawn.  A thin colored strip on
+# the left edge of the terminal area shows each command block's status
+# (green = success, red = failure, yellow = running).  "left" reserves the
+# strip; "off" disables the gutter entirely.
+# Default: "left".
+# gutter = "left"
+
 ## ##############################################################################
 # STARTUP & LAYOUTS
 ## ##############################################################################

--- a/flake.nix
+++ b/flake.nix
@@ -100,7 +100,7 @@
         {
           freminal = rustPlatform.buildRustPackage {
             pname = "freminal";
-            version = "0.9.0-beta.1";
+            version = "0.9.0-beta.2";
             src = pkgs.lib.cleanSource ./.;
 
             cargoLock.lockFile = ./Cargo.lock;
@@ -148,9 +148,9 @@
                     <key>CFBundleIdentifier</key>
                     <string>io.github.fredclausen.freminal</string>
                     <key>CFBundleVersion</key>
-                    <string>0.9.0-beta.1</string>
+                    <string>0.9.0-beta.2</string>
                     <key>CFBundleShortVersionString</key>
-                    <string>0.9.0-beta.1</string>
+                    <string>0.9.0-beta.2</string>
                     <key>CFBundleExecutable</key>
                     <string>freminal</string>
                     <key>CFBundleIconFile</key>

--- a/freminal-buffer/src/buffer/flatten.rs
+++ b/freminal-buffer/src/buffer/flatten.rs
@@ -120,8 +120,27 @@ impl Buffer {
         &mut self,
         scroll_offset: usize,
     ) -> (Vec<TChar>, Vec<FormatTag>, Vec<usize>, Vec<usize>) {
-        let visible_start = self.visible_window_start(scroll_offset);
-        let visible_end = (visible_start + self.height).min(self.rows.len());
+        self.visible_as_tchars_and_tags_extended(scroll_offset, 0)
+    }
+
+    /// Like [`Self::visible_as_tchars_and_tags`] but extends the flatten window
+    /// upward by `extra_rows` (see
+    /// [`Buffer::visible_window_bounds`](super::Buffer::visible_window_bounds)).
+    ///
+    /// The GUI passes a non-zero `extra_rows` when command-block folds collapse
+    /// rows in the visible window: the extra rows above the normal window
+    /// provide real content to fill the screen once the folds are collapsed,
+    /// so the live bottom stays pinned instead of leaving a blank gap.
+    ///
+    /// When `extra_rows == 0` this is identical to
+    /// [`Self::visible_as_tchars_and_tags`].
+    #[must_use]
+    pub fn visible_as_tchars_and_tags_extended(
+        &mut self,
+        scroll_offset: usize,
+        extra_rows: usize,
+    ) -> (Vec<TChar>, Vec<FormatTag>, Vec<usize>, Vec<usize>) {
+        let (visible_start, visible_end) = self.visible_window_bounds(scroll_offset, extra_rows);
         let auto_detect = self.auto_detect_urls;
         Self::rows_as_tchars_and_tags_cached(
             &mut self.rows[visible_start..visible_end],
@@ -711,4 +730,101 @@ fn splice_auto_urls(tags: &[FormatTag], ranges: &[AutoUrlRange]) -> Vec<FormatTa
     }
 
     current
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod extended_window_tests {
+    use crate::buffer::Buffer;
+    use freminal_common::buffer_states::tchar::TChar;
+
+    fn t(s: &str) -> Vec<TChar> {
+        s.chars().map(TChar::from).collect()
+    }
+
+    /// Build a 4-wide, 3-tall buffer containing 6 rows of distinct content
+    /// ("r0".."r5"), so rows 0..=2 are scrollback and rows 3..=5 are the live
+    /// visible window.
+    fn buffer_with_scrollback() -> Buffer {
+        let mut buf = Buffer::new(4, 3);
+        for i in 0..6 {
+            buf.insert_text(&t(&format!("r{i}")));
+            if i < 5 {
+                buf.handle_lf();
+                buf.handle_cr();
+            }
+        }
+        assert_eq!(buf.rows().len(), 6, "expected 6 total rows");
+        buf
+    }
+
+    #[test]
+    fn bounds_no_extra_is_normal_window() {
+        let buf = buffer_with_scrollback();
+        // height = 3, total = 6, scroll 0 → normal window [3, 6).
+        let (start, end) = buf.visible_window_bounds(0, 0);
+        assert_eq!((start, end), (3, 6));
+    }
+
+    #[test]
+    fn bounds_extra_extends_window_upward() {
+        let buf = buffer_with_scrollback();
+        // Pull in 2 extra rows above the window: [1, 6).
+        let (start, end) = buf.visible_window_bounds(0, 2);
+        assert_eq!((start, end), (1, 6));
+    }
+
+    #[test]
+    fn bounds_extra_clamped_at_row_zero() {
+        let buf = buffer_with_scrollback();
+        // Request more extra rows than exist above the window: clamps to 0.
+        let (start, end) = buf.visible_window_bounds(0, 99);
+        assert_eq!((start, end), (0, 6));
+    }
+
+    #[test]
+    fn bounds_extra_with_scroll_offset() {
+        let buf = buffer_with_scrollback();
+        // Scrolled back 1 row → normal window [2, 5); plus 1 extra → [1, 5).
+        let (start, end) = buf.visible_window_bounds(1, 1);
+        assert_eq!((start, end), (1, 5));
+    }
+
+    #[test]
+    fn extended_flatten_has_more_rows() {
+        let mut buf = buffer_with_scrollback();
+        let (_c0, _t0, ro0, _u0) = buf.visible_as_tchars_and_tags_extended(0, 0);
+        let (_c2, _t2, ro2, _u2) = buf.visible_as_tchars_and_tags_extended(0, 2);
+        assert_eq!(ro0.len(), 3, "normal window has term_height rows");
+        assert_eq!(ro2.len(), 5, "extended window has term_height + extra rows");
+    }
+
+    #[test]
+    fn extended_flatten_starts_earlier() {
+        let mut buf = buffer_with_scrollback();
+        // The extended window's first row should be buffer row 1 ("r1").
+        let (chars, _tags, row_offsets, _url) = buf.visible_as_tchars_and_tags_extended(0, 2);
+        // First row's first char is 'r'.
+        assert_eq!(chars[row_offsets[0]], TChar::from('r'));
+        // Second char of first row is '1' (buffer row 1).
+        assert_eq!(chars[row_offsets[0] + 1], TChar::from('1'));
+    }
+
+    #[test]
+    fn extended_line_widths_match_extended_window() {
+        let buf = buffer_with_scrollback();
+        assert_eq!(buf.visible_line_widths_extended(0, 0).len(), 3);
+        assert_eq!(buf.visible_line_widths_extended(0, 2).len(), 5);
+    }
+
+    #[test]
+    fn extended_dirty_check_covers_extra_rows() {
+        let mut buf = buffer_with_scrollback();
+        // Flatten the extended window to clear dirty flags across all 5 rows.
+        let _ = buf.visible_as_tchars_and_tags_extended(0, 2);
+        assert!(
+            !buf.any_visible_dirty_extended(0, 2),
+            "freshly flattened extended window must be clean"
+        );
+    }
 }

--- a/freminal-buffer/src/buffer/lifecycle.rs
+++ b/freminal-buffer/src/buffer/lifecycle.rs
@@ -243,11 +243,17 @@ impl Buffer {
     /// Set `output_start_row` to the current cursor row on the block whose
     /// `fid` matches and whose `output_start_row` is `None`.  Searches
     /// newest-to-oldest.  No-op if no matching block exists.
+    ///
+    /// Also stamps `executed_at = SystemTime::now()` — this is the moment the
+    /// command begins executing (`OSC 133 C`), which anchors the command's
+    /// duration (see [`CommandBlock::duration`]).  The user's typing time at
+    /// the prompt (`started_at` -> `executed_at`) is thereby excluded.
     pub fn mark_output_start_row(&mut self, fid: &str) {
         for block in self.command_blocks.iter_mut().rev() {
             if block.fid == fid {
                 if block.output_start_row.is_none() {
                     block.output_start_row = Some(self.cursor.pos.y);
+                    block.executed_at = Some(SystemTime::now());
                 }
                 return;
             }
@@ -487,6 +493,30 @@ mod command_block_tests {
 
         let block = buf.command_blocks.front().unwrap();
         assert_eq!(block.output_start_row, Some(6));
+    }
+
+    // ── 73.7: OSC 133 C stamps executed_at so duration excludes prompt-wait
+    #[test]
+    fn mark_output_start_row_stamps_executed_at() {
+        let mut buf = make_buf();
+        let _id = buf.start_command_block(None, "fid1".to_owned());
+        let block = buf.command_blocks.front().unwrap();
+        let started_at = block.started_at;
+        assert!(
+            block.executed_at.is_none(),
+            "executed_at must be None before OSC 133 C"
+        );
+
+        buf.mark_output_start_row("fid1");
+
+        let block = buf.command_blocks.front().unwrap();
+        let executed_at = block
+            .executed_at
+            .expect("executed_at must be stamped at OSC 133 C");
+        assert!(
+            executed_at >= started_at,
+            "executed_at must be at or after started_at"
+        );
     }
 
     // ── 6: finish_command_block full A→B→C→D cycle ───────────────────────
@@ -792,6 +822,7 @@ mod command_block_tests {
             output_start_row: Some(visible_start + 1),
             end_row: Some(visible_start + 3),
             started_at: SystemTime::now(),
+            executed_at: Some(SystemTime::now()),
             finished_at: Some(SystemTime::now()),
             cwd: None,
             exit_code: Some(0),

--- a/freminal-buffer/src/buffer/scroll.rs
+++ b/freminal-buffer/src/buffer/scroll.rs
@@ -34,8 +34,19 @@ impl Buffer {
     /// per-row line-width data through to the renderer.
     #[must_use]
     pub fn visible_line_widths(&self, scroll_offset: usize) -> Vec<crate::row::LineWidth> {
-        let start = self.visible_window_start(scroll_offset);
-        let end = (start + self.height).min(self.rows.len());
+        self.visible_line_widths_extended(scroll_offset, 0)
+    }
+
+    /// Like [`Self::visible_line_widths`] but extends the window upward by
+    /// `extra_rows` (see [`Self::visible_window_bounds`]). The returned vector
+    /// has one entry per row in the extended window, top-to-bottom.
+    #[must_use]
+    pub fn visible_line_widths_extended(
+        &self,
+        scroll_offset: usize,
+        extra_rows: usize,
+    ) -> Vec<crate::row::LineWidth> {
+        let (start, end) = self.visible_window_bounds(scroll_offset, extra_rows);
         self.rows[start..end].iter().map(|r| r.line_width).collect()
     }
 
@@ -128,6 +139,31 @@ impl Buffer {
         total.saturating_sub(h + offset)
     }
 
+    /// Compute the `[start, end)` row-index bounds of the flatten window for a
+    /// given `scroll_offset`, optionally extended **upward** by `extra_rows`.
+    ///
+    /// The window always ends at `visible_window_start(scroll_offset) +
+    /// height` (clamped to the buffer length); `extra_rows` pulls the *start*
+    /// earlier into scrollback so the window contains extra rows **above** the
+    /// normal visible window. This is what the GUI uses when command-block
+    /// folds collapse rows in the visible window: the renderer needs extra
+    /// real rows above the fold so that, after collapsing, a full screen of
+    /// rendered rows can still be painted with the live bottom pinned.
+    ///
+    /// `extra_rows` is clamped so the start never underflows past row 0.
+    /// When `extra_rows == 0` this is exactly the normal visible window.
+    #[must_use]
+    pub(in crate::buffer) fn visible_window_bounds(
+        &self,
+        scroll_offset: usize,
+        extra_rows: usize,
+    ) -> (usize, usize) {
+        let base_start = self.visible_window_start(scroll_offset);
+        let end = (base_start + self.height).min(self.rows.len());
+        let start = base_start.saturating_sub(extra_rows);
+        (start, end)
+    }
+
     /// Return `true` if any row in the visible window is dirty (needs re-flattening).
     ///
     /// The PTY thread calls this with `scroll_offset = 0`.  A `false` result means
@@ -136,11 +172,17 @@ impl Buffer {
     /// `visible_chars` / `visible_tags` vectors.
     #[must_use]
     pub fn any_visible_dirty(&self, scroll_offset: usize) -> bool {
+        self.any_visible_dirty_extended(scroll_offset, 0)
+    }
+
+    /// Like [`Self::any_visible_dirty`] but checks the window extended upward
+    /// by `extra_rows` (see [`Self::visible_window_bounds`]).
+    #[must_use]
+    pub fn any_visible_dirty_extended(&self, scroll_offset: usize, extra_rows: usize) -> bool {
         if self.rows.is_empty() || self.height == 0 {
             return false;
         }
-        let vis_start = self.visible_window_start(scroll_offset);
-        let vis_end = (vis_start + self.height).min(self.rows.len());
+        let (vis_start, vis_end) = self.visible_window_bounds(scroll_offset, extra_rows);
         self.rows[vis_start..vis_end].iter().any(|r| r.dirty)
     }
 
@@ -157,11 +199,23 @@ impl Buffer {
     /// of `visible_chars` so the caller can index them in parallel.
     #[must_use]
     pub fn visible_image_placements(&self, scroll_offset: usize) -> Vec<Option<ImagePlacement>> {
+        self.visible_image_placements_extended(scroll_offset, 0)
+    }
+
+    /// Like [`Self::visible_image_placements`] but extends the window upward by
+    /// `extra_rows` (see [`Self::visible_window_bounds`]). The returned vector
+    /// has `window_rows * width` entries in row-major order, matching the
+    /// extended `visible_chars` layout.
+    #[must_use]
+    pub fn visible_image_placements_extended(
+        &self,
+        scroll_offset: usize,
+        extra_rows: usize,
+    ) -> Vec<Option<ImagePlacement>> {
         if self.rows.is_empty() || self.height == 0 || self.width == 0 {
             return Vec::new();
         }
-        let vis_start = self.visible_window_start(scroll_offset);
-        let vis_end = (vis_start + self.height).min(self.rows.len());
+        let (vis_start, vis_end) = self.visible_window_bounds(scroll_offset, extra_rows);
         let mut out = Vec::with_capacity((vis_end - vis_start) * self.width);
         for row in &self.rows[vis_start..vis_end] {
             let cells = row.cells();

--- a/freminal-common/src/buffer_states/command_block.rs
+++ b/freminal-common/src/buffer_states/command_block.rs
@@ -99,10 +99,23 @@ pub struct CommandBlock {
     /// CWD captured from OSC 7 at the time of prompt start.
     pub cwd: Option<String>,
 
-    /// Wall-clock timestamp of prompt start.
+    /// Wall-clock timestamp of prompt start (`OSC 133 A`).
+    ///
+    /// This is when the prompt was drawn, NOT when the command began
+    /// executing — the interval between this and [`Self::executed_at`] is the
+    /// time the user spent typing the command (and reading the previous
+    /// output).  Do not use this for command-duration display; use
+    /// [`Self::duration`], which measures from `executed_at`.
     pub started_at: SystemTime,
 
-    /// Wall-clock timestamp of command-finished, if known.
+    /// Wall-clock timestamp of command execution start (`OSC 133 C`), if
+    /// known.  `None` until `C` is received (or if the shell omits it).
+    ///
+    /// This is the anchor for command duration: the user's typing/thinking
+    /// time at the prompt (`started_at` -> `executed_at`) is excluded.
+    pub executed_at: Option<SystemTime>,
+
+    /// Wall-clock timestamp of command-finished (`OSC 133 D`), if known.
     pub finished_at: Option<SystemTime>,
 }
 
@@ -122,6 +135,7 @@ impl CommandBlock {
             exit_code: None,
             cwd,
             started_at: SystemTime::now(),
+            executed_at: None,
             finished_at: None,
         }
     }
@@ -142,12 +156,21 @@ impl CommandBlock {
         }
     }
 
-    /// Duration if finished; `None` while still running or if `SystemTime`
-    /// arithmetic fails (clock skew).
+    /// Command execution duration if finished; `None` while still running or
+    /// if `SystemTime` arithmetic fails (clock skew).
+    ///
+    /// Measured from [`Self::executed_at`] (`OSC 133 C`, command-execution
+    /// start) to [`Self::finished_at`] (`OSC 133 D`).  This deliberately
+    /// excludes the time the user spent typing the command at the prompt
+    /// (`started_at` -> `executed_at`); measuring from `started_at` would
+    /// report multi-second durations for instant commands whenever the user
+    /// paused at the prompt.  Falls back to `started_at` only when
+    /// `executed_at` is unknown (no `C` marker was received).
     #[must_use]
     pub fn duration(&self) -> Option<Duration> {
         let finished = self.finished_at?;
-        finished.duration_since(self.started_at).ok()
+        let anchor = self.executed_at.unwrap_or(self.started_at);
+        finished.duration_since(anchor).ok()
     }
 
     /// Row range covered by this block: `(start, end)`.  `end` is `None`
@@ -316,6 +339,49 @@ mod tests {
         assert!(
             block.duration().is_none(),
             "clock skew should produce None duration"
+        );
+    }
+
+    #[test]
+    fn duration_measures_from_executed_at_not_started_at() {
+        // Regression for 73.7: an instant command after a long pause at the
+        // prompt must report only the execution time (C->D), not the time
+        // the user spent typing/reading (A->C->D).
+        let mut block = CommandBlock::new_running(0, None, "f1".to_owned());
+        // User sat at the prompt for 30 s before the command executed...
+        block.executed_at = Some(block.started_at + Duration::from_secs(30));
+        // ...and the command itself took 5 ms.
+        block.finished_at =
+            Some(block.started_at + Duration::from_secs(30) + Duration::from_millis(5));
+        match block.duration() {
+            Some(dur) => assert_eq!(
+                dur,
+                Duration::from_millis(5),
+                "duration must be C->D (5ms), not A->D (30.005s)"
+            ),
+            None => panic!("expected Some duration"),
+        }
+    }
+
+    #[test]
+    fn duration_falls_back_to_started_at_when_executed_at_missing() {
+        // When no `OSC 133 C` was received (executed_at is None), fall back
+        // to started_at so a duration is still reported.
+        let mut block = CommandBlock::new_running(0, None, "f1".to_owned());
+        assert!(block.executed_at.is_none());
+        block.finished_at = Some(block.started_at + Duration::from_millis(250));
+        assert_eq!(block.duration(), Some(Duration::from_millis(250)));
+    }
+
+    #[test]
+    fn duration_clock_skew_against_executed_at_is_none() {
+        let mut block = CommandBlock::new_running(0, None, "f1".to_owned());
+        block.executed_at = Some(block.started_at + Duration::from_secs(2));
+        // finished_at before executed_at — skew relative to the new anchor.
+        block.finished_at = Some(block.started_at + Duration::from_secs(1));
+        assert!(
+            block.duration().is_none(),
+            "finished before executed should produce None"
         );
     }
 

--- a/freminal-common/src/config.rs
+++ b/freminal-common/src/config.rs
@@ -523,6 +523,66 @@ impl Default for ShellIntegrationConfig {
 //  Command Blocks
 // ------------------------------------------------------------------------------------------------
 
+/// Width, in physical pixels, of the colored command-block gutter strip
+/// itself when it is enabled (`GutterPosition::Left`).
+///
+/// This is only the painted bar.  The cell grid is shifted further right by
+/// an additional [`COMMAND_BLOCK_GUTTER_PADDING_PX`] so glyphs do not sit
+/// flush against the strip; see [`GutterPosition::total_inset_px`].
+pub const COMMAND_BLOCK_GUTTER_WIDTH_PX: f32 = 4.0;
+
+/// Padding, in physical pixels, between the colored gutter strip and the
+/// first glyph column.  Gives the status bar visual breathing room without
+/// widening the painted strip.
+pub const COMMAND_BLOCK_GUTTER_PADDING_PX: f32 = 4.0;
+
+/// Where the command-block status gutter is drawn relative to the terminal
+/// cell grid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum GutterPosition {
+    /// Reserve a thin strip on the left edge of the terminal area and draw a
+    /// per-command status color bar in it.  Default.
+    #[default]
+    Left,
+    /// No gutter.  The full terminal width is used for cell content and no
+    /// status bar is drawn.
+    Off,
+}
+
+impl GutterPosition {
+    /// The painted gutter-strip width in physical pixels for this position.
+    ///
+    /// [`GutterPosition::Off`] reserves zero width.
+    #[must_use]
+    pub const fn width_px(self) -> f32 {
+        match self {
+            Self::Left => COMMAND_BLOCK_GUTTER_WIDTH_PX,
+            Self::Off => 0.0,
+        }
+    }
+
+    /// The total left inset in physical pixels: the painted strip width plus
+    /// the padding gap before the first glyph column.
+    ///
+    /// This is the single source of truth shared by the column-count
+    /// computation (which subtracts it from the available width before
+    /// dividing by the cell width) and the renderer (which shifts the cell
+    /// grid right by the same amount).  Keeping both consumers tied to this
+    /// one value is what guarantees the column count reported to the PTY
+    /// always matches the rendered cell-grid width.
+    ///
+    /// [`GutterPosition::Off`] reserves zero inset so both consumers fall
+    /// back to the full terminal width with no shift.
+    #[must_use]
+    pub const fn total_inset_px(self) -> f32 {
+        match self {
+            Self::Left => COMMAND_BLOCK_GUTTER_WIDTH_PX + COMMAND_BLOCK_GUTTER_PADDING_PX,
+            Self::Off => 0.0,
+        }
+    }
+}
+
 /// Configuration for OSC 133 command-block visualization.
 ///
 /// Command blocks group each shell command's prompt, input, and output into
@@ -535,6 +595,7 @@ impl Default for ShellIntegrationConfig {
 /// enabled = true
 /// show_duration = true
 /// duration_threshold_secs = 2.0
+/// gutter = "left"
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -556,6 +617,11 @@ pub struct CommandBlocksConfig {
     /// rendered.  Below this threshold the label is suppressed to avoid
     /// flicker on fast commands.  Default: `2.0`.
     pub duration_threshold_secs: f32,
+
+    /// Where the per-command status gutter is drawn.  `"left"` reserves a
+    /// thin strip on the left edge of the terminal area; `"off"` disables
+    /// the gutter entirely.  Default: `"left"`.
+    pub gutter: GutterPosition,
 }
 
 impl Default for CommandBlocksConfig {
@@ -564,6 +630,7 @@ impl Default for CommandBlocksConfig {
             enabled: true,
             show_duration: true,
             duration_threshold_secs: 2.0,
+            gutter: GutterPosition::Left,
         }
     }
 }
@@ -1447,6 +1514,13 @@ pub fn log_dir() -> Option<PathBuf> {
 mod tests {
     use super::*;
 
+    /// Minimal wrapper used to assert the TOML key/value form of
+    /// [`GutterPosition`] independent of the full [`Config`] document.
+    #[derive(Serialize)]
+    struct GutterToml {
+        gutter: GutterPosition,
+    }
+
     #[test]
     fn font_config_default_ligatures_true() {
         let cfg = FontConfig::default();
@@ -1506,6 +1580,7 @@ size = 14.0
         cfg.command_blocks.enabled = false;
         cfg.command_blocks.show_duration = false;
         cfg.command_blocks.duration_threshold_secs = 5.5;
+        cfg.command_blocks.gutter = GutterPosition::Off;
 
         let toml = toml::to_string_pretty(&cfg).expect("serialise default config");
         let parsed: Config = toml::from_str(&toml).expect("re-parse");
@@ -1514,6 +1589,48 @@ size = 14.0
         assert!(!parsed.command_blocks.enabled);
         assert!(!parsed.command_blocks.show_duration);
         assert!((parsed.command_blocks.duration_threshold_secs - 5.5_f32).abs() < f32::EPSILON);
+        assert_eq!(parsed.command_blocks.gutter, GutterPosition::Off);
+    }
+
+    #[test]
+    fn gutter_position_defaults_to_left() {
+        assert_eq!(CommandBlocksConfig::default().gutter, GutterPosition::Left);
+    }
+
+    #[test]
+    fn gutter_position_serializes_as_kebab_case() {
+        // "left"/"off" lowercase in TOML, per the documented config key.
+        let toml = toml::to_string(&GutterToml {
+            gutter: GutterPosition::Left,
+        })
+        .expect("serialise");
+        assert!(toml.contains("gutter = \"left\""), "got: {toml}");
+        let toml_off = toml::to_string(&GutterToml {
+            gutter: GutterPosition::Off,
+        })
+        .expect("serialise");
+        assert!(toml_off.contains("gutter = \"off\""), "got: {toml_off}");
+    }
+
+    #[test]
+    fn gutter_position_width_px_matches_constant() {
+        assert!(
+            (GutterPosition::Left.width_px() - COMMAND_BLOCK_GUTTER_WIDTH_PX).abs() < f32::EPSILON
+        );
+        assert!(GutterPosition::Off.width_px().abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn gutter_position_total_inset_includes_padding() {
+        // The cell grid is shifted by strip width + padding; the painted
+        // strip is just the strip width.
+        let expected = COMMAND_BLOCK_GUTTER_WIDTH_PX + COMMAND_BLOCK_GUTTER_PADDING_PX;
+        assert!((GutterPosition::Left.total_inset_px() - expected).abs() < f32::EPSILON);
+        assert!(
+            GutterPosition::Left.total_inset_px() > GutterPosition::Left.width_px(),
+            "total inset must exceed the painted strip width (padding gap)"
+        );
+        assert!(GutterPosition::Off.total_inset_px().abs() < f32::EPSILON);
     }
 
     #[test]

--- a/freminal-common/src/themes.rs
+++ b/freminal-common/src/themes.rs
@@ -3,6 +3,8 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+use crate::buffer_states::command_block::CommandStatus;
+
 /// A complete terminal color palette.
 ///
 /// Contains the 16 ANSI colors (normal + bright), special-purpose colors
@@ -41,6 +43,54 @@ pub struct ThemePalette {
     /// Layout: `[black, red, green, yellow, blue, magenta, cyan, white,
     ///          bright_black, bright_red, ..., bright_white]`
     pub ansi: [(u8, u8, u8); 16],
+
+    /// Command-block gutter color for a successful command (OSC 133 exit
+    /// code 0).  `None` falls back to the normal-green ANSI color
+    /// (`ansi[2]`).  See [`ThemePalette::gutter_color_for`].
+    pub gutter_success: Option<(u8, u8, u8)>,
+
+    /// Command-block gutter color for a failed command (OSC 133 non-zero
+    /// exit code).  `None` falls back to the normal-red ANSI color
+    /// (`ansi[1]`).  See [`ThemePalette::gutter_color_for`].
+    pub gutter_failure: Option<(u8, u8, u8)>,
+
+    /// Command-block gutter color for a running command (OSC 133 A
+    /// received, no D yet).  `None` falls back to the normal-yellow ANSI
+    /// color (`ansi[3]`).  See [`ThemePalette::gutter_color_for`].
+    pub gutter_running: Option<(u8, u8, u8)>,
+}
+
+impl ThemePalette {
+    /// Resolve the gutter color for a command-block [`CommandStatus`].
+    ///
+    /// Returns the theme's configured override when present, otherwise a
+    /// sensible default derived from the palette's normal ANSI colors:
+    ///
+    /// - [`CommandStatus::Success`] -> `gutter_success` or green (`ansi[2]`).
+    /// - [`CommandStatus::Failure`] -> `gutter_failure` or red (`ansi[1]`).
+    /// - [`CommandStatus::Running`] -> `gutter_running` or yellow (`ansi[3]`).
+    /// - [`CommandStatus::Unknown`] -> the normal-white ANSI color
+    ///   (`ansi[7]`); there is no dedicated override for the unknown
+    ///   state because it is not a status a user typically wants to
+    ///   recolor.
+    #[must_use]
+    pub const fn gutter_color_for(&self, status: CommandStatus) -> (u8, u8, u8) {
+        match status {
+            CommandStatus::Success => match self.gutter_success {
+                Some(c) => c,
+                None => self.ansi[2],
+            },
+            CommandStatus::Failure(_) => match self.gutter_failure {
+                Some(c) => c,
+                None => self.ansi[1],
+            },
+            CommandStatus::Running => match self.gutter_running {
+                Some(c) => c,
+                None => self.ansi[3],
+            },
+            CommandStatus::Unknown => self.ansi[7],
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -78,6 +128,9 @@ pub const CATPPUCCIN_MOCHA: ThemePalette = ThemePalette {
         (0x6b, 0xd7, 0xca), // 14 BrightCyan
         (0xba, 0xc2, 0xde), // 15 BrightWhite (Subtext1)
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -115,6 +168,9 @@ pub const CATPPUCCIN_MACCHIATO: ThemePalette = ThemePalette {
         (0x63, 0xcb, 0xbe), // 14 BrightCyan
         (0xb8, 0xc0, 0xe0), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -152,6 +208,9 @@ pub const CATPPUCCIN_FRAPPE: ThemePalette = ThemePalette {
         (0x5f, 0xbf, 0xb4), // 14 BrightCyan
         (0xb5, 0xbf, 0xe2), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -189,6 +248,9 @@ pub const CATPPUCCIN_LATTE: ThemePalette = ThemePalette {
         (0x14, 0x8f, 0x93), // 14 BrightCyan
         (0xbc, 0xc0, 0xcc), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -226,6 +288,9 @@ pub const DRACULA: ThemePalette = ThemePalette {
         (0xa4, 0xff, 0xff), // 14 BrightCyan
         (0xff, 0xff, 0xff), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -263,6 +328,9 @@ pub const NORD: ThemePalette = ThemePalette {
         (0x8f, 0xbc, 0xbb), // 14 BrightCyan
         (0xec, 0xef, 0xf4), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -300,6 +368,9 @@ pub const SOLARIZED_DARK: ThemePalette = ThemePalette {
         (0x93, 0xa1, 0xa1), // 14 BrightCyan
         (0xfd, 0xf6, 0xe3), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -337,6 +408,9 @@ pub const SOLARIZED_LIGHT: ThemePalette = ThemePalette {
         (0x93, 0xa1, 0xa1), // 14 BrightCyan
         (0xfd, 0xf6, 0xe3), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -374,6 +448,9 @@ pub const GRUVBOX_DARK: ThemePalette = ThemePalette {
         (0x8e, 0xc0, 0x7c), // 14 BrightCyan
         (0xeb, 0xdb, 0xb2), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -411,6 +488,9 @@ pub const GRUVBOX_LIGHT: ThemePalette = ThemePalette {
         (0x42, 0x7b, 0x58), // 14 BrightCyan
         (0x3c, 0x38, 0x36), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -448,6 +528,9 @@ pub const ONE_DARK: ThemePalette = ThemePalette {
         (0x56, 0xb6, 0xc2), // 14 BrightCyan
         (0xc8, 0xcc, 0xd4), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -485,6 +568,9 @@ pub const ONE_LIGHT: ThemePalette = ThemePalette {
         (0x01, 0x84, 0xbc), // 14 BrightCyan
         (0xfa, 0xfa, 0xfa), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -522,6 +608,9 @@ pub const TOKYO_NIGHT: ThemePalette = ThemePalette {
         (0x7d, 0xcf, 0xff), // 14 BrightCyan
         (0xc0, 0xca, 0xf5), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -559,6 +648,9 @@ pub const TOKYO_NIGHT_STORM: ThemePalette = ThemePalette {
         (0x7d, 0xcf, 0xff), // 14 BrightCyan
         (0xc0, 0xca, 0xf5), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -596,6 +688,9 @@ pub const KANAGAWA: ThemePalette = ThemePalette {
         (0x7a, 0xa8, 0x9f), // 14 BrightCyan
         (0xdc, 0xd7, 0xba), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -633,6 +728,9 @@ pub const ROSE_PINE: ThemePalette = ThemePalette {
         (0xeb, 0xbc, 0xba), // 14 BrightCyan
         (0xe0, 0xde, 0xf4), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -670,6 +768,9 @@ pub const ROSE_PINE_MOON: ThemePalette = ThemePalette {
         (0xea, 0x9a, 0x97), // 14 BrightCyan
         (0xe0, 0xde, 0xf4), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -707,6 +808,9 @@ pub const ROSE_PINE_DAWN: ThemePalette = ThemePalette {
         (0xd7, 0x82, 0x7e), // 14 BrightCyan
         (0x57, 0x52, 0x79), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -744,6 +848,9 @@ pub const MONOKAI_PRO: ThemePalette = ThemePalette {
         (0x78, 0xdc, 0xe8), // 14 BrightCyan
         (0xfc, 0xfc, 0xfa), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -781,6 +888,9 @@ pub const AYU_DARK: ThemePalette = ThemePalette {
         (0x95, 0xe6, 0xcb), // 14 BrightCyan
         (0xff, 0xff, 0xff), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -818,6 +928,9 @@ pub const AYU_LIGHT: ThemePalette = ThemePalette {
         (0x4c, 0xbf, 0x99), // 14 BrightCyan
         (0xff, 0xff, 0xff), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -855,6 +968,9 @@ pub const EVERFOREST_DARK: ThemePalette = ThemePalette {
         (0x83, 0xc0, 0x92), // 14 BrightCyan
         (0xd3, 0xc6, 0xaa), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -892,6 +1008,9 @@ pub const EVERFOREST_LIGHT: ThemePalette = ThemePalette {
         (0x35, 0xa7, 0x7c), // 14 BrightCyan
         (0xdf, 0xdd, 0xc8), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -929,6 +1048,9 @@ pub const MATERIAL_DARK: ThemePalette = ThemePalette {
         (0x90, 0xe7, 0xd4), // 14 BrightCyan
         (0xff, 0xff, 0xff), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -966,6 +1088,9 @@ pub const XTERM_DEFAULT: ThemePalette = ThemePalette {
         (0x00, 0xff, 0xff), // 14 BrightCyan
         (0xff, 0xff, 0xff), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -1002,6 +1127,9 @@ pub const WEZTERM_DEFAULT: ThemePalette = ThemePalette {
         (0x55, 0xff, 0xff), // 14 BrightCyan
         (0xff, 0xff, 0xff), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 // ---------------------------------------------------------------------------
@@ -1038,6 +1166,9 @@ pub const GHOSTTY_DEFAULT: ThemePalette = ThemePalette {
         (0x70, 0xc0, 0xb1), // 14 BrightCyan
         (0xea, 0xea, 0xea), // 15 BrightWhite
     ],
+    gutter_success: None,
+    gutter_failure: None,
+    gutter_running: None,
 };
 
 /// The default theme used when no theme is configured or the configured slug
@@ -1258,5 +1389,49 @@ mod tests {
                 window[1].name,
             );
         }
+    }
+
+    #[test]
+    fn all_themes_default_gutter_overrides_to_none() {
+        // No shipped theme customizes the gutter colors yet; they all
+        // rely on the ANSI-derived fallback.
+        for theme in all_themes() {
+            assert_eq!(theme.gutter_success, None, "theme {}", theme.slug);
+            assert_eq!(theme.gutter_failure, None, "theme {}", theme.slug);
+            assert_eq!(theme.gutter_running, None, "theme {}", theme.slug);
+        }
+    }
+
+    #[test]
+    fn gutter_color_for_falls_back_to_ansi_when_unset() {
+        let t = CATPPUCCIN_MOCHA;
+        assert_eq!(t.gutter_color_for(CommandStatus::Success), t.ansi[2]);
+        assert_eq!(t.gutter_color_for(CommandStatus::Failure(1)), t.ansi[1]);
+        assert_eq!(t.gutter_color_for(CommandStatus::Running), t.ansi[3]);
+        // Unknown has no override; it always uses normal white (ansi[7]).
+        assert_eq!(t.gutter_color_for(CommandStatus::Unknown), t.ansi[7]);
+    }
+
+    #[test]
+    fn gutter_color_for_failure_ignores_exit_code_value() {
+        let t = CATPPUCCIN_MOCHA;
+        // The exit code carried by Failure does not change the color.
+        assert_eq!(
+            t.gutter_color_for(CommandStatus::Failure(1)),
+            t.gutter_color_for(CommandStatus::Failure(137)),
+        );
+    }
+
+    #[test]
+    fn gutter_color_for_prefers_override_when_set() {
+        let mut t = CATPPUCCIN_MOCHA;
+        t.gutter_success = Some((1, 2, 3));
+        t.gutter_failure = Some((4, 5, 6));
+        t.gutter_running = Some((7, 8, 9));
+        assert_eq!(t.gutter_color_for(CommandStatus::Success), (1, 2, 3));
+        assert_eq!(t.gutter_color_for(CommandStatus::Failure(2)), (4, 5, 6));
+        assert_eq!(t.gutter_color_for(CommandStatus::Running), (7, 8, 9));
+        // Unknown is unaffected by overrides.
+        assert_eq!(t.gutter_color_for(CommandStatus::Unknown), t.ansi[7]);
     }
 }

--- a/freminal-terminal-emulator/build.rs
+++ b/freminal-terminal-emulator/build.rs
@@ -7,16 +7,16 @@
 extern crate vergen;
 use std::path::PathBuf;
 use std::process::Command;
-use vergen::{BuildBuilder, CargoBuilder, Emitter, RustcBuilder, SysinfoBuilder};
+use vergen::{Build, Cargo, Emitter, Rustc, Sysinfo};
 
 // https://github.com/sagiegurari/cargo-make
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Building....");
     println!("cargo:rerun-if-changed=build.rs");
-    let build = BuildBuilder::all_build()?;
-    let cargo = CargoBuilder::all_cargo()?;
-    let rustc = RustcBuilder::all_rustc()?;
-    let si = SysinfoBuilder::all_sysinfo()?;
+    let build = Build::all_build();
+    let cargo = Cargo::all_cargo();
+    let rustc = Rustc::all_rustc();
+    let si = Sysinfo::all_sysinfo();
 
     Emitter::default()
         .add_instructions(&build)?

--- a/freminal-terminal-emulator/src/interface.rs
+++ b/freminal-terminal-emulator/src/interface.rs
@@ -158,10 +158,24 @@ pub struct TerminalEmulator {
     /// Updated when an `InputEvent::ScrollOffset(n)` is received.  Reset to 0
     /// when new PTY output arrives (auto-scroll to bottom).
     gui_scroll_offset: usize,
+    /// Number of extra rows the GUI wants flattened **above** the normal
+    /// visible window (command-block fold support).
+    ///
+    /// Updated alongside `gui_scroll_offset` when an
+    /// `InputEvent::ScrollOffset` is received. When the GUI has folds active
+    /// in the visible window, it requests extra rows so the renderer can fill
+    /// the screen after collapsing folds (keeping the live bottom pinned).
+    /// `0` for the common case (no folds). Reset to 0 on new PTY output along
+    /// with the scroll offset.
+    gui_extra_rows: usize,
     /// The scroll offset used for the previous snapshot.  When this differs
     /// from the current `gui_scroll_offset`, the visible window has moved and
     /// the cached snapshot must be invalidated.
     previous_scroll_offset: usize,
+    /// The `gui_extra_rows` value used for the previous snapshot. When this
+    /// differs from the current value the flatten window grew/shrank and the
+    /// cached snapshot must be invalidated.
+    previous_extra_rows: usize,
     /// The terminal dimensions (cols, rows) at the time of the previous
     /// snapshot.  When these change (e.g. after a pane resize), the cached
     /// snapshot must be invalidated — it was built for a different grid size.
@@ -198,7 +212,9 @@ impl TerminalEmulator {
             previous_visible_snap: None,
             previous_was_alternate: false,
             gui_scroll_offset: 0,
+            gui_extra_rows: 0,
             previous_scroll_offset: 0,
+            previous_extra_rows: 0,
             previous_term_size: (0, 0),
             dont_draw_entered_at: None,
         }
@@ -225,7 +241,9 @@ impl TerminalEmulator {
             previous_visible_snap: None,
             previous_was_alternate: false,
             gui_scroll_offset: 0,
+            gui_extra_rows: 0,
             previous_scroll_offset: 0,
+            previous_extra_rows: 0,
             previous_term_size: (0, 0),
             dont_draw_entered_at: None,
         };
@@ -303,7 +321,9 @@ impl TerminalEmulator {
             previous_visible_snap: None,
             previous_was_alternate: false,
             gui_scroll_offset: 0,
+            gui_extra_rows: 0,
             previous_scroll_offset: 0,
+            previous_extra_rows: 0,
             previous_term_size: (0, 0),
             dont_draw_entered_at: None,
         };
@@ -460,15 +480,33 @@ impl TerminalEmulator {
     /// Called by the PTY consumer thread when it receives
     /// `InputEvent::ScrollOffset(n)`.  The value is clamped to
     /// `max_scroll_offset()` during the next `build_snapshot()` call.
+    ///
+    /// Leaves `gui_extra_rows` unchanged; use
+    /// [`Self::set_gui_scroll_window`] to update both at once.
     pub const fn set_gui_scroll_offset(&mut self, offset: usize) {
         self.gui_scroll_offset = offset;
     }
 
-    /// Reset the scroll offset to 0 (live bottom).
+    /// Update the GUI-requested scroll offset together with the number of
+    /// extra rows to flatten above the visible window (command-block fold
+    /// support).
+    ///
+    /// Called by the PTY consumer thread when it receives an
+    /// `InputEvent::ScrollOffset`. Both values are clamped during the next
+    /// `build_snapshot()` call (`offset` to `max_scroll_offset()`, and the
+    /// effective `extra_rows` to the available scrollback above the window).
+    pub const fn set_gui_scroll_window(&mut self, offset: usize, extra_rows: usize) {
+        self.gui_scroll_offset = offset;
+        self.gui_extra_rows = extra_rows;
+    }
+
+    /// Reset the scroll offset to 0 (live bottom) and clear any extra-row
+    /// fold request.
     ///
     /// Called when new PTY data arrives while the user is scrolled back.
     pub const fn reset_scroll_offset(&mut self) {
         self.gui_scroll_offset = 0;
+        self.gui_extra_rows = 0;
     }
 
     /// Write to the terminal
@@ -536,6 +574,8 @@ impl TerminalEmulator {
         let (term_width, term_height) = self.internal.handler.win_size();
         let is_alternate_screen = self.internal.handler.is_alternate_screen();
 
+        let total_rows = self.internal.handler.buffer().rows().len();
+
         // On the alternate screen scrollback is meaningless — clamp to 0.
         let (scroll_offset, max_scroll_offset) = if is_alternate_screen {
             (0, 0)
@@ -544,6 +584,25 @@ impl TerminalEmulator {
             // (e.g. from a previous buffer state) doesn't panic.
             let max = self.internal.handler.buffer().max_scroll_offset();
             (self.gui_scroll_offset.min(max), max)
+        };
+
+        // ── Extra rows above the visible window (command-block folds) ────────
+        //
+        // The GUI requests `gui_extra_rows` extra rows flattened ABOVE the
+        // normal visible window so it can fill the screen after collapsing
+        // folded command blocks (keeping the live bottom pinned). The
+        // effective count is clamped to the rows actually available above the
+        // window (`visible_window_start`), and forced to 0 on the alternate
+        // screen (no scrollback). This never moves the live bottom — only the
+        // top of the flatten window — so `scroll_offset`, `show_cursor`, and
+        // `scroll_changed` are all unaffected by folding.
+        let extra_rows = if is_alternate_screen {
+            0
+        } else {
+            let available_above = total_rows
+                .saturating_sub(term_height)
+                .saturating_sub(scroll_offset);
+            self.gui_extra_rows.min(available_above)
         };
 
         // ── Invalidate the snap cache on primary ↔ alternate screen switch ───
@@ -565,6 +624,16 @@ impl TerminalEmulator {
             self.previous_scroll_offset = scroll_offset;
         }
 
+        // ── Invalidate the snap cache when the extra-row count changes ───────
+        //
+        // A fold/unfold changes how many rows are flattened above the window;
+        // the cached flat content covers a different row span and must not be
+        // reused.
+        if extra_rows != self.previous_extra_rows {
+            self.previous_visible_snap = None;
+            self.previous_extra_rows = extra_rows;
+        }
+
         // ── Invalidate the snap cache when terminal dimensions change ────
         //
         // After a resize the grid has a different number of columns and/or
@@ -579,15 +648,18 @@ impl TerminalEmulator {
         }
 
         // ── Determine whether any visible row changed since last snapshot ────
-        let any_dirty = self.internal.handler.any_visible_dirty(scroll_offset);
+        let any_dirty = self
+            .internal
+            .handler
+            .any_visible_dirty_extended(scroll_offset, extra_rows);
 
         // ── Produce (visible_chars, visible_tags, content_changed) ───────
         //
-        // Only flatten the *visible* rows — scrollback is not part of the
-        // snapshot.  The previous code called `data_and_format_data_for_gui`
-        // which also flattened scrollback, then discarded the result.
+        // Only flatten the *visible* rows (plus any fold-requested extra rows
+        // above them) — scrollback below the window is not part of the
+        // snapshot.
         let (visible_chars, visible_tags, row_offsets, url_tag_indices, content_changed) =
-            self.flatten_visible(any_dirty, scroll_offset);
+            self.flatten_visible(any_dirty, scroll_offset, extra_rows);
 
         // ── Remaining cheap reads ────────────────────────────────────────────
         self.apply_sync_updates_timeout();
@@ -637,23 +709,23 @@ impl TerminalEmulator {
         let theme = self.internal.handler.theme();
 
         // ── Inline image data ────────────────────────────────────────────────
-        let (images, visible_image_placements) = self.collect_visible_images(scroll_offset);
+        let (images, visible_image_placements) =
+            self.collect_visible_images(scroll_offset, extra_rows);
 
         // ── Per-row line-width attributes (DECDWL / DECDHL) ──────────────────
         let visible_line_widths = Arc::new(
             self.internal
                 .handler
                 .buffer()
-                .visible_line_widths(scroll_offset),
+                .visible_line_widths_extended(scroll_offset, extra_rows),
         );
-
-        let total_rows = self.internal.handler.buffer().rows().len();
 
         TerminalSnapshot {
             visible_chars,
             visible_tags,
             scroll_offset,
             max_scroll_offset,
+            window_extra_rows: extra_rows,
             height: term_height,
             cursor_pos,
             show_cursor,
@@ -704,14 +776,19 @@ impl TerminalEmulator {
     /// The `row_offsets` contains per-row flat-index offsets into the chars vec
     /// (one entry per visible row).  `url_tag_indices` contains the indices of
     /// tags in `tags` that carry a URL.
-    fn flatten_visible(&mut self, any_dirty: bool, scroll_offset: usize) -> FlattenResult {
+    fn flatten_visible(
+        &mut self,
+        any_dirty: bool,
+        scroll_offset: usize,
+        extra_rows: usize,
+    ) -> FlattenResult {
         if any_dirty {
             // At least one visible row is dirty — re-flatten via the cache.
             let (vis_chars, vis_tags, vis_row_offsets, vis_url_indices) = self
                 .internal
                 .handler
                 .buffer_mut()
-                .visible_as_tchars_and_tags(scroll_offset);
+                .visible_as_tchars_and_tags_extended(scroll_offset, extra_rows);
             let vc = Arc::new(vis_chars);
             let vt = Arc::new(vis_tags);
             let vr = Arc::new(vis_row_offsets);
@@ -751,7 +828,7 @@ impl TerminalEmulator {
                 .internal
                 .handler
                 .buffer_mut()
-                .visible_as_tchars_and_tags(scroll_offset);
+                .visible_as_tchars_and_tags_extended(scroll_offset, extra_rows);
             let vc = Arc::new(vis_chars);
             let vt = Arc::new(vis_tags);
             let vr = Arc::new(vis_row_offsets);
@@ -825,7 +902,7 @@ impl TerminalEmulator {
     /// Returns `(images, placements)` — both wrapped in `Arc` for cheap
     /// snapshot cloning.  The common case (no images) returns empty containers
     /// with zero allocation.
-    fn collect_visible_images(&self, scroll_offset: usize) -> VisibleImages {
+    fn collect_visible_images(&self, scroll_offset: usize, extra_rows: usize) -> VisibleImages {
         if !self.internal.handler.has_visible_images(scroll_offset) {
             return (Arc::new(HashMap::new()), Arc::new(Vec::new()));
         }
@@ -833,7 +910,7 @@ impl TerminalEmulator {
         let placements = self
             .internal
             .handler
-            .visible_image_placements(scroll_offset);
+            .visible_image_placements_extended(scroll_offset, extra_rows);
 
         // Collect only the images actually referenced by a visible cell so the
         // snapshot doesn't grow without bound.

--- a/freminal-terminal-emulator/src/io/mod.rs
+++ b/freminal-terminal-emulator/src/io/mod.rs
@@ -34,12 +34,19 @@ pub enum InputEvent {
     Resize(usize, usize, usize, usize),
     /// Window focus gained (`true`) or lost (`false`).
     FocusChange(bool),
-    /// Desired scroll offset (rows from the bottom, 0 = live view).
+    /// Desired scroll window: scroll offset (rows from the bottom, 0 = live
+    /// view) plus extra rows to flatten above the visible window.
     ///
-    /// Sent by the GUI when the user scrolls up/down on the primary screen.
-    /// The PTY thread stores this and uses it when building the next snapshot
-    /// so `visible_as_tchars_and_tags(offset)` renders the correct window.
-    ScrollOffset(usize),
+    /// Sent by the GUI when the user scrolls up/down on the primary screen, or
+    /// when command-block folds in the visible window change. The PTY thread
+    /// stores both and uses them when building the next snapshot so the
+    /// flattened window covers `term_height + extra_rows` rows (the extra rows
+    /// sit above the normal visible window).
+    ///
+    /// `extra_rows` is `0` in the common case (no folds in view). It only
+    /// moves the top of the flatten window; the live bottom, `show_cursor`,
+    /// and scroll position are unaffected.
+    ScrollOffset { offset: usize, extra_rows: usize },
     /// The user selected a new color theme in the Settings Modal.
     ///
     /// The PTY thread updates `handler.set_theme()` so subsequent snapshots

--- a/freminal-terminal-emulator/src/snapshot.rs
+++ b/freminal-terminal-emulator/src/snapshot.rs
@@ -77,6 +77,21 @@ pub struct TerminalSnapshot {
     /// size.  When `max_scroll_offset == 0` there is no scrollback history.
     pub max_scroll_offset: usize,
 
+    /// Number of extra rows flattened **above** the normal visible window for
+    /// command-block fold support.
+    ///
+    /// `visible_chars` / `visible_tags` / `row_offsets` / `visible_line_widths`
+    /// / `visible_image_placements` describe `term_height + window_extra_rows`
+    /// rows. The first `window_extra_rows` rows sit above the normal visible
+    /// window (i.e. the buffer-absolute window start is
+    /// `total_rows - term_height - scroll_offset - window_extra_rows`).
+    ///
+    /// `0` in the common case (no folds in view). The GUI uses these extra
+    /// rows to fill the screen after collapsing folded blocks, keeping the
+    /// live bottom pinned. It never affects `scroll_offset`, `show_cursor`, or
+    /// `scroll_changed` — only the top of the flatten window moves.
+    pub window_extra_rows: usize,
+
     /// Height of the visible window in rows.
     pub height: usize,
 
@@ -346,6 +361,7 @@ impl TerminalSnapshot {
             visible_tags: Arc::new(Vec::new()),
             scroll_offset: 0,
             max_scroll_offset: 0,
+            window_extra_rows: 0,
             height: 0,
             cursor_pos: CursorPos { x: 0, y: 0 },
             show_cursor: false,

--- a/freminal-terminal-emulator/src/terminal_handler/mod.rs
+++ b/freminal-terminal-emulator/src/terminal_handler/mod.rs
@@ -886,6 +886,14 @@ impl TerminalHandler {
         self.buffer.any_visible_dirty(scroll_offset)
     }
 
+    /// Like [`Self::any_visible_dirty`] but checks the window extended upward
+    /// by `extra_rows` (command-block fold support).
+    #[must_use]
+    pub fn any_visible_dirty_extended(&self, scroll_offset: usize, extra_rows: usize) -> bool {
+        self.buffer
+            .any_visible_dirty_extended(scroll_offset, extra_rows)
+    }
+
     /// Extract image placements for all cells in the visible window.
     ///
     /// Returns a flat `Vec` of `Option<ImagePlacement>`, one entry per cell
@@ -896,6 +904,19 @@ impl TerminalHandler {
         scroll_offset: usize,
     ) -> Vec<Option<freminal_buffer::image_store::ImagePlacement>> {
         self.buffer.visible_image_placements(scroll_offset)
+    }
+
+    /// Like [`Self::visible_image_placements`] but extends the window upward by
+    /// `extra_rows` (command-block fold support). The returned vector matches
+    /// the extended `visible_chars` layout.
+    #[must_use]
+    pub fn visible_image_placements_extended(
+        &self,
+        scroll_offset: usize,
+        extra_rows: usize,
+    ) -> Vec<Option<freminal_buffer::image_store::ImagePlacement>> {
+        self.buffer
+            .visible_image_placements_extended(scroll_offset, extra_rows)
     }
 
     /// Returns `true` if any cell in the visible window carries an image placement.

--- a/freminal-terminal-emulator/tests/snapshot_build.rs
+++ b/freminal-terminal-emulator/tests/snapshot_build.rs
@@ -610,3 +610,99 @@ fn has_urls_false_after_hyperlink_overwritten() {
         "has_urls must be false after all hyperlink cells are overwritten"
     );
 }
+
+// ─── window_extra_rows (command-block fold support) ──────────────────────────
+
+#[test]
+fn extra_rows_zero_by_default() {
+    let (mut emu, _rx) = make_emulator();
+    fill_scrollback(&mut emu, 150);
+    let snap = emu.build_snapshot();
+    assert_eq!(
+        snap.window_extra_rows, 0,
+        "no fold request → window_extra_rows must be 0"
+    );
+    assert_eq!(
+        snap.row_offsets.len(),
+        snap.term_height,
+        "default snapshot flattens exactly term_height rows"
+    );
+}
+
+#[test]
+fn extra_rows_extends_flattened_window() {
+    let (mut emu, _rx) = make_emulator();
+    fill_scrollback(&mut emu, 150);
+
+    let baseline = emu.build_snapshot();
+    let base_rows = baseline.row_offsets.len();
+    assert_eq!(base_rows, baseline.term_height);
+
+    // Request 5 extra rows above the live window (live bottom, offset 0).
+    emu.set_gui_scroll_window(0, 5);
+    let extended = emu.build_snapshot();
+    assert_eq!(
+        extended.window_extra_rows, 5,
+        "snapshot must report the requested extra-row count"
+    );
+    assert_eq!(
+        extended.row_offsets.len(),
+        baseline.term_height + 5,
+        "flattened window must carry term_height + extra rows"
+    );
+    assert_eq!(
+        extended.scroll_offset, 0,
+        "extra rows must NOT change the scroll offset (live bottom)"
+    );
+    assert!(
+        extended.show_cursor,
+        "extra rows must NOT hide the cursor (still at live bottom)"
+    );
+}
+
+#[test]
+fn extra_rows_clamped_to_available_scrollback() {
+    let (mut emu, _rx) = make_emulator();
+    fill_scrollback(&mut emu, 150);
+    let max = emu.build_snapshot().max_scroll_offset;
+
+    // Scroll to the very top, then request more extra rows than exist above.
+    emu.set_gui_scroll_window(max, 9999);
+    let snap = emu.build_snapshot();
+    // At the top of scrollback there are no rows above the window, so the
+    // effective extra-row count is clamped to 0.
+    assert_eq!(
+        snap.window_extra_rows, 0,
+        "extra rows must clamp to available scrollback above the window"
+    );
+}
+
+#[test]
+fn extra_rows_forced_zero_on_alternate_screen() {
+    let (mut emu, _rx) = make_emulator();
+    fill_scrollback(&mut emu, 150);
+    // Enter the alternate screen.
+    emu.handle_incoming_data(b"\x1b[?1049h");
+    emu.set_gui_scroll_window(0, 5);
+    let snap = emu.build_snapshot();
+    assert!(snap.is_alternate_screen);
+    assert_eq!(
+        snap.window_extra_rows, 0,
+        "alternate screen has no scrollback → extra rows must be 0"
+    );
+    assert_eq!(snap.row_offsets.len(), snap.term_height);
+}
+
+#[test]
+fn extra_rows_change_invalidates_cache() {
+    let (mut emu, _rx) = make_emulator();
+    fill_scrollback(&mut emu, 150);
+
+    emu.set_gui_scroll_window(0, 0);
+    let _ = emu.build_snapshot();
+    // Changing only the extra-row count must produce a fresh flatten with a
+    // different row count (cache cannot be reused).
+    emu.set_gui_scroll_window(0, 3);
+    let snap = emu.build_snapshot();
+    assert_eq!(snap.row_offsets.len(), snap.term_height + 3);
+}

--- a/freminal/src/gui/actions.rs
+++ b/freminal/src/gui/actions.rs
@@ -477,7 +477,11 @@ impl super::FreminalGui {
                 let snap = pane.arc_swap.load();
                 if let Some(offset) =
                     super::search::jump_to_prev_command(&mut pane.view_state, &snap)
-                    && let Err(e) = pane.input_tx.send(InputEvent::ScrollOffset(offset))
+                    && let Err(e) = pane.input_tx.send(super::terminal::input::scroll_event(
+                        &snap,
+                        &pane.view_state.folded_blocks,
+                        offset,
+                    ))
                 {
                     error!("Failed to send scroll offset to PTY: {e}");
                 }
@@ -491,7 +495,11 @@ impl super::FreminalGui {
                 let snap = pane.arc_swap.load();
                 if let Some(offset) =
                     super::search::jump_to_next_command(&mut pane.view_state, &snap)
-                    && let Err(e) = pane.input_tx.send(InputEvent::ScrollOffset(offset))
+                    && let Err(e) = pane.input_tx.send(super::terminal::input::scroll_event(
+                        &snap,
+                        &pane.view_state.folded_blocks,
+                        offset,
+                    ))
                 {
                     error!("Failed to send scroll offset to PTY: {e}");
                 }

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -837,6 +837,19 @@ impl freminal_windowing::App for FreminalGui {
             let logical_char_w = f32::approx_from(cell_w_u).unwrap_or(0.0) / ppp;
             let logical_char_h = f32::approx_from(cell_height_u).unwrap_or(0.0) / ppp;
 
+            // Command-block gutter inset, in logical points.  This is reserved
+            // on the left edge of every pane's content rect when the gutter is
+            // enabled.  It is subtracted from the available width BEFORE the
+            // column count is computed (below) so the column count reported to
+            // the PTY matches the rendered cell-grid width — the renderer
+            // shifts its terminal rect right by the same inset.  Zero when the
+            // feature is disabled or the gutter is set to `Off`.
+            let gutter_inset_logical = if self.config.command_blocks.enabled {
+                self.config.command_blocks.gutter.total_inset_px() / ppp
+            } else {
+                0.0
+            };
+
             let window_width = ui.input(|i: &egui::InputState| i.content_rect());
 
             // Drain window commands for ALL tabs and ALL panes within each tab.
@@ -1199,7 +1212,11 @@ impl freminal_windowing::App for FreminalGui {
                 };
 
                 // Per-pane character dimensions from this pane's content rect.
-                let pane_width_chars = (content_rect.width() / logical_char_w)
+                // The gutter inset is removed from the available width first so
+                // the column count matches the rendered cell grid (the widget
+                // shifts its terminal rect right by the same inset).
+                let pane_content_width = (content_rect.width() - gutter_inset_logical).max(0.0);
+                let pane_width_chars = (pane_content_width / logical_char_w)
                     .floor()
                     .approx_as::<usize>()
                     .unwrap_or_else(|e| {
@@ -1335,6 +1352,7 @@ impl freminal_windowing::App for FreminalGui {
                             self.config.ui.background_image_opacity,
                             self.config.ui.background_image_mode,
                             &self.config.command_blocks,
+                            gutter_inset_logical,
                             &self.binding_map,
                             is_echo_off,
                             is_active,

--- a/freminal/src/gui/command_blocks.rs
+++ b/freminal/src/gui/command_blocks.rs
@@ -284,6 +284,7 @@ mod tests {
             exit_code: exit,
             cwd: None,
             started_at: started,
+            executed_at: Some(started),
             finished_at: Some(started + Duration::from_secs(1)),
         }
     }
@@ -300,6 +301,7 @@ mod tests {
             exit_code: None,
             cwd: None,
             started_at: SystemTime::UNIX_EPOCH,
+            executed_at: None,
             finished_at: None,
         }
     }

--- a/freminal/src/gui/command_blocks.rs
+++ b/freminal/src/gui/command_blocks.rs
@@ -78,6 +78,34 @@ pub const fn block_is_foldable(block: &CommandBlock) -> bool {
     block.end_row.is_some()
 }
 
+/// Buffer-absolute row to anchor a block's duration label on (73.6): the
+/// block's **last on-screen row**.
+///
+/// The label is anchored to the bottom of the block's visible portion so it
+/// follows the block as it scrolls, instead of the first row (which scrolls
+/// off almost immediately for any command that produces output).
+///
+/// `win_start` / `win_end` are the visible window's buffer-row bounds
+/// (`win_end` exclusive).  `running_extent` is the last visible buffer row,
+/// used as the end of a running block.  Returns `None` when the block is
+/// entirely outside the visible window.
+#[must_use]
+pub fn duration_label_anchor_row(
+    block: &CommandBlock,
+    win_start: usize,
+    win_end: usize,
+    running_extent: usize,
+) -> Option<usize> {
+    let start = block.prompt_start_row;
+    let end = block.end_row.unwrap_or(running_extent);
+    if end < win_start || start >= win_end {
+        return None;
+    }
+    // Last visible row of the block: its end, clamped to the bottom of the
+    // viewport when the block extends below it.
+    Some(end.min(win_end.saturating_sub(1)))
+}
+
 /// Decide whether command-block visual overlays (hover-row tint and the
 /// duration label) may be drawn this frame.
 ///
@@ -411,5 +439,45 @@ mod tests {
         // A running command has no end_row; a gutter click on it is a
         // no-op fold (it only focuses the pane).
         assert!(!block_is_foldable(&running_block(4)));
+    }
+
+    // ── duration_label_anchor_row (73.6) ─────────────────────────────────
+
+    #[test]
+    fn anchor_is_the_blocks_last_row_not_first() {
+        // Block spans rows 2..=5.  The label must anchor on row 5 (last),
+        // not row 2 (first) — the regression this subtask fixes.
+        let block = finished_block(2, 5, Some(0));
+        assert_eq!(duration_label_anchor_row(&block, 0, 24, 23), Some(5));
+    }
+
+    #[test]
+    fn anchor_clamps_to_last_visible_row_when_block_extends_below() {
+        // Block ends at row 30 but the viewport bottom (win_end exclusive)
+        // is 24, so the anchor clamps to row 23.
+        let block = finished_block(2, 30, Some(0));
+        assert_eq!(duration_label_anchor_row(&block, 0, 24, 23), Some(23));
+    }
+
+    #[test]
+    fn anchor_none_when_block_entirely_above_viewport() {
+        // Block 0..=3 is entirely above a window starting at row 10.
+        let block = finished_block(0, 3, Some(0));
+        assert_eq!(duration_label_anchor_row(&block, 10, 34, 33), None);
+    }
+
+    #[test]
+    fn anchor_none_when_block_entirely_below_viewport() {
+        // Block starts at row 50, window is rows 0..24.
+        let block = finished_block(50, 53, Some(0));
+        assert_eq!(duration_label_anchor_row(&block, 0, 24, 23), None);
+    }
+
+    #[test]
+    fn anchor_running_block_uses_running_extent() {
+        // A running block (no end_row) extends to running_extent (23), so
+        // its label anchors there.
+        let block = running_block(4);
+        assert_eq!(duration_label_anchor_row(&block, 0, 24, 23), Some(23));
     }
 }

--- a/freminal/src/gui/command_blocks.rs
+++ b/freminal/src/gui/command_blocks.rs
@@ -22,34 +22,60 @@
 use freminal_common::buffer_states::command_block::{CommandBlock, CommandStatus};
 use std::time::Duration;
 
-/// Determine the [`CommandStatus`] of the command block containing the
-/// given buffer-absolute `row`, for gutter coloring.
+/// Find the command block containing the given buffer-absolute `row`, for
+/// gutter coloring, hover, and click hit-testing.
 ///
 /// A block spans from its `prompt_start_row` to its `end_row` (inclusive).
 /// A still-running block (no `end_row`) is treated as extending to
 /// `running_extent` — the last visible buffer row — so its gutter bar
 /// fills down to the live prompt.  Returns `None` for rows not covered by
-/// any block (those render an empty gutter).
+/// any block.
 ///
 /// When blocks overlap (which should not happen for well-formed OSC 133
 /// streams, but is not structurally prevented), the **last** matching
 /// block in iteration order wins, matching the most-recently-emitted
 /// command.
 #[must_use]
-pub fn gutter_status_for_row(
+pub fn gutter_block_for_row(
     blocks: &[CommandBlock],
     row: usize,
     running_extent: usize,
-) -> Option<CommandStatus> {
+) -> Option<&CommandBlock> {
     let mut found = None;
     for block in blocks {
         let start = block.prompt_start_row;
         let end = block.end_row.unwrap_or(running_extent);
         if row >= start && row <= end {
-            found = Some(block.status());
+            found = Some(block);
         }
     }
     found
+}
+
+/// Determine the [`CommandStatus`] of the command block containing the
+/// given buffer-absolute `row`, for gutter coloring.
+///
+/// Thin wrapper over [`gutter_block_for_row`]; see that function for the
+/// row-span and overlap semantics.
+#[must_use]
+pub fn gutter_status_for_row(
+    blocks: &[CommandBlock],
+    row: usize,
+    running_extent: usize,
+) -> Option<CommandStatus> {
+    gutter_block_for_row(blocks, row, running_extent).map(CommandBlock::status)
+}
+
+/// Whether a command block can be folded.
+///
+/// Only finished blocks (those with an `end_row`) are foldable; a running
+/// block has no defined output range to collapse, so a gutter click on it
+/// is a no-op (it still focuses the pane).  This mirrors the
+/// `command_start_row.is_some() && end_row.is_some()` guard used by the
+/// `FoldPreviousCommand` keybinding.
+#[must_use]
+pub const fn block_is_foldable(block: &CommandBlock) -> bool {
+    block.end_row.is_some()
 }
 
 /// Decide whether command-block visual overlays (hover-row tint and the
@@ -119,6 +145,7 @@ pub fn format_command_duration(d: Duration) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -357,5 +384,30 @@ mod tests {
             gutter_status_for_row(&blocks, 1, 100),
             Some(CommandStatus::Success)
         );
+    }
+
+    #[test]
+    fn gutter_block_for_row_returns_the_block_not_just_status() {
+        let blocks = [finished_block(2, 5, Some(7))];
+        let hit = gutter_block_for_row(&blocks, 3, 100).expect("row 3 is inside the block");
+        assert_eq!(hit.prompt_start_row, 2);
+        assert_eq!(hit.exit_code, Some(7));
+        assert!(gutter_block_for_row(&blocks, 6, 100).is_none());
+    }
+
+    // ── block_is_foldable ────────────────────────────────────────────────
+
+    #[test]
+    fn finished_block_is_foldable() {
+        assert!(block_is_foldable(&finished_block(0, 3, Some(0))));
+        assert!(block_is_foldable(&finished_block(0, 3, Some(1))));
+        assert!(block_is_foldable(&finished_block(0, 3, None)));
+    }
+
+    #[test]
+    fn running_block_is_not_foldable() {
+        // A running command has no end_row; a gutter click on it is a
+        // no-op fold (it only focuses the pane).
+        assert!(!block_is_foldable(&running_block(4)));
     }
 }

--- a/freminal/src/gui/command_blocks.rs
+++ b/freminal/src/gui/command_blocks.rs
@@ -12,11 +12,45 @@
 //! - [`command_block_overlays_visible`] — gate deciding whether any
 //!   command-block visual affordance (hover tint, duration label) may be
 //!   drawn for the current frame.
+//! - [`gutter_status_for_row`] — maps a buffer-absolute row to the
+//!   [`CommandStatus`] of the command block that contains it, if any
+//!   (the gutter color decision, factored out for unit testing).
 //!
 //! Kept as a standalone module so the formatter can be unit-tested
 //! without an egui or GPU context.
 
+use freminal_common::buffer_states::command_block::{CommandBlock, CommandStatus};
 use std::time::Duration;
+
+/// Determine the [`CommandStatus`] of the command block containing the
+/// given buffer-absolute `row`, for gutter coloring.
+///
+/// A block spans from its `prompt_start_row` to its `end_row` (inclusive).
+/// A still-running block (no `end_row`) is treated as extending to
+/// `running_extent` — the last visible buffer row — so its gutter bar
+/// fills down to the live prompt.  Returns `None` for rows not covered by
+/// any block (those render an empty gutter).
+///
+/// When blocks overlap (which should not happen for well-formed OSC 133
+/// streams, but is not structurally prevented), the **last** matching
+/// block in iteration order wins, matching the most-recently-emitted
+/// command.
+#[must_use]
+pub fn gutter_status_for_row(
+    blocks: &[CommandBlock],
+    row: usize,
+    running_extent: usize,
+) -> Option<CommandStatus> {
+    let mut found = None;
+    for block in blocks {
+        let start = block.prompt_start_row;
+        let end = block.end_row.unwrap_or(running_extent);
+        if row >= start && row <= end {
+            found = Some(block.status());
+        }
+    }
+    found
+}
 
 /// Decide whether command-block visual overlays (hover-row tint and the
 /// duration label) may be drawn this frame.
@@ -202,5 +236,126 @@ mod tests {
             let s = format_command_duration(Duration::from_secs(secs));
             assert!(!s.contains(' '), "duration '{s}' contains whitespace");
         }
+    }
+
+    // ── gutter_status_for_row ────────────────────────────────────────────
+
+    use freminal_common::buffer_states::command_block::CommandBlockId;
+    use std::time::SystemTime;
+
+    /// Build a finished block spanning `[prompt_start, end]` with the given
+    /// exit code.
+    fn finished_block(prompt_start: usize, end: usize, exit: Option<i32>) -> CommandBlock {
+        let started = SystemTime::UNIX_EPOCH;
+        CommandBlock {
+            id: CommandBlockId::next(),
+            fid: "t".to_owned(),
+            prompt_start_row: prompt_start,
+            command_start_row: Some(prompt_start),
+            output_start_row: Some(prompt_start + 1),
+            end_row: Some(end),
+            exit_code: exit,
+            cwd: None,
+            started_at: started,
+            finished_at: Some(started + Duration::from_secs(1)),
+        }
+    }
+
+    /// Build a still-running block starting at `prompt_start` (no end row).
+    fn running_block(prompt_start: usize) -> CommandBlock {
+        CommandBlock {
+            id: CommandBlockId::next(),
+            fid: "t".to_owned(),
+            prompt_start_row: prompt_start,
+            command_start_row: Some(prompt_start),
+            output_start_row: Some(prompt_start + 1),
+            end_row: None,
+            exit_code: None,
+            cwd: None,
+            started_at: SystemTime::UNIX_EPOCH,
+            finished_at: None,
+        }
+    }
+
+    #[test]
+    fn gutter_status_none_when_no_block_contains_row() {
+        let blocks = [finished_block(2, 5, Some(0))];
+        assert_eq!(gutter_status_for_row(&blocks, 0, 100), None);
+        assert_eq!(gutter_status_for_row(&blocks, 1, 100), None);
+        assert_eq!(gutter_status_for_row(&blocks, 6, 100), None);
+    }
+
+    #[test]
+    fn gutter_status_inclusive_of_both_endpoints() {
+        let blocks = [finished_block(2, 5, Some(0))];
+        // prompt_start_row (2) and end_row (5) are both inside the block.
+        assert_eq!(
+            gutter_status_for_row(&blocks, 2, 100),
+            Some(CommandStatus::Success)
+        );
+        assert_eq!(
+            gutter_status_for_row(&blocks, 5, 100),
+            Some(CommandStatus::Success)
+        );
+        assert_eq!(
+            gutter_status_for_row(&blocks, 3, 100),
+            Some(CommandStatus::Success)
+        );
+    }
+
+    #[test]
+    fn gutter_status_reflects_exit_code() {
+        let success = [finished_block(0, 3, Some(0))];
+        let failure = [finished_block(0, 3, Some(127))];
+        let unknown = [finished_block(0, 3, None)];
+        assert_eq!(
+            gutter_status_for_row(&success, 1, 100),
+            Some(CommandStatus::Success)
+        );
+        assert_eq!(
+            gutter_status_for_row(&failure, 1, 100),
+            Some(CommandStatus::Failure(127))
+        );
+        assert_eq!(
+            gutter_status_for_row(&unknown, 1, 100),
+            Some(CommandStatus::Unknown)
+        );
+    }
+
+    #[test]
+    fn gutter_status_running_block_extends_to_running_extent() {
+        let blocks = [running_block(4)];
+        // Inside [4, running_extent=10].
+        assert_eq!(
+            gutter_status_for_row(&blocks, 4, 10),
+            Some(CommandStatus::Running)
+        );
+        assert_eq!(
+            gutter_status_for_row(&blocks, 10, 10),
+            Some(CommandStatus::Running)
+        );
+        // Above prompt start — not in the block.
+        assert_eq!(gutter_status_for_row(&blocks, 3, 10), None);
+        // Past the running extent — not painted.
+        assert_eq!(gutter_status_for_row(&blocks, 11, 10), None);
+    }
+
+    #[test]
+    fn gutter_status_last_matching_block_wins_on_overlap() {
+        // Two blocks both claiming row 5; the later one (in iteration
+        // order) wins, matching the most-recently-emitted command.
+        let blocks = [
+            finished_block(0, 8, Some(0)), // success, spans 0..=8
+            finished_block(5, 9, Some(1)), // failure, spans 5..=9
+        ];
+        assert_eq!(
+            gutter_status_for_row(&blocks, 5, 100),
+            Some(CommandStatus::Failure(1))
+        );
+        // Row only in the first block stays success.
+        assert_eq!(
+            gutter_status_for_row(&blocks, 1, 100),
+            Some(CommandStatus::Success)
+        );
     }
 }

--- a/freminal/src/gui/command_blocks.rs
+++ b/freminal/src/gui/command_blocks.rs
@@ -9,11 +9,36 @@
 //! - [`format_command_duration`] — compact human-readable duration
 //!   formatter used by the duration-label overlay drawn at the end of a
 //!   finished block's first row.
+//! - [`command_block_overlays_visible`] — gate deciding whether any
+//!   command-block visual affordance (hover tint, duration label) may be
+//!   drawn for the current frame.
 //!
 //! Kept as a standalone module so the formatter can be unit-tested
 //! without an egui or GPU context.
 
 use std::time::Duration;
+
+/// Decide whether command-block visual overlays (hover-row tint and the
+/// duration label) may be drawn this frame.
+///
+/// Overlays are suppressed when:
+///
+/// - the command-block feature is disabled (`enabled == false`), or
+/// - the alternate screen is active — the stored [`CommandBlock`]s
+///   describe primary-screen buffer rows, so painting hover tints or
+///   duration labels over a full-screen TUI (vim, htop, less, …) would
+///   highlight unrelated rows, or
+/// - there are no command blocks to draw.
+///
+/// [`CommandBlock`]: freminal_common::buffer_states::command_block::CommandBlock
+#[must_use]
+pub const fn command_block_overlays_visible(
+    feature_enabled: bool,
+    is_alternate_screen: bool,
+    has_blocks: bool,
+) -> bool {
+    feature_enabled && !is_alternate_screen && has_blocks
+}
 
 /// Format a finished command's wall-clock duration as a compact label
 /// such as `"3s"`, `"2m15s"`, or `"1h3m"`.
@@ -128,6 +153,45 @@ mod tests {
     fn boundary_at_one_hour_no_extra_minutes() {
         // 3600s exactly should render as "1h" not "1h0m".
         assert_eq!(format_command_duration(Duration::from_hours(1)), "1h");
+    }
+
+    #[test]
+    fn overlays_visible_only_when_enabled_present_and_primary_screen() {
+        // All preconditions met → visible.
+        assert!(command_block_overlays_visible(true, false, true));
+    }
+
+    #[test]
+    fn overlays_hidden_when_feature_disabled() {
+        assert!(!command_block_overlays_visible(false, false, true));
+    }
+
+    #[test]
+    fn overlays_hidden_on_alternate_screen() {
+        // The regression this gate fixes: a full-screen TUI on the
+        // alternate screen must not show stale primary-screen command
+        // affordances, even though blocks are present and the feature
+        // is on.
+        assert!(!command_block_overlays_visible(true, true, true));
+    }
+
+    #[test]
+    fn overlays_hidden_when_no_blocks() {
+        assert!(!command_block_overlays_visible(true, false, false));
+    }
+
+    #[test]
+    fn alternate_screen_dominates_every_other_precondition() {
+        // No matter how the other two flags are set, the alternate
+        // screen always suppresses overlays.
+        for enabled in [false, true] {
+            for has_blocks in [false, true] {
+                assert!(
+                    !command_block_overlays_visible(enabled, true, has_blocks),
+                    "alt-screen should suppress overlays (enabled={enabled}, has_blocks={has_blocks})"
+                );
+            }
+        }
     }
 
     #[test]

--- a/freminal/src/gui/command_history.rs
+++ b/freminal/src/gui/command_history.rs
@@ -622,6 +622,7 @@ mod tests {
             exit_code,
             cwd: None,
             started_at: SystemTime::UNIX_EPOCH,
+            executed_at: Some(SystemTime::UNIX_EPOCH),
             finished_at: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1)),
         }
     }

--- a/freminal/src/gui/folding.rs
+++ b/freminal/src/gui/folding.rs
@@ -180,6 +180,160 @@ pub fn compute_fold_ranges<S: BuildHasher>(
     deduped
 }
 
+/// Compute how many extra rows to flatten **above** the visible window.
+///
+/// After collapsing every fold that overlaps the window, the extra rows let a
+/// full screen of rendered rows still be painted with the live bottom pinned.
+///
+/// `ranges` are the **buffer-absolute** fold ranges (as produced by
+/// [`compute_fold_ranges`]). `visible_window_start` is the buffer-absolute
+/// index of the topmost normally-visible row, and `term_height` the visible
+/// window height in rows.
+///
+/// For each fold overlapping the window `[visible_window_start,
+/// visible_window_start + term_height)`, collapsing it frees `overlap_len - 1`
+/// rows of screen space (the fold's visible rows become a single placeholder).
+/// The renderer must pull in that many real rows from above the window to keep
+/// the screen full. The total is the sum across all overlapping folds, capped
+/// by the rows actually available above the window (`visible_window_start`).
+///
+/// Returns `0` when no fold overlaps the window. The result is a stable
+/// function of `visible_window_start` (it does not depend on the extra-row
+/// count itself), so feeding it back through the scroll request does not
+/// oscillate.
+#[must_use]
+pub fn compute_extra_rows(
+    ranges: &[FoldRange],
+    visible_window_start: usize,
+    term_height: usize,
+) -> usize {
+    if term_height == 0 {
+        return 0;
+    }
+    let win_end = visible_window_start.saturating_add(term_height); // exclusive
+    let mut freed: usize = 0;
+    for r in ranges {
+        // Overlap of [start_row, end_row] (inclusive) with
+        // [visible_window_start, win_end) (half-open).
+        let ov_start = r.start_row.max(visible_window_start);
+        let ov_end_incl = r.end_row.min(win_end.saturating_sub(1));
+        if ov_start > ov_end_incl {
+            continue; // no overlap with the visible window
+        }
+        let overlap_len = ov_end_incl - ov_start + 1;
+        // Collapsing an overlapping fold frees `overlap_len - 1` rows.
+        freed = freed.saturating_add(overlap_len.saturating_sub(1));
+    }
+    // Cannot pull in more rows than exist above the window.
+    freed.min(visible_window_start)
+}
+
+/// Direction of a scroll step in [`apply_rendered_scroll`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScrollDir {
+    /// Scroll up, into history (increases the raw scroll offset).
+    Up,
+    /// Scroll down, toward the live bottom (decreases the raw scroll offset).
+    Down,
+}
+
+/// Convert a rendered-row scroll request into a new raw `scroll_offset`.
+///
+/// Steps are measured in **rendered rows** (visible lines); rows hidden inside
+/// collapsed folds are skipped so each step moves the view by exactly one
+/// visible line.
+///
+/// Without this, the raw scroll offset steps one buffer row at a time; while
+/// traversing a collapsed fold's hidden rows the visible content does not move
+/// (the rows are not painted), so scrolling feels stuck and the live bottom
+/// fails to track the input. With it, one rendered step that lands on a
+/// collapsed fold consumes the whole hidden span in a single move.
+///
+/// Parameters:
+/// - `ranges`: buffer-absolute fold ranges (from [`compute_fold_ranges`]).
+/// - `total_rows`, `term_height`: buffer / window geometry.
+/// - `max_scroll_offset`: clamp bound (raw rows of scrollback).
+/// - `raw_offset`: the current raw scroll offset.
+/// - `dir`, `steps`: scroll direction and the number of *rendered* rows.
+///
+/// Returns the new raw `scroll_offset`, clamped to `[0, max_scroll_offset]`.
+/// When `ranges` is empty this is exactly `raw_offset ± steps` (1:1 with the
+/// unfolded behaviour).
+#[must_use]
+pub fn apply_rendered_scroll(
+    ranges: &[FoldRange],
+    total_rows: usize,
+    term_height: usize,
+    max_scroll_offset: usize,
+    raw_offset: usize,
+    dir: ScrollDir,
+    steps: usize,
+) -> usize {
+    if ranges.is_empty() || term_height == 0 {
+        // No folds: rendered rows == raw rows.
+        return match dir {
+            ScrollDir::Up => raw_offset.saturating_add(steps).min(max_scroll_offset),
+            ScrollDir::Down => raw_offset.saturating_sub(steps),
+        };
+    }
+
+    // The first normally-visible buffer row at a given raw offset.
+    let top_of =
+        |raw: usize| -> usize { total_rows.saturating_sub(term_height).saturating_sub(raw) };
+    // Is buffer row `row` strictly inside a collapsed fold (i.e. hidden, not
+    // the placeholder anchor)? The placeholder occupies the fold's first row.
+    let hidden_in_fold = |row: usize| -> Option<&FoldRange> {
+        ranges
+            .iter()
+            .find(|r| row > r.start_row && row <= r.end_row)
+    };
+
+    let mut raw = raw_offset;
+    match dir {
+        ScrollDir::Up => {
+            for _ in 0..steps {
+                if raw >= max_scroll_offset {
+                    break;
+                }
+                let top = top_of(raw);
+                if top == 0 {
+                    break;
+                }
+                let revealed = top - 1; // buffer row revealed by one raw step up
+                // If the revealed row is hidden inside a fold, jump up to the
+                // fold's first (placeholder) row so the single placeholder is
+                // what appears, consuming the whole hidden span in one step.
+                // Otherwise reveal exactly one more row (raw + 1).
+                let next_raw = hidden_in_fold(revealed)
+                    .map_or(raw + 1, |fold| raw + (revealed - fold.start_row) + 1);
+                raw = next_raw.min(max_scroll_offset);
+            }
+        }
+        ScrollDir::Down => {
+            for _ in 0..steps {
+                if raw == 0 {
+                    break;
+                }
+                let top = top_of(raw);
+                // Scrolling down hides the current top row. If the row that
+                // would become the new top (`top + 1` after one raw step) is
+                // hidden inside a fold, jump down past the whole hidden span so
+                // one rendered row disappears, not a hidden one.
+                let new_top = top + 1;
+                // If the row that would become the new top is hidden inside a
+                // fold, jump down past the whole hidden span so one rendered
+                // row disappears, not a hidden one. Otherwise hide one row.
+                let next_raw = hidden_in_fold(new_top).map_or(raw - 1, |fold| {
+                    let target_top = fold.end_row + 1;
+                    raw.saturating_sub(target_top - top)
+                });
+                raw = next_raw;
+            }
+        }
+    }
+    raw.min(max_scroll_offset)
+}
+
 /// Translate a slice of [`FoldRange`] values from **buffer-absolute** row
 /// space into **snapshot-row** space (the row space [`RowMap`] consumes).
 ///
@@ -873,6 +1027,134 @@ mod tests {
         let r = fold(1, 4, 4);
         assert_eq!(r.len(), 1);
         assert!(r.contains(4));
+    }
+
+    // ── compute_extra_rows ──────────────────────────────────────────────
+
+    #[test]
+    fn extra_rows_zero_when_no_folds() {
+        assert_eq!(compute_extra_rows(&[], 100, 24), 0);
+    }
+
+    #[test]
+    fn extra_rows_zero_when_term_height_zero() {
+        let ranges = [fold(1, 100, 110)];
+        assert_eq!(compute_extra_rows(&ranges, 100, 0), 0);
+    }
+
+    #[test]
+    fn extra_rows_fold_fully_in_window() {
+        // Window [100, 124). Fold buffer rows 105..=110 (6 rows) is fully
+        // inside; collapsing frees 6 - 1 = 5 rows.
+        let ranges = [fold(1, 105, 110)];
+        assert_eq!(compute_extra_rows(&ranges, 100, 24), 5);
+    }
+
+    #[test]
+    fn extra_rows_fold_entirely_in_scrollback_above() {
+        // Window [100, 124). Fold 80..=90 is wholly above the window → no
+        // freed space.
+        let ranges = [fold(1, 80, 90)];
+        assert_eq!(compute_extra_rows(&ranges, 100, 24), 0);
+    }
+
+    #[test]
+    fn extra_rows_fold_straddles_top_of_window() {
+        // Window [100, 124). Fold 95..=110 overlaps rows 100..=110 (11 rows
+        // visible) → frees 11 - 1 = 10.
+        let ranges = [fold(1, 95, 110)];
+        assert_eq!(compute_extra_rows(&ranges, 100, 24), 10);
+    }
+
+    #[test]
+    fn extra_rows_capped_by_available_scrollback() {
+        // Window starts at row 3, so only 3 rows exist above it. A fold that
+        // would free 10 rows is capped at 3.
+        let ranges = [fold(1, 3, 20)];
+        assert_eq!(compute_extra_rows(&ranges, 3, 24), 3);
+    }
+
+    #[test]
+    fn extra_rows_sums_multiple_folds() {
+        // Window [100, 130). Fold A 102..=105 (4 rows → frees 3), fold B
+        // 110..=120 (11 rows → frees 10). Total freed 13, capped by 100.
+        let ranges = [fold(1, 102, 105), fold(2, 110, 120)];
+        assert_eq!(compute_extra_rows(&ranges, 100, 30), 13);
+    }
+
+    #[test]
+    fn extra_rows_single_row_fold_frees_nothing() {
+        // A 1-row fold collapses to a 1-row placeholder: no net space freed.
+        let ranges = [fold(1, 105, 105)];
+        assert_eq!(compute_extra_rows(&ranges, 100, 24), 0);
+    }
+
+    // ── apply_rendered_scroll ───────────────────────────────────────────
+
+    #[test]
+    fn rendered_scroll_no_folds_is_one_to_one_up() {
+        // total 100, height 24, max 76. Up 3 from offset 0 → 3.
+        let n = apply_rendered_scroll(&[], 100, 24, 76, 0, ScrollDir::Up, 3);
+        assert_eq!(n, 3);
+    }
+
+    #[test]
+    fn rendered_scroll_no_folds_is_one_to_one_down() {
+        let n = apply_rendered_scroll(&[], 100, 24, 76, 10, ScrollDir::Down, 3);
+        assert_eq!(n, 7);
+    }
+
+    #[test]
+    fn rendered_scroll_clamps_up_at_max() {
+        let n = apply_rendered_scroll(&[], 100, 24, 76, 75, ScrollDir::Up, 10);
+        assert_eq!(n, 76);
+    }
+
+    #[test]
+    fn rendered_scroll_clamps_down_at_zero() {
+        let n = apply_rendered_scroll(&[], 100, 24, 76, 2, ScrollDir::Down, 10);
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn rendered_scroll_up_skips_collapsed_fold_in_one_step() {
+        // total 100, height 24, max 76. Window top at offset 0 is row 76.
+        // A fold collapses buffer rows 70..=79 (start 70, end 79). The fold's
+        // first row (70) is the placeholder; rows 71..=79 are hidden.
+        //
+        // At a raw offset that places the top just below the fold's hidden
+        // span, scrolling up one rendered row must skip the entire hidden span
+        // in a single move and land the placeholder row at the top.
+        let ranges = [fold(1, 70, 79)];
+        // Offset 6 → top = 100 - 24 - 6 = 70 (the placeholder row already at
+        // top). One step up reveals row 69 (not folded) → raw 7.
+        let n = apply_rendered_scroll(&ranges, 100, 24, 76, 6, ScrollDir::Up, 1);
+        assert_eq!(n, 7, "row above the fold is normal → +1 raw");
+
+        // Offset 0 → top = 76, inside the fold's hidden span (71..=79).
+        // Revealed row would be 75 (hidden). One rendered step up must jump to
+        // the placeholder row 70: raw such that top == 70 → raw = 6.
+        let n2 = apply_rendered_scroll(&ranges, 100, 24, 76, 0, ScrollDir::Up, 1);
+        assert_eq!(
+            n2, 6,
+            "one rendered step from inside a fold jumps to the placeholder"
+        );
+    }
+
+    #[test]
+    fn rendered_scroll_down_skips_collapsed_fold() {
+        // Mirror of the up case. Fold 70..=79. From offset 7 (top = 69),
+        // scrolling down one rendered row: new top would be 70 (placeholder) —
+        // not hidden, so raw - 1 = 6.
+        let ranges = [fold(1, 70, 79)];
+        let n = apply_rendered_scroll(&ranges, 100, 24, 76, 7, ScrollDir::Down, 1);
+        assert_eq!(n, 6);
+
+        // From offset 6 (top = 70, the placeholder). Scrolling down, the new
+        // top (71) is hidden inside the fold → jump past the whole span so the
+        // new top is row 80 (after fold end): raw 6 - (80 - 70) saturates to 0.
+        let n2 = apply_rendered_scroll(&ranges, 100, 24, 76, 6, ScrollDir::Down, 1);
+        assert_eq!(n2, 0, "down past a fold skips the hidden span");
     }
 
     // ── translate_ranges_to_snapshot ────────────────────────────────────

--- a/freminal/src/gui/pty.rs
+++ b/freminal/src/gui/pty.rs
@@ -418,8 +418,8 @@ fn spawn_pty_consumer_thread(
                         Ok(InputEvent::FocusChange(focused)) => {
                             emulator.internal.send_focus_event(focused);
                         }
-                        Ok(InputEvent::ScrollOffset(offset)) => {
-                            emulator.set_gui_scroll_offset(offset);
+                        Ok(InputEvent::ScrollOffset { offset, extra_rows }) => {
+                            emulator.set_gui_scroll_window(offset, extra_rows);
                         }
                         Ok(InputEvent::ThemeChange(theme)) => {
                             emulator.internal.handler.set_theme(theme);

--- a/freminal/src/gui/search.rs
+++ b/freminal/src/gui/search.rs
@@ -297,7 +297,11 @@ pub fn scroll_to_match_and_send(
     input_tx: &Sender<InputEvent>,
 ) {
     if let Some(offset) = scroll_to_match(view_state, snap)
-        && let Err(e) = input_tx.send(InputEvent::ScrollOffset(offset))
+        && let Err(e) = input_tx.send(crate::gui::terminal::input::scroll_event(
+            snap,
+            &view_state.folded_blocks,
+            offset,
+        ))
     {
         error!("Failed to send scroll offset to PTY: {e}");
     }

--- a/freminal/src/gui/settings.rs
+++ b/freminal/src/gui/settings.rs
@@ -5,7 +5,7 @@
 
 use egui::{self, ComboBox, DragValue, FontData, FontDefinitions, FontFamily, Panel, Slider, Ui};
 use freminal_common::config::{
-    self, BackgroundImageMode, Config, CursorShapeConfig, TabBarPosition, ThemeMode,
+    self, BackgroundImageMode, Config, CursorShapeConfig, GutterPosition, TabBarPosition, ThemeMode,
 };
 use freminal_common::keybindings::{BindingMap, KeyAction, KeyCombo};
 use freminal_common::themes;
@@ -1287,6 +1287,32 @@ impl SettingsModal {
             egui::Color32::GRAY,
             "Minimum command duration before the duration label is shown.",
         );
+
+        ui.add_space(12.0);
+
+        ui.label("Status gutter:");
+        let current_label = gutter_position_label(self.draft.command_blocks.gutter);
+        ComboBox::from_id_salt("command_block_gutter")
+            .selected_text(current_label)
+            .show_ui(ui, |ui| {
+                ui.selectable_value(
+                    &mut self.draft.command_blocks.gutter,
+                    GutterPosition::Left,
+                    "Left",
+                );
+                ui.selectable_value(
+                    &mut self.draft.command_blocks.gutter,
+                    GutterPosition::Off,
+                    "Off",
+                );
+            });
+        ui.add_space(4.0);
+        ui.colored_label(
+            egui::Color32::GRAY,
+            "A thin colored strip on the left edge of each pane showing every \
+             command's status (green = success, red = failure, yellow = \
+             running). \"Off\" hides the gutter and reclaims its width for text.",
+        );
     }
 
     fn show_bell_tab(&mut self, ui: &mut Ui) {
@@ -1964,6 +1990,13 @@ const fn tab_bar_position_label(pos: TabBarPosition) -> &'static str {
     }
 }
 
+const fn gutter_position_label(pos: GutterPosition) -> &'static str {
+    match pos {
+        GutterPosition::Left => "Left",
+        GutterPosition::Off => "Off",
+    }
+}
+
 const fn bell_mode_label(mode: config::BellMode) -> &'static str {
     match mode {
         config::BellMode::Visual => "Visual",
@@ -2117,6 +2150,29 @@ mod tests {
     fn tab_bar_position_labels() {
         assert_eq!(tab_bar_position_label(TabBarPosition::Top), "Top");
         assert_eq!(tab_bar_position_label(TabBarPosition::Bottom), "Bottom");
+    }
+
+    #[test]
+    fn gutter_position_labels() {
+        assert_eq!(gutter_position_label(GutterPosition::Left), "Left");
+        assert_eq!(gutter_position_label(GutterPosition::Off), "Off");
+    }
+
+    #[test]
+    fn gutter_setting_persists_through_draft_apply() {
+        // Editing the draft's gutter and applying it must carry the value
+        // into the saved config (the modal edits `self.draft`, which is
+        // written back on Apply).  The TOML round-trip itself is covered by
+        // the freminal-common config test; here we verify the settings
+        // modal surfaces and mutates the same field.
+        let mut modal = SettingsModal::new(None);
+        let mut cfg = Config::default();
+        cfg.command_blocks.gutter = GutterPosition::Off;
+        modal.open(&cfg, Vec::new(), false);
+        assert_eq!(modal.draft.command_blocks.gutter, GutterPosition::Off);
+        modal.draft.command_blocks.gutter = GutterPosition::Left;
+        let applied = modal.draft.clone();
+        assert_eq!(applied.command_blocks.gutter, GutterPosition::Left);
     }
 
     #[test]

--- a/freminal/src/gui/terminal/coords.rs
+++ b/freminal/src/gui/terminal/coords.rs
@@ -23,9 +23,24 @@ use freminal_terminal_emulator::snapshot::TerminalSnapshot;
 /// buffer is at `total_rows - term_height`, and scrolling *back* subtracts
 /// from that position.
 pub(super) const fn visible_window_start(snap: &TerminalSnapshot) -> usize {
+    visible_window_start_for(snap, snap.scroll_offset)
+}
+
+/// Compute the buffer-absolute index of the first visible row for an arbitrary
+/// `scroll_offset` (not necessarily the snapshot's current one).
+///
+/// Used when computing the window start for a *prospective* scroll offset
+/// (e.g. while handling a scroll input that has not yet been reflected in a
+/// snapshot). `extra_rows` from command-block folding is intentionally NOT
+/// included here: this returns the start of the *normal* visible window, which
+/// is the reference point fold math is expressed against.
+pub(super) const fn visible_window_start_for(
+    snap: &TerminalSnapshot,
+    scroll_offset: usize,
+) -> usize {
     snap.total_rows
         .saturating_sub(snap.term_height)
-        .saturating_sub(snap.scroll_offset)
+        .saturating_sub(scroll_offset)
 }
 
 /// Convert a screen-relative `(row, col)` — where `col` is a **display

--- a/freminal/src/gui/terminal/input.rs
+++ b/freminal/src/gui/terminal/input.rs
@@ -33,8 +33,122 @@ use freminal_terminal_emulator::{
 };
 use std::borrow::Cow;
 
-use super::coords::{encode_egui_mouse_pos_as_usize, visible_window_start};
+use super::coords::{
+    encode_egui_mouse_pos_as_usize, visible_window_start, visible_window_start_for,
+};
 use super::widget::hit_test_placeholder;
+use crate::gui::folding::{compute_extra_rows, compute_fold_ranges};
+
+/// Build an [`InputEvent::ScrollOffset`] for a target raw scroll offset,
+/// computing the fold-aware `extra_rows` the renderer needs at that offset.
+///
+/// `extra_rows` is the number of rows that must be flattened above the normal
+/// visible window so the screen stays full after collapsing every fold that
+/// overlaps the window (see [`compute_extra_rows`]). When no fold is in view
+/// it is `0` and this is equivalent to the old `ScrollOffset(offset)`.
+pub fn scroll_event(
+    snap: &TerminalSnapshot,
+    folded_blocks: &std::collections::HashSet<CommandBlockId>,
+    offset: usize,
+) -> InputEvent {
+    let extra_rows = if folded_blocks.is_empty() {
+        0
+    } else {
+        let ranges = compute_fold_ranges(&snap.command_blocks, folded_blocks);
+        let win_start = visible_window_start_for(snap, offset);
+        compute_extra_rows(&ranges, win_start, snap.term_height)
+    };
+    InputEvent::ScrollOffset { offset, extra_rows }
+}
+
+/// Map an on-screen row (0 = top of the painted terminal area) to a
+/// buffer-absolute row, accounting for command-block folds and the
+/// bottom-anchored extra-row window.
+///
+/// Mirrors the renderer's `FoldLayout`: screen → rendered → snapshot →
+/// buffer. When the screen row lands on a fold placeholder, the folded block's
+/// first row is returned (so a click/selection on the placeholder anchors at
+/// the block). When no fold is in view this is exactly
+/// `visible_window_start(snap) + screen_row`.
+pub(super) fn screen_row_to_buffer_row(
+    snap: &TerminalSnapshot,
+    folded_blocks: &std::collections::HashSet<CommandBlockId>,
+    screen_row: usize,
+) -> usize {
+    if folded_blocks.is_empty() && snap.window_extra_rows == 0 {
+        return visible_window_start(snap) + screen_row;
+    }
+    let ranges = compute_fold_ranges(&snap.command_blocks, folded_blocks);
+    let flat_window_start = visible_window_start(snap).saturating_sub(snap.window_extra_rows);
+    let snap_rows = snap.term_height.saturating_add(snap.window_extra_rows);
+    let translated = crate::gui::folding::translate_ranges_to_snapshot(&ranges, flat_window_start);
+    let row_map = crate::gui::folding::RowMap::new(snap_rows, &translated);
+    let render_skip = row_map
+        .rendered_row_count()
+        .saturating_sub(snap.term_height);
+    let rendered = screen_row.saturating_add(render_skip);
+    match row_map.rendered_to_snapshot(rendered) {
+        Some(crate::gui::folding::RenderedRow::Snapshot(snap_row)) => flat_window_start + snap_row,
+        Some(crate::gui::folding::RenderedRow::Placeholder(range)) => {
+            flat_window_start + range.start_row
+        }
+        // Below the last rendered row → clamp to the live bottom.
+        None => visible_window_start(snap) + snap.term_height.saturating_sub(1),
+    }
+}
+
+/// Compute a new raw scroll offset for a scroll request expressed in
+/// **rendered rows** (visible lines), skipping over rows hidden inside
+/// collapsed folds so each step moves the view by exactly one visible line.
+///
+/// Delegates to [`crate::gui::folding::apply_rendered_scroll`]. When no fold is
+/// in view this is exactly `current ± steps` (clamped), matching the unfolded
+/// behaviour.
+pub(super) fn scrolled_offset(
+    snap: &TerminalSnapshot,
+    folded_blocks: &std::collections::HashSet<CommandBlockId>,
+    current: usize,
+    dir: crate::gui::folding::ScrollDir,
+    steps: usize,
+) -> usize {
+    if folded_blocks.is_empty() {
+        return match dir {
+            crate::gui::folding::ScrollDir::Up => {
+                current.saturating_add(steps).min(snap.max_scroll_offset)
+            }
+            crate::gui::folding::ScrollDir::Down => current.saturating_sub(steps),
+        };
+    }
+    let ranges = compute_fold_ranges(&snap.command_blocks, folded_blocks);
+    crate::gui::folding::apply_rendered_scroll(
+        &ranges,
+        snap.total_rows,
+        snap.term_height,
+        snap.max_scroll_offset,
+        current,
+        dir,
+        steps,
+    )
+}
+
+/// Re-send the current scroll window to the PTY so the snapshot's
+/// `window_extra_rows` is recomputed after a fold/unfold action.
+///
+/// Folding does not change `view_state.scroll_offset`, but it does change how
+/// many extra rows the renderer needs above the window. Without this resend
+/// the new extra-row count would not take effect until the user's next scroll
+/// event. Sends at the *current* offset.
+pub(super) fn resend_scroll_window(
+    snap: &TerminalSnapshot,
+    view_state: &ViewState,
+    input_tx: &Sender<InputEvent>,
+) {
+    send_or_log!(
+        input_tx,
+        scroll_event(snap, &view_state.folded_blocks, view_state.scroll_offset),
+        "Failed to send scroll window to PTY consumer"
+    );
+}
 
 /// Convert egui [`Modifiers`] to the terminal-emulator's [`KeyModifiers`].
 ///
@@ -371,26 +485,35 @@ pub(super) fn dispatch_binding_action(
             }
         }
         KeyAction::ScrollPageUp => {
-            let new_offset = view_state
-                .scroll_offset
-                .saturating_add(snap.term_height)
-                .min(snap.max_scroll_offset);
+            let new_offset = scrolled_offset(
+                snap,
+                &view_state.folded_blocks,
+                view_state.scroll_offset,
+                crate::gui::folding::ScrollDir::Up,
+                snap.term_height,
+            );
             if new_offset != view_state.scroll_offset {
                 view_state.scroll_offset = new_offset;
                 send_or_log!(
                     input_tx,
-                    InputEvent::ScrollOffset(new_offset),
+                    scroll_event(snap, &view_state.folded_blocks, new_offset),
                     "Failed to send scroll offset to PTY consumer"
                 );
             }
         }
         KeyAction::ScrollPageDown => {
-            let new_offset = view_state.scroll_offset.saturating_sub(snap.term_height);
+            let new_offset = scrolled_offset(
+                snap,
+                &view_state.folded_blocks,
+                view_state.scroll_offset,
+                crate::gui::folding::ScrollDir::Down,
+                snap.term_height,
+            );
             if new_offset != view_state.scroll_offset {
                 view_state.scroll_offset = new_offset;
                 send_or_log!(
                     input_tx,
-                    InputEvent::ScrollOffset(new_offset),
+                    scroll_event(snap, &view_state.folded_blocks, new_offset),
                     "Failed to send scroll offset to PTY consumer"
                 );
             }
@@ -401,7 +524,7 @@ pub(super) fn dispatch_binding_action(
                 view_state.scroll_offset = new_offset;
                 send_or_log!(
                     input_tx,
-                    InputEvent::ScrollOffset(new_offset),
+                    scroll_event(snap, &view_state.folded_blocks, new_offset),
                     "Failed to send scroll offset to PTY consumer"
                 );
             }
@@ -410,31 +533,40 @@ pub(super) fn dispatch_binding_action(
             view_state.scroll_offset = 0;
             send_or_log!(
                 input_tx,
-                InputEvent::ScrollOffset(0),
+                scroll_event(snap, &view_state.folded_blocks, 0),
                 "Failed to send scroll offset to PTY consumer"
             );
         }
         KeyAction::ScrollLineUp => {
-            let new_offset = view_state
-                .scroll_offset
-                .saturating_add(1)
-                .min(snap.max_scroll_offset);
+            let new_offset = scrolled_offset(
+                snap,
+                &view_state.folded_blocks,
+                view_state.scroll_offset,
+                crate::gui::folding::ScrollDir::Up,
+                1,
+            );
             if new_offset != view_state.scroll_offset {
                 view_state.scroll_offset = new_offset;
                 send_or_log!(
                     input_tx,
-                    InputEvent::ScrollOffset(new_offset),
+                    scroll_event(snap, &view_state.folded_blocks, new_offset),
                     "Failed to send scroll offset to PTY consumer"
                 );
             }
         }
         KeyAction::ScrollLineDown => {
-            let new_offset = view_state.scroll_offset.saturating_sub(1);
+            let new_offset = scrolled_offset(
+                snap,
+                &view_state.folded_blocks,
+                view_state.scroll_offset,
+                crate::gui::folding::ScrollDir::Down,
+                1,
+            );
             if new_offset != view_state.scroll_offset {
                 view_state.scroll_offset = new_offset;
                 send_or_log!(
                     input_tx,
-                    InputEvent::ScrollOffset(new_offset),
+                    scroll_event(snap, &view_state.folded_blocks, new_offset),
                     "Failed to send scroll offset to PTY consumer"
                 );
             }
@@ -455,13 +587,16 @@ pub(super) fn dispatch_binding_action(
         KeyAction::FoldPreviousCommand => {
             if let Some(id) = find_fold_target(snap) {
                 view_state.toggle_fold(id);
+                resend_scroll_window(snap, view_state, input_tx);
             }
         }
         KeyAction::FoldAll => {
             view_state.fold_all(snap.command_blocks.iter());
+            resend_scroll_window(snap, view_state, input_tx);
         }
         KeyAction::UnfoldAll => {
             view_state.unfold_all();
+            resend_scroll_window(snap, view_state, input_tx);
         }
         KeyAction::CopyLastCommandOutput => {
             if let Some(block) = find_last_copyable_block(snap)
@@ -740,20 +875,26 @@ pub(super) fn handle_scroll_fallback(
         const SCROLL_MULTIPLIER: usize = 3;
         let n = abs_lines.approx_as::<usize>().unwrap_or(0).max(1) * SCROLL_MULTIPLIER;
 
-        let new_offset = if lines > 0.0 {
-            // Scroll up (into history) — increase offset.
-            // The PTY thread will clamp to max_scroll_offset().
-            view_state.scroll_offset.saturating_add(n)
+        // Scroll by rendered (visible) rows so a tick over a collapsed fold
+        // moves one visible line, not one hidden buffer row.
+        let dir = if lines > 0.0 {
+            crate::gui::folding::ScrollDir::Up
         } else {
-            // Scroll down (toward live bottom) — decrease offset.
-            view_state.scroll_offset.saturating_sub(n)
+            crate::gui::folding::ScrollDir::Down
         };
+        let new_offset = scrolled_offset(
+            snap,
+            &view_state.folded_blocks,
+            view_state.scroll_offset,
+            dir,
+            n,
+        );
 
         if new_offset != view_state.scroll_offset {
             view_state.scroll_offset = new_offset;
             send_or_log!(
                 input_tx,
-                InputEvent::ScrollOffset(new_offset),
+                scroll_event(snap, &view_state.folded_blocks, new_offset),
                 "Failed to send scroll offset to PTY consumer"
             );
         }
@@ -770,13 +911,18 @@ fn release_end_col(
     view_state: &ViewState,
     snap: &TerminalSnapshot,
     x: usize,
-    y: usize,
     abs_row: usize,
 ) -> usize {
+    // Snapshot-row index for `visible_chars` lookups, derived from the
+    // buffer-absolute `abs_row` so it accounts for the extra-row fold window.
+    // `y` (the raw screen row) is NOT a valid `visible_chars` index when folds
+    // shift the window.
+    let snap_y =
+        abs_row.saturating_sub(visible_window_start(snap).saturating_sub(snap.window_extra_rows));
     if view_state.click_count >= 3 {
         let anchor_row = view_state.selection.anchor.map_or(abs_row, |a| a.row);
         let (line_start, line_end) =
-            crate::gui::view_state::line_boundaries(&snap.visible_chars, y);
+            crate::gui::view_state::line_boundaries(&snap.visible_chars, snap_y);
         if abs_row >= anchor_row {
             line_end
         } else {
@@ -786,7 +932,7 @@ fn release_end_col(
         let anchor_row = view_state.selection.anchor.map_or(abs_row, |a| a.row);
         let anchor_col = view_state.selection.anchor.map_or(x, |a| a.col);
         let (word_start, word_end) =
-            crate::gui::view_state::word_boundaries(&snap.visible_chars, y, x);
+            crate::gui::view_state::word_boundaries(&snap.visible_chars, snap_y, x);
         if abs_row > anchor_row || (abs_row == anchor_row && word_end >= anchor_col) {
             word_end
         } else {
@@ -1437,12 +1583,17 @@ pub(super) fn write_input_to_terminal(
                     // Mouse tracking is off — update text selection if a drag
                     // is in progress.
                     if view_state.selection.is_selecting {
-                        let abs_row = visible_window_start(snap) + y;
+                        let abs_row = screen_row_to_buffer_row(snap, &view_state.folded_blocks, y);
                         let end_col = if view_state.click_count >= 3 {
                             // Triple-click drag — snap end to line boundaries.
                             let anchor_row = view_state.selection.anchor.map_or(abs_row, |a| a.row);
-                            let (line_start, line_end) =
-                                crate::gui::view_state::line_boundaries(&snap.visible_chars, y);
+                            let snap_y = abs_row.saturating_sub(
+                                visible_window_start(snap).saturating_sub(snap.window_extra_rows),
+                            );
+                            let (line_start, line_end) = crate::gui::view_state::line_boundaries(
+                                &snap.visible_chars,
+                                snap_y,
+                            );
                             if abs_row >= anchor_row {
                                 line_end
                             } else {
@@ -1554,6 +1705,7 @@ pub(super) fn write_input_to_terminal(
                     && let Some(block_id) = hit_test_placeholder(placeholder_rects, *pos)
                 {
                     view_state.unfold(block_id);
+                    resend_scroll_window(snap, view_state, input_tx);
                     continue;
                 }
 
@@ -1565,7 +1717,7 @@ pub(super) fn write_input_to_terminal(
                     if *button == PointerButton::Secondary && *pressed {
                         // Record the right-clicked cell so the widget layer
                         // can open the context menu and detect URLs.
-                        let abs_row = visible_window_start(snap) + y;
+                        let abs_row = screen_row_to_buffer_row(snap, &view_state.folded_blocks, y);
                         view_state.context_menu_cell = Some(CellCoord {
                             col: x,
                             row: abs_row,
@@ -1588,7 +1740,14 @@ pub(super) fn write_input_to_terminal(
                             // Start a new selection at this cell.
                             // Use buffer-absolute row so the selection
                             // survives scroll offset changes.
-                            let abs_row = visible_window_start(snap) + y;
+                            let abs_row =
+                                screen_row_to_buffer_row(snap, &view_state.folded_blocks, y);
+                            // Snapshot-row index for `visible_chars` lookups
+                            // (word/line boundaries), accounting for the
+                            // extra-row fold window.
+                            let snap_y = abs_row.saturating_sub(
+                                visible_window_start(snap).saturating_sub(snap.window_extra_rows),
+                            );
                             let coord = CellCoord {
                                 col: x,
                                 row: abs_row,
@@ -1598,8 +1757,10 @@ pub(super) fn write_input_to_terminal(
 
                             if click_count >= 3 {
                                 // Triple-click — select the entire visual line.
-                                let (start_col, end_col) =
-                                    crate::gui::view_state::line_boundaries(&snap.visible_chars, y);
+                                let (start_col, end_col) = crate::gui::view_state::line_boundaries(
+                                    &snap.visible_chars,
+                                    snap_y,
+                                );
                                 view_state.selection.anchor = Some(CellCoord {
                                     col: start_col,
                                     row: abs_row,
@@ -1612,7 +1773,7 @@ pub(super) fn write_input_to_terminal(
                                 // Double-click — select the word under the cursor.
                                 let (start_col, end_col) = crate::gui::view_state::word_boundaries(
                                     &snap.visible_chars,
-                                    y,
+                                    snap_y,
                                     x,
                                 );
                                 view_state.selection.anchor = Some(CellCoord {
@@ -1636,8 +1797,9 @@ pub(super) fn write_input_to_terminal(
                             // Respect click_count so double/triple-click
                             // selections are not collapsed to the raw
                             // mouse position on release.
-                            let abs_row = visible_window_start(snap) + y;
-                            let end_col = release_end_col(view_state, snap, x, y, abs_row);
+                            let abs_row =
+                                screen_row_to_buffer_row(snap, &view_state.folded_blocks, y);
+                            let end_col = release_end_col(view_state, snap, x, abs_row);
                             let end_coord = CellCoord {
                                 col: end_col,
                                 row: abs_row,
@@ -2086,5 +2248,138 @@ mod fold_target_tests {
         partial.command_start_row = None;
         let snap = snap_with(vec![partial], 0);
         assert!(find_block_containing_row(&snap, 7).is_none());
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod scroll_window_tests {
+    //! Tests for the fold-aware scroll helpers [`scroll_event`] and
+    //! [`screen_row_to_buffer_row`].
+
+    use super::*;
+    use freminal_common::buffer_states::command_block::{CommandBlock, CommandBlockId};
+    use std::collections::HashSet;
+    use std::sync::Arc;
+    use std::time::SystemTime;
+
+    fn completed(id: u64, prompt: usize, end: usize) -> CommandBlock {
+        CommandBlock {
+            id: CommandBlockId(id),
+            fid: format!("test-{id}"),
+            prompt_start_row: prompt,
+            command_start_row: Some(prompt),
+            output_start_row: Some(prompt + 1),
+            end_row: Some(end),
+            exit_code: Some(0),
+            cwd: None,
+            started_at: SystemTime::UNIX_EPOCH,
+            executed_at: Some(SystemTime::UNIX_EPOCH),
+            finished_at: Some(SystemTime::UNIX_EPOCH),
+        }
+    }
+
+    /// Snapshot with `total_rows` buffer rows, `term_height` visible rows, the
+    /// given scroll offset, and the supplied command blocks.
+    fn snap_geo(
+        total_rows: usize,
+        term_height: usize,
+        scroll_offset: usize,
+        blocks: Vec<CommandBlock>,
+    ) -> TerminalSnapshot {
+        let mut s = TerminalSnapshot::empty();
+        s.total_rows = total_rows;
+        s.term_height = term_height;
+        s.scroll_offset = scroll_offset;
+        s.command_blocks = Arc::from(blocks);
+        s
+    }
+
+    fn folded(ids: &[u64]) -> HashSet<CommandBlockId> {
+        ids.iter().copied().map(CommandBlockId).collect()
+    }
+
+    #[test]
+    fn scroll_event_no_folds_has_zero_extra() {
+        // total 100, height 24, at live bottom. No folds → extra 0.
+        let snap = snap_geo(100, 24, 0, vec![]);
+        match scroll_event(&snap, &HashSet::new(), 0) {
+            InputEvent::ScrollOffset { offset, extra_rows } => {
+                assert_eq!(offset, 0);
+                assert_eq!(extra_rows, 0);
+            }
+            other => panic!("expected ScrollOffset, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scroll_event_fold_in_window_requests_extra() {
+        // total 100, height 24, live bottom → window [76, 100).
+        // Block 80..=89: the prompt/command line (row 80) stays visible and
+        // only the OUTPUT rows 81..=89 (9 rows) are folded; collapsing them to
+        // one placeholder frees 8 rows of screen.
+        let snap = snap_geo(100, 24, 0, vec![completed(1, 80, 89)]);
+        match scroll_event(&snap, &folded(&[1]), 0) {
+            InputEvent::ScrollOffset { offset, extra_rows } => {
+                assert_eq!(offset, 0);
+                assert_eq!(extra_rows, 8, "9 folded output rows free 8 rows of screen");
+            }
+            other => panic!("expected ScrollOffset, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scroll_event_unfolded_block_no_extra() {
+        // The block exists but is not in the folded set → no extra rows.
+        let snap = snap_geo(100, 24, 0, vec![completed(1, 80, 89)]);
+        match scroll_event(&snap, &HashSet::new(), 0) {
+            InputEvent::ScrollOffset { extra_rows, .. } => assert_eq!(extra_rows, 0),
+            other => panic!("expected ScrollOffset, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scroll_event_uses_target_offset_window() {
+        // At a scrolled-back offset the window moves; the fold must be
+        // evaluated against the *target* window, not the snapshot's current
+        // one. Offset 20 → window [56, 80). Block 80..=89 is below the window
+        // (its end is at the live bottom edge) — only its overlap counts.
+        let snap = snap_geo(100, 24, 0, vec![completed(1, 60, 69)]);
+        // Target offset 20 → window [56, 80). Block 60..=69: output rows
+        // 61..=69 (9 rows) folded → frees 8.
+        match scroll_event(&snap, &folded(&[1]), 20) {
+            InputEvent::ScrollOffset { offset, extra_rows } => {
+                assert_eq!(offset, 20);
+                assert_eq!(extra_rows, 8);
+            }
+            other => panic!("expected ScrollOffset, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn screen_row_to_buffer_no_folds_is_window_start_plus_row() {
+        // No folds → screen row maps directly: win_start (76) + screen.
+        let snap = snap_geo(100, 24, 0, vec![]);
+        assert_eq!(screen_row_to_buffer_row(&snap, &HashSet::new(), 0), 76);
+        assert_eq!(screen_row_to_buffer_row(&snap, &HashSet::new(), 5), 81);
+    }
+
+    #[test]
+    fn screen_row_to_buffer_with_fold_skips_collapsed_rows() {
+        // Window [76, 100); fold block 80..=89 (output 81..=89 folded, 9 rows)
+        // collapses to a placeholder. Screen rows above the fold map 1:1;
+        // rows below the placeholder jump past the hidden rows.
+        let snap = snap_geo(100, 24, 0, vec![completed(1, 80, 89)]);
+        let f = folded(&[1]);
+        // Row 0 is buffer row 76 (well above the fold which starts at output
+        // row 81).
+        assert_eq!(screen_row_to_buffer_row(&snap, &f, 0), 76);
+        // A row well past the placeholder must map beyond the folded span
+        // (>= 90), proving the hidden rows are skipped.
+        let late = screen_row_to_buffer_row(&snap, &f, 20);
+        assert!(
+            late >= 90,
+            "rows after the fold placeholder must skip the hidden span, got {late}"
+        );
     }
 }

--- a/freminal/src/gui/terminal/input.rs
+++ b/freminal/src/gui/terminal/input.rs
@@ -1900,6 +1900,7 @@ mod fold_target_tests {
             exit_code: Some(0),
             cwd: None,
             started_at: SystemTime::UNIX_EPOCH,
+            executed_at: Some(SystemTime::UNIX_EPOCH),
             finished_at: Some(SystemTime::UNIX_EPOCH),
         }
     }
@@ -1916,6 +1917,7 @@ mod fold_target_tests {
             exit_code: None,
             cwd: None,
             started_at: SystemTime::UNIX_EPOCH,
+            executed_at: None,
             finished_at: None,
         }
     }

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -2489,10 +2489,11 @@ impl FreminalTerminalWidget {
             let label_color = egui::Color32::from_rgba_unmultiplied(fg_r, fg_g, fg_b, 153);
             let font_id = egui::FontId::monospace(logical_cell_h * 0.75);
             for block in snap.command_blocks.iter() {
-                let Some(finished_at) = block.finished_at else {
-                    continue;
-                };
-                let Ok(elapsed) = finished_at.duration_since(block.started_at) else {
+                // `duration()` measures from command-execution start
+                // (`executed_at`/OSC 133 C), excluding the user's typing time
+                // at the prompt — so instant commands no longer report
+                // multi-second durations.  `None` while the block is running.
+                let Some(elapsed) = block.duration() else {
                     continue;
                 };
                 if elapsed < threshold {

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -15,7 +15,9 @@ use crate::gui::{
 
 use crossbeam_channel::{Receiver, Sender};
 use freminal_common::{
-    buffer_states::{pointer_shape::PointerShape, tchar::TChar, url::Url},
+    buffer_states::{
+        command_block::CommandStatus, pointer_shape::PointerShape, tchar::TChar, url::Url,
+    },
     config::Config,
     send_or_log,
     themes::ThemePalette,
@@ -1088,6 +1090,7 @@ impl FreminalTerminalWidget {
         bg_image_opacity: f32,
         bg_image_mode: freminal_common::config::BackgroundImageMode,
         command_blocks_config: &freminal_common::config::CommandBlocksConfig,
+        gutter_inset_logical: f32,
         binding_map: &freminal_common::keybindings::BindingMap,
         is_echo_off: bool,
         is_active_pane: bool,
@@ -1169,7 +1172,30 @@ impl FreminalTerminalWidget {
         // corner to get terminal-grid-relative coordinates.  The full rect
         // is also used to reject pointer events outside the terminal area
         // (e.g. clicks on the tab bar).
-        let terminal_rect = ui.available_rect_before_wrap();
+        //
+        // The command-block gutter (if enabled) reserves `gutter_inset_logical`
+        // points on the LEFT edge.  That total inset is the painted strip
+        // width PLUS a padding gap, so `terminal_rect` is shifted right by the
+        // whole inset (keeping the cell grid, mouse hit-testing — which
+        // subtracts `terminal_rect.min` — and the PTY column count in agreement;
+        // `app_impl` computes the column count from the identical inset).  The
+        // painted `gutter_rect` is only the strip width; the remaining padding
+        // is left blank so glyphs are not flush against the status bar.
+        let pane_rect = ui.available_rect_before_wrap();
+        let gutter_inset = gutter_inset_logical.max(0.0);
+        let gutter_strip_w = if gutter_inset > 0.0 {
+            command_blocks_config.gutter.width_px() / ppp
+        } else {
+            0.0
+        };
+        let gutter_rect = egui::Rect::from_min_max(
+            pane_rect.min,
+            egui::pos2(pane_rect.min.x + gutter_strip_w, pane_rect.max.y),
+        );
+        let terminal_rect = egui::Rect::from_min_max(
+            egui::pos2(pane_rect.min.x + gutter_inset, pane_rect.min.y),
+            pane_rect.max,
+        );
 
         // ── Scrollbar pre-check ──────────────────────────────────────────
         // Detect if the user is clicking or starting a drag on the scrollbar
@@ -1961,13 +1987,15 @@ impl FreminalTerminalWidget {
             snap.height.approx_as::<f32>().unwrap_or(0.0) * logical_cell_h,
         );
         let (_rect, _response) = ui.allocate_exact_size(desired_size, egui::Sense::hover());
-        // Use the full available pane area as the PaintCallback rect so the
-        // post-process shader covers the entire pane, not just the integer-cell
-        // sub-rect.  The cell-content vertex coordinates are already computed
-        // relative to (0,0) in physical pixels; the FBO is sized to the full
-        // pane dimensions (vp.width_px × vp.height_px), so the shader can
-        // cover any sub-cell padding at the right/bottom edges.
-        let rect = ui.max_rect();
+        // Use the terminal area (the full pane minus the command-block gutter
+        // strip on the left) as the PaintCallback rect.  The cell-content
+        // vertex coordinates are computed relative to (0,0) in physical pixels,
+        // so the GL viewport origin must be the terminal rect's left edge —
+        // otherwise column 0 would render under the gutter strip.  The right
+        // and bottom edges are unchanged, so the post-process shader still
+        // covers the full cell area (any sub-cell padding at the right/bottom).
+        // The gutter slice itself is painted separately by egui below.
+        let rect = terminal_rect;
 
         // Hand off the draw call to egui's paint phase via PaintCallback.
         // The closure must be `Send + Sync + 'static`, so only `Arc<Mutex<…>>`
@@ -2137,6 +2165,71 @@ impl FreminalTerminalWidget {
                 egui::FontId::proportional(logical_cell_h),
                 egui::Color32::from_rgb(255, 200, 50),
             );
+        }
+
+        // ── Command-block status gutter ──────────────────────────────
+        // Fill the reserved left strip (`gutter_rect`) with a per-row
+        // status color: each visible rendered row maps back to a buffer
+        // row; if a command block contains that row, the gutter cell is
+        // painted with the block's status color (green = success,
+        // red = failure, yellow = running, white = unknown).  Rows in no
+        // block render the terminal background (empty gutter).
+        //
+        // Suppressed on the alternate screen for the same reason the
+        // overlays are: the stored blocks describe primary-screen rows.
+        // The 4px strip is OUTSIDE the cell grid (`terminal_rect` was
+        // shifted right by the inset), so it never overlaps glyph cells.
+        if gutter_inset > 0.0
+            && command_blocks_config.enabled
+            && !snap.is_alternate_screen
+            && !snap.command_blocks.is_empty()
+        {
+            let win_start = visible_window_start(snap);
+            // Running blocks extend to the last visible buffer row.
+            let running_extent = win_start + snap.term_height.saturating_sub(1);
+            let rendered_rows = row_map.rendered_row_count();
+            for rendered_row in 0..rendered_rows {
+                // Resolve each rendered row to a status color.  Snapshot
+                // rows map back to a buffer row and use row containment;
+                // fold placeholders are colored (desaturated) by the
+                // folded block's own status, looked up by id.
+                let resolved: Option<(CommandStatus, bool)> =
+                    match row_map.rendered_to_snapshot(rendered_row) {
+                        Some(RenderedRow::Snapshot(screen_row)) => {
+                            let buffer_row = win_start + screen_row;
+                            crate::gui::command_blocks::gutter_status_for_row(
+                                &snap.command_blocks,
+                                buffer_row,
+                                running_extent,
+                            )
+                            .map(|s| (s, false))
+                        }
+                        Some(RenderedRow::Placeholder(range)) => snap
+                            .command_blocks
+                            .iter()
+                            .find(|b| b.id == range.command_block_id)
+                            .map(|b| (b.status(), true)),
+                        None => None,
+                    };
+                let Some((status, desaturate)) = resolved else {
+                    continue;
+                };
+                let (cr, cg, cb) = snap.theme.gutter_color_for(status);
+                let color = if desaturate {
+                    // Half-alpha for folded placeholder rows so a collapsed
+                    // block still shows its status, muted.
+                    egui::Color32::from_rgba_unmultiplied(cr, cg, cb, 128)
+                } else {
+                    egui::Color32::from_rgb(cr, cg, cb)
+                };
+                let rendered_f = rendered_row.approx_as::<f32>().unwrap_or(0.0);
+                let y0 = rendered_f.mul_add(logical_cell_h, terminal_rect.min.y);
+                let row_rect = egui::Rect::from_min_max(
+                    egui::pos2(gutter_rect.min.x, y0),
+                    egui::pos2(gutter_rect.max.x, y0 + logical_cell_h),
+                );
+                ui.painter().rect_filled(row_rect, 0.0, color);
+            }
         }
 
         // ── Command-block duration overlay ───────────────────────────

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -114,6 +114,150 @@ pub fn hit_test_placeholder(
         .map(|(_, id)| *id)
 }
 
+/// Resolve a pointer position in the command-block gutter to the
+/// `CommandBlockId` of the block whose rendered row range the pointer is
+/// over, accounting for folds.
+///
+/// `pos` is a logical-point position; only its `y` is used (the gutter
+/// spans the full pane height to the left of `terminal_rect`).  Returns
+/// `None` when the row maps to a fold placeholder for no block, or to a
+/// row not covered by any block.  Mirrors the fold-aware row mapping the
+/// renderer uses so the hit-test agrees with what is painted.
+fn gutter_block_id_at_pos(
+    pos: Pos2,
+    snap: &TerminalSnapshot,
+    view_state: &ViewState,
+    terminal_rect: Rect,
+    logical_cell_h: f32,
+) -> Option<freminal_common::buffer_states::command_block::CommandBlockId> {
+    if logical_cell_h <= 0.0 {
+        return None;
+    }
+    // Rendered row under the pointer (relative to the terminal area top).
+    let rendered_row = ((pos.y - terminal_rect.min.y) / logical_cell_h)
+        .floor()
+        .approx_as::<usize>()
+        .ok()?;
+
+    // Build the same fold-aware row map the renderer uses this frame.
+    let raw_fold_ranges = compute_fold_ranges(&snap.command_blocks, &view_state.folded_blocks);
+    let win_start = super::coords::visible_window_start(snap);
+    let fold_ranges =
+        crate::gui::folding::translate_ranges_to_snapshot(&raw_fold_ranges, win_start);
+    let row_map = RowMap::new(snap.term_height, &fold_ranges);
+
+    match row_map.rendered_to_snapshot(rendered_row) {
+        // A live snapshot row → containment hit-test against the blocks.
+        Some(RenderedRow::Snapshot(screen_row)) => {
+            let buffer_row = win_start + screen_row;
+            let running_extent = win_start + snap.term_height.saturating_sub(1);
+            crate::gui::command_blocks::gutter_block_for_row(
+                &snap.command_blocks,
+                buffer_row,
+                running_extent,
+            )
+            .map(|b| b.id)
+        }
+        // A fold placeholder → the folded block itself.
+        Some(RenderedRow::Placeholder(range)) => Some(range.command_block_id),
+        None => None,
+    }
+}
+
+/// Compute the rendered-row span (inclusive) of the command block the pointer
+/// is currently hovering, for the hover-tint overlay.
+///
+/// Two trigger surfaces feed this: hovering a cell inside the terminal area
+/// (72.12) and hovering the command-block gutter strip (73.3).  Returns `None`
+/// when the feature is off, the alternate screen is active, there are no
+/// blocks, the pointer is elsewhere, or the hovered block is entirely inside a
+/// fold.  The result must be recomputed before the vertex-rebuild decision so a
+/// hover-only change can invalidate the cached background instances.
+#[allow(clippy::too_many_arguments)]
+fn compute_command_block_hover_rows(
+    snap: &TerminalSnapshot,
+    view_state: &ViewState,
+    command_blocks_config: &freminal_common::config::CommandBlocksConfig,
+    row_map: &RowMap,
+    win_start: usize,
+    pane_rect: Rect,
+    terminal_rect: Rect,
+    gutter_inset: f32,
+    logical_cell_w: f32,
+    logical_cell_h: f32,
+) -> Option<(usize, usize)> {
+    if !crate::gui::command_blocks::command_block_overlays_visible(
+        command_blocks_config.enabled,
+        snap.is_alternate_screen,
+        !snap.command_blocks.is_empty(),
+    ) {
+        return None;
+    }
+    if logical_cell_h <= 0.0 {
+        return None;
+    }
+
+    // Resolve the hovered buffer row from whichever surface the pointer is
+    // over: the gutter (left of the terminal rect) or a terminal cell.
+    let mouse_position = view_state.mouse_position?;
+    let hovered_buffer_row: Option<usize> = if gutter_inset > 0.0
+        && mouse_position.x >= pane_rect.min.x
+        && mouse_position.x < terminal_rect.min.x
+        && mouse_position.y >= terminal_rect.min.y
+        && mouse_position.y < terminal_rect.max.y
+    {
+        // Gutter hover: map y → rendered row → buffer row (live rows only; a
+        // placeholder resolves to the folded block via its first row).
+        let rendered_row = ((mouse_position.y - terminal_rect.min.y) / logical_cell_h)
+            .floor()
+            .approx_as::<usize>()
+            .ok()?;
+        match row_map.rendered_to_snapshot(rendered_row) {
+            Some(RenderedRow::Snapshot(r)) => Some(win_start + r),
+            Some(RenderedRow::Placeholder(range)) => Some(win_start + range.start_row),
+            None => None,
+        }
+    } else if terminal_rect.contains(mouse_position) {
+        // Terminal-cell hover.
+        let (_col, rendered_row) = encode_egui_mouse_pos_as_usize(
+            mouse_position,
+            (logical_cell_w, logical_cell_h),
+            terminal_rect.min,
+        );
+        match row_map.rendered_to_snapshot(rendered_row) {
+            Some(RenderedRow::Snapshot(r)) => Some(win_start + r),
+            Some(RenderedRow::Placeholder(_)) | None => None,
+        }
+    } else {
+        None
+    };
+
+    let buffer_row = hovered_buffer_row?;
+    // Find the block containing this absolute row.  A running block (no
+    // `end_row`) extends to the last visible row so its gutter is hoverable.
+    let running_extent = win_start + snap.term_height.saturating_sub(1);
+    let block = crate::gui::command_blocks::gutter_block_for_row(
+        &snap.command_blocks,
+        buffer_row,
+        running_extent,
+    )?;
+    let start = block.command_start_row?;
+    let end = block.end_row.unwrap_or(running_extent);
+    // Clip [start, end] to the visible window, then convert each endpoint into
+    // rendered-row space.  If the entire block sits inside a fold, None.
+    let win_end = win_start + snap.term_height;
+    if end < win_start || start >= win_end {
+        return None;
+    }
+    let s_screen = start.saturating_sub(win_start);
+    let e_screen = end
+        .saturating_sub(win_start)
+        .min(snap.term_height.saturating_sub(1));
+    let s_rendered = row_map.snapshot_to_rendered(s_screen)?;
+    let e_rendered = row_map.snapshot_to_rendered(e_screen)?;
+    Some((s_rendered.min(e_rendered), s_rendered.max(e_rendered)))
+}
+
 ///
 /// The scrollbar is shown when the user is actively scrolled back
 /// (`scroll_offset > 0`).  It disappears at the live bottom.
@@ -823,6 +967,10 @@ pub struct PaneRenderCache {
     /// The terminal cell `(col, row)` the mouse was hovering over in the
     /// previous frame.
     pub(super) previous_hover_cell: Option<(usize, usize)>,
+    /// The command-block hover-tint rendered-row range from the previous
+    /// frame.  A hover change (different range, or appearing/disappearing)
+    /// forces a vertex rebuild so the tint is baked into the background VBO.
+    pub(super) previous_command_block_hover_rows: Option<(usize, usize)>,
     /// Cached URL from the most recent URL hover lookup.
     pub(super) cached_hovered_url: Option<Arc<Url>>,
     /// Pointer identity of the `visible_chars` `Arc` used for the last URL
@@ -832,6 +980,10 @@ pub struct PaneRenderCache {
     pub(crate) shaping_cache: crate::gui::shaping::ShapingCache,
     /// Whether the user is currently dragging the scrollbar thumb.
     pub(super) scrollbar_dragging: bool,
+    /// Whether the pointer was over the command-block gutter hit zone on the
+    /// previous frame.  Used to request one extra repaint on the frame the
+    /// pointer leaves the gutter so the hover-tint clearing frame is drawn.
+    pub(super) pointer_in_gutter_last_frame: bool,
     /// Terminal width (columns) from the last full vertex rebuild.  When this
     /// changes (window resize), the cell-instance VBOs still contain vertices
     /// for the old column count; drawing them into a smaller viewport leaves
@@ -884,10 +1036,12 @@ impl PaneRenderCache {
             previous_search_match_count: 0,
             previous_search_current_match: 0,
             previous_hover_cell: None,
+            previous_command_block_hover_rows: None,
             cached_hovered_url: None,
             hover_snap_ptr: 0,
             shaping_cache: crate::gui::shaping::ShapingCache::new(),
             scrollbar_dragging: false,
+            pointer_in_gutter_last_frame: false,
             previous_term_width: 0,
             previous_term_height: 0,
             previous_fold_epoch: 0,
@@ -1197,6 +1351,51 @@ impl FreminalTerminalWidget {
             pane_rect.max,
         );
 
+        // Keep the gutter hover-tint live.  This works together with the
+        // `hover_changed` cache invalidation below; both are required:
+        //
+        //   1. WAKING A FRAME on cursor motion.  The windowing layer's
+        //      cursor-move fast path (Task 65/68 idle-CPU optimization) only
+        //      schedules a repaint when egui itself reports `repaint` — i.e.
+        //      when an egui-tracked interactive region's hover state changes.
+        //      Registering the gutter as a `Sense::click()` region makes egui
+        //      report that on enter/leave, so the frame runs and the hover
+        //      recompute happens.
+        //   2. REBUILDING THE VBO (the `hover_changed` term, further below):
+        //      the hover tint is baked into the background instance buffer,
+        //      which is otherwise only rebuilt on content/selection/search
+        //      changes.  Without `hover_changed` the woken frame would reuse
+        //      stale vertices and show nothing.
+        //
+        // The click itself is still handled by the pre-check that follows; this
+        // response is only used for the repaint wake-up and the hand cursor.
+        // We also force one repaint on the frame the pointer leaves so the
+        // clearing frame is guaranteed.
+        if gutter_inset > 0.0 && command_blocks_config.enabled && !snap.is_alternate_screen {
+            let gutter_hit_rect = egui::Rect::from_min_max(
+                pane_rect.min,
+                egui::pos2(terminal_rect.min.x, pane_rect.max.y),
+            );
+            let gutter_response = ui.interact(
+                gutter_hit_rect,
+                ui.id().with(("command_block_gutter", pane_id)),
+                egui::Sense::click(),
+            );
+            let hovered = gutter_response.hovered();
+            if hovered {
+                ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+            }
+            if hovered || cache.pointer_in_gutter_last_frame {
+                ui.ctx().request_repaint();
+            }
+            cache.pointer_in_gutter_last_frame = hovered;
+        } else if cache.pointer_in_gutter_last_frame {
+            // Feature toggled off / alt-screen entered while we were hovering:
+            // draw one clearing frame.
+            ui.ctx().request_repaint();
+            cache.pointer_in_gutter_last_frame = false;
+        }
+
         // ── Scrollbar pre-check ──────────────────────────────────────────
         // Detect if the user is clicking or starting a drag on the scrollbar
         // BEFORE processing terminal input, so the click is not forwarded
@@ -1224,6 +1423,56 @@ impl FreminalTerminalWidget {
             }
         }
 
+        // ── Command-block gutter pre-check ────────────────────────────────
+        // Intercept primary clicks that land in the reserved gutter inset
+        // (left of `terminal_rect`) BEFORE they reach `write_input_to_terminal`
+        // — gutter positions are outside `terminal_rect`, so they would
+        // otherwise be dropped entirely (no fold, no focus).  A click on a
+        // FINISHED block toggles its fold; a click on a RUNNING block is a
+        // no-op fold but still focuses the pane.  Hovering the gutter is
+        // handled later (it feeds the same hover-tint overlay as the cell
+        // grid).  Suppressed on the alternate screen.
+        let mut left_mouse_button_pressed_gutter = false;
+        if gutter_inset > 0.0
+            && command_blocks_config.enabled
+            && !snap.is_alternate_screen
+            && !snap.command_blocks.is_empty()
+            && !suppress_input
+            && !context_menu_open
+            && !view_state.search_state.is_open
+            && !view_state.command_history.is_open
+        {
+            let gutter_press_pos = ui.input(|i| {
+                let ptr = &i.pointer;
+                if ptr.primary_pressed() {
+                    ptr.interact_pos()
+                } else {
+                    None
+                }
+            });
+            // The hit zone is the whole inset region [pane left, terminal
+            // left), i.e. the painted strip plus the padding gap — a more
+            // forgiving target than the 4px strip alone.
+            if let Some(pos) = gutter_press_pos
+                && pos.x >= pane_rect.min.x
+                && pos.x < terminal_rect.min.x
+                && pos.y >= terminal_rect.min.y
+                && pos.y < terminal_rect.max.y
+                && let Some(block_id) =
+                    gutter_block_id_at_pos(pos, snap, view_state, terminal_rect, logical_cell_h)
+            {
+                // Focus the pane regardless of fold outcome.
+                left_mouse_button_pressed_gutter = true;
+                // Only finished blocks can fold (running blocks have no
+                // `end_row`).
+                if let Some(block) = snap.command_blocks.iter().find(|b| b.id == block_id)
+                    && crate::gui::command_blocks::block_is_foldable(block)
+                {
+                    view_state.toggle_fold(block_id);
+                }
+            }
+        }
+
         // When a modal dialog (e.g. the settings window) or the right-click
         // context menu is open — or the modal was open last frame — do NOT
         // forward keyboard/mouse events to the PTY.  For modals, the one-frame
@@ -1232,7 +1481,9 @@ impl FreminalTerminalWidget {
         // menu button (e.g. Copy) is delivered to egui's Area widget instead
         // of being consumed by `write_input_to_terminal` as a terminal click.
         let mut deferred_actions = Vec::new();
-        let mut left_mouse_button_pressed = false;
+        // A gutter click never reaches `write_input_to_terminal` (it is outside
+        // `terminal_rect`), so its click-to-focus intent is carried here.
+        let mut left_mouse_button_pressed = left_mouse_button_pressed_gutter;
         if suppress_input
             || context_menu_open
             || view_state.search_state.is_open
@@ -1272,7 +1523,7 @@ impl FreminalTerminalWidget {
                     &cache.placeholder_hit_rects,
                 )
             });
-            left_mouse_button_pressed = left_mouse_button_pressed_inner;
+            left_mouse_button_pressed |= left_mouse_button_pressed_inner;
             cache.previous_mouse_state = new_mouse_pos;
             cache.previous_key = previous_key;
             cache.previous_scroll_amount = scroll_amount;
@@ -1515,6 +1766,28 @@ impl FreminalTerminalWidget {
             // Convert buffer-absolute selection coordinates to screen-relative
             // for the renderer (which iterates `shaped_lines` by screen row).
             let win_start = visible_window_start(snap);
+
+            // Compute the command-block hover-row range NOW (before the
+            // vertex-rebuild decision) so a hover-only change — which does not
+            // touch text content, selection, or search — still forces a full
+            // rebuild.  The hover tint is baked into the background instance
+            // VBO, so without this a hover change would be invisible until some
+            // other event (PTY output, fold) invalidated the cache.
+            let command_block_hover_rows_early = compute_command_block_hover_rows(
+                snap,
+                view_state,
+                command_blocks_config,
+                &row_map,
+                win_start,
+                pane_rect,
+                terminal_rect,
+                gutter_inset,
+                logical_cell_w,
+                logical_cell_h,
+            );
+            let hover_changed =
+                command_block_hover_rows_early != cache.previous_command_block_hover_rows;
+
             let screen_selection = current_selection.and_then(|(s, e)| {
                 // Clamp the selection to the visible window.  If both start
                 // and end are outside the visible range, there is nothing to
@@ -1630,6 +1903,7 @@ impl FreminalTerminalWidget {
                 && !selection_changed
                 && !text_blink_changed
                 && !search_changed
+                && !hover_changed
                 && cursor_state_changed
                 && !render_state
                     .lock()
@@ -1675,6 +1949,7 @@ impl FreminalTerminalWidget {
                 || selection_changed
                 || text_blink_changed
                 || search_changed
+                || hover_changed
                 || render_state
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1811,62 +2086,16 @@ impl FreminalTerminalWidget {
                 // the same vertex batch.  Disabled when the feature is
                 // off, when the alternate screen is active (command
                 // blocks describe primary-screen rows and must not tint
-                // a full-screen TUI), when no blocks exist, or when the
-                // mouse is not inside the terminal area.
-                let command_block_hover_rows: Option<(usize, usize)> =
-                    if crate::gui::command_blocks::command_block_overlays_visible(
-                        command_blocks_config.enabled,
-                        snap.is_alternate_screen,
-                        !snap.command_blocks.is_empty(),
-                    ) && let Some(mouse_position) = view_state.mouse_position
-                        && terminal_rect.contains(mouse_position)
-                    {
-                        let (_col, rendered_row) = encode_egui_mouse_pos_as_usize(
-                            mouse_position,
-                            (logical_cell_w, logical_cell_h),
-                            terminal_rect.min,
-                        );
-                        // Translate to a snapshot (buffer-absolute) row via the
-                        // fold-aware row map; placeholder / out-of-range rows
-                        // never hover-tint a block.
-                        let snap_screen_row = match row_map.rendered_to_snapshot(rendered_row) {
-                            Some(RenderedRow::Snapshot(r)) => Some(r),
-                            Some(RenderedRow::Placeholder(_)) | None => None,
-                        };
-                        snap_screen_row.and_then(|screen_row| {
-                            let buffer_row = win_start + screen_row;
-                            // Find the block containing this absolute row.
-                            // Skips running blocks (no end_row) and blocks
-                            // missing `command_start_row`.
-                            let block = snap.command_blocks.iter().find(|b| {
-                                match (b.command_start_row, b.end_row) {
-                                    (Some(s), Some(e)) => buffer_row >= s && buffer_row <= e,
-                                    _ => false,
-                                }
-                            })?;
-                            let start = block.command_start_row?;
-                            let end = block.end_row?;
-                            // Clip the block's [start, end] to the visible
-                            // window, then convert each endpoint into
-                            // rendered-row space.  Endpoints inside a fold
-                            // are snapped to the placeholder's surviving
-                            // row via the row-map lookup; if the entire
-                            // block sits inside a fold the result is None.
-                            let win_end = win_start + snap.term_height;
-                            if end < win_start || start >= win_end {
-                                return None;
-                            }
-                            let s_screen = start.saturating_sub(win_start);
-                            let e_screen = end
-                                .saturating_sub(win_start)
-                                .min(snap.term_height.saturating_sub(1));
-                            let s_rendered = row_map.snapshot_to_rendered(s_screen)?;
-                            let e_rendered = row_map.snapshot_to_rendered(e_screen)?;
-                            Some((s_rendered.min(e_rendered), s_rendered.max(e_rendered)))
-                        })
-                    } else {
-                        None
-                    };
+                // a full-screen TUI), or when no blocks exist.
+                //
+                // Two trigger surfaces feed this: hovering a cell inside
+                // the terminal area (72.12), and hovering the command-block
+                // gutter strip (73.3).  73.5 will retire the cell trigger,
+                // leaving the gutter as the sole affordance.
+                // `command_block_hover_rows` was computed earlier (before the
+                // vertex-rebuild decision) so a hover-only change can force a
+                // rebuild; reuse it here.
+                let command_block_hover_rows = command_block_hover_rows_early;
 
                 // Acquire the lock early so all vertex builders can write
                 // directly into the persistent `RenderState` Vecs, reusing
@@ -1959,6 +2188,7 @@ impl FreminalTerminalWidget {
                 cache.previous_text_blink_fast_visible = view_state.text_blink_fast_visible;
                 cache.previous_search_match_count = search_match_count;
                 cache.previous_search_current_match = search_current_match;
+                cache.previous_command_block_hover_rows = command_block_hover_rows_early;
                 cache.previous_term_width = snap.term_width;
                 cache.previous_term_height = snap.term_height;
                 cache.previous_fold_epoch = fold_epoch;

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -1783,60 +1783,64 @@ impl FreminalTerminalWidget {
                 // result is passed into `BackgroundFrame` so the tint
                 // is drawn alongside selection / search highlights in
                 // the same vertex batch.  Disabled when the feature is
-                // off, when no blocks exist, or when the mouse is not
-                // inside the terminal area.
-                let command_block_hover_rows: Option<(usize, usize)> = if command_blocks_config
-                    .enabled
-                    && !snap.command_blocks.is_empty()
-                    && let Some(mouse_position) = view_state.mouse_position
-                    && terminal_rect.contains(mouse_position)
-                {
-                    let (_col, rendered_row) = encode_egui_mouse_pos_as_usize(
-                        mouse_position,
-                        (logical_cell_w, logical_cell_h),
-                        terminal_rect.min,
-                    );
-                    // Translate to a snapshot (buffer-absolute) row via the
-                    // fold-aware row map; placeholder / out-of-range rows
-                    // never hover-tint a block.
-                    let snap_screen_row = match row_map.rendered_to_snapshot(rendered_row) {
-                        Some(RenderedRow::Snapshot(r)) => Some(r),
-                        Some(RenderedRow::Placeholder(_)) | None => None,
-                    };
-                    snap_screen_row.and_then(|screen_row| {
-                        let buffer_row = win_start + screen_row;
-                        // Find the block containing this absolute row.
-                        // Skips running blocks (no end_row) and blocks
-                        // missing `command_start_row`.
-                        let block = snap.command_blocks.iter().find(|b| {
-                            match (b.command_start_row, b.end_row) {
-                                (Some(s), Some(e)) => buffer_row >= s && buffer_row <= e,
-                                _ => false,
+                // off, when the alternate screen is active (command
+                // blocks describe primary-screen rows and must not tint
+                // a full-screen TUI), when no blocks exist, or when the
+                // mouse is not inside the terminal area.
+                let command_block_hover_rows: Option<(usize, usize)> =
+                    if crate::gui::command_blocks::command_block_overlays_visible(
+                        command_blocks_config.enabled,
+                        snap.is_alternate_screen,
+                        !snap.command_blocks.is_empty(),
+                    ) && let Some(mouse_position) = view_state.mouse_position
+                        && terminal_rect.contains(mouse_position)
+                    {
+                        let (_col, rendered_row) = encode_egui_mouse_pos_as_usize(
+                            mouse_position,
+                            (logical_cell_w, logical_cell_h),
+                            terminal_rect.min,
+                        );
+                        // Translate to a snapshot (buffer-absolute) row via the
+                        // fold-aware row map; placeholder / out-of-range rows
+                        // never hover-tint a block.
+                        let snap_screen_row = match row_map.rendered_to_snapshot(rendered_row) {
+                            Some(RenderedRow::Snapshot(r)) => Some(r),
+                            Some(RenderedRow::Placeholder(_)) | None => None,
+                        };
+                        snap_screen_row.and_then(|screen_row| {
+                            let buffer_row = win_start + screen_row;
+                            // Find the block containing this absolute row.
+                            // Skips running blocks (no end_row) and blocks
+                            // missing `command_start_row`.
+                            let block = snap.command_blocks.iter().find(|b| {
+                                match (b.command_start_row, b.end_row) {
+                                    (Some(s), Some(e)) => buffer_row >= s && buffer_row <= e,
+                                    _ => false,
+                                }
+                            })?;
+                            let start = block.command_start_row?;
+                            let end = block.end_row?;
+                            // Clip the block's [start, end] to the visible
+                            // window, then convert each endpoint into
+                            // rendered-row space.  Endpoints inside a fold
+                            // are snapped to the placeholder's surviving
+                            // row via the row-map lookup; if the entire
+                            // block sits inside a fold the result is None.
+                            let win_end = win_start + snap.term_height;
+                            if end < win_start || start >= win_end {
+                                return None;
                             }
-                        })?;
-                        let start = block.command_start_row?;
-                        let end = block.end_row?;
-                        // Clip the block's [start, end] to the visible
-                        // window, then convert each endpoint into
-                        // rendered-row space.  Endpoints inside a fold
-                        // are snapped to the placeholder's surviving
-                        // row via the row-map lookup; if the entire
-                        // block sits inside a fold the result is None.
-                        let win_end = win_start + snap.term_height;
-                        if end < win_start || start >= win_end {
-                            return None;
-                        }
-                        let s_screen = start.saturating_sub(win_start);
-                        let e_screen = end
-                            .saturating_sub(win_start)
-                            .min(snap.term_height.saturating_sub(1));
-                        let s_rendered = row_map.snapshot_to_rendered(s_screen)?;
-                        let e_rendered = row_map.snapshot_to_rendered(e_screen)?;
-                        Some((s_rendered.min(e_rendered), s_rendered.max(e_rendered)))
-                    })
-                } else {
-                    None
-                };
+                            let s_screen = start.saturating_sub(win_start);
+                            let e_screen = end
+                                .saturating_sub(win_start)
+                                .min(snap.term_height.saturating_sub(1));
+                            let s_rendered = row_map.snapshot_to_rendered(s_screen)?;
+                            let e_rendered = row_map.snapshot_to_rendered(e_screen)?;
+                            Some((s_rendered.min(e_rendered), s_rendered.max(e_rendered)))
+                        })
+                    } else {
+                        None
+                    };
 
                 // Acquire the lock early so all vertex builders can write
                 // directly into the persistent `RenderState` Vecs, reusing
@@ -2141,10 +2145,16 @@ impl FreminalTerminalWidget {
         // the block's first visible rendered row.  Running blocks have
         // no `finished_at` and are skipped.  Blocks entirely outside
         // the visible window or hidden inside a fold are also skipped
-        // (the row-map lookup yields `None`).
-        if command_blocks_config.enabled
-            && command_blocks_config.show_duration
-            && !snap.command_blocks.is_empty()
+        // (the row-map lookup yields `None`).  Suppressed entirely on
+        // the alternate screen: the stored blocks describe primary-
+        // screen rows, so their durations must not be painted over a
+        // full-screen TUI.
+        if command_blocks_config.show_duration
+            && crate::gui::command_blocks::command_block_overlays_visible(
+                command_blocks_config.enabled,
+                snap.is_alternate_screen,
+                !snap.command_blocks.is_empty(),
+            )
         {
             let threshold =
                 Duration::from_secs_f32(command_blocks_config.duration_threshold_secs.max(0.0));

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -2449,17 +2449,21 @@ impl FreminalTerminalWidget {
             }
         }
 
-        // ── Command-block duration overlay ───────────────────────────
-        // For each finished command block whose duration meets the
-        // configured threshold, paint a compact right-aligned label on
-        // the block's first visible rendered row.  Running blocks have
-        // no `finished_at` and are skipped.  Blocks entirely outside
-        // the visible window or hidden inside a fold are also skipped
-        // (the row-map lookup yields `None`).  Suppressed entirely on
-        // the alternate screen: the stored blocks describe primary-
-        // screen rows, so their durations must not be painted over a
-        // full-screen TUI.
+        // ── Command-block duration label (gutter-anchored, 73.6) ─────
+        // For each finished block whose duration meets the configured
+        // threshold, paint a compact duration label as a floating layer
+        // immediately RIGHT of the gutter strip, anchored to the block's
+        // LAST visible rendered row.  Anchoring to the last on-screen row
+        // (rather than the first, as 72.12 did) keeps the label visible:
+        // the first row scrolls off almost immediately for any command
+        // that produces output, whereas the gutter follows the block.
+        //
+        // Requires the gutter to be present (`gutter_inset > 0`) — the
+        // label is positioned against it.  Running blocks (no duration)
+        // are skipped.  Suppressed on the alternate screen for the usual
+        // reason (stored blocks describe primary-screen rows).
         if command_blocks_config.show_duration
+            && gutter_inset > 0.0
             && crate::gui::command_blocks::command_block_overlays_visible(
                 command_blocks_config.enabled,
                 snap.is_alternate_screen,
@@ -2470,11 +2474,18 @@ impl FreminalTerminalWidget {
                 Duration::from_secs_f32(command_blocks_config.duration_threshold_secs.max(0.0));
             let win_start = visible_window_start(snap);
             let win_end = win_start + snap.term_height;
+            let running_extent = win_start + snap.term_height.saturating_sub(1);
             let (fg_r, fg_g, fg_b) = snap.theme.foreground;
             // Muted: ~60% alpha so the label reads without overpowering
             // the underlying cell content.
             let label_color = egui::Color32::from_rgba_unmultiplied(fg_r, fg_g, fg_b, 153);
             let font_id = egui::FontId::monospace(logical_cell_h * 0.75);
+            // Floating layer (option a): anchored just inside the cell grid,
+            // immediately right of the gutter inset, on the block's last
+            // visible row.  It overlays the first cells of that row — a small
+            // muted label on the block's bottom line, which follows the block
+            // as it scrolls (unlike the old first-row placement).
+            let label_x = terminal_rect.min.x + 2.0;
             for block in snap.command_blocks.iter() {
                 // `duration()` measures from command-execution start
                 // (`executed_at`/OSC 133 C), excluding the user's typing time
@@ -2486,24 +2497,29 @@ impl FreminalTerminalWidget {
                 if elapsed < threshold {
                     continue;
                 }
-                // Anchor on `command_start_row` when available, else
-                // fall back to `prompt_start_row` (very early blocks
-                // that finished before any output line).
-                let anchor_buffer_row = block.command_start_row.unwrap_or(block.prompt_start_row);
-                if anchor_buffer_row < win_start || anchor_buffer_row >= win_end {
-                    continue;
-                }
-                let screen_row = anchor_buffer_row - win_start;
+                // Anchor on the block's LAST visible row so the label follows
+                // the block as it scrolls (see `duration_label_anchor_row`).
+                let Some(last_visible_buffer_row) =
+                    crate::gui::command_blocks::duration_label_anchor_row(
+                        block,
+                        win_start,
+                        win_end,
+                        running_extent,
+                    )
+                else {
+                    continue; // block entirely outside the viewport
+                };
+                let screen_row = last_visible_buffer_row.saturating_sub(win_start);
                 let Some(rendered_row) = row_map.snapshot_to_rendered(screen_row) else {
-                    continue;
+                    continue; // last row hidden inside a fold
                 };
                 let rendered_f = rendered_row.approx_as::<f32>().unwrap_or(0.0);
                 let y = rendered_f.mul_add(logical_cell_h, terminal_rect.min.y);
-                let pos = egui::pos2(terminal_rect.max.x - 4.0, y);
+                let pos = egui::pos2(label_x, y);
                 let label = crate::gui::command_blocks::format_command_duration(elapsed);
                 ui.painter().text(
                     pos,
-                    egui::Align2::RIGHT_TOP,
+                    egui::Align2::LEFT_TOP,
                     label,
                     font_id.clone(),
                     label_color,

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -114,6 +114,70 @@ pub fn hit_test_placeholder(
         .map(|(_, id)| *id)
 }
 
+/// Fold-aware window layout for one frame.
+///
+/// Centralises the coordinate math shared by the renderer and every overlay
+/// that maps between buffer rows, snapshot rows, rendered rows, and on-screen
+/// rows. Computed once from a snapshot plus the GUI-local folded-block set so
+/// the renderer, gutter, duration labels, hover, and hit-tests all agree.
+///
+/// Coordinate spaces:
+/// - **buffer row**: absolute index into the scrollback buffer.
+/// - **snapshot row** `[0, snap_rows)`: index into `visible_chars` etc. The
+///   window covers `term_height + window_extra_rows` rows starting at
+///   `flat_window_start`.
+/// - **rendered row** `[0, rendered_row_count)`: snapshot rows with folded
+///   ranges collapsed to placeholders.
+/// - **screen row** `[0, term_height)`: rendered rows with the top
+///   `render_skip` rows scrolled off (bottom-anchored so the live bottom is
+///   pinned).
+struct FoldLayout {
+    /// Buffer-absolute index of the first snapshot row.
+    flat_window_start: usize,
+    /// Snapshot → rendered row mapping with folds collapsed.
+    row_map: RowMap,
+    /// Rendered rows scrolled off the top so the bottom `term_height` rendered
+    /// rows fill the screen.
+    render_skip: usize,
+}
+
+impl FoldLayout {
+    /// Build the layout for `snap` given the folded-block set.
+    fn new(
+        snap: &TerminalSnapshot,
+        folded_blocks: &std::collections::HashSet<
+            freminal_common::buffer_states::command_block::CommandBlockId,
+        >,
+    ) -> Self {
+        let raw_fold_ranges = compute_fold_ranges(&snap.command_blocks, folded_blocks);
+        let flat_window_start =
+            super::coords::visible_window_start(snap).saturating_sub(snap.window_extra_rows);
+        let snap_rows = snap.term_height.saturating_add(snap.window_extra_rows);
+        let fold_ranges =
+            crate::gui::folding::translate_ranges_to_snapshot(&raw_fold_ranges, flat_window_start);
+        let row_map = RowMap::new(snap_rows, &fold_ranges);
+        let render_skip = row_map
+            .rendered_row_count()
+            .saturating_sub(snap.term_height);
+        Self {
+            flat_window_start,
+            row_map,
+            render_skip,
+        }
+    }
+
+    /// Map a rendered row to an on-screen row, or `None` if it is scrolled off
+    /// the top of the screen (above the bottom-anchored window).
+    const fn rendered_to_screen(&self, rendered_row: usize) -> Option<usize> {
+        rendered_row.checked_sub(self.render_skip)
+    }
+
+    /// Map an on-screen row to its rendered row.
+    const fn screen_to_rendered(&self, screen_row: usize) -> usize {
+        screen_row.saturating_add(self.render_skip)
+    }
+}
+
 /// Resolve a pointer position in the command-block gutter to the
 /// `CommandBlockId` of the block whose rendered row range the pointer is
 /// over, accounting for folds.
@@ -133,24 +197,24 @@ fn gutter_block_id_at_pos(
     if logical_cell_h <= 0.0 {
         return None;
     }
-    // Rendered row under the pointer (relative to the terminal area top).
-    let rendered_row = ((pos.y - terminal_rect.min.y) / logical_cell_h)
+    // Screen row under the pointer (relative to the terminal area top), then
+    // its rendered row in the bottom-anchored layout.
+    let screen_row = ((pos.y - terminal_rect.min.y) / logical_cell_h)
         .floor()
         .approx_as::<usize>()
         .ok()?;
 
-    // Build the same fold-aware row map the renderer uses this frame.
-    let raw_fold_ranges = compute_fold_ranges(&snap.command_blocks, &view_state.folded_blocks);
-    let win_start = super::coords::visible_window_start(snap);
-    let fold_ranges =
-        crate::gui::folding::translate_ranges_to_snapshot(&raw_fold_ranges, win_start);
-    let row_map = RowMap::new(snap.term_height, &fold_ranges);
+    // Build the same fold-aware layout the renderer uses this frame.
+    let layout = FoldLayout::new(snap, &view_state.folded_blocks);
+    let rendered_row = layout.screen_to_rendered(screen_row);
+    // Running blocks extend to the live bottom row (last normally-visible row).
+    let running_extent =
+        super::coords::visible_window_start(snap) + snap.term_height.saturating_sub(1);
 
-    match row_map.rendered_to_snapshot(rendered_row) {
+    match layout.row_map.rendered_to_snapshot(rendered_row) {
         // A live snapshot row → containment hit-test against the blocks.
-        Some(RenderedRow::Snapshot(screen_row)) => {
-            let buffer_row = win_start + screen_row;
-            let running_extent = win_start + snap.term_height.saturating_sub(1);
+        Some(RenderedRow::Snapshot(snap_row)) => {
+            let buffer_row = layout.flat_window_start + snap_row;
             crate::gui::command_blocks::gutter_block_for_row(
                 &snap.command_blocks,
                 buffer_row,
@@ -180,8 +244,7 @@ fn compute_command_block_hover_rows(
     snap: &TerminalSnapshot,
     view_state: &ViewState,
     command_blocks_config: &freminal_common::config::CommandBlocksConfig,
-    row_map: &RowMap,
-    win_start: usize,
+    layout: &FoldLayout,
     pane_rect: Rect,
     terminal_rect: Rect,
     gutter_inset: f32,
@@ -210,20 +273,25 @@ fn compute_command_block_hover_rows(
         return None;
     }
 
-    // Map y → rendered row → buffer row (live rows only; a placeholder
-    // resolves to the folded block via its first row).
-    let rendered_row = ((mouse_position.y - terminal_rect.min.y) / logical_cell_h)
+    let win_start = layout.flat_window_start;
+    let snap_rows = snap.term_height.saturating_add(snap.window_extra_rows);
+
+    // Map y → screen row → rendered row → buffer row (live rows only; a
+    // placeholder resolves to the folded block via its first row).
+    let screen_row = ((mouse_position.y - terminal_rect.min.y) / logical_cell_h)
         .floor()
         .approx_as::<usize>()
         .ok()?;
-    let buffer_row = match row_map.rendered_to_snapshot(rendered_row) {
+    let rendered_row = layout.screen_to_rendered(screen_row);
+    let buffer_row = match layout.row_map.rendered_to_snapshot(rendered_row) {
         Some(RenderedRow::Snapshot(r)) => win_start + r,
         Some(RenderedRow::Placeholder(range)) => win_start + range.start_row,
         None => return None,
     };
     // Find the block containing this absolute row.  A running block (no
-    // `end_row`) extends to the last visible row so its gutter is hoverable.
-    let running_extent = win_start + snap.term_height.saturating_sub(1);
+    // `end_row`) extends to the live bottom so its gutter is hoverable.
+    let running_extent =
+        super::coords::visible_window_start(snap) + snap.term_height.saturating_sub(1);
     let block = crate::gui::command_blocks::gutter_block_for_row(
         &snap.command_blocks,
         buffer_row,
@@ -231,19 +299,20 @@ fn compute_command_block_hover_rows(
     )?;
     let start = block.command_start_row?;
     let end = block.end_row.unwrap_or(running_extent);
-    // Clip [start, end] to the visible window, then convert each endpoint into
-    // rendered-row space.  If the entire block sits inside a fold, None.
-    let win_end = win_start + snap.term_height;
+    // Clip [start, end] to the flattened window, then convert each endpoint
+    // into screen-row space.  If the entire block sits inside a fold or is
+    // scrolled off the top, None.
+    let win_end = win_start + snap_rows;
     if end < win_start || start >= win_end {
         return None;
     }
-    let s_screen = start.saturating_sub(win_start);
-    let e_screen = end
+    let s_snap = start.saturating_sub(win_start);
+    let e_snap = end
         .saturating_sub(win_start)
-        .min(snap.term_height.saturating_sub(1));
-    let s_rendered = row_map.snapshot_to_rendered(s_screen)?;
-    let e_rendered = row_map.snapshot_to_rendered(e_screen)?;
-    Some((s_rendered.min(e_rendered), s_rendered.max(e_rendered)))
+        .min(snap_rows.saturating_sub(1));
+    let s_screen = layout.rendered_to_screen(layout.row_map.snapshot_to_rendered(s_snap)?)?;
+    let e_screen = layout.rendered_to_screen(layout.row_map.snapshot_to_rendered(e_snap)?)?;
+    Some((s_screen.min(e_screen), s_screen.max(e_screen)))
 }
 
 ///
@@ -1457,6 +1526,7 @@ impl FreminalTerminalWidget {
                     && crate::gui::command_blocks::block_is_foldable(block)
                 {
                     view_state.toggle_fold(block_id);
+                    super::input::resend_scroll_window(snap, view_state, input_tx);
                 }
             }
         }
@@ -1657,24 +1727,32 @@ impl FreminalTerminalWidget {
         // Translate before constructing the map; otherwise ranges with
         // `start_row >= term_height` are silently dropped and the fold
         // becomes a visual no-op.
-        let raw_fold_ranges = compute_fold_ranges(&snap.command_blocks, &view_state.folded_blocks);
-        let fold_ranges = crate::gui::folding::translate_ranges_to_snapshot(
-            &raw_fold_ranges,
-            visible_window_start(snap),
-        );
-        let row_map = RowMap::new(snap.term_height, &fold_ranges);
+        // Fold-aware window layout for this frame: with command-block folds in
+        // view the PTY flattens `window_extra_rows` extra rows ABOVE the normal
+        // visible window so the screen can be filled after collapsing folds
+        // (see `TerminalSnapshot::window_extra_rows`).  `FoldLayout` centralises
+        // the buffer/snapshot/rendered/screen row mapping; the renderer paints
+        // the bottom `term_height` rendered rows so the live bottom is pinned.
+        // When no fold is in view (`window_extra_rows == 0`) `render_skip == 0`
+        // and rendering is identical to the unfolded path.
+        let layout = FoldLayout::new(snap, &view_state.folded_blocks);
+        let flat_window_start = layout.flat_window_start;
+        let render_skip = layout.render_skip;
+        let row_map = &layout.row_map;
         // Per-frame epoch: a stable hash of the sorted, non-overlapping ranges
-        // list.  When the user folds or unfolds a block this changes, and we
-        // use it below to invalidate the vertex cache (the rendered row layout
-        // has shifted).
+        // list (plus the bottom-anchor skip).  When the user folds or unfolds a
+        // block — or scrolls such that the visible fold span changes — this
+        // changes, and we use it below to invalidate the vertex cache (the
+        // rendered row layout has shifted).
         let fold_epoch: u64 = {
             use std::hash::{Hash, Hasher};
             let mut h = rustc_hash::FxHasher::default();
-            for r in &fold_ranges {
+            for r in row_map.ranges() {
                 r.command_block_id.hash(&mut h);
                 r.start_row.hash(&mut h);
                 r.end_row.hash(&mut h);
             }
+            render_skip.hash(&mut h);
             h.finish()
         };
 
@@ -1751,9 +1829,13 @@ impl FreminalTerminalWidget {
             let search_changed = search_match_count != cache.previous_search_match_count
                 || search_current_match != cache.previous_search_current_match;
 
-            // Convert buffer-absolute selection coordinates to screen-relative
-            // for the renderer (which iterates `shaped_lines` by screen row).
-            let win_start = visible_window_start(snap);
+            // Convert buffer-absolute selection coordinates to snapshot-row
+            // space for the renderer.  `win_start` is the flattened window top
+            // (it includes the fold extra rows); the snapshot covers `snap_rows`
+            // rows.  Selection rows are later mapped snapshot → rendered →
+            // screen alongside the shaped lines.
+            let win_start = flat_window_start;
+            let snap_rows = snap.term_height.saturating_add(snap.window_extra_rows);
 
             // Compute the command-block hover-row range NOW (before the
             // vertex-rebuild decision) so a hover-only change — which does not
@@ -1765,8 +1847,7 @@ impl FreminalTerminalWidget {
                 snap,
                 view_state,
                 command_blocks_config,
-                &row_map,
-                win_start,
+                &layout,
                 pane_rect,
                 terminal_rect,
                 gutter_inset,
@@ -1776,10 +1857,10 @@ impl FreminalTerminalWidget {
                 command_block_hover_rows_early != cache.previous_command_block_hover_rows;
 
             let screen_selection = current_selection.and_then(|(s, e)| {
-                // Clamp the selection to the visible window.  If both start
-                // and end are outside the visible range, there is nothing to
+                // Clamp the selection to the flattened window.  If both start
+                // and end are outside the window, there is nothing to
                 // highlight on screen.
-                let win_end = win_start + snap.term_height;
+                let win_end = win_start + snap_rows;
                 if e.row < win_start || s.row >= win_end {
                     return None; // entirely outside visible window
                 }
@@ -1787,7 +1868,7 @@ impl FreminalTerminalWidget {
                 let e_row = e
                     .row
                     .saturating_sub(win_start)
-                    .min(snap.term_height.saturating_sub(1));
+                    .min(snap_rows.saturating_sub(1));
 
                 let is_block = view_state.selection.is_block;
 
@@ -1821,14 +1902,22 @@ impl FreminalTerminalWidget {
             // is *inside* a folded range (which shouldn't happen normally
             // because the prompt is never folded, but is defensible against
             // races) we suppress the cursor for this frame.
-            let cursor_rendered_row = row_map.snapshot_to_rendered(snap.cursor_pos.y);
-            let cursor_visible = cursor_rendered_row.is_some();
-            // If the cursor's snapshot row is hidden behind a fold, suppress
-            // it for this frame.  AND-ing here means the cursor-only fast
-            // path and the full rebuild path agree on visibility.
+            // The cursor row is reported relative to the *normal* visible
+            // window top; shift it into snapshot-row space (the flattened
+            // window has `window_extra_rows` extra rows above it), map through
+            // the fold collapse, then to the bottom-anchored screen row.
+            let cursor_snap_row = snap.cursor_pos.y.saturating_add(snap.window_extra_rows);
+            let cursor_screen_row = row_map
+                .snapshot_to_rendered(cursor_snap_row)
+                .and_then(|rendered| layout.rendered_to_screen(rendered));
+            let cursor_visible = cursor_screen_row.is_some();
+            // If the cursor's snapshot row is hidden behind a fold (or scrolled
+            // off the top), suppress it for this frame.  AND-ing here means the
+            // cursor-only fast path and the full rebuild path agree on
+            // visibility.
             effective_show_cursor = effective_show_cursor && cursor_visible;
             let target_col = snap.cursor_pos.x.approx_as::<f32>().unwrap_or(0.0);
-            let target_row = cursor_rendered_row
+            let target_row = cursor_screen_row
                 .unwrap_or(snap.cursor_pos.y)
                 .approx_as::<f32>()
                 .unwrap_or(0.0);
@@ -1848,7 +1937,7 @@ impl FreminalTerminalWidget {
             // so it aligns with the magnified glyphs.
             let cursor_row_lw = snap
                 .visible_line_widths
-                .get(snap.cursor_pos.y)
+                .get(cursor_snap_row)
                 .copied()
                 .unwrap_or(freminal_terminal_emulator::LineWidth::Normal);
             let cursor_x_scale = if cursor_row_lw.is_double_width() {
@@ -1971,7 +2060,11 @@ impl FreminalTerminalWidget {
                 // `cache.placeholder_hit_rects` so the input handler can
                 // turn primary clicks on those rows into `view_state.unfold()`.
                 cache.placeholder_hit_rects.clear();
-                let rendered_shaped_lines: Vec<Arc<ShapedLine>> = if fold_ranges.is_empty() {
+                let rendered_shaped_lines: Vec<Arc<ShapedLine>> = if row_map.ranges().is_empty()
+                    && render_skip == 0
+                    && snap.window_extra_rows == 0
+                {
+                    // No folds and no extra rows: snapshot rows == screen rows.
                     shaped_lines
                 } else {
                     let empty_placeholder = Arc::new(ShapedLine {
@@ -1979,9 +2072,12 @@ impl FreminalTerminalWidget {
                         line_width: LineWidth::Normal,
                     });
                     let dim_fg = freminal_common::colors::TerminalColor::BrightBlack;
-                    let row_count = row_map.rendered_row_count().min(snap.term_height);
-                    let mut out: Vec<Arc<ShapedLine>> = Vec::with_capacity(row_count);
-                    for rendered in 0..row_count {
+                    // Paint exactly the bottom `term_height` rendered rows
+                    // (screen rows). `render_skip` rendered rows are scrolled
+                    // off the top so the live bottom stays pinned.
+                    let mut out: Vec<Arc<ShapedLine>> = Vec::with_capacity(snap.term_height);
+                    for screen in 0..snap.term_height {
+                        let rendered = layout.screen_to_rendered(screen);
                         match row_map.rendered_to_snapshot(rendered) {
                             Some(RenderedRow::Snapshot(snap_row)) => {
                                 out.push(
@@ -2006,13 +2102,12 @@ impl FreminalTerminalWidget {
                                 out.push(Arc::new(shaped));
 
                                 // Record the placeholder's hit rect in
-                                // logical pixel coordinates so the input
-                                // handler (which sees pointer positions in
-                                // window coordinates) can hit-test against
-                                // it directly.
-                                let rendered_f = rendered.approx_as::<f32>().unwrap_or(0.0);
-                                let row_top =
-                                    rendered_f.mul_add(logical_cell_h, terminal_rect.min.y);
+                                // logical pixel coordinates (screen row) so the
+                                // input handler (which sees pointer positions in
+                                // window coordinates) can hit-test against it
+                                // directly.
+                                let screen_f = screen.approx_as::<f32>().unwrap_or(0.0);
+                                let row_top = screen_f.mul_add(logical_cell_h, terminal_rect.min.y);
                                 let rect = Rect::from_min_size(
                                     egui::pos2(terminal_rect.min.x, row_top),
                                     egui::vec2(terminal_rect.width(), logical_cell_h),
@@ -2030,37 +2125,40 @@ impl FreminalTerminalWidget {
                 };
 
                 // Build search match highlights from the current search state.
-                // Only matches within the visible window are included, with
-                // rows converted from buffer-absolute to screen-relative.
-                let win_start = visible_window_start(snap);
+                // Only matches within the flattened window are included, with
+                // rows converted from buffer-absolute to snapshot-relative.
+                let win_start = flat_window_start;
+                let snap_rows = snap.term_height.saturating_add(snap.window_extra_rows);
                 let search_highlights_snap: Vec<MatchHighlight> =
-                    matches_to_highlights(&view_state.search_state, win_start, snap.term_height);
-                // Translate from snapshot-row space to rendered-row space and
-                // drop highlights inside folded ranges (they're not visible).
-                let search_highlights: Vec<MatchHighlight> = if fold_ranges.is_empty() {
-                    search_highlights_snap
-                } else {
-                    search_highlights_snap
-                        .into_iter()
-                        .filter_map(|h| {
-                            row_map
-                                .snapshot_to_rendered(h.row)
-                                .map(|rendered| MatchHighlight { row: rendered, ..h })
-                        })
-                        .collect()
-                };
+                    matches_to_highlights(&view_state.search_state, win_start, snap_rows);
+                // Translate from snapshot-row space to screen-row space and
+                // drop highlights inside folded ranges or scrolled off the top.
+                let search_highlights: Vec<MatchHighlight> =
+                    if row_map.ranges().is_empty() && render_skip == 0 {
+                        search_highlights_snap
+                    } else {
+                        search_highlights_snap
+                            .into_iter()
+                            .filter_map(|h| {
+                                let rendered = row_map.snapshot_to_rendered(h.row)?;
+                                let screen = layout.rendered_to_screen(rendered)?;
+                                Some(MatchHighlight { row: screen, ..h })
+                            })
+                            .collect()
+                    };
 
-                // Translate the screen selection's row indices from snapshot
-                // to rendered space.  If either endpoint sits inside a folded
-                // range, drop the selection for this frame (it will reappear
-                // when the user unfolds the block).
-                let screen_selection_rendered = if fold_ranges.is_empty() {
+                // Translate the selection's row indices from snapshot to
+                // bottom-anchored screen space.  If either endpoint sits inside
+                // a folded range or is scrolled off the top, drop the selection
+                // for this frame (it will reappear when the user unfolds /
+                // scrolls back).
+                let screen_selection_rendered = if row_map.ranges().is_empty() && render_skip == 0 {
                     screen_selection
                 } else {
                     screen_selection.and_then(|(sc, sr, ec, er)| {
-                        let sr_r = row_map.snapshot_to_rendered(sr)?;
-                        let er_r = row_map.snapshot_to_rendered(er)?;
-                        Some((sc, sr_r, ec, er_r))
+                        let sr_s = layout.rendered_to_screen(row_map.snapshot_to_rendered(sr)?)?;
+                        let er_s = layout.rendered_to_screen(row_map.snapshot_to_rendered(er)?)?;
+                        Some((sc, sr_s, ec, er_s))
                     })
                 };
 
@@ -2357,7 +2455,11 @@ impl FreminalTerminalWidget {
             &mut cache.scrollbar_dragging,
         ) {
             view_state.scroll_offset = new_offset;
-            let _ = input_tx.try_send(InputEvent::ScrollOffset(new_offset));
+            let _ = input_tx.try_send(super::input::scroll_event(
+                snap,
+                &view_state.folded_blocks,
+                new_offset,
+            ));
         }
 
         // ── Visual bell flash overlay ────────────────────────────────
@@ -2401,19 +2503,21 @@ impl FreminalTerminalWidget {
             && !snap.is_alternate_screen
             && !snap.command_blocks.is_empty()
         {
-            let win_start = visible_window_start(snap);
-            // Running blocks extend to the last visible buffer row.
-            let running_extent = win_start + snap.term_height.saturating_sub(1);
-            let rendered_rows = row_map.rendered_row_count();
-            for rendered_row in 0..rendered_rows {
+            let win_start = flat_window_start;
+            // Running blocks extend to the live bottom row.
+            let running_extent = visible_window_start(snap) + snap.term_height.saturating_sub(1);
+            // Iterate on-screen rows (bottom-anchored); map each back through
+            // rendered → snapshot → buffer.
+            for screen_row_idx in 0..snap.term_height {
+                let rendered_row = layout.screen_to_rendered(screen_row_idx);
                 // Resolve each rendered row to a status color.  Snapshot
                 // rows map back to a buffer row and use row containment;
                 // fold placeholders are colored (desaturated) by the
                 // folded block's own status, looked up by id.
                 let resolved: Option<(CommandStatus, bool)> =
                     match row_map.rendered_to_snapshot(rendered_row) {
-                        Some(RenderedRow::Snapshot(screen_row)) => {
-                            let buffer_row = win_start + screen_row;
+                        Some(RenderedRow::Snapshot(snap_row)) => {
+                            let buffer_row = win_start + snap_row;
                             crate::gui::command_blocks::gutter_status_for_row(
                                 &snap.command_blocks,
                                 buffer_row,
@@ -2439,8 +2543,8 @@ impl FreminalTerminalWidget {
                 } else {
                     egui::Color32::from_rgb(cr, cg, cb)
                 };
-                let rendered_f = rendered_row.approx_as::<f32>().unwrap_or(0.0);
-                let y0 = rendered_f.mul_add(logical_cell_h, terminal_rect.min.y);
+                let screen_f = screen_row_idx.approx_as::<f32>().unwrap_or(0.0);
+                let y0 = screen_f.mul_add(logical_cell_h, terminal_rect.min.y);
                 let row_rect = egui::Rect::from_min_max(
                     egui::pos2(gutter_rect.min.x, y0),
                     egui::pos2(gutter_rect.max.x, y0 + logical_cell_h),
@@ -2472,9 +2576,9 @@ impl FreminalTerminalWidget {
         {
             let threshold =
                 Duration::from_secs_f32(command_blocks_config.duration_threshold_secs.max(0.0));
-            let win_start = visible_window_start(snap);
-            let win_end = win_start + snap.term_height;
-            let running_extent = win_start + snap.term_height.saturating_sub(1);
+            let win_start = flat_window_start;
+            let win_end = win_start + snap.term_height.saturating_add(snap.window_extra_rows);
+            let running_extent = visible_window_start(snap) + snap.term_height.saturating_sub(1);
             let (fg_r, fg_g, fg_b) = snap.theme.foreground;
             // Muted: ~60% alpha so the label reads without overpowering
             // the underlying cell content.
@@ -2509,12 +2613,15 @@ impl FreminalTerminalWidget {
                 else {
                     continue; // block entirely outside the viewport
                 };
-                let screen_row = last_visible_buffer_row.saturating_sub(win_start);
-                let Some(rendered_row) = row_map.snapshot_to_rendered(screen_row) else {
-                    continue; // last row hidden inside a fold
+                let snap_row = last_visible_buffer_row.saturating_sub(win_start);
+                let Some(screen_row) = row_map
+                    .snapshot_to_rendered(snap_row)
+                    .and_then(|rendered| layout.rendered_to_screen(rendered))
+                else {
+                    continue; // last row hidden inside a fold or scrolled off
                 };
-                let rendered_f = rendered_row.approx_as::<f32>().unwrap_or(0.0);
-                let y = rendered_f.mul_add(logical_cell_h, terminal_rect.min.y);
+                let screen_f = screen_row.approx_as::<f32>().unwrap_or(0.0);
+                let y = screen_f.mul_add(logical_cell_h, terminal_rect.min.y);
                 let pos = egui::pos2(label_x, y);
                 let label = crate::gui::command_blocks::format_command_duration(elapsed);
                 ui.painter().text(
@@ -2590,10 +2697,11 @@ impl FreminalTerminalWidget {
                     // against a URL — clear the cache.  When `row` is past
                     // the bottom of the rendered viewport, `rendered_to_snapshot`
                     // returns None and we likewise clear.
-                    let snap_row = match row_map.rendered_to_snapshot(row) {
-                        Some(RenderedRow::Snapshot(r)) => Some(r),
-                        Some(RenderedRow::Placeholder(_)) | None => None,
-                    };
+                    let snap_row =
+                        match row_map.rendered_to_snapshot(layout.screen_to_rendered(row)) {
+                            Some(RenderedRow::Snapshot(r)) => Some(r),
+                            Some(RenderedRow::Placeholder(_)) | None => None,
+                        };
                     cache.cached_hovered_url = snap_row.and_then(|snap_row| {
                         // Recompute the hovered URL: convert the mouse's
                         // display-column position to a flat index into
@@ -3078,18 +3186,17 @@ mod gutter_hover_trigger_tests {
     fn hovering_gutter_row_tints_the_block() {
         let snap = snapshot_with_block(24);
         let (pane_rect, terminal_rect, inset, cell_h) = geometry();
-        let row_map = RowMap::new(snap.term_height, &[]);
         let cfg = CommandBlocksConfig::default();
         let mut vs = ViewState::new();
         // Pointer in the gutter (x=4, inside [0,8)), at row 2 (y=25 -> row 2).
         vs.mouse_position = Some(egui::pos2(4.0, 25.0));
+        let layout = FoldLayout::new(&snap, &vs.folded_blocks);
 
         let rows = compute_command_block_hover_rows(
             &snap,
             &vs,
             &cfg,
-            &row_map,
-            0,
+            &layout,
             pane_rect,
             terminal_rect,
             inset,
@@ -3103,19 +3210,18 @@ mod gutter_hover_trigger_tests {
     fn hovering_output_cell_does_not_tint() {
         let snap = snapshot_with_block(24);
         let (pane_rect, terminal_rect, inset, cell_h) = geometry();
-        let row_map = RowMap::new(snap.term_height, &[]);
         let cfg = CommandBlocksConfig::default();
         let mut vs = ViewState::new();
         // Pointer over a terminal cell well inside the block's rows (x=100,
         // which is >= terminal_rect.min.x=8), row 2.
         vs.mouse_position = Some(egui::pos2(100.0, 25.0));
+        let layout = FoldLayout::new(&snap, &vs.folded_blocks);
 
         let rows = compute_command_block_hover_rows(
             &snap,
             &vs,
             &cfg,
-            &row_map,
-            0,
+            &layout,
             pane_rect,
             terminal_rect,
             inset,
@@ -3128,21 +3234,20 @@ mod gutter_hover_trigger_tests {
     fn gutter_off_disables_hover() {
         let snap = snapshot_with_block(24);
         let (pane_rect, terminal_rect, _inset, cell_h) = geometry();
-        let row_map = RowMap::new(snap.term_height, &[]);
         let cfg = CommandBlocksConfig {
             gutter: GutterPosition::Off,
             ..CommandBlocksConfig::default()
         };
         let mut vs = ViewState::new();
         vs.mouse_position = Some(egui::pos2(4.0, 25.0));
+        let layout = FoldLayout::new(&snap, &vs.folded_blocks);
 
         // gutter_inset == 0 when the gutter is off.
         let rows = compute_command_block_hover_rows(
             &snap,
             &vs,
             &cfg,
-            &row_map,
-            0,
+            &layout,
             pane_rect,
             terminal_rect,
             0.0,
@@ -3155,16 +3260,15 @@ mod gutter_hover_trigger_tests {
     fn no_pointer_no_tint() {
         let snap = snapshot_with_block(24);
         let (pane_rect, terminal_rect, inset, cell_h) = geometry();
-        let row_map = RowMap::new(snap.term_height, &[]);
         let cfg = CommandBlocksConfig::default();
         let vs = ViewState::new(); // mouse_position == None
+        let layout = FoldLayout::new(&snap, &vs.folded_blocks);
 
         let rows = compute_command_block_hover_rows(
             &snap,
             &vs,
             &cfg,
-            &row_map,
-            0,
+            &layout,
             pane_rect,
             terminal_rect,
             inset,

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -164,15 +164,17 @@ fn gutter_block_id_at_pos(
     }
 }
 
-/// Compute the rendered-row span (inclusive) of the command block the pointer
-/// is currently hovering, for the hover-tint overlay.
+/// Compute the rendered-row span (inclusive) of the command block whose
+/// gutter the pointer is currently hovering, for the hover-tint overlay.
 ///
-/// Two trigger surfaces feed this: hovering a cell inside the terminal area
-/// (72.12) and hovering the command-block gutter strip (73.3).  Returns `None`
-/// when the feature is off, the alternate screen is active, there are no
-/// blocks, the pointer is elsewhere, or the hovered block is entirely inside a
-/// fold.  The result must be recomputed before the vertex-rebuild decision so a
-/// hover-only change can invalidate the cached background instances.
+/// The **gutter strip is the sole hover trigger** (73.5): hovering a cell in
+/// the terminal output area does nothing block-related, so the tint no longer
+/// fires during text selection, mouse-tracking apps, or passive cursor motion.
+/// Returns `None` when the feature is off, the gutter is disabled
+/// (`gutter_inset == 0`), the alternate screen is active, there are no blocks,
+/// the pointer is not over the gutter, or the hovered block is entirely inside
+/// a fold.  The result must be recomputed before the vertex-rebuild decision so
+/// a hover-only change can invalidate the cached background instances.
 #[allow(clippy::too_many_arguments)]
 fn compute_command_block_hover_rows(
     snap: &TerminalSnapshot,
@@ -183,7 +185,6 @@ fn compute_command_block_hover_rows(
     pane_rect: Rect,
     terminal_rect: Rect,
     gutter_inset: f32,
-    logical_cell_w: f32,
     logical_cell_h: f32,
 ) -> Option<(usize, usize)> {
     if !crate::gui::command_blocks::command_block_overlays_visible(
@@ -193,46 +194,33 @@ fn compute_command_block_hover_rows(
     ) {
         return None;
     }
-    if logical_cell_h <= 0.0 {
+    // No gutter (feature off / `gutter = "off"`) means no hover trigger.
+    if gutter_inset <= 0.0 || logical_cell_h <= 0.0 {
         return None;
     }
 
-    // Resolve the hovered buffer row from whichever surface the pointer is
-    // over: the gutter (left of the terminal rect) or a terminal cell.
+    // The gutter strip is the only hover surface: the pointer must be in the
+    // reserved inset, left of the terminal rect.
     let mouse_position = view_state.mouse_position?;
-    let hovered_buffer_row: Option<usize> = if gutter_inset > 0.0
-        && mouse_position.x >= pane_rect.min.x
-        && mouse_position.x < terminal_rect.min.x
-        && mouse_position.y >= terminal_rect.min.y
-        && mouse_position.y < terminal_rect.max.y
+    if mouse_position.x < pane_rect.min.x
+        || mouse_position.x >= terminal_rect.min.x
+        || mouse_position.y < terminal_rect.min.y
+        || mouse_position.y >= terminal_rect.max.y
     {
-        // Gutter hover: map y → rendered row → buffer row (live rows only; a
-        // placeholder resolves to the folded block via its first row).
-        let rendered_row = ((mouse_position.y - terminal_rect.min.y) / logical_cell_h)
-            .floor()
-            .approx_as::<usize>()
-            .ok()?;
-        match row_map.rendered_to_snapshot(rendered_row) {
-            Some(RenderedRow::Snapshot(r)) => Some(win_start + r),
-            Some(RenderedRow::Placeholder(range)) => Some(win_start + range.start_row),
-            None => None,
-        }
-    } else if terminal_rect.contains(mouse_position) {
-        // Terminal-cell hover.
-        let (_col, rendered_row) = encode_egui_mouse_pos_as_usize(
-            mouse_position,
-            (logical_cell_w, logical_cell_h),
-            terminal_rect.min,
-        );
-        match row_map.rendered_to_snapshot(rendered_row) {
-            Some(RenderedRow::Snapshot(r)) => Some(win_start + r),
-            Some(RenderedRow::Placeholder(_)) | None => None,
-        }
-    } else {
-        None
-    };
+        return None;
+    }
 
-    let buffer_row = hovered_buffer_row?;
+    // Map y → rendered row → buffer row (live rows only; a placeholder
+    // resolves to the folded block via its first row).
+    let rendered_row = ((mouse_position.y - terminal_rect.min.y) / logical_cell_h)
+        .floor()
+        .approx_as::<usize>()
+        .ok()?;
+    let buffer_row = match row_map.rendered_to_snapshot(rendered_row) {
+        Some(RenderedRow::Snapshot(r)) => win_start + r,
+        Some(RenderedRow::Placeholder(range)) => win_start + range.start_row,
+        None => return None,
+    };
     // Find the block containing this absolute row.  A running block (no
     // `end_row`) extends to the last visible row so its gutter is hoverable.
     let running_extent = win_start + snap.term_height.saturating_sub(1);
@@ -1782,7 +1770,6 @@ impl FreminalTerminalWidget {
                 pane_rect,
                 terminal_rect,
                 gutter_inset,
-                logical_cell_w,
                 logical_cell_h,
             );
             let hover_changed =
@@ -3021,6 +3008,153 @@ mod subtask_1_7_tests {
         assert_eq!(super::truncate_url(url, 5), "abcde");
         // One over — truncates.
         assert_eq!(super::truncate_url(url, 4), "abcd…");
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod gutter_hover_trigger_tests {
+    //! 73.5: the gutter strip is the sole hover trigger; hovering output
+    //! cells does not tint a command block.
+    use super::*;
+    use freminal_common::buffer_states::command_block::{CommandBlock, CommandBlockId};
+    use freminal_common::config::{CommandBlocksConfig, GutterPosition};
+    use freminal_terminal_emulator::snapshot::TerminalSnapshot;
+    use std::time::SystemTime;
+
+    /// A snapshot with a single finished block spanning screen rows 1..=3,
+    /// `term_height` rows tall, scrolled to the live bottom (so
+    /// `win_start == 0`).
+    fn snapshot_with_block(term_height: usize) -> TerminalSnapshot {
+        let mut snap = TerminalSnapshot::empty();
+        snap.term_width = 80;
+        snap.term_height = term_height;
+        snap.total_rows = term_height; // win_start = total - height - 0 = 0
+        snap.scroll_offset = 0;
+        let block = CommandBlock {
+            id: CommandBlockId::next(),
+            fid: "t".to_owned(),
+            prompt_start_row: 1,
+            command_start_row: Some(1),
+            output_start_row: Some(2),
+            end_row: Some(3),
+            exit_code: Some(0),
+            cwd: None,
+            started_at: SystemTime::UNIX_EPOCH,
+            executed_at: Some(SystemTime::UNIX_EPOCH),
+            finished_at: Some(SystemTime::UNIX_EPOCH),
+        };
+        snap.command_blocks = std::sync::Arc::from(vec![block]);
+        snap
+    }
+
+    /// Geometry: 10px logical cells, gutter inset 8px, pane top-left at (0,0).
+    /// Terminal rect therefore starts at x=8.  Row 2 spans y in [20,30).
+    fn geometry() -> (Rect, Rect, f32, f32) {
+        let cell_h = 10.0_f32;
+        let inset = 8.0_f32;
+        let pane_rect = Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(808.0, 500.0));
+        let terminal_rect = Rect::from_min_max(egui::pos2(inset, 0.0), egui::pos2(808.0, 500.0));
+        (pane_rect, terminal_rect, inset, cell_h)
+    }
+
+    #[test]
+    fn hovering_gutter_row_tints_the_block() {
+        let snap = snapshot_with_block(24);
+        let (pane_rect, terminal_rect, inset, cell_h) = geometry();
+        let row_map = RowMap::new(snap.term_height, &[]);
+        let cfg = CommandBlocksConfig::default();
+        let mut vs = ViewState::new();
+        // Pointer in the gutter (x=4, inside [0,8)), at row 2 (y=25 -> row 2).
+        vs.mouse_position = Some(egui::pos2(4.0, 25.0));
+
+        let rows = compute_command_block_hover_rows(
+            &snap,
+            &vs,
+            &cfg,
+            &row_map,
+            0,
+            pane_rect,
+            terminal_rect,
+            inset,
+            cell_h,
+        );
+        // Block spans command_start_row..=end_row = rows 1..=3.
+        assert_eq!(rows, Some((1, 3)), "gutter hover must tint the block");
+    }
+
+    #[test]
+    fn hovering_output_cell_does_not_tint() {
+        let snap = snapshot_with_block(24);
+        let (pane_rect, terminal_rect, inset, cell_h) = geometry();
+        let row_map = RowMap::new(snap.term_height, &[]);
+        let cfg = CommandBlocksConfig::default();
+        let mut vs = ViewState::new();
+        // Pointer over a terminal cell well inside the block's rows (x=100,
+        // which is >= terminal_rect.min.x=8), row 2.
+        vs.mouse_position = Some(egui::pos2(100.0, 25.0));
+
+        let rows = compute_command_block_hover_rows(
+            &snap,
+            &vs,
+            &cfg,
+            &row_map,
+            0,
+            pane_rect,
+            terminal_rect,
+            inset,
+            cell_h,
+        );
+        assert_eq!(rows, None, "hovering output cells must not tint a block");
+    }
+
+    #[test]
+    fn gutter_off_disables_hover() {
+        let snap = snapshot_with_block(24);
+        let (pane_rect, terminal_rect, _inset, cell_h) = geometry();
+        let row_map = RowMap::new(snap.term_height, &[]);
+        let cfg = CommandBlocksConfig {
+            gutter: GutterPosition::Off,
+            ..CommandBlocksConfig::default()
+        };
+        let mut vs = ViewState::new();
+        vs.mouse_position = Some(egui::pos2(4.0, 25.0));
+
+        // gutter_inset == 0 when the gutter is off.
+        let rows = compute_command_block_hover_rows(
+            &snap,
+            &vs,
+            &cfg,
+            &row_map,
+            0,
+            pane_rect,
+            terminal_rect,
+            0.0,
+            cell_h,
+        );
+        assert_eq!(rows, None, "gutter = off disables the hover trigger");
+    }
+
+    #[test]
+    fn no_pointer_no_tint() {
+        let snap = snapshot_with_block(24);
+        let (pane_rect, terminal_rect, inset, cell_h) = geometry();
+        let row_map = RowMap::new(snap.term_height, &[]);
+        let cfg = CommandBlocksConfig::default();
+        let vs = ViewState::new(); // mouse_position == None
+
+        let rows = compute_command_block_hover_rows(
+            &snap,
+            &vs,
+            &cfg,
+            &row_map,
+            0,
+            pane_rect,
+            terminal_rect,
+            inset,
+            cell_h,
+        );
+        assert_eq!(rows, None);
     }
 }
 

--- a/freminal/src/shell_integration.rs
+++ b/freminal/src/shell_integration.rs
@@ -34,7 +34,7 @@ use std::path::Path;
 /// (e.g. payload format, marker semantics) so downstream tooling can
 /// detect mismatched on-disk copies.
 #[cfg(test)]
-const FREMINAL_SHELL_INTEGRATION_VERSION: u32 = 2;
+const FREMINAL_SHELL_INTEGRATION_VERSION: u32 = 4;
 
 /// The bundled bash init script (loaded via `ENV=`).
 pub const FREMINAL_BASH_INIT: &str =

--- a/shell-integration/README.md
+++ b/shell-integration/README.md
@@ -1,4 +1,4 @@
-<!-- freminal-shell-integration v2 -->
+<!-- freminal-shell-integration v4 -->
 
 # Freminal Shell Integration
 

--- a/shell-integration/bash/freminal-init.bash
+++ b/shell-integration/bash/freminal-init.bash
@@ -1,4 +1,4 @@
-# freminal-shell-integration v2
+# freminal-shell-integration v4
 # shellcheck shell=bash
 #
 # Freminal bash integration — loaded automatically when Freminal spawns bash.
@@ -137,6 +137,9 @@ __freminal_prompt_command() {
 	# when the user runs a command), and the next prompt_command's D.
 	__freminal_fid_next
 
+	# Allow the DEBUG trap to emit exactly one C for the upcoming command.
+	__FREMINAL_C_EMITTED=0
+
 	# OSC 7 cwd notification.
 	local __freminal_hostname
 	__freminal_hostname="$(hostname 2>/dev/null || echo localhost)"
@@ -152,6 +155,12 @@ __freminal_prompt_command() {
 	PS1='\[\033]133;A;${__FREMINAL_FID_PAYLOAD}\007\]'"${PS1}"'\[\033]133;B;${__FREMINAL_FID_PAYLOAD}\007\]'
 
 	__freminal_rearm_prompt_command
+
+	# Re-arm the C hook every cycle.  bash-preexec (Starship et al.) may have
+	# loaded after us, or may re-install its DEBUG dispatcher each prompt and
+	# clobber our trap; re-running the installer keeps our `preexec_functions`
+	# entry / DEBUG trap in place.  Idempotent.
+	__freminal_install_c_hook
 }
 
 # Strip any existing freminal A/B wrap from PS1 (defensive: avoids stacking
@@ -208,32 +217,72 @@ else
 	fi
 fi
 
-# ── DEBUG trap (C marker) ─────────────────────────────────────────────────────
-# The DEBUG trap fires before every simple command.  C shares the fid
-# established at the most recent PROMPT_COMMAND (and embedded in the A/B
-# markers of the prompt the user just submitted).  No fid roll here.
+# ── C marker (command execution start) ───────────────────────────────────────
+# C must fire once, just before the user's command runs, carrying the fid
+# established at the most recent PROMPT_COMMAND (the same fid embedded in the
+# A/B markers of the prompt the user just submitted).  freminal computes the
+# command's duration from C->D, so a missing C makes the duration fall back
+# to the prompt-start time (A->D) — which over-reports by however long the
+# user sat at the prompt.
 #
-# Conditions where we must NOT emit C:
+# We emit C from a DEBUG trap that we OWN and re-arm every prompt cycle.
+#
+# Why not bash-preexec's `preexec_functions`?  Freminal launches bash with
+# `--posix` (so it honours $ENV to load this file).  Under that launch,
+# bash-preexec's interactive-mode gating never enables, so its
+# `preexec_functions` dispatch silently never runs — WezTerm's and Starship's
+# preexec C markers are dropped too.  A DEBUG trap, by contrast, fires
+# natively regardless of bash-preexec's state.
+#
+# Why re-arm every cycle?  Prompt frameworks (Starship via bash-preexec,
+# WezTerm) install their own DEBUG trap on the first prompt, clobbering ours.
+# `__freminal_prompt_command` re-arms itself to the END of PROMPT_COMMAND and
+# calls `__freminal_install_c_hook` from there, so our re-install runs AFTER
+# any framework's install each cycle and composes our handler in front of
+# whatever DEBUG trap currently exists.
+__freminal_emit_c() {
+	printf '\033]133;C;%s\007' "${__FREMINAL_FID_PAYLOAD}"
+}
+
+# The DEBUG trap fires before every simple command, so it needs guards:
 #   1. During tab-completion ($COMP_LINE is set).
 #   2. When $BASH_COMMAND is empty.
 #   3. When the command is one of our own internal helpers.
+#   4. When the command is part of the prompt machinery (PROMPT_COMMAND,
+#      bash-preexec, WezTerm, Starship); those are not user commands.
+#   5. Only once per command lifecycle (a compound command / pipeline fires
+#      DEBUG per simple command; we want a single C per submitted command).
 __freminal_debug_trap() {
 	[ -n "${COMP_LINE+x}" ] && return 0
 	[ -z "${BASH_COMMAND:-}" ] && return 0
 	case "${BASH_COMMAND}" in
-	__freminal_*) return 0 ;;
+	__freminal_* | __bp_* | __wezterm_* | starship_* | _*) return 0 ;;
 	esac
-	printf '\033]133;C;%s\007' "${__FREMINAL_FID_PAYLOAD}"
+	# Emit C only once between prompts.  Reset to 0 in PROMPT_COMMAND.
+	[ "${__FREMINAL_C_EMITTED:-0}" = "1" ] && return 0
+	__FREMINAL_C_EMITTED=1
+	__freminal_emit_c
 }
 
-# Install the DEBUG trap, composing with any existing trap.
-__freminal_existing_debug_trap="$(trap -p DEBUG 2>/dev/null)"
-if [ -n "${__freminal_existing_debug_trap}" ]; then
-	__freminal_existing_debug_cmd="${__freminal_existing_debug_trap#trap -- \'}"
-	__freminal_existing_debug_cmd="${__freminal_existing_debug_cmd%\' DEBUG}"
-	# shellcheck disable=SC2064
-	trap "__freminal_debug_trap; ${__freminal_existing_debug_cmd}" DEBUG
-else
-	trap '__freminal_debug_trap' DEBUG
-fi
-unset __freminal_existing_debug_trap __freminal_existing_debug_cmd
+# Install (or re-install) our DEBUG trap, composing IN FRONT of any existing
+# DEBUG trap (e.g. bash-preexec's dispatcher) so both run.  Idempotent: if our
+# handler is already the leading command, do nothing.  Re-armed every prompt
+# cycle from `__freminal_prompt_command`.
+__freminal_install_c_hook() {
+	local __freminal_existing
+	__freminal_existing="$(trap -p DEBUG 2>/dev/null)"
+	case "${__freminal_existing}" in
+	"trap -- '__freminal_debug_trap"*) return 0 ;; # already leading
+	esac
+	if [ -n "${__freminal_existing}" ]; then
+		# Strip `trap -- '` prefix and `' DEBUG` suffix to recover the command.
+		local __freminal_cmd="${__freminal_existing#trap -- \'}"
+		__freminal_cmd="${__freminal_cmd%\' DEBUG}"
+		# shellcheck disable=SC2064
+		trap "__freminal_debug_trap; ${__freminal_cmd}" DEBUG
+	else
+		trap '__freminal_debug_trap' DEBUG
+	fi
+}
+
+__freminal_install_c_hook

--- a/shell-integration/fish/vendor_conf.d/freminal.fish
+++ b/shell-integration/fish/vendor_conf.d/freminal.fish
@@ -1,4 +1,4 @@
-# freminal-shell-integration v2
+# freminal-shell-integration v4
 #
 # Freminal fish integration — installed under `vendor_conf.d/` and loaded
 # automatically by fish when Freminal prepends our resources directory to

--- a/shell-integration/zsh/.zshenv
+++ b/shell-integration/zsh/.zshenv
@@ -1,4 +1,4 @@
-# freminal-shell-integration v2
+# freminal-shell-integration v4
 #
 # Freminal zsh `.zshenv` — loaded automatically when Freminal spawns zsh.
 #

--- a/shell-integration/zsh/freminal-integration
+++ b/shell-integration/zsh/freminal-integration
@@ -1,4 +1,4 @@
-# freminal-shell-integration v2
+# freminal-shell-integration v4
 #
 # Freminal zsh integration body — sourced by our `.zshenv` after the user's
 # own zsh startup files have run.


### PR DESCRIPTION
## Summary

Implements **Task 73 — Command Gutters** (`Documents/PLAN_VERSION_090.md`):
a per-row status gutter strip for OSC 133 command blocks, plus the
interaction and polish work around it. Also fixes a fold scrolling bug
surfaced while testing the gutter.

## Task 73 subtasks

- **73.1** — add command-block gutter colors to `ThemePalette`.
- **73.2** — render the command-block status gutter column (green = success,
  red = failure, yellow = running, white = unknown).
- **73.3** — gutter click (fold/select) and hover highlight.
- **73.4** — settings dropdown for gutter position.
- **73.5** — the gutter strip is the sole command-block hover trigger
  (hovering output cells no longer tints).
- **73.6** — move the command-duration label into the gutter, anchored to
  the block's last visible row so it follows the block as it scrolls.
- **73.7** — measure command duration from execution start (OSC 133 C),
  not prompt start, so instant commands no longer report multi-second times.

Plus supporting fixes: suppress command-block overlays on the alternate
screen, and emit OSC 133 C under `bash --posix`.

## Fold scrolling fix

Collapsing a command block (OSC 133 fold, Task 72.10) left scrolling
broken: the renderer top-anchored the shortened content (blank gap at the
bottom) and the raw-row scroll offset stepped through the fold's hidden
rows, so scrolling appeared to do nothing until the hidden span scrolled
off. Fixed end to end:

- **Buffer**: visible-window flatten/line-width/image/dirty helpers can
  extend the window **upward** by `extra_rows` (the live bottom stays fixed).
- **Emulator**: `build_snapshot` flattens `term_height + extra_rows` rows on
  request (`set_gui_scroll_window`), clamped to available scrollback and
  forced to 0 on the alternate screen; `TerminalSnapshot.window_extra_rows`
  carries the count and invalidates the snapshot cache when it changes.
  `scroll_offset` / `show_cursor` are unaffected — no fold state leaks into
  PTY-side rendering decisions.
- **GUI render**: a `FoldLayout` centralises buffer/snapshot/rendered/screen
  row mapping; the renderer paints the bottom `term_height` rendered rows so
  the live prompt stays pinned and freed space is filled with real content
  pulled from above. Gutter, duration labels, hover, selection, search,
  cursor, and URL hover all map through it.
- **Scrolling**: `apply_rendered_scroll` converts wheel/line/page scroll into
  rendered-row units, skipping collapsed fold spans so each tick moves
  exactly one visible line and scroll-down at the live bottom is a no-op.

## Verification

- `cargo test --all` — green (new tests: extended window bounds/flatten,
  `compute_extra_rows`, `apply_rendered_scroll` incl. fold-skip, snapshot
  `window_extra_rows` clamping/alt-screen/cache, fold-aware scroll helpers).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `cargo machete` — clean.
- Benchmarks (`bench_build_snapshot`, `bench_visible_flatten`): no
  significant regression (deltas within run-to-run noise, well under 15%);
  the no-fold hot path adds only a `saturating_sub` to the window math.