### PR TITLE
fix: RPM-legal nightly version + tombi TOML lint hook

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -325,7 +325,7 @@ jobs:
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: ${{ needs.check-changes.outputs.tag }}
-          name: "Nightly ${{ needs.check-changes.outputs.tag }}"
+          name: "Nightly ${{ needs.check-changes.outputs.nightly_version }}"
           prerelease: true
           generate_release_notes: true
           files: artifacts/*

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,5 @@
+# .taplo.toml or taplo.toml
+[formatting]
+column_width = 254
+array_auto_expand = false
+inline_table_expand = false

--- a/.tombi.toml
+++ b/.tombi.toml
@@ -1,0 +1,3 @@
+# .tombi.toml or tombi.toml
+[format.rules]
+line-width = 254

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3772,9 +3772,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "swash"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842f3cd369c2ba38966204f983eaa5e54a8e84a7d7159ed36ade2b6c335aae64"
+checksum = "d1804632b66a35ca2b1d277eb0a138e10f46cb365b9a6d297e876b69ef79de43"
 dependencies = [
  "skrifa",
  "yazi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,7 @@
 [workspace]
 resolver = "3"
-members = [
-  "freminal",
-  "freminal-buffer",
-  "freminal-common",
-  "freminal-terminal-emulator",
-  "freminal-windowing",
-  "portable-pty",
-  "xtask",
-]
-default-members = [
-  "freminal",
-  "freminal-buffer",
-  "freminal-common",
-  "freminal-terminal-emulator",
-]
+members = ["freminal", "freminal-buffer", "freminal-common", "freminal-terminal-emulator", "freminal-windowing", "portable-pty", "xtask"]
+default-members = ["freminal", "freminal-buffer", "freminal-common", "freminal-terminal-emulator"]
 
 [workspace.package]
 version = "0.9.0-beta.2"
@@ -75,7 +62,7 @@ serial2 = "0.2.37"
 shared_library = "0.1.9"
 shell-words = "1.1.1"
 smol = "2.0.2"
-swash = "0.2.7"
+swash = "0.2.8"
 sysinfo = { version = "0.39.3", default-features = false, features = ["system"] }
 sys-locale = "0.3.2"
 tar = "0.4.46"

--- a/flake.nix
+++ b/flake.nix
@@ -184,28 +184,76 @@
       ## CHECKS — unified base+rust via mkCheck
       ##########################################################################
       checks = builtins.listToAttrs (
-        map (system: {
-          name = system;
-          value = {
-            pre-commit-check = precommit.lib.mkCheck {
-              inherit system;
-              src = ./.;
-              check_rust = true;
+        map (
+          system:
+          let
+            pkgs = import nixpkgs { inherit system; };
+
+            # git-hooks.nix, reached transitively through the shared precommit
+            # flake.  Used to re-run the hook generation with our extra TOML
+            # hook merged in (mkCheck has no extraHooks parameter, so we
+            # reconstruct the merged hook set the same way mkCheck does).
+            gitHooks = precommit.inputs.git-hooks;
+
+            extraExcludes = [
+              "^speed_tests/"
+              "^Documents/reference"
+              "^res/"
+              "typos.toml"
+              "\\.bin$"
+              "assets/"
+            ];
+
+            # The shared base + rust modules, exactly as mkCheck would build
+            # them.  We merge their hooks/excludes/passthru ourselves so we can
+            # add the tombi hook before handing the result to git-hooks.
+            baseModule = precommit.lib.mkBaseCheck { inherit system extraExcludes; };
+            rustModule = precommit.lib.mkRustCheck {
+              inherit system extraExcludes;
               enableXtask = true;
-              rust_options = {
-                xtaskCheck = "pc";
-              };
-              extraExcludes = [
-                "^speed_tests/"
-                "^Documents/reference"
-                "^res/"
-                "typos.toml"
-                "\\.bin$"
-                "assets/"
-              ];
+              xtaskType = "pc";
             };
-          };
-        }) systems
+
+            # Custom hook: lint every staged TOML file with tombi, failing the
+            # commit on warnings as well as errors.  TOML files are the Cargo
+            # manifests and config_example.toml; `--error-on-warnings` makes
+            # tombi exit non-zero on lint warnings (verified: clean files exit
+            # 0, any warning exits 1), so this gates the commit.
+            tombiHook = {
+              tombi = {
+                enable = true;
+                name = "tombi (TOML lint)";
+                description = "Lint TOML files with tombi, failing on warnings.";
+                entry = "${pkgs.tombi}/bin/tombi lint --error-on-warnings";
+                files = "\\.toml$";
+                language = "system";
+                pass_filenames = true;
+              };
+            };
+
+            mergedHooks = baseModule.hooks // rustModule.hooks // tombiHook;
+            mergedExcludes = (baseModule.excludes or [ ]) ++ (rustModule.excludes or [ ]) ++ extraExcludes;
+
+            run = gitHooks.lib.${system}.run {
+              src = ./.;
+              hooks = mergedHooks;
+              excludes = mergedExcludes;
+            };
+          in
+          {
+            name = system;
+            value = {
+              pre-commit-check = run // {
+                passthru = {
+                  devPackages = (baseModule.passthru.devPackages or [ ]) ++ (rustModule.passthru.devPackages or [ ]);
+                  libPath = (baseModule.passthru.libPath or [ ]) ++ (rustModule.passthru.libPath or [ ]);
+                };
+                shellHook = run.shellHook or "";
+                enabledPackages = run.enabledPackages or [ ];
+              };
+            };
+          }
+        ) systems
       );
 
       ##########################################################################
@@ -228,6 +276,7 @@
               # Extra Rust / tooling packages (NO extra rustc here)
               extraRustTools = [
                 chk.passthru.devPackages
+                pkgs.tombi
                 pkgs.cargo-deny
                 pkgs.cargo-machete
                 pkgs.cargo-make

--- a/freminal/Cargo.toml
+++ b/freminal/Cargo.toml
@@ -28,6 +28,17 @@ deb_depends = ["libgl1-mesa-glx"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[package.metadata.generate-rpm]
+# RPM forbids '-' in the Version field (it is the NEVRA Version/Release
+# separator), so a SemVer pre-release such as "0.9.0-beta.2" is illegal as-is.
+# `cargo xtask bump-version` keeps this in sync, translating the SemVer
+# pre-release separator to the RPM tilde operator (e.g. "0.9.0~beta.2"), which
+# sorts older than the final release just like the SemVer pre-release does.
+version = "0.9.0~beta.2"
+assets = [
+  { source = "target/release/freminal", dest = "/usr/bin/freminal", mode = "755" },
+]
+
 [[bench]]
 harness = false
 name = "render_loop_bench"
@@ -44,19 +55,24 @@ egui_glow.workspace = true
 fontdb.workspace = true
 freminal-common = { path = "../freminal-common" }
 freminal-terminal-emulator = { path = "../freminal-terminal-emulator" }
+freminal-windowing = { path = "../freminal-windowing" }
 glow.workspace = true
 image.workspace = true
-thiserror.workspace = true
 open.workspace = true
+regex.workspace = true
+rustc-hash.workspace = true
 rustybuzz.workspace = true
 swash.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
 tracing-appender.workspace = true
 tracing-subscriber.workspace = true
-regex.workspace = true
-rustc-hash.workspace = true
 unicode-width.workspace = true
-freminal-windowing = { path = "../freminal-windowing" }
+
+# dev dependencies
+[dev-dependencies]
+criterion.workspace = true
+tempfile.workspace = true
 
 # Platform-specific: CWD readback for layout save / recording snapshots.
 # See freminal/src/gui/platform.rs::read_cwd and plan subtask 71.16.
@@ -66,16 +82,6 @@ freminal-windowing = { path = "../freminal-windowing" }
 [target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
 sysinfo.workspace = true
 
-# dev dependencies
-[dev-dependencies]
-criterion.workspace = true
-tempfile.workspace = true
-
 [features]
 default = []
 validation = []
-
-[package.metadata.generate-rpm]
-assets = [
-    { source = "target/release/freminal", dest = "/usr/bin/freminal", mode = "755" },
-]

--- a/portable-pty/Cargo.toml
+++ b/portable-pty/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "portable-pty"
 version = "0.9.1"
-authors = ["Wez Furlong"]
+# Originally authored by Wez Furlong as part of wezterm; the `authors` key is
+# deprecated by Cargo, so attribution is retained here as a comment.
 edition = "2018"
 repository = "https://github.com/wezterm/wezterm"
 description = "Cross platform pty interface"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -466,10 +466,59 @@ fn precommit() -> Result<()> {
 /// matching occurrences with the new version. Missing expected occurrences
 /// are not ignored silently: the command emits warnings for files that do
 /// not contain the old version string and then continues successfully.
-fn bump_version(new_version: &str) -> Result<()> {
-    // Validate that the new version is valid semver.
+/// Translate a `SemVer` version into an RPM-legal `Version` string.
+///
+/// RPM's `Version` field forbids the hyphen `-` (it is the separator between
+/// the `Version` and `Release` components of a `NEVRA`), but `SemVer` uses `-`
+/// to introduce the pre-release identifier. RPM does, however, understand the
+/// tilde operator `~`, which sorts *older* than the same version without it —
+/// exactly mirroring `SemVer` pre-release ordering (`0.9.0~beta.2` < `0.9.0`).
+///
+/// The translation is:
+///
+/// * the first `-` (the `SemVer` pre-release separator) becomes `~`;
+/// * any further `-` (hyphens permitted *inside* `SemVer` identifiers, e.g.
+///   `0.9.0-x-y`) become `_`, which is RPM-legal and ordering-neutral;
+/// * everything else is left untouched (`.`, `+` build metadata, and ASCII
+///   alphanumerics are all valid in an RPM `Version`).
+///
+/// The input is first parsed with [`semver::Version::parse`], so it is
+/// guaranteed to contain only the `SemVer`-legal character set
+/// (`0-9A-Za-z.-+`). That guarantee is what makes this translation total: the
+/// only RPM-illegal character a parsed `SemVer` can contain is `-`, and both
+/// occurrences of it are handled above. Any genuinely malformed input (e.g.
+/// containing `&`) is rejected by the parse before translation.
+fn rpm_version(new_version: &str) -> Result<String> {
+    // Parsing rejects anything that is not well-formed SemVer, which also
+    // rejects any character outside the SemVer-legal set.
     semver::Version::parse(new_version)
         .wrap_err_with(|| format!("invalid semver version: {new_version}"))?;
+
+    let mut out = String::with_capacity(new_version.len());
+    let mut seen_hyphen = false;
+    for ch in new_version.chars() {
+        if ch == '-' {
+            if seen_hyphen {
+                // A hyphen inside an identifier — RPM-illegal, map to '_'.
+                out.push('_');
+            } else {
+                // The pre-release separator — map to the tilde operator.
+                out.push('~');
+                seen_hyphen = true;
+            }
+        } else {
+            out.push(ch);
+        }
+    }
+    Ok(out)
+}
+
+fn bump_version(new_version: &str) -> Result<()> {
+    // Validate that the new version is valid semver, and derive the RPM-legal
+    // form up front so an invalid version fails before any files are touched.
+    semver::Version::parse(new_version)
+        .wrap_err_with(|| format!("invalid semver version: {new_version}"))?;
+    let new_rpm_version = rpm_version(new_version)?;
 
     // Read current version from Cargo.toml.
     let cargo_toml_path = "Cargo.toml";
@@ -489,6 +538,11 @@ fn bump_version(new_version: &str) -> Result<()> {
 
     if old_version == new_version {
         tracing::info!("version is already {new_version}, nothing to do");
+        // Still reconcile the RPM Version override in case it has drifted out
+        // of sync with the workspace version (the override is RPM-illegal to
+        // leave stale, and `cargo generate-rpm` reads it instead of the
+        // workspace version).
+        update_rpm_version("freminal/Cargo.toml", &new_rpm_version)?;
         return Ok(());
     }
 
@@ -522,9 +576,68 @@ fn bump_version(new_version: &str) -> Result<()> {
         tracing::info!("  updated {flake_path} ({replacements} occurrences)");
     }
 
+    // 3. Update the RPM `Version` override in freminal/Cargo.toml.
+    //
+    // RPM forbids '-' in its Version field, so `cargo generate-rpm` reads this
+    // tilde-translated override from `[package.metadata.generate-rpm].version`
+    // instead of the workspace SemVer version.
+    update_rpm_version("freminal/Cargo.toml", &new_rpm_version)?;
+
     tracing::info!("version bump complete: {old_version} -> {new_version}");
+    tracing::info!("  rpm Version override: {new_rpm_version}");
     tracing::info!("remember to run `cargo check` to update Cargo.lock");
 
+    Ok(())
+}
+
+/// Rewrite the `version = "…"` line under `[package.metadata.generate-rpm]`
+/// in the given manifest to `new_rpm_version`.
+///
+/// The package's own version is set via `version.workspace = true`, so the
+/// only literal `version = "…"` line in `freminal/Cargo.toml` is the RPM
+/// override; this locates the `[package.metadata.generate-rpm]` table and
+/// rewrites the first `version = "…"` line that follows it.
+fn update_rpm_version(manifest_path: &str, new_rpm_version: &str) -> Result<()> {
+    let content = fs::read_to_string(manifest_path)
+        .wrap_err_with(|| format!("failed to read {manifest_path}"))?;
+
+    let mut in_rpm_section = false;
+    let mut replaced = false;
+    let mut updated = String::with_capacity(content.len());
+
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('[') {
+            in_rpm_section = trimmed.starts_with("[package.metadata.generate-rpm]");
+        }
+
+        if in_rpm_section && !replaced && trimmed.starts_with("version = \"") {
+            updated.push_str("version = \"");
+            updated.push_str(new_rpm_version);
+            updated.push('"');
+            replaced = true;
+        } else {
+            updated.push_str(line);
+        }
+        updated.push('\n');
+    }
+
+    color_eyre::eyre::ensure!(
+        replaced,
+        "could not find a 'version = \"…\"' line under \
+         [package.metadata.generate-rpm] in {manifest_path}"
+    );
+
+    // Preserve the absence of a trailing newline if the original lacked one.
+    let final_content = if content.ends_with('\n') {
+        updated
+    } else {
+        updated.trim_end_matches('\n').to_owned()
+    };
+
+    fs::write(manifest_path, final_content)
+        .wrap_err_with(|| format!("failed to write {manifest_path}"))?;
+    tracing::info!("  updated {manifest_path} (rpm Version = {new_rpm_version})");
     Ok(())
 }
 
@@ -587,5 +700,66 @@ impl ExpressionExt for duct::Expression {
             // The command that was run may have scrolled off the screen, so repeat it here
             tracing::error!("failed to run command: {:?}", self);
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rpm_version;
+
+    #[test]
+    fn release_version_is_unchanged() {
+        // A plain release version contains no RPM-illegal characters.
+        assert_eq!(rpm_version("0.9.0").unwrap(), "0.9.0");
+        assert_eq!(rpm_version("1.2.3").unwrap(), "1.2.3");
+    }
+
+    #[test]
+    fn pre_release_separator_becomes_tilde() {
+        assert_eq!(rpm_version("0.9.0-beta.2").unwrap(), "0.9.0~beta.2");
+        assert_eq!(rpm_version("0.9.0-rc.1").unwrap(), "0.9.0~rc.1");
+        assert_eq!(rpm_version("1.0.0-alpha").unwrap(), "1.0.0~alpha");
+    }
+
+    #[test]
+    fn nightly_pre_release_becomes_tilde() {
+        // The exact case from the failing nightly run.
+        assert_eq!(
+            rpm_version("0.9.0-beta.2.nightly.20260609").unwrap(),
+            "0.9.0~beta.2.nightly.20260609"
+        );
+        // Base version without a pre-release, nightly appended as a pre-release.
+        assert_eq!(
+            rpm_version("0.9.0-nightly.20260609").unwrap(),
+            "0.9.0~nightly.20260609"
+        );
+    }
+
+    #[test]
+    fn build_metadata_plus_is_preserved() {
+        // '+' is RPM-legal and must survive untouched.
+        assert_eq!(
+            rpm_version("0.9.0-beta.2+build.5").unwrap(),
+            "0.9.0~beta.2+build.5"
+        );
+        assert_eq!(rpm_version("0.9.0+build.5").unwrap(), "0.9.0+build.5");
+    }
+
+    #[test]
+    fn hyphen_inside_identifier_becomes_underscore() {
+        // SemVer permits hyphens inside pre-release identifiers; only the
+        // first (separator) hyphen becomes '~', the rest become '_'.
+        assert_eq!(rpm_version("0.9.0-x-y").unwrap(), "0.9.0~x_y");
+        assert_eq!(rpm_version("0.9.0-a-b-c").unwrap(), "0.9.0~a_b_c");
+    }
+
+    #[test]
+    fn invalid_semver_is_rejected() {
+        // Garbage that is not SemVer at all is rejected before translation,
+        // so RPM-illegal characters like '&' can never reach the output.
+        assert!(rpm_version("0.9.0-beta&2").is_err());
+        assert!(rpm_version("not-a-version").is_err());
+        assert!(rpm_version("1.0").is_err());
+        assert!(rpm_version("").is_err());
     }
 }


### PR DESCRIPTION
## Why

The nightly RPM build (run #51) failed with:

```
invalid version "0.9.0-beta.2.nightly.20260609": contains invalid character
```

RPM's `Version` field forbids `-` (it is the NEVRA `Version`/`Release`
separator). The repo version `0.9.0-beta.2` is valid SemVer and valid
Cargo, but illegal as an RPM `Version`, so `cargo generate-rpm` rejected
it. While in here, this branch also adds the tombi TOML lint hook fred
wired into the flake and fixes the lints it surfaced.

## What

### `fix: emit RPM-legal Version for pre-release builds`

- Translate the SemVer pre-release separator to RPM's tilde operator
  `~` (sorts older than the final release, mirroring SemVer ordering:
  `0.9.0~beta.2` < `0.9.0`). First `-` → `~`, any hyphen inside an
  identifier → `_`, build metadata `+` preserved. Input is parsed as
  SemVer first, so RPM-illegal garbage is rejected before translation.
- `cargo xtask bump-version` writes the RPM-legal version into
  `[package.metadata.generate-rpm].version` and reconciles it even on
  the no-op path, keeping it in lockstep with the workspace version.
  `cargo-generate-rpm` reads that override instead of the SemVer
  version, so both `nightly.yml` and `deploy.yaml` are fixed with no
  workflow edits.
- Fix the doubled nightly release title (`Nightly nightly-DATE`) to use
  the SemVer nightly version (`Nightly 0.9.0-nightly.DATE`).
- 6 new unit tests cover release / pre-release / nightly / `+build` /
  intra-identifier hyphen / invalid-SemVer-rejection.

### `ci: add tombi TOML lint pre-commit hook`

- The shared precommit flake's `mkCheck` has no custom-hook extension
  point, so the base + rust hook set is reconstructed in this repo's
  flake (via the public `mkBaseCheck` / `mkRustCheck`) and a `tombi`
  hook is merged before handing the result to `git-hooks`.
- Hook runs `tombi lint --error-on-warnings` on staged `.toml` files
  and fails the commit on warnings as well as errors. Verified through
  the real `pre-commit run` machinery: clean files exit 0, any warning
  exits 1 and reports `Failed`.
- Remove the Cargo-deprecated `package.authors` from the vendored
  `portable-pty` manifest (attribution retained as a comment).

### `fix: stop tombi/taplo from reformatting cargo.toml long lines` + `chore: bump cargo dep versions`

- `.taplo.toml` / `.tombi.toml` config so long lines in Cargo manifests
  are left alone.
- Cargo dependency version bump.

## Verification

- `cargo test -p xtask` — 6/6 pass
- `cargo clippy -p xtask --all-targets -- -D warnings` — clean
- `tombi lint --error-on-warnings .` — 13/13 files clean
- `nixfmt --check` / `statix check` / `deadnix --fail` on `flake.nix` — clean
- All pre-commit hooks (incl. live tombi, clippy, xtask-check, nix
  linters) pass on both core commits.

## Not done

No local `.rpm` was built end-to-end: `cargo-generate-rpm` is not in
nixpkgs, so it cannot be added to the dev shell. CI installs it from
crates.io. The translation is unit-tested and follows the documented
`cargo-generate-rpm` override + rpm-version(7) grammar.