### PR TITLE
Task 76 — Notification System (OSC 9 / OSC 777)

### DIFF
--- a/.opencode/skills/freminal-config-options/SKILL.md
+++ b/.opencode/skills/freminal-config-options/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: freminal-config-options
+description: Use ONLY when working in the freminal repository AND adding, renaming, or removing a configuration option (a field on `Config` or any of its section structs in `freminal-common/src/config.rs`, e.g. a new `[notifications]`/`[command_blocks]` key or a whole new section). Codifies the mandatory wiring checklist that prevents the "user sets it in config.toml but it silently does nothing" bug class — the `ConfigPartial` / `apply_partial` omission that dropped `[notifications] enabled = true` (fix 76.4a).
+---
+
+# Freminal: adding a config option is a multi-file ritual
+
+Freminal's config has a **layered-merge load path** that is easy to half-wire.
+The canonical failure: you add a field to `Config`, set it in `config.toml`,
+and it silently has no effect because the loader never copied your value onto
+the defaults. This happened to `[notifications]`, `[command_blocks]`,
+`[shell_integration]`, and `[tab_title]` — all added to `Config` but not to
+`ConfigPartial` (fix `76.4a` / audit `76.4c`).
+
+Read this before touching `freminal-common/src/config.rs`.
+
+## Why it breaks: the load path
+
+`load_config` does **not** deserialize `Config` directly. It:
+
+1. Starts from `Config::default()`.
+2. For each layer (system → user → `FREMINAL_CONFIG` env, or a single
+   `--config` file), deserializes the TOML into a **separate** `ConfigPartial`
+   struct whose fields are all `Option<…>`.
+3. Merges each partial onto the running `Config` via `Config::apply_partial`,
+   which copies a section **only if** `partial.<section>.is_some()`.
+
+So a `Config` field that is missing from `ConfigPartial`, or has no arm in
+`apply_partial`, is **never populated from user TOML**. It compiles fine and
+fails silently at runtime. `save_config`, by contrast, serializes the whole
+`Config` — so the round trip is asymmetric and the bug is invisible to a
+naive "does it serialize?" check.
+
+## The checklist — every step is mandatory
+
+When adding a **new field to an existing section struct** (e.g. a new key in
+`NotificationsConfig`):
+
+1. **Add the field** to the section struct, with a doc comment.
+2. **Default it** in that struct's `Default` impl (the struct has
+   `#[serde(default)]`, so also fine to rely on `#[serde(default)]` per-field,
+   but the `Default` impl must produce the intended default).
+3. **Document it** in `config_example.toml` under the right `[section]`, with
+   the default value shown (commented out).
+4. **Surface it in the Settings UI** if user-facing: a widget in
+   `freminal/src/gui/settings.rs` and, if it triggers an action, a dispatch
+   arm in `freminal/src/gui/settings_dispatch.rs`.
+5. **Mirror it in the Nix home-manager module**
+   (`nix/home-manager-module.nix`) as an `mkOption`, so managed installs can
+   set it. (See "The Nix home-manager module mirror" below for the three
+   edits this requires.)
+6. **Test it**: a round-trip test (`toml::to_string_pretty` → `toml::from_str`
+   → assert the field survived) in the section's test group.
+
+No `ConfigPartial` / `apply_partial` change is needed here, because the whole
+section sub-struct deserializes as a unit.
+
+When adding a **whole new section** to `Config` (e.g. `pub profiles:
+ProfilesConfig`), do **all of the above for the section's fields, PLUS** these
+four merge-wiring steps:
+
+1. **Add the field to `Config`** and its `Default` impl.
+2. **Add the field to `ConfigPartial`** as `Option<TheConfig>`.
+3. **Add a merge arm to `Config::apply_partial`**:
+
+   ```rust
+   if let Some(profiles) = partial.profiles {
+       self.profiles = profiles;
+   }
+   ```
+
+   (Keybindings is the one exception — it merges its inner `HashMap`
+   additively rather than replacing the whole section. Follow that pattern
+   only for additive map-style sections.)
+
+4. **Update the guard test** `every_config_section_survives_partial_merge`
+   in `config.rs`: add a non-default mutation, an assertion, and the new
+   field name to the trailing exhaustive `let Config { … } = loaded;`
+   destructure.
+
+## The guard test will catch you (use it)
+
+`every_config_section_survives_partial_merge` is a deliberate tripwire with
+two layers:
+
+- **Compile-time:** its trailing `let Config { field: _, … } = loaded;` has
+  **no `..` rest pattern**. Add a field to `Config` and this test stops
+  compiling with `E0027: pattern does not mention field <name>` until you
+  acknowledge it. That is the signal to do the four merge-wiring steps above.
+- **Runtime:** it mutates one field per section, runs the real load path, and
+  asserts each survived. A missing/broken `apply_partial` arm fails with
+  `"<section> section dropped"`.
+
+If you hit the `E0027` build error: **do not** just add `field: _` to silence
+it. That defeats the guard. Add the `ConfigPartial` + `apply_partial` merge
+wiring and a real assertion first, then the destructure entry.
+
+## Serde gotchas
+
+- `#[serde(skip_serializing_if = "Option::is_none")]` is fine — it omits only
+  absent optionals. `#[serde(skip)]` is **not** fine for anything a user
+  should be able to set; it drops the field from both load and save.
+- `#[serde(rename_all = "kebab-case")]` / `"snake_case"` on an enum must match
+  what you document in `config_example.toml`. Add a serialization test
+  (`assert!(toml.contains("key = \"value\""))`) for any new enum.
+- A new enum used as a config value needs `Serialize + Deserialize + Default`
+  and a `#[serde(rename_all = …)]` consistent with the rest of the file.
+
+## The Nix home-manager module mirror (`nix/home-manager-module.nix`)
+
+Every config section must be settable through the home-manager module, or
+managed installs cannot configure it. Mirroring a section there means three
+edits in `nix/home-manager-module.nix`:
+
+1. A `<section>Section` `let`-binding (a `lib.filterAttrs (_: v: v != null)`
+   over the section's keys, so unset keys are omitted).
+2. A `// lib.optionalAttrs (<section>Section != { }) { <section> = … }` arm in
+   the `result` merge.
+3. The `options.programs.freminal.settings.<section>` `mkOption`s — each
+   `types.nullOr …` with `default = null` and a description naming the Rust
+   default. Enums become `types.enum [ … ]` with the `#[serde(rename_all)]`
+   string values.
+
+Run `nixfmt --check`, `statix check`, and `deadnix --fail` on the module
+afterward (see `nix-best-practices`). As of the `76.4c` audit + follow-up,
+all sections through `notifications` are mirrored; keep it that way.
+
+## When to stop and ask
+
+- You want to skip the Nix module or Settings UI step "for now". Don't —
+  surface the omission to the user explicitly and let them decide; a
+  half-wired option is the exact bug this skill exists to prevent.
+- The guard test's `E0027` is tempting you to add `field: _` without wiring
+  the merge. Stop — wire `ConfigPartial` + `apply_partial` first.
+- A new section needs non-replace merge semantics (like keybindings). Confirm
+  the merge strategy with the user before copying the additive pattern.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +333,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-signal"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +366,17 @@ name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -368,7 +402,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -408,6 +442,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
  "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -1165,6 +1208,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enumn"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1469,6 +1539,7 @@ dependencies = [
  "freminal-windowing",
  "glow",
  "image",
+ "notify-rust",
  "open",
  "regex",
  "rustc-hash",
@@ -1668,7 +1739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1858,6 +1929,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "icu_collections"
@@ -2075,7 +2152,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2183,7 +2260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2242,6 +2319,18 @@ name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "mac-notification-sys"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50efa634682b3fc5a1ab6f3dd5b2bce7b848011fc485b53b063dc68f2f74feae"
+dependencies = [
+ "cc",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "time",
+]
 
 [[package]]
 name = "matchers"
@@ -2351,6 +2440,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "notify-rust"
+version = "4.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2446,7 +2549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
  "objc2-core-data",
@@ -2475,7 +2578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
@@ -2487,7 +2590,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2499,7 +2602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2534,7 +2637,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
@@ -2546,7 +2649,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
@@ -2565,7 +2668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "dispatch",
  "libc",
  "objc2 0.5.2",
@@ -2578,6 +2681,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -2609,7 +2714,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -2622,7 +2727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2645,7 +2750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
@@ -2668,7 +2773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
@@ -2700,7 +2805,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2712,7 +2817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
@@ -2770,6 +2875,16 @@ checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
 dependencies = [
  "libc",
  "libredox",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2833,7 +2948,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3120,6 +3235,15 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quick-xml"
@@ -3508,6 +3632,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3829,7 +3964,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "objc2-open-directory",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -3841,6 +3976,18 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-version",
 ]
 
 [[package]]
@@ -4203,6 +4350,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4286,7 +4444,9 @@ version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
+ "js-sys",
  "serde_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4604,7 +4764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.39.4",
  "quote",
 ]
 
@@ -4695,14 +4855,36 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4711,7 +4893,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -4722,9 +4917,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
@@ -4733,9 +4939,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -4762,9 +4968,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-numerics"
@@ -4772,8 +4994,17 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
- "windows-link",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4782,7 +5013,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4791,7 +5031,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4827,7 +5067,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4852,7 +5092,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -4865,11 +5105,29 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4978,7 +5236,7 @@ dependencies = [
  "android-activity",
  "atomic-waker",
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "bytemuck",
  "calloop 0.13.0",
  "cfg_aliases",
@@ -5258,6 +5516,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
+]
+
+[[package]]
 name = "zeno"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5356,4 +5675,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,4 @@ winit = { version = "0.30.13", features = ["rwh_06"] }
 winreg = "0.56.0"
 
 [workspace.metadata.cargo-machete]
-# `notify-rust` is added in Task 76.1 but not referenced until Task 76.4
-# wires the notification router. Remove this entry once 76.4 lands.
-ignored = ["vergen", "notify-rust"]
+ignored = ["vergen"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ lazy_static = "1.5.0"
 libc = "0.2.186"
 log = "0.4.32"
 nix = "0.31.3"
+notify-rust = "4.17.0"
 open = "5.3.5"
 predicates = "3.1.4"
 proptest = "1.11.0"
@@ -63,8 +64,8 @@ shared_library = "0.1.9"
 shell-words = "1.1.1"
 smol = "2.0.2"
 swash = "0.2.8"
-sysinfo = { version = "0.39.3", default-features = false, features = ["system"] }
 sys-locale = "0.3.2"
+sysinfo = { version = "0.39.3", default-features = false, features = ["system"] }
 tar = "0.4.46"
 tempfile = "3.27.0"
 test-log = { version = "0.2.21", features = ["trace"] }
@@ -82,4 +83,6 @@ winit = { version = "0.30.13", features = ["rwh_06"] }
 winreg = "0.56.0"
 
 [workspace.metadata.cargo-machete]
-ignored = ["vergen"]
+# `notify-rust` is added in Task 76.1 but not referenced until Task 76.4
+# wires the notification router. Remove this entry once 76.4 lands.
+ignored = ["vergen", "notify-rust"]

--- a/Documents/ESCAPE_SEQUENCE_COVERAGE.md
+++ b/Documents/ESCAPE_SEQUENCE_COVERAGE.md
@@ -2,10 +2,10 @@
 
 ## Last updated
 
-Last updated: 2026-06-03 — Task 72.13: cross-checked OSC 133 coverage against the
-shipped Task 72 surface (storage, navigation, fold, copy, hover, duration) and
-confirmed full support. No new entries; the existing OSC 133 row is already accurate.
-(Tasks 20, 22, 23, 35, 41, 47, 48, 49, 52, 72)
+Last updated: 2026-06-09 — Task 76.2: added OSC 9 (iTerm2/WezTerm) and promoted
+OSC 777 (urxvt) to implemented. Both parse into `AnsiOscType::Notify` and are
+routed by the GUI notification system per the `[notifications]` config.
+(Tasks 20, 22, 23, 35, 41, 47, 48, 49, 52, 72, 76)
 
 ## Overview
 
@@ -170,26 +170,27 @@ is verified by unit tests (`c0_bs_inside_csi`, `c0_cr_inside_csi`, `c0_vt_inside
 
 ## OSC — Operating System Commands
 
-| Sequence                 | Purpose                       | Status | Notes                                                                                                    |
-| ------------------------ | ----------------------------- | ------ | -------------------------------------------------------------------------------------------------------- |
-| OSC 0 ; txt BEL          | Set icon + window title       | 🚧     | Works, but icon name vs. title not distinguished                                                         |
-| OSC 1 ; txt BEL          | Set icon title only           | 🚧     | Shares handler with OSC 0 (treats as full title)                                                         |
-| OSC 2 ; txt BEL          | Set window title only         | ✅     | Implemented                                                                                              |
-| OSC 4 ; n ; rgb          | Set palette entry             | ✅     | Sets 256-color palette entry; query responds with current value                                          |
-| OSC 7 ; URI              | Current Working Directory     | ✅     | Parsed and stored in `TerminalHandler.current_working_directory`                                         |
-| OSC 8 ; params ; URI BEL | Hyperlink                     | ✅     | Fully implemented — hyperlink start/end with URL metadata                                                |
-| OSC 10 ; ? BEL           | Foreground color query/set    | ✅     | Query returns theme fg (or dynamic override); set stores override                                        |
-| OSC 11 ; ? BEL           | Background color query/set    | ✅     | Query returns theme bg (or dynamic override); set stores override                                        |
-| OSC 12 ; color           | Set/query cursor color        | ✅     | Set/query/reset via `cursor_color_override`; snapshotted and consumed by renderer                        |
-| OSC 52 ; c ; data BEL    | Clipboard copy/paste          | ✅     | Implemented — base64 encode/decode, clipboard set/query                                                  |
-| OSC 66 ; theme BEL       | ColorScheme Notification      | ⬜     | Parsed/recognized; silently consumed. DECRPM ?2031 is the functional adaptive-theme query path (Task 52) |
-| OSC 104                  | Reset palette entry           | ✅     | Resets specific or all palette entries to defaults                                                       |
-| OSC 110                  | Reset foreground color        | ✅     | Clears dynamic fg override; query returns theme default                                                  |
-| OSC 111                  | Reset background color        | ✅     | Clears dynamic bg override; query returns theme default                                                  |
-| OSC 112                  | Reset cursor color            | ✅     | Clears `cursor_color_override`                                                                           |
-| OSC 133 ; …              | FTCS / Shell Integration      | ✅     | All four markers parsed; freminal=1 extension required (see FTCS section below)                          |
-| OSC 777                  | System notification (Konsole) | ⬜     | Not implemented; Task 76 (v0.9.0)                                                                        |
-| OSC 1337                 | iTerm2 inline images          | ✅     | Full `File=`, `MultipartFile=`/`FilePart=`/`FileEnd` handling; decoded and placed                        |
+| Sequence                 | Purpose                       | Status | Notes                                                                                                       |
+| ------------------------ | ----------------------------- | ------ | ----------------------------------------------------------------------------------------------------------- |
+| OSC 0 ; txt BEL          | Set icon + window title       | 🚧     | Works, but icon name vs. title not distinguished                                                            |
+| OSC 1 ; txt BEL          | Set icon title only           | 🚧     | Shares handler with OSC 0 (treats as full title)                                                            |
+| OSC 2 ; txt BEL          | Set window title only         | ✅     | Implemented                                                                                                 |
+| OSC 4 ; n ; rgb          | Set palette entry             | ✅     | Sets 256-color palette entry; query responds with current value                                             |
+| OSC 7 ; URI              | Current Working Directory     | ✅     | Parsed and stored in `TerminalHandler.current_working_directory`                                            |
+| OSC 8 ; params ; URI BEL | Hyperlink                     | ✅     | Fully implemented — hyperlink start/end with URL metadata                                                   |
+| OSC 9 ; body BEL         | Desktop notification (iTerm2) | ✅     | Body parsed into `AnsiOscType::Notify`; routed by GUI per `[notifications]` config (Task 76)                |
+| OSC 10 ; ? BEL           | Foreground color query/set    | ✅     | Query returns theme fg (or dynamic override); set stores override                                           |
+| OSC 11 ; ? BEL           | Background color query/set    | ✅     | Query returns theme bg (or dynamic override); set stores override                                           |
+| OSC 12 ; color           | Set/query cursor color        | ✅     | Set/query/reset via `cursor_color_override`; snapshotted and consumed by renderer                           |
+| OSC 52 ; c ; data BEL    | Clipboard copy/paste          | ✅     | Implemented — base64 encode/decode, clipboard set/query                                                     |
+| OSC 66 ; theme BEL       | ColorScheme Notification      | ⬜     | Parsed/recognized; silently consumed. DECRPM ?2031 is the functional adaptive-theme query path (Task 52)    |
+| OSC 104                  | Reset palette entry           | ✅     | Resets specific or all palette entries to defaults                                                          |
+| OSC 110                  | Reset foreground color        | ✅     | Clears dynamic fg override; query returns theme default                                                     |
+| OSC 111                  | Reset background color        | ✅     | Clears dynamic bg override; query returns theme default                                                     |
+| OSC 112                  | Reset cursor color            | ✅     | Clears `cursor_color_override`                                                                              |
+| OSC 133 ; …              | FTCS / Shell Integration      | ✅     | All four markers parsed; freminal=1 extension required (see FTCS section below)                             |
+| OSC 777 ; notify ; T ; B | Desktop notification (urxvt)  | ✅     | `notify;TITLE;BODY` parsed into `AnsiOscType::Notify`; routed by GUI per `[notifications]` config (Task 76) |
+| OSC 1337                 | iTerm2 inline images          | ✅     | Full `File=`, `MultipartFile=`/`FilePart=`/`FileEnd` handling; decoded and placed                           |
 
 ---
 
@@ -337,7 +338,7 @@ The gaps that remain are either low-priority polish or require significant new i
 
 1. **Cell-level DECSCNM inversion** — Panel fill is inverted, but individual cell fg/bg are not swapped.
 2. **SO/SI G1 charset switching** — Consumed as control characters; G1 rendering not implemented (simplified single-slot charset model).
-3. **OSC 66 / OSC 777** — Recognized/not-recognized respectively; OSC 777 slated for Task 76 (v0.9.0).
+3. **OSC 66** — Recognized; silently consumed (DECRPM ?2031 is the functional adaptive-theme path). OSC 777 is now implemented (Task 76).
 4. **Standard mode SRM (12)** — Rare in practice.
 5. **?1034 (Interpret meta key)** and **?1001 functional hilite tracking** — Niche.
 6. **OSC 133 command-block UI** — Markers parsed; navigation/gutter UI planned for Task 72 (v0.9.0).

--- a/Documents/ESCAPE_SEQUENCE_GAPS.md
+++ b/Documents/ESCAPE_SEQUENCE_GAPS.md
@@ -1,9 +1,9 @@
 # Escape Sequence Gaps
 
-Last updated: 2026-06-03 — Task 72.13: OSC 133 command-block storage and navigation
-complete; only the gutter UI (v0.9.0 Task 73) remains. Added XTGETTCAP capability-
-recognition polish entry (Task 72.16.e demoted the unknown-capability log to debug).
-(Tasks 20, 22, 23, 35, 41, 47, 48, 49, 52, 72)
+Last updated: 2026-06-09 — Task 76.2: removed OSC 777 from the gap list and the OSC
+gaps prose — OSC 9 (iTerm2/WezTerm) and OSC 777 (urxvt) now parse into
+`AnsiOscType::Notify` and are routed by the GUI notification system.
+(Tasks 20, 22, 23, 35, 41, 47, 48, 49, 52, 72, 76)
 
 This document lists escape sequences and features that are **not yet fully implemented** in
 Freminal. Items resolved during v0.3.0–v0.7.0 have been removed; this document reflects only
@@ -26,7 +26,7 @@ and iTerm2 inline images (OSC 1337) are fully implemented (Task 13). Kitty keybo
 protocol is complete (Task 35). The remaining gaps are:
 
 - **Renderer gaps:** DECSCNM cell-level fg/bg swap (panel-fill swap exists)
-- **OSC gaps:** OSC 66 (recognized but no effect), OSC 777 (Konsole notification)
+- **OSC gaps:** OSC 66 (recognized but no effect)
 - **Charset gaps:** SO/SI (G1 rendering), G2/G3 switching
 - **Rare/low-priority:** SRM standard mode, ?1034, functional ?1001 hilite tracking
 - **UI work:** OSC 133 command-block gutter rendering (v0.9.0 Task 73; markers,
@@ -55,7 +55,6 @@ These features are tracked at the state-machine level but the renderer does not 
 | Sequence   | Importance | Type | Planned        | Notes                                                                                                                              |
 | ---------- | ---------- | ---- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | OSC 66     | ⬜         | ⬜   | —              | ColorScheme Notification (Contour) — recognized/silently consumed; DECRPM ?2031 is the query path we implement                     |
-| OSC 777    | ⬜         | ⬜   | v0.9.0 Task 76 | Konsole system notification — scheduled under Notification System task                                                             |
 | OSC 133 UI | 🟨         | 🚧   | v0.9.0 Task 73 | Markers A/B/C/D parsed and stored; fold/copy/hover/duration overlays shipped under Task 72; gutter rendering remains under Task 73 |
 
 ---
@@ -145,10 +144,9 @@ during CSI sequence parsing, per ECMA-48. This is verified by unit tests. This i
 
 ### Priority 2 — Polish
 
-| Item                           | Rationale                                                                                                                                                                    | Planned        |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| OSC 777                        | Konsole notification compat                                                                                                                                                  | v0.9.0 Task 76 |
-| XTGETTCAP capability expansion | Common queries we currently decline: `indn` (indent N), `query-os-name` (Kitty extension). Both protocol-correct with `0+r<hex>`; recognising them is a cosmetic improvement | —              |
+| Item                           | Rationale                                                                                                                                                                    | Planned |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| XTGETTCAP capability expansion | Common queries we currently decline: `indn` (indent N), `query-os-name` (Kitty extension). Both protocol-correct with `0+r<hex>`; recognising them is a cosmetic improvement | —       |
 
 ### Priority 3 — Low priority / optional
 

--- a/Documents/MASTER_PLAN.md
+++ b/Documents/MASTER_PLAN.md
@@ -106,7 +106,7 @@ Panes) was subsumed by Task 58. Task 56 (Session Restore) was subsumed by Task 6
 | 73  | Command Gutters                          | `PLAN_VERSION_090.md` (Task 73)               | Stub          | Task 72                |
 | 74  | Broadcast Input to Panes                 | `PLAN_VERSION_090.md` (Task 74)               | Stub          | v0.8.0, Task 58        |
 | 75  | Workspace-Scoped Environment             | `PLAN_VERSION_090.md` (Task 75)               | Stub          | v0.8.0, Task 61        |
-| 76  | Notification System (OSC 9 / OSC 777)    | `PLAN_VERSION_090.md` (Task 76)               | Stub          | v0.8.0, Task 72        |
+| 76  | Notification System (OSC 9 / OSC 777)    | `PLAN_VERSION_090.md` (Task 76)               | Pending merge | v0.8.0, Task 72        |
 | 77  | Smart Paste Guard                        | `PLAN_VERSION_090.md` (Task 77)               | Stub          | v0.8.0                 |
 | 78  | Profiles + Quick Profile Switching       | `PLAN_VERSION_100.md` (Task 78)               | Stub          | v0.8.0                 |
 | 79  | Theme Preview + Color Picker             | `PLAN_VERSION_100.md` (Task 79)               | Stub          | v0.8.0                 |
@@ -515,6 +515,7 @@ Update this section as tasks complete:
 | 72   | 2026-05-17 | 2026-06-04 | 16 subtasks (72.1-72.16) complete on task-72/osc-133-command-blocks; PR pending |
 | 94   | 2026-06-04 | 2026-06-04 | All 7 subtasks complete; merged via PR #343                                     |
 | 95   | 2026-06-04 | 2026-06-04 | All 5 subtasks complete; merged via PR #343                                     |
+| 76   | 2026-06-09 | 2026-06-09 | All subtasks (76.1-76.8) complete on task-76/notifications; PR pending          |
 
 ---
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -2822,6 +2822,40 @@ Two small fixes found during manual testing of 76.4 on Linux/Hyprland:
 
 `cargo test --all`, clippy `-D warnings`, fmt, machete all clean.
 
+#### 76.4c — Config load-path audit + self-protecting guard test ✅ 2026-06-09
+
+Follow-up to 76.4a: a full audit of the config load/save path to find any
+other silently-dropped options, plus a durable guard so the bug class
+cannot recur.
+
+**Audit findings (only 76.4a was a real bug):**
+
+- Section-level sync of `Config` ↔ `ConfigPartial` ↔ `apply_partial` is
+  now complete (all 20 top-level fields; verified field-by-field).
+- Serde attributes are safe: only `skip_serializing_if =
+"Option::is_none"` / `"KeybindingsConfig::is_empty"` (which omit only
+  absent/empty values) and a correct `#[serde(flatten)]` on the
+  keybindings map. No `#[serde(skip)]` drops data.
+- CLI override path (`apply_cli_overrides`) is narrow by design (shell,
+  hide_menu_bar, deprecated write-logs flag) — no silent drops.
+- Save/load is symmetric: `save_config` serializes the full `Config`;
+  `load_config` merges via the now-field-complete `ConfigPartial`.
+- `config_example.toml` has no documentation drift against the structs.
+
+**Guard test `every_config_section_survives_partial_merge`:** sets a
+non-default value in every section, runs the real load path
+(`to_string_pretty` → `ConfigPartial` → `apply_partial`), and asserts
+each value survived. Two protection layers, both proven:
+
+- **Runtime:** disabling any merge arm fails with `"<section> section
+dropped"` (verified by temporarily disabling the notifications arm).
+- **Compile-time:** a trailing exhaustive `let Config { .. } = loaded`
+  destructure with **no** `..` rest pattern means adding a new field to
+  `Config` fails to compile the test (`E0027`) until the author wires it
+  in — verified by temporarily adding a dummy field.
+
+`cargo test --all`, clippy `-D warnings`, fmt, machete all clean.
+
 #### 76.5 — Notification templates and bell
 
 **Scope:** `freminal-common/src/config.rs` (extend NotificationsConfig and

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -2638,7 +2638,7 @@ wants_toast(focused)` and `const fn wants_system(focused)` helpers so
 --all-targets --all-features -- -D warnings` clean, `cargo fmt --all --
 --check` clean, `cargo machete` clean.
 
-#### 76.3 — OSC 9/777 dispatch
+#### 76.3 — OSC 9/777 dispatch ✅ 2026-06-09
 
 **Scope:** `freminal-terminal-emulator/src/terminal_handler/osc.rs`.
 
@@ -2650,6 +2650,54 @@ title: Option<String>, body: String }` to the GUI thread via the existing
 
 **Verification:** Unit test that emitting OSC 9 produces a
 `WindowCommand::Notification`.
+
+**Architectural note — routed via `WindowManipulation`, not a new
+`WindowCommand` variant (decided 2026-06-09):**
+
+The plan called for a `WindowCommand::Notification { kind, title, body }`
+variant forwarded "via the existing window-post channel". Investigation
+confirmed the same constraint documented in 72.3: the `TerminalHandler`
+does not own a `Sender<WindowCommand>`. It produces a
+`Vec<WindowManipulation>` (drained by `take_window_commands`); the PTY
+loop in `freminal/src/gui/pty.rs` then wraps each into
+`WindowCommand::Viewport`/`Report`. The `WindowCommand` enum
+(`io/mod.rs`) only wraps `WindowManipulation` — it has no free-standing
+payload variants. The idiomatic transport for a handler→GUI side-effect
+signal is therefore a new `WindowManipulation` variant, exactly how
+`Bell` and `SetClipboard` already flow. So 76.3 adds
+`WindowManipulation::Notification { kind, title, body }` rather than a
+`WindowCommand::Notification`. It still arrives on the GUI through the
+`WindowCommand::Viewport` wrapper and is consumed in
+`rendering::handle_window_manipulation`, which is where 76.4 hooks the
+`NotificationRouter`.
+
+**Completion notes (2026-06-09):**
+
+- **`NotificationKind` enum** (`OscText`, `CommandFinished`, `Error`,
+  `Info`) added to `freminal-common/src/buffer_states/window_manipulation.rs`.
+- **`WindowManipulation::Notification { kind, title, body }`** variant
+  added to the same enum, documented alongside `Bell`.
+- **`TerminalHandler::handle_osc`** `AnsiOscType::Notify` arm (the 76.2
+  `TODO(76.3)` placeholder) now pushes
+  `WindowManipulation::Notification { kind: OscText, title, body }` onto
+  `window_commands` instead of only logging.
+- **`rendering::handle_window_manipulation`** (GUI) gained a
+  `WindowManipulation::Notification` arm. For 76.3 it logs at debug with
+  a `TODO(76.4)` marker — the actual routing (toast vs system daemon per
+  `[notifications]`) is 76.4's scope. The arm exists so the exhaustive
+  match compiles.
+- **Tests:** 2 new in a new `terminal_handler::osc::tests` module
+  (`osc_notify_pushes_window_command`,
+  `osc_notify_without_title_pushes_window_command`) verifying a
+  `TerminalOutput::OscResponse(AnsiOscType::Notify { … })` produces
+  exactly one `WindowManipulation::Notification` with the right kind /
+  title / body. Byte-stream coverage (raw OSC 9 / 777 through the
+  parser) already lives in 76.2's `osc_notify.rs`; the parser pipeline
+  is not re-driven here because `TerminalHandler::handle_data` only
+  inserts text — the ANSI parser sits above the handler.
+- **Verification:** `cargo test --all` (no regressions), `cargo clippy
+--all-targets --all-features -- -D warnings` clean, `cargo fmt --all --
+--check` clean, `cargo machete` clean.
 
 #### 76.4 — GUI notification router
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -2937,7 +2937,7 @@ command, tab_name)` helper. Tokens: `{command}` (trimmed, or
   template and the routing dropdowns live in the Notifications tab,
   which 76.7 builds.
 
-#### 76.6 — Capability detection (verify existing responders + document TERM_PROGRAM)
+#### 76.6 — Capability detection (verify existing responders + document TERM_PROGRAM) ✅ 2026-06-09
 
 **Scope:** `freminal/freminal.ti` (terminfo source),
 `freminal-terminal-emulator/src/terminal_handler/dcs.rs` (existing
@@ -2984,6 +2984,50 @@ Work to do:
 existing terminfo-audit harness, see PLAN_12_TERMINFO.md — note that
 PLAN_12 is now retired into the v0.2.0 task set; the tests live in
 `dcs.rs` and `xtversion.rs`).
+
+**Completion notes (2026-06-09) — verification + documentation only,
+no behavior change (decided with the user):**
+
+- **Both plan-suggested response changes were intentionally NOT made**
+  because each conflicts with deliberate, documented codebase behavior:
+  - **XTGETTCAP `TN` stays `xterm-256color`** (not `freminal`). `TN`
+    means "the value of `$TERM`", and `io::pty::run_terminal` sets
+    `TERM=xterm-256color` as the documented Task-12 compatibility
+    strategy (mirroring WezTerm/Alacritty). Reporting `freminal` would
+    desync TN from TERM and break terminfo lookups.
+  - **XTVERSION stays `>|XTerm(Freminal <version>)`** (not
+    `freminal v<version>`). The `XTerm(` prefix is load-bearing: tmux
+    only enables `extkeys` / `modifyOtherKeys` when it recognises the
+    prefix (`tty_keys_extended_device_attributes`). Dropping it would
+    regress extended-key forwarding inside tmux — already documented in
+    `reports.rs::handle_device_name_and_version`.
+  - The freminal-identifying signal is `TERM_PROGRAM=freminal` (set in
+    72.6), and `Freminal` is already present in the XTVERSION payload.
+- **Verified existing responders first:** ran the existing 29 XTGETTCAP
+  tests + XTVERSION parser tests (all green) before touching anything.
+- **New regression guard test** `reports.rs::tests::
+device_name_and_version_keeps_xterm_prefix_and_freminal_token`
+  asserts the exact 7-bit-framed XTVERSION response
+  `\x1bP>|XTerm(Freminal <version>)\x1b\\` (the `reports.rs` response
+  builder previously had no test module — only the parser emitting
+  `RequestDeviceNameAndVersion` was covered).
+- **Hardened the existing `xtgettcap_known_capability_tn` test** with a
+  comment explaining the TN-must-equal-TERM invariant, and added an
+  explanatory comment to the `TN` arm of `lookup_termcap`.
+- **Terminfo (`res/freminal.ti`):** added a top-of-file comment block
+  explaining OSC 9 / OSC 777 have no terminfo capability code and that
+  detection is via `TERM_PROGRAM`. Comment-only; `tic -c` still
+  compiles.
+- **`shell-integration/README.md`:** added a "Desktop Notifications
+  (OSC 9 / OSC 777)" section documenting the `TERM_PROGRAM`-guarded
+  emission idiom for both sequences. The version marker was not bumped
+  (prose-only doc change; the marker tracks script protocol version).
+- **No escape-sequence dual-doc update needed:** 76.6 adds/removes/alters
+  no escape-sequence support. OSC 9/777 (76.2) and XTVERSION/XTGETTCAP
+  are already ✅ in `ESCAPE_SEQUENCE_COVERAGE.md`.
+- **Verification:** `cargo fmt --all -- --check`, `cargo clippy
+--all-targets --all-features -- -D warnings`, `cargo test --all`, and
+  `cargo machete` all clean.
 
 #### 76.7 — Settings UI: Notifications tab
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -2494,7 +2494,7 @@ existing `BellConfig`).
 
 ### 76 Subtasks
 
-#### 76.1 — Add `notify-rust` and capability flags
+#### 76.1 — Add `notify-rust` and capability flags ✅ 2026-06-09
 
 **Scope:** `freminal/Cargo.toml`, `freminal-common/src/config.rs`.
 
@@ -2533,6 +2533,47 @@ existing `BellConfig`).
 
 **Verification:** Config round-trip test. `cargo build` succeeds with
 notify-rust dep.
+
+**Completion notes (2026-06-09):**
+
+- `notify-rust = "4"` added to the workspace `[workspace.dependencies]`
+  (alphabetical, after `nix`) and referenced as `notify-rust.workspace
+= true` in `freminal/Cargo.toml` `[dependencies]` only — matching the
+  workspace's `crate.workspace = true` convention. **Not** added to
+  `freminal-common`, `freminal-buffer`, or
+  `freminal-terminal-emulator`. Resolves to `notify-rust v4.17.0`,
+  which uses pure-Rust `zbus` on Linux — no system dbus dev library is
+  required in the dev shell.
+- `NotificationsConfig` added to `freminal-common/src/config.rs` with
+  all eight documented fields (`enabled`, `osc_9`, `osc_777`,
+  `on_command_finished`, `command_finished_threshold_secs`,
+  `routing_error`, `routing_info`, `routing_command_finished`), wired
+  into the top-level `Config` struct and its `Default` impl between
+  `command_blocks` and `keybindings`.
+- New `NotificationRouting` enum (`Toast`, `System`, `Both`,
+  `SystemWhenUnfocused`) with `#[serde(rename_all = "snake_case")]`,
+  mirroring the `GutterPosition` pattern. Added `const fn
+wants_toast(focused)` and `const fn wants_system(focused)` helpers so
+  the routing decision is unit-testable and reusable by the 76.4
+  router. Default is `SystemWhenUnfocused`.
+- `NotificationsConfig` required a localized
+  `#[allow(clippy::struct_excessive_bools)]` (four independent TOML
+  toggles), matching the documented precedent in `snapshot.rs`,
+  `gui/mod.rs`, `rendering.rs`, `widget.rs`, and `view_state.rs`.
+- `[notifications]` section added to `config_example.toml` (all keys
+  commented out, defaults documented) under a new `NOTIFICATIONS`
+  banner between `[command_blocks]` and `[startup]`.
+- `notify-rust` is unused until 76.4, so it was added to the
+  `[workspace.metadata.cargo-machete] ignored` list with a comment
+  instructing its removal once 76.4 lands. This keeps the 76.1 commit's
+  `cargo machete` verification green without a permanent suppression.
+- 4 new tests in `config::tests`: `notifications_default_is_opt_in`,
+  `notifications_round_trip_through_toml`,
+  `notification_routing_serializes_as_snake_case`,
+  `notification_routing_dispatch_decisions`.
+- Verification: `cargo test --all` (no regressions), `cargo clippy
+--all-targets --all-features -- -D warnings` clean, `cargo fmt --all
+-- --check` clean, `cargo machete` clean.
 
 #### 76.2 — OSC 9 and OSC 777 parsing
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -2575,7 +2575,7 @@ wants_toast(focused)` and `const fn wants_system(focused)` helpers so
 --all-targets --all-features -- -D warnings` clean, `cargo fmt --all
 -- --check` clean, `cargo machete` clean.
 
-#### 76.2 — OSC 9 and OSC 777 parsing
+#### 76.2 — OSC 9 and OSC 777 parsing ✅ 2026-06-09
 
 **Scope:** `freminal-common/src/buffer_states/osc.rs`,
 `freminal-terminal-emulator/src/ansi_components/osc.rs`.
@@ -2594,6 +2594,49 @@ wants_toast(focused)` and `const fn wants_system(focused)` helpers so
 
 **Verification:** Unit tests for both parsers. Update
 `ESCAPE_SEQUENCE_COVERAGE.md` and `ESCAPE_SEQUENCE_GAPS.md` per AGENTS.md.
+
+**Completion notes (2026-06-09):**
+
+- **`AnsiOscType::Notify { title: Option<String>, body: String }`** added to
+  `freminal-common/src/buffer_states/osc.rs` (single variant for both OSC 9
+  and OSC 777, as specified) with a `Display` arm. Two new `OscTarget`
+  variants `Notify9` (OSC 9) and `Notify777` (OSC 777), wired into the
+  `From<&AnsiOscToken>` code→target table (9 → `Notify9`, 777 → `Notify777`).
+- **New handler module `freminal-terminal-emulator/src/ansi_components/osc_notify.rs`**
+  mirroring the `osc_shell_info.rs` pattern. Both parsers read from the
+  **raw (un-split) parameter bytes** rather than the upstream semicolon
+  token split, because notification bodies legitimately contain `;` and the
+  token split is too aggressive. Declared `pub mod osc_notify;` in
+  `ansi_components/mod.rs`.
+  - **OSC 9:** body = everything after the first `;`. `title = None`. Empty
+    or missing body silently consumed.
+  - **OSC 777:** strips the `notify;` prefix when present, then splits the
+    remainder on the _first_ `;` into `(title, body)` (preserving semicolons
+    in the body). `notify;TITLE` → title only, empty body. A payload without
+    the `notify;` prefix is treated as an all-body notification with no
+    title. Empty notifications silently consumed.
+  - Non-UTF-8 payloads are dropped (logged at debug), not lossy-decoded.
+- **Dispatch arms** for `OscTarget::Notify9`/`Notify777` added to
+  `dispatch_osc_target` in `osc.rs`, forwarding to the new handlers.
+- **`TerminalHandler::handle_osc`** (the exhaustive `AnsiOscType` match in
+  `terminal_handler/osc.rs`) gained an explicit `AnsiOscType::Notify` arm
+  that logs at debug with a `TODO(76.3)` marker — actual GUI forwarding is
+  76.3's scope; this arm only keeps the match exhaustive/compiling.
+- **Clippy:** `dispatch_osc_target` crossed 100 lines (106) with the two new
+  arms; added a localized `#[allow(clippy::too_many_lines)]` with
+  justification (flat dispatch table), consistent with the 72.4 precedent.
+- **Escape-sequence docs (mandatory dual-doc update):**
+  `ESCAPE_SEQUENCE_COVERAGE.md` gained an OSC 9 row and promoted OSC 777 to
+  ✅; `ESCAPE_SEQUENCE_GAPS.md` removed the OSC 777 gap entries (Priority 2
+  table + OSC Gaps table + prose). "Last updated" headers refreshed in both.
+- **Tests:** 4 new in `freminal-common` (target mappings + Notify Display);
+  17 new in `osc_notify.rs` (OSC 9 body/empty/semicolon/ST; OSC 777
+  title+body / title-only / no-prefix / semicolon-body / empty / ST;
+  non-UTF-8 and missing-semicolon direct-call branches; `parse_777_payload`
+  unit).
+- **Verification:** `cargo test --all` (no regressions), `cargo clippy
+--all-targets --all-features -- -D warnings` clean, `cargo fmt --all --
+--check` clean, `cargo machete` clean.
 
 #### 76.3 — OSC 9/777 dispatch
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -2779,6 +2779,49 @@ notifications), macOS (Notification Center), Windows (toast notifications).
 --all-targets --all-features -- -D warnings` clean, `cargo fmt --all --
 --check` clean, `cargo machete` clean.
 
+#### 76.4a — Cleanup: `[notifications]` (and siblings) never loaded from user TOML ✅ 2026-06-09
+
+**Surfaced during manual testing of 76.4:** with `[notifications]
+enabled = true` in a user `config.toml`, no notifications fired — not
+even a direct `printf '\e]9;hi\a'` toast. Root cause: the config loader
+deserializes into a `ConfigPartial` (all-`Option` fields) and merges it
+onto `Config::default()` via `Config::apply_partial`. `ConfigPartial`
+was **missing** the `notifications`, `shell_integration`,
+`command_blocks`, and `tab_title` fields, so those four whole sections
+were silently dropped on load and always kept their defaults
+(`notifications.enabled = false`). This is a latent bug predating Task
+76 — `shell_integration` / `command_blocks` (Task 72) and `tab_title`
+(Task 94) were added to `Config` but never to `ConfigPartial`. Task
+76.1 added `notifications` with the same omission.
+
+**Fix:** added all four fields to `ConfigPartial` and their merge arms
+to `apply_partial`. Regression tests:
+`notifications_apply_partial_enables_from_toml` and
+`previously_dropped_sections_apply_partial` (covers all four sections
+through the partial-merge path). `cargo test --all`, clippy
+`-D warnings`, fmt, machete all clean.
+
+#### 76.4b — Polish: zbus log silencer + desktop-notification urgency ✅ 2026-06-09
+
+Two small fixes found during manual testing of 76.4 on Linux/Hyprland:
+
+- **zbus log spam.** `notify-rust`'s `zbus` D-Bus dependency emits
+  `INFO`-level connection-handshake spans on every notification, which
+  flooded stdout and the log file. Added `zbus=warn` to the existing
+  framework-silencer directive list (alongside `winit=off` / `wgpu=off`
+  / `egui=off`) on both the stdout and file `EnvFilter`s in `main.rs`.
+  `warn` rather than `off` so genuine D-Bus errors still surface.
+- **Desktop-notification urgency + appname.** `show_system` now sets
+  `appname("freminal")` and an urgency hint —
+  `notify_rust::Urgency::Critical` for `Error`-kind notifications,
+  `Normal` for everything else. Many Linux notification daemons only
+  raise a banner (rather than silently filing the notification in the
+  tray) when an urgency hint is present. (Whether a banner appears, and
+  on which monitor, is ultimately the daemon's policy — verified working
+  end-to-end under `wayle` on Hyprland.)
+
+`cargo test --all`, clippy `-D warnings`, fmt, machete all clean.
+
 #### 76.5 — Notification templates and bell
 
 **Scope:** `freminal-common/src/config.rs` (extend NotificationsConfig and

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -2699,7 +2699,7 @@ signal is therefore a new `WindowManipulation` variant, exactly how
 --all-targets --all-features -- -D warnings` clean, `cargo fmt --all --
 --check` clean, `cargo machete` clean.
 
-#### 76.4 — GUI notification router
+#### 76.4 — GUI notification router ✅ 2026-06-09
 
 **Scope:** `freminal/src/gui/app_impl.rs` (handle WindowCommand) and a new
 `freminal/src/gui/notifications.rs` module.
@@ -2722,6 +2722,62 @@ signal is therefore a new `WindowManipulation` variant, exactly how
 **Verification:** Integration tests using a mock router that records calls
 instead of dispatching. Manual test on Linux (notify-osd or KDE
 notifications), macOS (Notification Center), Windows (toast notifications).
+
+**Completion notes (2026-06-09):**
+
+- **New module `freminal/src/gui/notifications.rs`** exporting
+  `NotificationRouter` (a stateless zero-field struct) and a
+  `NotificationRequest { kind, title, body }` type.
+  - `NotificationRouter::route(req, config, focused, &mut ToastStack)` is
+    the single dispatch entry. Returns early when
+    `config.enabled == false`. Selects the per-category
+    `NotificationRouting` (`routing_error` / `routing_command_finished` /
+    `routing_info`) via `routing_for`, then uses the focus-aware
+    `wants_toast` / `wants_system` helpers (76.1) to decide each leg.
+  - **Toast leg:** `Error`-kind → `ToastStack::error`, everything else →
+    `ToastStack::info`. (No `warning` push method exists; that's fine —
+    OSC text / command-finished are informational.)
+  - **System leg:** spawns a named `freminal-notify` thread that calls
+    `notify_rust::Notification::new().summary(..).body(..).show()`,
+    mirroring the existing `freminal-open-url` thread pattern in
+    `terminal/widget.rs`. `notify-rust`'s `show()` blocks on D-Bus on
+    Linux, so it must not run on the egui frame thread. Failures (no
+    daemon) are logged and ignored.
+  - `command_finished_request(block, command, config) -> Option<NotificationRequest>`
+    builds the command-finished notification, applying the `enabled` +
+    `on_command_finished` + `command_finished_threshold_secs` +
+    not-`Running` gates. Failure → `Error` kind with `(exit N)`; success /
+    unknown-exit → `CommandFinished` kind. Duration rendered via the
+    existing `command_blocks::format_command_duration`. Empty command text
+    falls back to `"Command"`.
+- **OSC 9/777 wiring:** `rendering::handle_window_manipulation` gained a
+  `&mut Vec<NotificationRequest>` out-parameter; its `Notification` arm
+  (the 76.3 `TODO(76.4)` placeholder) now pushes a request into it. The
+  caller in `app_impl::update()` collects across all panes and routes them
+  after the pane loop, where `self.config.notifications` and the toast
+  stack are borrowable. This avoids threading `&mut self` into the free
+  `handle_window_manipulation` function.
+- **Command-finished wiring:** the 72.9 drain site
+  (`app_impl.rs`, formerly the `TODO(Task 76)` marker) now calls
+  `command_finished_request` for each finished block (before it is moved
+  into the recent-commands ring) and routes the collected requests after
+  the loop. Focus state read from the active pane's
+  `view_state.window_focused`. The `win` local is owned (removed from
+  `self.windows`), so routing alongside `win.tabs.iter_mut()` does not
+  conflict with the `self.toasts` borrow.
+- **`notify-rust` removed from the `cargo-machete` ignore list** — it is
+  now genuinely referenced, so the temporary 76.1 suppression is gone.
+- **Tests:** 14 in `gui::notifications::tests` — summary fallback per
+  kind / explicit title; `routing_for` mapping; disabled-config no-op;
+  toast-only / system-only / both / system-when-unfocused leg decisions;
+  and `command_finished_request` gating (disabled, off, threshold,
+  running, success-kind, failure-kind, empty-command placeholder). A
+  test-only `ToastStack::len()` was added to assert toast-leg outcomes
+  without rendering. The system leg (background thread) is not asserted —
+  it is best-effort and has no observable state in-process.
+- **Verification:** `cargo test --all` (no regressions), `cargo clippy
+--all-targets --all-features -- -D warnings` clean, `cargo fmt --all --
+--check` clean, `cargo machete` clean.
 
 #### 76.5 — Notification templates and bell
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -2856,7 +2856,7 @@ dropped"` (verified by temporarily disabling the notifications arm).
 
 `cargo test --all`, clippy `-D warnings`, fmt, machete all clean.
 
-#### 76.5 — Notification templates and bell
+#### 76.5 — Notification templates and bell ✅ 2026-06-09
 
 **Scope:** `freminal-common/src/config.rs` (extend NotificationsConfig and
 existing `BellConfig`).
@@ -2884,6 +2884,58 @@ existing `BellConfig`).
 
 **Verification:** Template-render unit test. Bell-ring integration with the
 existing test harness (if any).
+
+**Completion notes (2026-06-09):**
+
+- **`NotificationsConfig::command_finished_template: String`** added with
+  default `"{command} finished in {duration} (exit {exit_code})"`. Both
+  the struct doc-comment TOML example and `config_example.toml` document
+  the five tokens.
+- **`BellConfig::on_command_finished: bool`** added, default `false`.
+  Both `NotificationsConfig` and `BellConfig` already round-trip as
+  whole-struct `Option<…>` fields in `ConfigPartial` / `apply_partial`,
+  so the two new fields merge from user TOML with no extra wiring (the
+  76.4a/76.4c class of bug does not apply at the field level).
+- **Template rendering** moved into a new
+  `gui::notifications::render_command_finished_template(template, block,
+command, tab_name)` helper. Tokens: `{command}` (trimmed, or
+  `"Command"` when empty), `{duration}` (`format_command_duration`, empty
+  when unknown), `{exit_code}` (numeric, or `"?"` when the shell omitted
+  it), `{cwd}` (block cwd, empty when unknown), `{tab_name}`. Unknown
+  tokens are left untouched. The five token literals are module
+  constants so clippy's nursery `literal_string_with_formatting_args`
+  does not flag the brace placeholders as `format!` directives.
+- **`command_finished_request`** gained a `tab_name: &str` parameter and
+  now renders the body via the template instead of the hard-coded
+  string. The Error-vs-CommandFinished `kind` is still driven by the
+  exit code (non-zero ⇒ `Error`), independent of the template body.
+- **Tab name** is resolved at the 72.9 drain site in `app_impl::update()`
+  via `tab.display_name(policy, separator)` (computed before the
+  `iter_panes_mut` borrow, since that borrows `tab` mutably) using the
+  existing `[tab_title]` policy/separator.
+- **Bell on command finished:** the drain loop, when
+  `config.bell.on_command_finished` is set, rings the bell using the
+  configured `bell.mode` — visual sets `pane.bell_active` +
+  `pane.view_state.bell_since`, audio calls `platform::system_beep()`,
+  mirroring the `WindowManipulation::Bell` path in `rendering`. This
+  fires on every finished command (not gated by the notification
+  duration threshold).
+- **Tests:** 7 new in `gui::notifications::tests` (all-token
+  substitution, empty-command placeholder, unknown exit ⇒ `?`, unknown
+  cwd ⇒ empty, unknown token untouched, custom-template through
+  `command_finished_request`, default-template format + Error kind). The
+  pre-existing failure-kind test had its `"failed"` body assertion
+  replaced (the default template uses `{exit_code}`, not a "failed"
+  verb; the Error kind assertion is unchanged). Config-side: extended
+  `notifications_default_is_opt_in` + `notifications_round_trip_through_toml`
+  for the template field, extended `bell_config_defaults_to_visual`, and
+  added `bell_on_command_finished_round_trip`.
+- **Verification:** `cargo fmt --all -- --check`, `cargo clippy
+--all-targets --all-features -- -D warnings`, `cargo test --all`, and
+  `cargo machete` all clean.
+- **Not in scope (deferred to 76.7):** the Settings UI text-edit for the
+  template and the routing dropdowns live in the Notifications tab,
+  which 76.7 builds.
 
 #### 76.6 — Capability detection (verify existing responders + document TERM_PROGRAM)
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -3029,7 +3029,7 @@ device_name_and_version_keeps_xterm_prefix_and_freminal_token`
 --all-targets --all-features -- -D warnings`, `cargo test --all`, and
   `cargo machete` all clean.
 
-#### 76.7 — Settings UI: Notifications tab
+#### 76.7 — Settings UI: Notifications tab ✅ 2026-06-09
 
 **Scope:** `freminal/src/gui/settings.rs`, `settings_dispatch.rs`.
 
@@ -3048,6 +3048,45 @@ device_name_and_version_keeps_xterm_prefix_and_freminal_token`
 
 **Verification:** Toggle persistence; "Test Notification" actually fires a
 notification through the configured routing.
+
+**Completion notes (2026-06-09):**
+
+- **New `SettingsTab::Notifications`** inserted between `Bell` and
+  `Security`. `SettingsTab::ALL` grew `[Self; 13] → [Self; 14]`; the
+  `all_tabs_present` assertion and `settings_tab_labels` updated.
+- **`show_notifications_tab`** renders: master `enabled` checkbox;
+  Sources (`osc_9`, `osc_777`, `on_command_finished`); a
+  `command_finished_threshold_secs` `DragValue` (0–600 s); three routing
+  combo boxes via the extracted `notification_routing_row` helper
+  (Toast / System / Both / System-when-unfocused); a full-width
+  `command_finished_template` text edit with a token hint; a "Test
+  Notification" button; and a Bell cross-reference checkbox bound to the
+  same `bell.on_command_finished` field shown in the Bell tab.
+- **Bell tab** also gained the `bell.on_command_finished` checkbox (the
+  same field is editable from both tabs; egui binds both to the draft).
+- **"Test Notification"** sets a `pending_test_notification` flag (the
+  same pattern as `pending_delete_layout`), drained in both `show` and
+  `show_standalone` to return the new `SettingsAction::TestNotification`.
+  The dispatcher in `settings_dispatch.rs` routes a
+  `NotificationRequest::sample()` (Info kind, "Freminal" / "Test
+  notification") through `NotificationRouter::route_test` using the draft
+  `[notifications]` config (so unsaved routing changes are reflected) and
+  the focused state.
+- **`route_test`** is a sibling of `route` that skips only the `enabled`
+  master-switch gate — the test button must give feedback even while the
+  system is disabled; the per-category routing policy still applies.
+- **`draft_notifications()`** accessor added so the dispatcher reads the
+  draft config without exposing the private `draft` field.
+- **`NotificationRouting` label helper** `notification_routing_label`
+  added next to `bell_mode_label`.
+- **Tests:** `notification_routing_labels`,
+  `notification_settings_persist_through_draft`,
+  `test_notification_button_sets_pending_flag` (settings.rs);
+  `route_test_ignores_enabled_master_switch`, `sample_request_is_info_kind`
+  (notifications.rs).
+- **Verification:** `cargo fmt --all -- --check`, `cargo clippy
+--all-targets --all-features -- -D warnings`, `cargo test --all`, and
+  `cargo machete` all clean.
 
 #### 76.8 — Docs
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -24,7 +24,7 @@ top of the correctness debts identified in the post-v0.7.0 audit.
 | 73  | Command Gutters (exit-status indicator) | Medium       | Pending       | Task 72         | `task-73/command-gutters`        |
 | 74  | Broadcast Input to Panes                | Medium       | Pending       | v0.8.0, Task 58 | `task-74/broadcast-input`        |
 | 75  | Verify per-pane env round-trip          | Small        | Pending       | v0.8.0          | `task-75/pane-env-roundtrip`     |
-| 76  | Notification System (OSC 9 / OSC 777)   | Medium       | Pending       | v0.8.0, Task 72 | `task-76/notifications`          |
+| 76  | Notification System (OSC 9 / OSC 777)   | Medium       | Pending merge | v0.8.0, Task 72 | `task-76/notifications`          |
 | 77  | Smart Paste Guard                       | Small–Medium | Pending       | v0.8.0          | `task-77/paste-guard`            |
 | 94  | Tab Title Precedence (prefix default)   | Small        | Complete      | v0.8.0 (71.1)   | `task-94/tab-title-precedence`   |
 | 95  | Persist Custom Tab Names in Layouts     | Small        | Complete      | v0.8.0, Task 61 | `task-95/persist-tab-names`      |
@@ -3088,7 +3088,7 @@ notification through the configured routing.
 --all-targets --all-features -- -D warnings`, `cargo test --all`, and
   `cargo machete` all clean.
 
-#### 76.8 — Docs
+#### 76.8 — Docs ✅ 2026-06-09
 
 **Scope:** `Documents/ESCAPE_SEQUENCE_COVERAGE.md`, `Documents/ESCAPE_SEQUENCE_GAPS.md`,
 `shell-integration/README.md`.
@@ -3099,6 +3099,18 @@ notification through the configured routing.
   with the `TERM_PROGRAM` detection idiom.
 
 **Verification:** Per AGENTS.md "Escape Sequence Documentation" rules.
+
+**Completion notes (2026-06-09) — scope absorbed into 76.2 and 76.6:**
+
+- The escape-sequence dual-doc update was done in **76.2**: OSC 9
+  (iTerm2/WezTerm) and OSC 777 (urxvt) are ✅ in
+  `ESCAPE_SEQUENCE_COVERAGE.md` and were removed from
+  `ESCAPE_SEQUENCE_GAPS.md` (both files' "Last updated" headers cite
+  Task 76.2).
+- The `shell-integration/README.md` "Desktop Notifications (OSC 9 /
+  OSC 777)" section documenting the `TERM_PROGRAM` detection idiom was
+  added in **76.6**.
+- No further work was required; this subtask is bookkeeping only.
 
 ### 76 Open Questions Resolved
 

--- a/agents.md
+++ b/agents.md
@@ -87,6 +87,7 @@ The `freminal-numeric-conversions` skill expands the `as`-casts /
 | `freminal-frec-decoder`          | Analyzing `.frec` / `.bin` recording files. Use `sequence_decoder.py`, not ad-hoc parsers.                                                    |
 | `freminal-escape-sequence-docs`  | Adding / removing / altering escape sequence support. Dual-doc update required.                                                               |
 | `freminal-numeric-conversions`   | Numeric type conversions. `conv2` crate; no raw `as` in production.                                                                           |
+| `freminal-config-options`        | Adding / renaming / removing a config option (`Config` field in `config.rs`). Mandatory `ConfigPartial` / `apply_partial` wiring checklist.   |
 | `rust-best-practices`            | Any Rust edit. Panic-free production, clippy maxed, no bypass.                                                                                |
 | `performance-benchmarks`         | Generic before/after capture procedure and 15% regression threshold (used together with `freminal-bench-table`).                              |
 | `flake-dev-shell-discipline`     | About to need a system tool not in the dev shell. Add to `flake.nix`, stop, wait for `nix develop`.                                           |

--- a/config_example.toml
+++ b/config_example.toml
@@ -228,6 +228,11 @@ limit = 4000
 # Default: "visual"
 # mode = "visual"
 
+# Ring the bell (using the mode above) when a command finishes (OSC 133 D).
+# Lets long-running commands beep even when the program emitted no \x07.
+# Default: false.
+# on_command_finished = false
+
 ## ##############################################################################
 # SECURITY SETTINGS
 ## ##############################################################################
@@ -326,6 +331,15 @@ limit = 4000
 # routing_error = "both"
 # routing_info = "toast"
 # routing_command_finished = "system_when_unfocused"
+
+# Template for the body of command-finished notifications.  Tokens:
+#   {command}   - the command text (or "Command" if it scrolled away)
+#   {duration}  - human-readable elapsed time (e.g. "3s", "2m15s")
+#   {exit_code} - the numeric exit code, or "?" if the shell omitted it
+#   {cwd}       - the working directory at prompt start, or empty
+#   {tab_name}  - the display name of the tab the command ran in
+# Default: "{command} finished in {duration} (exit {exit_code})".
+# command_finished_template = "{command} finished in {duration} (exit {exit_code})"
 
 ## ##############################################################################
 # STARTUP & LAYOUTS

--- a/config_example.toml
+++ b/config_example.toml
@@ -288,6 +288,46 @@ limit = 4000
 # gutter = "left"
 
 ## ##############################################################################
+# NOTIFICATIONS
+## ##############################################################################
+
+[notifications]
+# Master switch for the notification system.  When false, no notifications
+# of any kind are produced (toast or desktop).
+# Default: false (opt-in).
+# enabled = false
+
+# When true, OSC 9 (iTerm2/WezTerm) text payloads create notifications.
+# Default: true.
+# osc_9 = true
+
+# When true, OSC 777 ("notify;TITLE;BODY", urxvt) payloads create
+# notifications.
+# Default: true.
+# osc_777 = true
+
+# When true, an OSC 133 D (command finished) event fires a notification.
+# Default: true.
+# on_command_finished = true
+
+# Minimum command duration in seconds before a command-finished
+# notification fires.  Avoids spamming notifications for fast commands.
+# Default: 10.0.
+# command_finished_threshold_secs = 10.0
+
+# Routing per category.  One of:
+#   "toast"                  - in-app toast only
+#   "system"                 - desktop notification only
+#   "both"                   - both a toast and a desktop notification
+#   "system_when_unfocused"  - desktop notification when freminal is
+#                              unfocused, in-app toast when focused
+# Defaults: error = "both", info = "toast",
+#           command_finished = "system_when_unfocused".
+# routing_error = "both"
+# routing_info = "toast"
+# routing_command_finished = "system_when_unfocused"
+
+## ##############################################################################
 # STARTUP & LAYOUTS
 ## ##############################################################################
 

--- a/freminal-common/src/buffer_states/osc.rs
+++ b/freminal-common/src/buffer_states/osc.rs
@@ -167,6 +167,13 @@ pub enum OscTarget {
     /// OSC 66 — Konsole/zsh color-scheme notification (one-way; no response).
     /// Silently consumed.
     ColorSchemeNotification,
+    /// OSC 9 — iTerm2/WezTerm desktop notification.  The entire payload after
+    /// `9;` is the notification body; there is no separate title.  One-way,
+    /// fire-and-forget.
+    Notify9,
+    /// OSC 777 — urxvt-style desktop notification of the form
+    /// `notify;TITLE;BODY`.  One-way, fire-and-forget.
+    Notify777,
     Unknown,
     ITerm2,
     /// OSC 1338 — Freminal-private shell-information sub-protocol.
@@ -222,6 +229,7 @@ impl From<&AnsiOscToken> for OscTarget {
             AnsiOscToken::OscValue(4) => Self::PaletteColor,
             AnsiOscToken::OscValue(7) => Self::RemoteHost,
             AnsiOscToken::OscValue(8) => Self::Url,
+            AnsiOscToken::OscValue(9) => Self::Notify9,
             AnsiOscToken::OscValue(11) => Self::Background,
             AnsiOscToken::OscValue(10) => Self::Foreground,
             AnsiOscToken::OscValue(12) => Self::CursorColor,
@@ -241,6 +249,7 @@ impl From<&AnsiOscToken> for OscTarget {
             AnsiOscToken::OscValue(1338) => Self::ShellInfo,
             AnsiOscToken::OscValue(110) => Self::ResetForeground,
             AnsiOscToken::OscValue(111) => Self::ResetBackground,
+            AnsiOscToken::OscValue(777) => Self::Notify777,
             _ => Self::Unknown,
         }
     }
@@ -342,6 +351,18 @@ pub enum AnsiOscType {
     /// command-history seed with the authoritative path the shell itself
     /// reports.  See [`OscTarget::ShellInfo`].
     ShellInfoHistFile(PathBuf),
+    /// OSC 9 / OSC 777 — desktop notification request.
+    ///
+    /// `title` is `None` for OSC 9 (which has no title field) and `Some` for
+    /// OSC 777 (`notify;TITLE;BODY`) when a title is present.  `body` holds
+    /// the notification text.  One-way; the GUI routes it to a toast and/or
+    /// the system notification daemon per the `[notifications]` config.
+    Notify {
+        /// The notification title, if any.
+        title: Option<String>,
+        /// The notification body text.
+        body: String,
+    },
 }
 
 impl std::fmt::Display for AnsiOscType {
@@ -394,6 +415,7 @@ impl std::fmt::Display for AnsiOscType {
             Self::ResetBackgroundColor => write!(f, "ResetBackgroundColor"),
             Self::SetPointerShape(shape) => write!(f, "SetPointerShape({shape})"),
             Self::ShellInfoHistFile(path) => write!(f, "ShellInfoHistFile({})", path.display()),
+            Self::Notify { title, body } => write!(f, "Notify(title={title:?}, body={body:?})"),
         }
     }
 }
@@ -1027,6 +1049,45 @@ mod tests {
             OscTarget::from(&AnsiOscToken::OscValue(111)),
             OscTarget::ResetBackground
         );
+    }
+
+    #[test]
+    fn osc_target_from_token_notify9() {
+        assert_eq!(
+            OscTarget::from(&AnsiOscToken::OscValue(9)),
+            OscTarget::Notify9
+        );
+    }
+
+    #[test]
+    fn osc_target_from_token_notify777() {
+        assert_eq!(
+            OscTarget::from(&AnsiOscToken::OscValue(777)),
+            OscTarget::Notify777
+        );
+    }
+
+    #[test]
+    fn display_ansi_osc_notify_with_title() {
+        let s = AnsiOscType::Notify {
+            title: Some("Build".to_string()),
+            body: "done".to_string(),
+        }
+        .to_string();
+        assert!(s.contains("Notify"), "got: {s}");
+        assert!(s.contains("Build"), "got: {s}");
+        assert!(s.contains("done"), "got: {s}");
+    }
+
+    #[test]
+    fn display_ansi_osc_notify_without_title() {
+        let s = AnsiOscType::Notify {
+            title: None,
+            body: "hello".to_string(),
+        }
+        .to_string();
+        assert!(s.contains("Notify"), "got: {s}");
+        assert!(s.contains("hello"), "got: {s}");
     }
 
     #[test]

--- a/freminal-common/src/buffer_states/window_manipulation.rs
+++ b/freminal-common/src/buffer_states/window_manipulation.rs
@@ -5,6 +5,22 @@
 
 use thiserror::Error;
 
+/// Category of a desktop/in-app notification (Task 76).
+///
+/// Determines which routing policy in `[notifications]` applies and which
+/// toast styling the GUI uses when surfacing the notification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotificationKind {
+    /// Free-form text from an OSC 9 / OSC 777 sequence.
+    OscText,
+    /// A shell command finished (OSC 133 D).
+    CommandFinished,
+    /// An error-category notification.
+    Error,
+    /// An informational notification.
+    Info,
+}
+
 /// Errors produced when converting a raw `(Ps1, Ps2, Ps3)` XTWINOPS parameter
 /// triple into a [`WindowManipulation`].
 #[derive(Debug, Error, Eq, PartialEq, Clone)]
@@ -98,6 +114,20 @@ pub enum WindowManipulation {
     /// Forwarded to the GUI so it can trigger a visual bell indicator
     /// and/or mark the originating tab as having an unacknowledged bell.
     Bell,
+    /// Desktop/in-app notification request (OSC 9 / OSC 777, Task 76).
+    ///
+    /// Forwarded to the GUI so it can route the notification to an in-app
+    /// toast and/or the system notification daemon per the `[notifications]`
+    /// config.  `title` is `None` for OSC 9 and `Some` for OSC 777 when a
+    /// title is present.
+    Notification {
+        /// The notification category, selecting the routing policy.
+        kind: NotificationKind,
+        /// The notification title, if any.
+        title: Option<String>,
+        /// The notification body text.
+        body: String,
+    },
 }
 
 impl TryFrom<(usize, usize, usize)> for WindowManipulation {

--- a/freminal-common/src/config.rs
+++ b/freminal-common/src/config.rs
@@ -37,6 +37,7 @@ pub struct Config {
     pub security: SecurityConfig,
     pub shell_integration: ShellIntegrationConfig,
     pub command_blocks: CommandBlocksConfig,
+    pub notifications: NotificationsConfig,
     #[serde(default, skip_serializing_if = "KeybindingsConfig::is_empty")]
     pub keybindings: KeybindingsConfig,
 
@@ -79,6 +80,7 @@ impl Default for Config {
             security: SecurityConfig::default(),
             shell_integration: ShellIntegrationConfig::default(),
             command_blocks: CommandBlocksConfig::default(),
+            notifications: NotificationsConfig::default(),
             keybindings: KeybindingsConfig::default(),
             managed_by: None,
             startup: StartupConfig::default(),
@@ -685,6 +687,137 @@ impl Default for CommandBlocksConfig {
             show_duration: true,
             duration_threshold_secs: 2.0,
             gutter: GutterPosition::Left,
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+//  Notifications
+// ------------------------------------------------------------------------------------------------
+
+/// Where a notification of a given category is delivered.
+///
+/// Notifications can surface as an in-app toast, a desktop notification via
+/// the system notification daemon, both, or — for the command-finished
+/// category — a desktop notification only when freminal is unfocused
+/// (falling back to a toast when focused).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum NotificationRouting {
+    /// In-app toast only.
+    Toast,
+    /// Desktop notification only.
+    System,
+    /// Both an in-app toast and a desktop notification.
+    Both,
+    /// Desktop notification when freminal is unfocused; an in-app toast when
+    /// it is focused.  Default for command-finished events.
+    #[default]
+    SystemWhenUnfocused,
+}
+
+impl NotificationRouting {
+    /// Whether this routing dispatches an in-app toast given the current
+    /// focus state.
+    ///
+    /// [`Self::SystemWhenUnfocused`] produces a toast only when freminal is
+    /// focused (the desktop notification is reserved for the unfocused case).
+    #[must_use]
+    pub const fn wants_toast(self, focused: bool) -> bool {
+        match self {
+            Self::Toast | Self::Both => true,
+            Self::SystemWhenUnfocused => focused,
+            Self::System => false,
+        }
+    }
+
+    /// Whether this routing dispatches a desktop notification given the
+    /// current focus state.
+    ///
+    /// [`Self::SystemWhenUnfocused`] produces a desktop notification only when
+    /// freminal is unfocused.
+    #[must_use]
+    pub const fn wants_system(self, focused: bool) -> bool {
+        match self {
+            Self::System | Self::Both => true,
+            Self::SystemWhenUnfocused => !focused,
+            Self::Toast => false,
+        }
+    }
+}
+
+/// Configuration for the notification system (Task 76).
+///
+/// Notifications are produced from three sources: OSC 9 (iTerm2/WezTerm)
+/// text payloads, OSC 777 (`notify;TITLE;BODY`, urxvt) payloads, and OSC 133
+/// `D` command-finished events.  Each category routes independently to an
+/// in-app toast and/or a desktop notification per [`NotificationRouting`].
+///
+/// The system is opt-in: [`Self::enabled`] defaults to `false`.
+///
+/// ```toml
+/// [notifications]
+/// enabled = false
+/// osc_9 = true
+/// osc_777 = true
+/// on_command_finished = true
+/// command_finished_threshold_secs = 10.0
+/// routing_error = "both"
+/// routing_info = "toast"
+/// routing_command_finished = "system_when_unfocused"
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+// Four independent TOML config toggles (master switch + per-source enables).
+// Each maps directly to a documented `[notifications]` key; collapsing them
+// into an enum would distort the config schema and add noise.
+#[allow(clippy::struct_excessive_bools)]
+pub struct NotificationsConfig {
+    /// Master switch for the notification system.  When `false`, no
+    /// notifications of any kind are produced.  Default: `false` (opt-in).
+    pub enabled: bool,
+
+    /// When `true`, OSC 9 (iTerm2) text payloads create notifications.
+    /// Default: `true`.
+    pub osc_9: bool,
+
+    /// When `true`, OSC 777 (`notify;TITLE;BODY`) payloads create
+    /// notifications.  Default: `true`.
+    pub osc_777: bool,
+
+    /// When `true`, an OSC 133 `D` (command finished) event fires a
+    /// notification.  Default: `true`.
+    pub on_command_finished: bool,
+
+    /// Minimum command duration (in seconds) before a command-finished
+    /// notification fires.  Avoids spamming notifications for fast commands.
+    /// Default: `10.0`.
+    pub command_finished_threshold_secs: f32,
+
+    /// Routing for error-category notifications.  Default:
+    /// [`NotificationRouting::Both`].
+    pub routing_error: NotificationRouting,
+
+    /// Routing for informational notifications.  Default:
+    /// [`NotificationRouting::Toast`].
+    pub routing_info: NotificationRouting,
+
+    /// Routing for command-finished notifications.  Default:
+    /// [`NotificationRouting::SystemWhenUnfocused`].
+    pub routing_command_finished: NotificationRouting,
+}
+
+impl Default for NotificationsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            osc_9: true,
+            osc_777: true,
+            on_command_finished: true,
+            command_finished_threshold_secs: 10.0,
+            routing_error: NotificationRouting::Both,
+            routing_info: NotificationRouting::Toast,
+            routing_command_finished: NotificationRouting::SystemWhenUnfocused,
         }
     }
 }
@@ -1644,6 +1777,101 @@ size = 14.0
         assert!(!parsed.command_blocks.show_duration);
         assert!((parsed.command_blocks.duration_threshold_secs - 5.5_f32).abs() < f32::EPSILON);
         assert_eq!(parsed.command_blocks.gutter, GutterPosition::Off);
+    }
+
+    #[test]
+    fn notifications_default_is_opt_in() {
+        let cfg = NotificationsConfig::default();
+        assert!(!cfg.enabled);
+        assert!(cfg.osc_9);
+        assert!(cfg.osc_777);
+        assert!(cfg.on_command_finished);
+        assert!((cfg.command_finished_threshold_secs - 10.0_f32).abs() < f32::EPSILON);
+        assert_eq!(cfg.routing_error, NotificationRouting::Both);
+        assert_eq!(cfg.routing_info, NotificationRouting::Toast);
+        assert_eq!(
+            cfg.routing_command_finished,
+            NotificationRouting::SystemWhenUnfocused
+        );
+    }
+
+    #[test]
+    fn notifications_round_trip_through_toml() {
+        let mut cfg = Config::default();
+        cfg.notifications.enabled = true;
+        cfg.notifications.osc_9 = false;
+        cfg.notifications.osc_777 = false;
+        cfg.notifications.on_command_finished = false;
+        cfg.notifications.command_finished_threshold_secs = 3.5;
+        cfg.notifications.routing_error = NotificationRouting::System;
+        cfg.notifications.routing_info = NotificationRouting::Both;
+        cfg.notifications.routing_command_finished = NotificationRouting::Toast;
+
+        let toml = toml::to_string_pretty(&cfg).expect("serialise config");
+        let parsed: Config = toml::from_str(&toml).expect("re-parse");
+
+        assert!(parsed.notifications.enabled);
+        assert!(!parsed.notifications.osc_9);
+        assert!(!parsed.notifications.osc_777);
+        assert!(!parsed.notifications.on_command_finished);
+        assert!(
+            (parsed.notifications.command_finished_threshold_secs - 3.5_f32).abs() < f32::EPSILON
+        );
+        assert_eq!(
+            parsed.notifications.routing_error,
+            NotificationRouting::System
+        );
+        assert_eq!(parsed.notifications.routing_info, NotificationRouting::Both);
+        assert_eq!(
+            parsed.notifications.routing_command_finished,
+            NotificationRouting::Toast
+        );
+    }
+
+    #[test]
+    fn notification_routing_serializes_as_snake_case() {
+        #[derive(Serialize)]
+        struct RoutingToml {
+            routing: NotificationRouting,
+        }
+        let cases = [
+            (NotificationRouting::Toast, "routing = \"toast\""),
+            (NotificationRouting::System, "routing = \"system\""),
+            (NotificationRouting::Both, "routing = \"both\""),
+            (
+                NotificationRouting::SystemWhenUnfocused,
+                "routing = \"system_when_unfocused\"",
+            ),
+        ];
+        for (routing, expected) in cases {
+            let toml = toml::to_string(&RoutingToml { routing }).expect("serialise");
+            assert!(toml.contains(expected), "got: {toml}");
+        }
+    }
+
+    #[test]
+    fn notification_routing_dispatch_decisions() {
+        // Toast: always toast, never system.
+        assert!(NotificationRouting::Toast.wants_toast(true));
+        assert!(NotificationRouting::Toast.wants_toast(false));
+        assert!(!NotificationRouting::Toast.wants_system(true));
+        assert!(!NotificationRouting::Toast.wants_system(false));
+
+        // System: never toast, always system.
+        assert!(!NotificationRouting::System.wants_toast(true));
+        assert!(!NotificationRouting::System.wants_toast(false));
+        assert!(NotificationRouting::System.wants_system(true));
+        assert!(NotificationRouting::System.wants_system(false));
+
+        // Both: always toast, always system.
+        assert!(NotificationRouting::Both.wants_toast(true));
+        assert!(NotificationRouting::Both.wants_system(false));
+
+        // SystemWhenUnfocused: toast when focused, system when unfocused.
+        assert!(NotificationRouting::SystemWhenUnfocused.wants_toast(true));
+        assert!(!NotificationRouting::SystemWhenUnfocused.wants_toast(false));
+        assert!(!NotificationRouting::SystemWhenUnfocused.wants_system(true));
+        assert!(NotificationRouting::SystemWhenUnfocused.wants_system(false));
     }
 
     #[test]

--- a/freminal-common/src/config.rs
+++ b/freminal-common/src/config.rs
@@ -2571,6 +2571,163 @@ mode = "none"
         assert_eq!(cfg.bell.mode, BellMode::None);
     }
 
+    /// Round-trip guard: every top-level `Config` section must survive the
+    /// real load path (`toml::to_string_pretty` -> `ConfigPartial` ->
+    /// `apply_partial`). This is the regression net for the class of bug
+    /// where a section is added to `Config` but not wired into
+    /// `ConfigPartial` / `apply_partial`, causing user TOML to be silently
+    /// dropped (see fix 76.4a). A non-default value is set in EVERY section;
+    /// if any section fails to merge, that section's assertion reverts to the
+    /// default and fails here.
+    #[test]
+    // One comprehensive guard covering every section plus the exhaustive
+    // destructure; splitting it would scatter the invariant and weaken it.
+    #[allow(clippy::too_many_lines)]
+    fn every_config_section_survives_partial_merge() {
+        // `version` is the only top-level (non-nested) field mutated, so set
+        // it via struct-update syntax to avoid `field_reassign_with_default`;
+        // every other mutation targets a nested section field, which the lint
+        // does not flag.
+        let mut original = Config {
+            version: 7,
+            ..Config::default()
+        };
+
+        // Mutate one distinctive, non-default field per section.
+        original.font.size = 18.0;
+        original.cursor.blink = !Config::default().cursor.blink;
+        original.theme.mode = ThemeMode::Light;
+        original.shell.path = Some("/bin/dash".to_owned());
+        original.logging.write_to_file = !Config::default().logging.write_to_file;
+        original.scrollback.limit = 12_345;
+        original.ui.hide_menu_bar = !Config::default().ui.hide_menu_bar;
+        original.shader.hot_reload = !Config::default().shader.hot_reload;
+        original.tabs.show_single_tab = !Config::default().tabs.show_single_tab;
+        original.tab_title.policy = TabTitlePolicy::OscWins;
+        original.bell.mode = BellMode::None;
+        original.security.allow_clipboard_read = !Config::default().security.allow_clipboard_read;
+        original.shell_integration.set_term_program =
+            !Config::default().shell_integration.set_term_program;
+        original.command_blocks.enabled = !Config::default().command_blocks.enabled;
+        original.notifications.enabled = !Config::default().notifications.enabled;
+        original
+            .keybindings
+            .overrides
+            .insert("copy".to_owned(), "Ctrl+Shift+C".to_owned());
+        original.startup.restore_last_session = !Config::default().startup.restore_last_session;
+        original.onboarding.first_run_complete = !Config::default().onboarding.first_run_complete;
+
+        // Serialize exactly as `save_config` does, then re-load exactly as
+        // `load_config` does (partial deserialize + merge onto defaults).
+        let toml = toml::to_string_pretty(&original).expect("serialize Config");
+        let partial: ConfigPartial = toml::from_str(&toml).expect("deserialize ConfigPartial");
+        let mut loaded = Config::default();
+        loaded.apply_partial(partial);
+
+        // Each section's mutated field must have survived the merge.
+        assert_eq!(loaded.version, 7, "version section dropped");
+        assert!(
+            (loaded.font.size - 18.0).abs() < f32::EPSILON,
+            "font section dropped"
+        );
+        assert_eq!(
+            loaded.cursor.blink, original.cursor.blink,
+            "cursor section dropped"
+        );
+        assert_eq!(loaded.theme.mode, ThemeMode::Light, "theme section dropped");
+        assert_eq!(
+            loaded.shell.path.as_deref(),
+            Some("/bin/dash"),
+            "shell section dropped"
+        );
+        assert_eq!(
+            loaded.logging.write_to_file, original.logging.write_to_file,
+            "logging section dropped"
+        );
+        assert_eq!(
+            loaded.scrollback.limit, 12_345,
+            "scrollback section dropped"
+        );
+        assert_eq!(
+            loaded.ui.hide_menu_bar, original.ui.hide_menu_bar,
+            "ui section dropped"
+        );
+        assert_eq!(
+            loaded.shader.hot_reload, original.shader.hot_reload,
+            "shader section dropped"
+        );
+        assert_eq!(
+            loaded.tabs.show_single_tab, original.tabs.show_single_tab,
+            "tabs section dropped"
+        );
+        assert_eq!(
+            loaded.tab_title.policy,
+            TabTitlePolicy::OscWins,
+            "tab_title section dropped"
+        );
+        assert_eq!(loaded.bell.mode, BellMode::None, "bell section dropped");
+        assert_eq!(
+            loaded.security.allow_clipboard_read, original.security.allow_clipboard_read,
+            "security section dropped"
+        );
+        assert_eq!(
+            loaded.shell_integration.set_term_program, original.shell_integration.set_term_program,
+            "shell_integration section dropped"
+        );
+        assert_eq!(
+            loaded.command_blocks.enabled, original.command_blocks.enabled,
+            "command_blocks section dropped"
+        );
+        assert_eq!(
+            loaded.notifications.enabled, original.notifications.enabled,
+            "notifications section dropped"
+        );
+        assert_eq!(
+            loaded.keybindings.overrides.get("copy").map(String::as_str),
+            Some("Ctrl+Shift+C"),
+            "keybindings section dropped"
+        );
+        assert_eq!(
+            loaded.startup.restore_last_session, original.startup.restore_last_session,
+            "startup section dropped"
+        );
+        assert_eq!(
+            loaded.onboarding.first_run_complete, original.onboarding.first_run_complete,
+            "onboarding section dropped"
+        );
+
+        // Exhaustiveness guard: this destructure has NO `..` rest pattern, so
+        // adding a new field to `Config` breaks compilation here until the
+        // author adds a mutation + assertion for it above. That converts the
+        // "new section silently not wired into ConfigPartial/apply_partial"
+        // bug class (see fix 76.4a) from a runtime surprise into a
+        // compile-time failure. If you are here because of a build error:
+        // wire your new field into `ConfigPartial` and `apply_partial`, then
+        // add a mutation and an assertion to this test.
+        let Config {
+            version: _,
+            font: _,
+            cursor: _,
+            theme: _,
+            shell: _,
+            logging: _,
+            scrollback: _,
+            ui: _,
+            shader: _,
+            tabs: _,
+            tab_title: _,
+            bell: _,
+            security: _,
+            shell_integration: _,
+            command_blocks: _,
+            notifications: _,
+            keybindings: _,
+            managed_by: _,
+            startup: _,
+            onboarding: _,
+        } = loaded;
+    }
+
     #[test]
     fn notifications_apply_partial_enables_from_toml() {
         // Regression: [notifications] (and its sibling sections) must survive

--- a/freminal-common/src/config.rs
+++ b/freminal-common/src/config.rs
@@ -1184,8 +1184,12 @@ struct ConfigPartial {
     pub ui: Option<UiConfig>,
     pub shader: Option<ShaderConfig>,
     pub tabs: Option<TabsConfig>,
+    pub tab_title: Option<TabTitleConfig>,
     pub bell: Option<BellConfig>,
     pub security: Option<SecurityConfig>,
+    pub shell_integration: Option<ShellIntegrationConfig>,
+    pub command_blocks: Option<CommandBlocksConfig>,
+    pub notifications: Option<NotificationsConfig>,
     pub keybindings: Option<KeybindingsConfig>,
     pub managed_by: Option<String>,
     pub startup: Option<StartupConfig>,
@@ -1224,11 +1228,23 @@ impl Config {
         if let Some(tabs) = partial.tabs {
             self.tabs = tabs;
         }
+        if let Some(tab_title) = partial.tab_title {
+            self.tab_title = tab_title;
+        }
         if let Some(bell) = partial.bell {
             self.bell = bell;
         }
         if let Some(security) = partial.security {
             self.security = security;
+        }
+        if let Some(shell_integration) = partial.shell_integration {
+            self.shell_integration = shell_integration;
+        }
+        if let Some(command_blocks) = partial.command_blocks {
+            self.command_blocks = command_blocks;
+        }
+        if let Some(notifications) = partial.notifications {
+            self.notifications = notifications;
         }
         if let Some(keybindings) = partial.keybindings {
             // Merge override maps: later layers add to / overwrite earlier ones.
@@ -2553,6 +2569,63 @@ mode = "none"
         .expect("valid TOML");
         cfg.apply_partial(partial);
         assert_eq!(cfg.bell.mode, BellMode::None);
+    }
+
+    #[test]
+    fn notifications_apply_partial_enables_from_toml() {
+        // Regression: [notifications] (and its sibling sections) must survive
+        // the ConfigPartial -> Config merge.  Previously ConfigPartial omitted
+        // these fields, so `enabled = true` was silently dropped on load.
+        let mut cfg = Config::default();
+        assert!(!cfg.notifications.enabled, "default is opt-out");
+
+        let partial: ConfigPartial = toml::from_str(
+            r"
+[notifications]
+enabled = true
+",
+        )
+        .expect("valid TOML");
+        cfg.apply_partial(partial);
+        assert!(
+            cfg.notifications.enabled,
+            "[notifications] enabled must merge through ConfigPartial"
+        );
+    }
+
+    #[test]
+    fn previously_dropped_sections_apply_partial() {
+        // Regression for the ConfigPartial omission: tab_title,
+        // shell_integration, command_blocks, and notifications must all merge.
+        let mut cfg = Config::default();
+        // Pick non-default values for each section.
+        assert!(cfg.command_blocks.enabled);
+        assert!(cfg.shell_integration.set_term_program);
+
+        let partial: ConfigPartial = toml::from_str(
+            r#"
+[tab_title]
+policy = "osc_wins"
+
+[shell_integration]
+set_term_program = false
+
+[command_blocks]
+enabled = false
+
+[notifications]
+enabled = true
+osc_9 = false
+"#,
+        )
+        .expect("valid TOML");
+        cfg.apply_partial(partial);
+
+        assert_eq!(cfg.tab_title.policy, TabTitlePolicy::OscWins);
+        assert!(!cfg.shell_integration.set_term_program);
+        assert!(!cfg.command_blocks.enabled);
+        assert!(cfg.notifications.enabled);
+        assert!(!cfg.notifications.osc_9);
     }
 
     #[test]

--- a/freminal-common/src/config.rs
+++ b/freminal-common/src/config.rs
@@ -494,12 +494,20 @@ pub enum BellMode {
 pub struct BellConfig {
     /// Bell mode: `"visual"` (default) or `"none"`.
     pub mode: BellMode,
+
+    /// When `true`, ring the bell (using the configured [`Self::mode`]) on an
+    /// OSC 133 `D` (command finished) event.  Lets long-running commands beep
+    /// even when no `\x07` was emitted by the program.
+    ///
+    /// Default: `false`.
+    pub on_command_finished: bool,
 }
 
 impl Default for BellConfig {
     fn default() -> Self {
         Self {
             mode: BellMode::Visual,
+            on_command_finished: false,
         }
     }
 }
@@ -765,6 +773,7 @@ impl NotificationRouting {
 /// routing_error = "both"
 /// routing_info = "toast"
 /// routing_command_finished = "system_when_unfocused"
+/// command_finished_template = "{command} finished in {duration} (exit {exit_code})"
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -805,6 +814,22 @@ pub struct NotificationsConfig {
     /// Routing for command-finished notifications.  Default:
     /// [`NotificationRouting::SystemWhenUnfocused`].
     pub routing_command_finished: NotificationRouting,
+
+    /// Template for the body of command-finished notifications.
+    ///
+    /// Supported tokens, substituted at notification time:
+    ///
+    /// - `{command}` — the command text (or `Command` if it scrolled out
+    ///   of the buffer before extraction);
+    /// - `{duration}` — human-readable elapsed time (e.g. `3s`, `2m15s`);
+    /// - `{exit_code}` — the numeric exit code, or `?` when the shell
+    ///   omitted it;
+    /// - `{cwd}` — the working directory captured at prompt start, or an
+    ///   empty string when unknown;
+    /// - `{tab_name}` — the display name of the tab the command ran in.
+    ///
+    /// Default: `"{command} finished in {duration} (exit {exit_code})"`.
+    pub command_finished_template: String,
 }
 
 impl Default for NotificationsConfig {
@@ -818,6 +843,9 @@ impl Default for NotificationsConfig {
             routing_error: NotificationRouting::Both,
             routing_info: NotificationRouting::Toast,
             routing_command_finished: NotificationRouting::SystemWhenUnfocused,
+            command_finished_template: String::from(
+                "{command} finished in {duration} (exit {exit_code})",
+            ),
         }
     }
 }
@@ -1809,6 +1837,10 @@ size = 14.0
             cfg.routing_command_finished,
             NotificationRouting::SystemWhenUnfocused
         );
+        assert_eq!(
+            cfg.command_finished_template,
+            "{command} finished in {duration} (exit {exit_code})"
+        );
     }
 
     #[test]
@@ -1822,6 +1854,7 @@ size = 14.0
         cfg.notifications.routing_error = NotificationRouting::System;
         cfg.notifications.routing_info = NotificationRouting::Both;
         cfg.notifications.routing_command_finished = NotificationRouting::Toast;
+        cfg.notifications.command_finished_template = "{command}: {exit_code}".to_owned();
 
         let toml = toml::to_string_pretty(&cfg).expect("serialise config");
         let parsed: Config = toml::from_str(&toml).expect("re-parse");
@@ -1841,6 +1874,10 @@ size = 14.0
         assert_eq!(
             parsed.notifications.routing_command_finished,
             NotificationRouting::Toast
+        );
+        assert_eq!(
+            parsed.notifications.command_finished_template,
+            "{command}: {exit_code}"
         );
     }
 
@@ -2542,6 +2579,19 @@ show_single_tab = true
             BellMode::Visual,
             "bell mode should default to Visual"
         );
+        assert!(
+            !cfg.on_command_finished,
+            "on_command_finished should default to false"
+        );
+    }
+
+    #[test]
+    fn bell_on_command_finished_round_trip() {
+        let mut cfg = Config::default();
+        cfg.bell.on_command_finished = true;
+        let toml_str = toml::to_string_pretty(&cfg).expect("serialise config");
+        let parsed: Config = toml::from_str(&toml_str).expect("re-parse");
+        assert!(parsed.bell.on_command_finished);
     }
 
     #[test]

--- a/freminal-terminal-emulator/src/ansi_components/mod.rs
+++ b/freminal-terminal-emulator/src/ansi_components/mod.rs
@@ -10,6 +10,7 @@ pub mod dcs;
 pub mod osc;
 pub mod osc_clipboard;
 pub mod osc_iterm2;
+pub mod osc_notify;
 pub mod osc_palette;
 pub mod osc_shell_info;
 pub mod standard;

--- a/freminal-terminal-emulator/src/ansi_components/osc.rs
+++ b/freminal-terminal-emulator/src/ansi_components/osc.rs
@@ -15,6 +15,7 @@ use freminal_common::buffer_states::terminal_output::TerminalOutput;
 
 use super::osc_clipboard::handle_osc_clipboard;
 use super::osc_iterm2::handle_osc_iterm2;
+use super::osc_notify::{handle_osc_notify_9, handle_osc_notify_777};
 use super::osc_palette::{handle_osc_palette_color, handle_osc_reset_palette};
 use super::osc_shell_info::handle_osc_shell_info;
 
@@ -213,6 +214,11 @@ fn handle_osc_pointer_shape(params: &[Option<AnsiOscToken>], output: &mut Vec<Te
     )));
 }
 
+// A flat dispatch match over every recognised OSC target.  Its bulk is the
+// match itself; splitting it would scatter one-line arms across helpers and
+// obscure the dispatch table, so the over-100-line lint is suppressed here
+// (consistent with similar flat-match allows elsewhere in the parser).
+#[allow(clippy::too_many_lines)]
 fn dispatch_osc_target(
     osc_target: &OscTarget,
     osc_internal_type: AnsiOscInternalType,
@@ -309,6 +315,14 @@ fn dispatch_osc_target(
         }
         OscTarget::ShellInfo => {
             handle_osc_shell_info(raw_params, seq_trace, output);
+        }
+        // OSC 9 / OSC 777 — desktop notifications (Task 76).  Parsed from the
+        // raw bytes so notification bodies containing `;` survive intact.
+        OscTarget::Notify9 => {
+            handle_osc_notify_9(raw_params, seq_trace, output);
+        }
+        OscTarget::Notify777 => {
+            handle_osc_notify_777(raw_params, seq_trace, output);
         }
         // OSC 22 — set the pointer (mouse cursor) shape.
         OscTarget::PointerShape => {

--- a/freminal-terminal-emulator/src/ansi_components/osc_notify.rs
+++ b/freminal-terminal-emulator/src/ansi_components/osc_notify.rs
@@ -1,0 +1,328 @@
+// Copyright (C) 2024-2026 Fred Clausen
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! OSC 9 / OSC 777 — desktop notification parsers (Task 76).
+//!
+//! Both sequences are one-way, fire-and-forget notification requests. They
+//! produce an [`AnsiOscType::Notify`] which the GUI routes to an in-app
+//! toast and/or the system notification daemon per the `[notifications]`
+//! config.
+//!
+//! Wire formats:
+//!
+//! ```text
+//! OSC 9 ; <body>                       ST   (iTerm2 / WezTerm)
+//! OSC 777 ; notify ; <title> ; <body>  ST   (urxvt)
+//! ```
+//!
+//! We parse from the raw (un-split) parameter bytes because a notification
+//! body may legitimately contain `;` characters, and the upstream
+//! semicolon split is too aggressive for free-form text. The OSC parser
+//! upstream has already validated byte ranges and stripped the terminator,
+//! so `raw_params` contains only the printable payload bytes (e.g.
+//! `9;Build finished` or `777;notify;Title;Body`).
+
+use crate::ansi_components::tracer::SequenceTracer;
+use freminal_common::buffer_states::osc::AnsiOscType;
+use freminal_common::buffer_states::terminal_output::TerminalOutput;
+
+/// Handle OSC 9 (`iTerm2` / `WezTerm` notification).
+///
+/// The entire payload after the leading `9;` is the notification body;
+/// there is no separate title. An empty body is silently consumed (nothing
+/// useful to display).
+pub(super) fn handle_osc_notify_9(
+    raw_params: &[u8],
+    seq_trace: &SequenceTracer,
+    output: &mut Vec<TerminalOutput>,
+) {
+    // raw_params looks like: b"9;Build finished"
+    let Some(first_semi) = raw_params.iter().position(|&b| b == b';') else {
+        // `OSC 9 ST` with no body — nothing to notify.
+        tracing::debug!(
+            "OSC 9: missing notification body: recent='{}'",
+            seq_trace.as_str()
+        );
+        return;
+    };
+
+    let body_bytes = &raw_params[first_semi + 1..];
+    let Some(body) = decode_utf8(body_bytes, seq_trace) else {
+        return;
+    };
+
+    if body.is_empty() {
+        tracing::debug!(
+            "OSC 9: empty notification body: recent='{}'",
+            seq_trace.as_str()
+        );
+        return;
+    }
+
+    output.push(TerminalOutput::OscResponse(AnsiOscType::Notify {
+        title: None,
+        body,
+    }));
+}
+
+/// Handle OSC 777 (urxvt notification).
+///
+/// Canonical form is `777;notify;TITLE;BODY`. The `notify;` prefix is
+/// consumed when present. The remainder is split on the first `;` into
+/// title and body:
+///
+/// - `notify;TITLE;BODY` → title = `TITLE`, body = `BODY`.
+/// - `notify;TITLE`      → title = `TITLE`, body = `""` (empty).
+/// - payload without the `notify;` prefix → the entire payload (after the
+///   leading `777;`) is the body, with no title.
+///
+/// An entirely empty payload is silently consumed.
+pub(super) fn handle_osc_notify_777(
+    raw_params: &[u8],
+    seq_trace: &SequenceTracer,
+    output: &mut Vec<TerminalOutput>,
+) {
+    // raw_params looks like: b"777;notify;Title;Body"
+    let Some(first_semi) = raw_params.iter().position(|&b| b == b';') else {
+        tracing::debug!("OSC 777: missing payload: recent='{}'", seq_trace.as_str());
+        return;
+    };
+
+    let rest = &raw_params[first_semi + 1..];
+    let Some(rest) = decode_utf8(rest, seq_trace) else {
+        return;
+    };
+
+    let (title, body) = parse_777_payload(&rest);
+
+    // Nothing to show if both fields are empty.
+    if title.as_deref().is_none_or(str::is_empty) && body.is_empty() {
+        tracing::debug!(
+            "OSC 777: empty notification: recent='{}'",
+            seq_trace.as_str()
+        );
+        return;
+    }
+
+    output.push(TerminalOutput::OscResponse(AnsiOscType::Notify {
+        title,
+        body,
+    }));
+}
+
+/// Split an OSC 777 payload (already stripped of the leading `777;`) into an
+/// optional title and a body.
+fn parse_777_payload(payload: &str) -> (Option<String>, String) {
+    // Strip the urxvt `notify;` sub-command prefix when present.
+    payload.strip_prefix("notify;").map_or_else(
+        || {
+            // No `notify;` prefix: treat the whole payload as the body.
+            (None, payload.to_owned())
+        },
+        |after| {
+            // `after` is `TITLE` or `TITLE;BODY`.  Split on the first `;`
+            // only, so a body containing further semicolons is preserved.
+            after.split_once(';').map_or_else(
+                || (Some(after.to_owned()), String::new()),
+                |(title, body)| (Some(title.to_owned()), body.to_owned()),
+            )
+        },
+    )
+}
+
+/// Decode notification payload bytes as UTF-8, logging and bailing on
+/// invalid input rather than lossy-decoding (which would corrupt the
+/// displayed text).
+fn decode_utf8(bytes: &[u8], seq_trace: &SequenceTracer) -> Option<String> {
+    std::str::from_utf8(bytes).map_or_else(
+        |_| {
+            tracing::debug!(
+                "OSC notification: non-UTF-8 payload (ignored): recent='{}'",
+                seq_trace.as_str()
+            );
+            None
+        },
+        |s| Some(s.to_owned()),
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::super::osc::AnsiOscParser;
+    use super::super::tracer::SequenceTracer;
+    use freminal_common::buffer_states::osc::AnsiOscType;
+    use freminal_common::buffer_states::terminal_output::TerminalOutput;
+
+    fn feed_osc(payload: &[u8]) -> Vec<TerminalOutput> {
+        let mut parser = AnsiOscParser::new();
+        let mut output = Vec::new();
+        for &b in payload {
+            parser.ansiparser_inner_osc(b, &mut output);
+        }
+        output
+    }
+
+    fn tracer() -> SequenceTracer {
+        SequenceTracer::new()
+    }
+
+    fn expect_notify(output: &[TerminalOutput]) -> (&Option<String>, &str) {
+        assert_eq!(output.len(), 1, "expected one output, got: {output:?}");
+        match &output[0] {
+            TerminalOutput::OscResponse(AnsiOscType::Notify { title, body }) => {
+                (title, body.as_str())
+            }
+            other => panic!("expected Notify, got: {other:?}"),
+        }
+    }
+
+    // ── OSC 9 ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn osc9_basic_body_bel() {
+        let output = feed_osc(b"9;Build finished\x07");
+        let (title, body) = expect_notify(&output);
+        assert_eq!(*title, None);
+        assert_eq!(body, "Build finished");
+    }
+
+    #[test]
+    fn osc9_basic_body_st_terminator() {
+        let output = feed_osc(b"9;Done\x1b\\");
+        let (title, body) = expect_notify(&output);
+        assert_eq!(*title, None);
+        assert_eq!(body, "Done");
+    }
+
+    #[test]
+    fn osc9_body_with_semicolons_preserved() {
+        // A body containing semicolons must survive intact (no token split).
+        let output = feed_osc(b"9;a;b;c\x07");
+        let (title, body) = expect_notify(&output);
+        assert_eq!(*title, None);
+        assert_eq!(body, "a;b;c");
+    }
+
+    #[test]
+    fn osc9_empty_body_no_output() {
+        let output = feed_osc(b"9;\x07");
+        assert!(output.is_empty(), "got: {output:?}");
+    }
+
+    #[test]
+    fn osc9_missing_body_no_output() {
+        // `OSC 9 ST` with no semicolon — the upstream parser produces a single
+        // `9` token; dispatch reaches us but raw_params has no `;`.
+        let output = feed_osc(b"9\x07");
+        assert!(output.is_empty(), "got: {output:?}");
+    }
+
+    // ── OSC 777 ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn osc777_notify_title_body() {
+        let output = feed_osc(b"777;notify;Title;Body text\x07");
+        let (title, body) = expect_notify(&output);
+        assert_eq!(title.as_deref(), Some("Title"));
+        assert_eq!(body, "Body text");
+    }
+
+    #[test]
+    fn osc777_notify_title_only() {
+        let output = feed_osc(b"777;notify;Just a title\x07");
+        let (title, body) = expect_notify(&output);
+        assert_eq!(title.as_deref(), Some("Just a title"));
+        assert_eq!(body, "");
+    }
+
+    #[test]
+    fn osc777_body_with_semicolons_preserved() {
+        let output = feed_osc(b"777;notify;T;a;b;c\x07");
+        let (title, body) = expect_notify(&output);
+        assert_eq!(title.as_deref(), Some("T"));
+        assert_eq!(body, "a;b;c");
+    }
+
+    #[test]
+    fn osc777_without_notify_prefix_is_all_body() {
+        // No `notify;` prefix → entire payload is the body, no title.
+        let output = feed_osc(b"777;raw message\x07");
+        let (title, body) = expect_notify(&output);
+        assert_eq!(*title, None);
+        assert_eq!(body, "raw message");
+    }
+
+    #[test]
+    fn osc777_st_terminator() {
+        let output = feed_osc(b"777;notify;T;B\x1b\\");
+        let (title, body) = expect_notify(&output);
+        assert_eq!(title.as_deref(), Some("T"));
+        assert_eq!(body, "B");
+    }
+
+    #[test]
+    fn osc777_empty_notify_no_output() {
+        // `notify;` with nothing after it → empty title, empty body → consumed.
+        let output = feed_osc(b"777;notify;\x07");
+        assert!(output.is_empty(), "got: {output:?}");
+    }
+
+    #[test]
+    fn osc777_missing_payload_no_output() {
+        let output = feed_osc(b"777\x07");
+        assert!(output.is_empty(), "got: {output:?}");
+    }
+
+    // ── Direct-call coverage for error branches ──────────────────────────
+
+    #[test]
+    fn notify9_non_utf8_direct_call() {
+        let mut output = Vec::new();
+        let mut raw = b"9;".to_vec();
+        raw.extend_from_slice(&[0xFF, 0xFE, 0xFD]);
+        super::handle_osc_notify_9(&raw, &tracer(), &mut output);
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn notify9_missing_semicolon_direct_call() {
+        let mut output = Vec::new();
+        super::handle_osc_notify_9(b"9", &tracer(), &mut output);
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn notify777_non_utf8_direct_call() {
+        let mut output = Vec::new();
+        let mut raw = b"777;".to_vec();
+        raw.extend_from_slice(&[0xFF, 0xFE, 0xFD]);
+        super::handle_osc_notify_777(&raw, &tracer(), &mut output);
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn notify777_missing_semicolon_direct_call() {
+        let mut output = Vec::new();
+        super::handle_osc_notify_777(b"777", &tracer(), &mut output);
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn parse_777_payload_variants() {
+        assert_eq!(
+            super::parse_777_payload("notify;T;B"),
+            (Some("T".to_owned()), "B".to_owned())
+        );
+        assert_eq!(
+            super::parse_777_payload("notify;T"),
+            (Some("T".to_owned()), String::new())
+        );
+        assert_eq!(
+            super::parse_777_payload("raw body"),
+            (None, "raw body".to_owned())
+        );
+    }
+}

--- a/freminal-terminal-emulator/src/terminal_handler/dcs.rs
+++ b/freminal-terminal-emulator/src/terminal_handler/dcs.rs
@@ -707,7 +707,15 @@ impl TerminalHandler {
             "setrgbb" => Some("\x1b[48;2;%p1%d;%p2%d;%p3%dm"),
             // colors — number of colors supported
             "colors" | "Co" => Some("256"),
-            // TN — terminal name
+            // TN — terminal name.  This MUST match the runtime `TERM` value
+            // (`xterm-256color`, set in `io::pty::run_terminal`), since TN is
+            // defined as "the value of $TERM".  Freminal deliberately presents
+            // as `xterm-256color` for maximum compatibility (the Task-12
+            // strategy mirroring WezTerm/Alacritty); the freminal identity is
+            // advertised separately via `TERM_PROGRAM=freminal` (Task 72.6)
+            // and the XTVERSION `>|XTerm(Freminal ...)` payload.  Do not change
+            // TN to `freminal` — it would desync from TERM and break terminfo
+            // lookups.
             "TN" => Some("xterm-256color"),
             // Ms — set selection (clipboard) via OSC 52
             "Ms" => Some("\x1b]52;%p1%s;%p2%s\x1b\\"),
@@ -1328,7 +1336,11 @@ mod tests {
         handler.handle_device_control_string(&dcs);
 
         let response = recv_pty_response(&rx);
-        // "xterm-256color" → hex
+        // Regression guard (Task 76.6): TN must report `xterm-256color`, the
+        // same value as the runtime `TERM` env var.  TN is "the value of
+        // $TERM"; reporting `freminal` would desync from TERM and break
+        // terminfo lookups.  Freminal advertises its identity via
+        // TERM_PROGRAM and XTVERSION instead.
         let expected_hex = TerminalHandler::hex_encode("xterm-256color");
         assert_eq!(response, format!("\x1bP1+r544E={expected_hex}\x1b\\"));
     }

--- a/freminal-terminal-emulator/src/terminal_handler/osc.rs
+++ b/freminal-terminal-emulator/src/terminal_handler/osc.rs
@@ -145,6 +145,15 @@ impl TerminalHandler {
                 self.pointer_shape = *shape;
             }
 
+            // OSC 9 / OSC 777 — desktop notification.  Parsing landed in 76.2;
+            // forwarding to the GUI notification router is wired in 76.3.
+            // TODO(76.3): dispatch a WindowCommand::Notification here.
+            AnsiOscType::Notify { title, body } => {
+                tracing::debug!(
+                    "OSC notification (pending 76.3 dispatch): title={title:?}, body={body:?}"
+                );
+            }
+
             AnsiOscType::NoOp => {}
         }
     }

--- a/freminal-terminal-emulator/src/terminal_handler/osc.rs
+++ b/freminal-terminal-emulator/src/terminal_handler/osc.rs
@@ -16,7 +16,7 @@ use freminal_common::buffer_states::{
     kitty_graphics::{KittyParseError, parse_kitty_graphics},
     osc::{AnsiOscType, UrlResponse},
     url::Url,
-    window_manipulation::WindowManipulation,
+    window_manipulation::{NotificationKind, WindowManipulation},
 };
 
 use super::{TerminalHandler, shell_integration};
@@ -145,13 +145,15 @@ impl TerminalHandler {
                 self.pointer_shape = *shape;
             }
 
-            // OSC 9 / OSC 777 — desktop notification.  Parsing landed in 76.2;
-            // forwarding to the GUI notification router is wired in 76.3.
-            // TODO(76.3): dispatch a WindowCommand::Notification here.
+            // OSC 9 / OSC 777 — desktop notification.  Forward to the GUI via
+            // the window-command channel; the GUI's notification router
+            // (Task 76.4) applies the `[notifications]` routing policy.
             AnsiOscType::Notify { title, body } => {
-                tracing::debug!(
-                    "OSC notification (pending 76.3 dispatch): title={title:?}, body={body:?}"
-                );
+                self.window_commands.push(WindowManipulation::Notification {
+                    kind: NotificationKind::OscText,
+                    title: title.clone(),
+                    body: body.clone(),
+                });
             }
 
             AnsiOscType::NoOp => {}
@@ -196,6 +198,61 @@ impl TerminalHandler {
                 // the type of the next prompt (initial, continuation, right)
                 // but does not change the FTCS state machine.
             }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::TerminalHandler;
+    use freminal_common::buffer_states::osc::AnsiOscType;
+    use freminal_common::buffer_states::terminal_output::TerminalOutput;
+    use freminal_common::buffer_states::window_manipulation::{
+        NotificationKind, WindowManipulation,
+    };
+
+    #[test]
+    fn osc_notify_pushes_window_command() {
+        let mut handler = TerminalHandler::new(80, 24);
+        assert!(
+            handler.window_commands.is_empty(),
+            "no window commands initially"
+        );
+
+        handler.process_outputs(&[TerminalOutput::OscResponse(AnsiOscType::Notify {
+            title: Some("Build".to_owned()),
+            body: "done".to_owned(),
+        })]);
+
+        assert_eq!(handler.window_commands.len(), 1);
+        match &handler.window_commands[0] {
+            WindowManipulation::Notification { kind, title, body } => {
+                assert_eq!(*kind, NotificationKind::OscText);
+                assert_eq!(title.as_deref(), Some("Build"));
+                assert_eq!(body, "done");
+            }
+            other => panic!("expected Notification, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn osc_notify_without_title_pushes_window_command() {
+        let mut handler = TerminalHandler::new(80, 24);
+
+        handler.process_outputs(&[TerminalOutput::OscResponse(AnsiOscType::Notify {
+            title: None,
+            body: "hello".to_owned(),
+        })]);
+
+        assert_eq!(handler.window_commands.len(), 1);
+        match &handler.window_commands[0] {
+            WindowManipulation::Notification { kind, title, body } => {
+                assert_eq!(*kind, NotificationKind::OscText);
+                assert_eq!(*title, None);
+                assert_eq!(body, "hello");
+            }
+            other => panic!("expected Notification, got: {other:?}"),
         }
     }
 }

--- a/freminal-terminal-emulator/src/terminal_handler/reports.rs
+++ b/freminal-terminal-emulator/src/terminal_handler/reports.rs
@@ -92,3 +92,42 @@ impl TerminalHandler {
         }
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use crate::terminal_handler::TerminalHandler;
+    use freminal_common::pty_write::PtyWrite;
+
+    fn recv_pty_response(rx: &crossbeam_channel::Receiver<PtyWrite>) -> String {
+        let Ok(PtyWrite::Write(bytes)) = rx.try_recv() else {
+            panic!("expected PtyWrite::Write response");
+        };
+        String::from_utf8(bytes).expect("response should be valid UTF-8")
+    }
+
+    /// Regression guard (Task 76.6): the XTVERSION / XTGETTCAP device-name
+    /// response must keep the `>|XTerm(Freminal ...)` shape. The `XTerm(`
+    /// prefix is load-bearing — tmux only enables `extkeys`
+    /// (`modifyOtherKeys`) when it recognises the prefix
+    /// (`tty_keys_extended_device_attributes`). Dropping it regresses
+    /// extended-key forwarding inside tmux. The `Freminal` token is the
+    /// freminal-identifying part of the payload.
+    #[test]
+    fn device_name_and_version_keeps_xterm_prefix_and_freminal_token() {
+        let mut handler = TerminalHandler::new(80, 24);
+        let (tx, rx) = crossbeam_channel::unbounded::<PtyWrite>();
+        handler.set_write_tx(tx);
+
+        handler.handle_device_name_and_version();
+
+        let response = recv_pty_response(&rx);
+        let version = env!("CARGO_PKG_VERSION");
+        // 7-bit DCS framing: ESC P {body} ESC \
+        assert_eq!(
+            response,
+            format!("\x1bP>|XTerm(Freminal {version})\x1b\\"),
+            "XTVERSION response must keep the tmux-compatible XTerm( prefix"
+        );
+    }
+}

--- a/freminal/Cargo.toml
+++ b/freminal/Cargo.toml
@@ -58,6 +58,7 @@ freminal-terminal-emulator = { path = "../freminal-terminal-emulator" }
 freminal-windowing = { path = "../freminal-windowing" }
 glow.workspace = true
 image.workspace = true
+notify-rust.workspace = true
 open.workspace = true
 regex.workspace = true
 rustc-hash.workspace = true

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -591,9 +591,17 @@ impl freminal_windowing::App for FreminalGui {
         // recent_commands ring (cap RECENT_COMMANDS_CAP) and set the tab's
         // has_pending_event flag if the event arrived on a non-active tab.
         //
-        // TODO(Task 76): dispatch CommandFinishedEvent to the notification
-        // subsystem here (OSC 9 / OSC 777) before the badge is set.
+        // Command-finished notifications (Task 76.4) are collected here and
+        // routed after the loop, where `self.config` / the toast stack are
+        // borrowable without conflicting with `win.tabs`.
         let active_tab_idx = win.tabs.active_index();
+        let cmd_window_focused = win
+            .tabs
+            .active_tab()
+            .active_pane()
+            .is_some_and(|p| p.view_state.window_focused);
+        let mut command_notifications: Vec<crate::gui::notifications::NotificationRequest> =
+            Vec::new();
         for (tab_idx, tab) in win.tabs.iter_mut().enumerate() {
             let mut tab_received_event = false;
             if let Ok(panes) = tab.pane_tree.iter_panes_mut() {
@@ -608,12 +616,24 @@ impl freminal_windowing::App for FreminalGui {
                         // seed half of the palette still works in that
                         // case.
                         let snap = pane.arc_swap.load();
-                        if let Some(text) =
-                            crate::gui::command_history::extract_command_text(&snap, &event.block)
-                        {
-                            pane.record_command_text(event.block.id, text);
+                        let command_text =
+                            crate::gui::command_history::extract_command_text(&snap, &event.block);
+                        if let Some(text) = &command_text {
+                            pane.record_command_text(event.block.id, text.clone());
                         }
                         drop(snap);
+
+                        // Build a command-finished notification request (the
+                        // builder applies the enable + threshold gates) before
+                        // the block is moved into the recent-commands ring.
+                        if let Some(req) = crate::gui::notifications::command_finished_request(
+                            &event.block,
+                            command_text.as_deref().unwrap_or(""),
+                            &self.config.notifications,
+                        ) {
+                            command_notifications.push(req);
+                        }
+
                         pane.push_recent_command(event.block);
                         tab_received_event = true;
                     }
@@ -621,6 +641,20 @@ impl freminal_windowing::App for FreminalGui {
             }
             if tab_received_event && tab_idx != active_tab_idx {
                 tab.has_pending_event = true;
+            }
+        }
+
+        // Route command-finished notifications collected above (Task 76.4).
+        if !command_notifications.is_empty()
+            && let Ok(mut toasts) = self.toasts.try_borrow_mut()
+        {
+            for req in &command_notifications {
+                crate::gui::notifications::NotificationRouter::route(
+                    req,
+                    &self.config.notifications,
+                    cmd_window_focused,
+                    &mut toasts,
+                );
             }
         }
 
@@ -866,6 +900,10 @@ impl freminal_windowing::App for FreminalGui {
                 .active_tab()
                 .active_pane()
                 .is_some_and(|p| p.view_state.window_focused);
+            // OSC 9 / OSC 777 notifications collected from every pane this
+            // frame, routed after the loop (Task 76.4).
+            let mut osc_notifications: Vec<crate::gui::notifications::NotificationRequest> =
+                Vec::new();
             for (idx, tab) in win.tabs.iter_mut().enumerate() {
                 let is_active_tab = idx == active_idx;
                 let is_only_pane = match tab.pane_tree.pane_count() {
@@ -897,6 +935,7 @@ impl freminal_windowing::App for FreminalGui {
                                 window_focused,
                                 is_only_pane,
                             },
+                            &mut osc_notifications,
                         );
                         if shell_set {
                             tab_shell_set_title = true;
@@ -906,6 +945,22 @@ impl freminal_windowing::App for FreminalGui {
                     // 0/1/2 title clears the user-pinned custom name (only
                     // under `OscWins`); see `Tab::apply_osc_title_policy`.
                     tab.apply_osc_title_policy(self.config.tab_title.policy, tab_shell_set_title);
+                }
+            }
+
+            // Route OSC 9 / OSC 777 notifications collected above (Task 76.4).
+            // Done after the pane loop so `self.config` and the toast stack
+            // are borrowable without conflicting with the `win.tabs` borrow.
+            if !osc_notifications.is_empty()
+                && let Ok(mut toasts) = self.toasts.try_borrow_mut()
+            {
+                for req in &osc_notifications {
+                    crate::gui::notifications::NotificationRouter::route(
+                        req,
+                        &self.config.notifications,
+                        window_focused,
+                        &mut toasts,
+                    );
                 }
             }
 

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -602,8 +602,17 @@ impl freminal_windowing::App for FreminalGui {
             .is_some_and(|p| p.view_state.window_focused);
         let mut command_notifications: Vec<crate::gui::notifications::NotificationRequest> =
             Vec::new();
+        let tab_title_policy = self.config.tab_title.policy;
+        let tab_title_separator = self.config.tab_title.separator.clone();
         for (tab_idx, tab) in win.tabs.iter_mut().enumerate() {
             let mut tab_received_event = false;
+            // Resolve the tab display name up front: `iter_panes_mut` borrows
+            // `tab` mutably, so `display_name` cannot be called inside the
+            // inner loop.  Used for the `{tab_name}` notification template
+            // token (Task 76.5).
+            let tab_name = tab
+                .display_name(tab_title_policy, &tab_title_separator)
+                .into_owned();
             if let Ok(panes) = tab.pane_tree.iter_panes_mut() {
                 for pane in panes {
                     while let Ok(event) = pane.command_event_rx.try_recv() {
@@ -629,9 +638,26 @@ impl freminal_windowing::App for FreminalGui {
                         if let Some(req) = crate::gui::notifications::command_finished_request(
                             &event.block,
                             command_text.as_deref().unwrap_or(""),
+                            &tab_name,
                             &self.config.notifications,
                         ) {
                             command_notifications.push(req);
+                        }
+
+                        // Ring the bell on command completion when
+                        // `[bell] on_command_finished` is set (Task 76.5).
+                        // Uses the configured bell mode, mirroring the
+                        // `WindowManipulation::Bell` path in `rendering`.
+                        if self.config.bell.on_command_finished {
+                            use freminal_common::config::BellMode;
+                            let mode = self.config.bell.mode;
+                            if matches!(mode, BellMode::Visual | BellMode::Both) {
+                                pane.bell_active = true;
+                                pane.view_state.bell_since = Some(std::time::Instant::now());
+                            }
+                            if matches!(mode, BellMode::Audio | BellMode::Both) {
+                                crate::gui::platform::system_beep();
+                            }
                         }
 
                         pane.push_recent_command(event.block);

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -41,6 +41,7 @@ mod command_history;
 mod hot_reload;
 mod layout_ops;
 mod menu;
+mod notifications;
 mod platform;
 mod recording;
 mod rendering;

--- a/freminal/src/gui/notifications.rs
+++ b/freminal/src/gui/notifications.rs
@@ -42,6 +42,18 @@ pub(super) struct NotificationRequest {
 }
 
 impl NotificationRequest {
+    /// A sample notification used by the Settings "Test Notification" button
+    /// so the user can verify their routing/template configuration without
+    /// running a command. Categorised as [`NotificationKind::Info`] so it
+    /// follows the `routing_info` policy.
+    pub(super) fn sample() -> Self {
+        Self {
+            kind: NotificationKind::Info,
+            title: Some("Freminal".to_owned()),
+            body: "Test notification".to_owned(),
+        }
+    }
+
     /// The summary/title string shown to the user, falling back to a
     /// category-derived default when the source supplied no title.
     fn summary(&self) -> &str {
@@ -205,6 +217,30 @@ impl NotificationRouter {
         }
     }
 
+    /// Route a request for the Settings "Test Notification" button, ignoring
+    /// the [`NotificationsConfig::enabled`] master switch.
+    ///
+    /// The test button must give the user feedback even while the master
+    /// switch is off (they may be configuring routing before enabling the
+    /// system), so the only difference from [`Self::route`] is the skipped
+    /// `enabled` check. The per-category routing policy still applies.
+    pub(super) fn route_test(
+        req: &NotificationRequest,
+        config: &NotificationsConfig,
+        focused: bool,
+        toasts: &mut ToastStack,
+    ) {
+        let routing = Self::routing_for(req.kind, config);
+
+        if routing.wants_toast(focused) {
+            Self::push_toast(req, toasts);
+        }
+
+        if routing.wants_system(focused) {
+            Self::show_system(req);
+        }
+    }
+
     /// Select the routing policy for a notification category.
     const fn routing_for(
         kind: NotificationKind,
@@ -334,6 +370,27 @@ mod tests {
         let mut toasts = ToastStack::default();
         NotificationRouter::route(&osc_req("hello"), &config, true, &mut toasts);
         assert_eq!(toasts.len(), 0);
+    }
+
+    #[test]
+    fn route_test_ignores_enabled_master_switch() {
+        // route() drops everything when disabled; route_test() must still
+        // fire so the Settings "Test Notification" button gives feedback.
+        let config = NotificationsConfig {
+            enabled: false,
+            routing_info: NotificationRouting::Toast,
+            ..NotificationsConfig::default()
+        };
+        let mut toasts = ToastStack::default();
+        NotificationRouter::route_test(&NotificationRequest::sample(), &config, true, &mut toasts);
+        assert_eq!(toasts.len(), 1);
+    }
+
+    #[test]
+    fn sample_request_is_info_kind() {
+        let req = NotificationRequest::sample();
+        assert_eq!(req.kind, NotificationKind::Info);
+        assert_eq!(req.summary(), "Freminal");
     }
 
     #[test]

--- a/freminal/src/gui/notifications.rs
+++ b/freminal/src/gui/notifications.rs
@@ -274,25 +274,43 @@ impl NotificationRouter {
     fn show_system(req: &NotificationRequest) {
         let summary = req.summary().to_owned();
         let body = req.body.clone();
-        // Error-category notifications use Critical urgency so they persist
-        // and pop as a banner; everything else is Normal. Many Linux
-        // notification daemons only raise a banner (rather than silently
-        // filing the notification in the tray) when an urgency hint is set.
-        let urgency = match req.kind {
-            NotificationKind::Error => notify_rust::Urgency::Critical,
-            NotificationKind::OscText
-            | NotificationKind::CommandFinished
-            | NotificationKind::Info => notify_rust::Urgency::Normal,
-        };
+        // `notify-rust`'s `urgency()` setter exists on Linux/BSD and Windows
+        // but NOT on macOS, so capture whether this is a high-urgency
+        // (error-category) notification here and apply the hint only on the
+        // platforms that support it (see the cfg-gated block below).
+        let critical = matches!(req.kind, NotificationKind::Error);
         let builder = std::thread::Builder::new().name("freminal-notify".to_owned());
         if let Err(e) = builder.spawn(move || {
-            if let Err(e) = notify_rust::Notification::new()
+            let mut notification = notify_rust::Notification::new();
+            notification
                 .appname("freminal")
                 .summary(&summary)
-                .body(&body)
-                .urgency(urgency)
-                .show()
+                .body(&body);
+
+            // Error-category notifications use Critical urgency so they persist
+            // and pop as a banner; everything else is Normal. Many Linux
+            // notification daemons only raise a banner (rather than silently
+            // filing the notification in the tray) when an urgency hint is set.
+            //
+            // `notify_rust`'s `urgency()` exists on Linux/BSD and Windows but
+            // NOT on macOS (the `Urgency` type is re-exported there but
+            // deprecated and the method is absent), so gate the call on
+            // `not(target_os = "macos")`.
+            #[cfg(not(target_os = "macos"))]
             {
+                let urgency = if critical {
+                    notify_rust::Urgency::Critical
+                } else {
+                    notify_rust::Urgency::Normal
+                };
+                notification.urgency(urgency);
+            }
+            // Silence the unused-variable warning on macOS, where the urgency
+            // hint is unavailable.
+            #[cfg(target_os = "macos")]
+            let _ = critical;
+
+            if let Err(e) = notification.show() {
                 tracing::warn!("failed to show desktop notification: {e}");
             }
         }) {

--- a/freminal/src/gui/notifications.rs
+++ b/freminal/src/gui/notifications.rs
@@ -67,10 +67,16 @@ impl NotificationRequest {
 /// A failed command produces an [`NotificationKind::Error`]; success or
 /// unknown-exit produces [`NotificationKind::CommandFinished`]. `command`
 /// is the extracted command text (may be empty if it scrolled out of the
-/// buffer before extraction).
+/// buffer before extraction). `tab_name` is the display name of the tab the
+/// command ran in, used for the `{tab_name}` template token.
+///
+/// The body is rendered from
+/// [`NotificationsConfig::command_finished_template`] via
+/// [`render_command_finished_template`].
 pub(super) fn command_finished_request(
     block: &CommandBlock,
     command: &str,
+    tab_name: &str,
     config: &NotificationsConfig,
 ) -> Option<NotificationRequest> {
     if !config.enabled || !config.on_command_finished {
@@ -87,27 +93,20 @@ pub(super) fn command_finished_request(
         return None;
     }
 
-    let duration_label = format_command_duration(duration);
-    let command = command.trim();
-    let command_label = if command.is_empty() {
-        "Command".to_owned()
-    } else {
-        command.to_owned()
-    };
+    let body = render_command_finished_template(
+        &config.command_finished_template,
+        block,
+        command,
+        tab_name,
+    );
 
     // A non-zero exit is an error notification; success / unknown-exit
     // (shell omitted the code) are informational "finished" notifications.
     // `Running` was already excluded by the status check above.
-    let (kind, body) = if let CommandStatus::Failure(code) = status {
-        (
-            NotificationKind::Error,
-            format!("{command_label} failed in {duration_label} (exit {code})"),
-        )
+    let kind = if matches!(status, CommandStatus::Failure(_)) {
+        NotificationKind::Error
     } else {
-        (
-            NotificationKind::CommandFinished,
-            format!("{command_label} finished in {duration_label}"),
-        )
+        NotificationKind::CommandFinished
     };
 
     Some(NotificationRequest {
@@ -116,6 +115,59 @@ pub(super) fn command_finished_request(
         body,
     })
 }
+
+/// Render a command-finished notification body from a template string.
+///
+/// Substitutes the documented tokens with values derived from `block`,
+/// `command`, and `tab_name`:
+///
+/// - `{command}` — `command` trimmed, or `"Command"` when empty;
+/// - `{duration}` — [`format_command_duration`] of the block's duration, or
+///   an empty string when the duration is unknown;
+/// - `{exit_code}` — the block's exit code, or `"?"` when the shell omitted
+///   it;
+/// - `{cwd}` — the block's captured working directory, or an empty string;
+/// - `{tab_name}` — `tab_name` verbatim.
+///
+/// Unknown tokens are left untouched.
+fn render_command_finished_template(
+    template: &str,
+    block: &CommandBlock,
+    command: &str,
+    tab_name: &str,
+) -> String {
+    let command = command.trim();
+    let command_label = if command.is_empty() {
+        "Command"
+    } else {
+        command
+    };
+    let duration_label = block
+        .duration()
+        .map(format_command_duration)
+        .unwrap_or_default();
+    let exit_label = block
+        .exit_code
+        .map_or_else(|| "?".to_owned(), |code| code.to_string());
+    let cwd_label = block.cwd.as_deref().unwrap_or("");
+
+    template
+        .replace(TOKEN_COMMAND, command_label)
+        .replace(TOKEN_DURATION, &duration_label)
+        .replace(TOKEN_EXIT_CODE, &exit_label)
+        .replace(TOKEN_CWD, cwd_label)
+        .replace(TOKEN_TAB_NAME, tab_name)
+}
+
+// Template token literals, defined as module constants so the
+// brace-delimited placeholders are not mistaken for `format!`-style
+// arguments by clippy's `literal_string_with_formatting_args` lint —
+// these are user-facing template tokens, not Rust formatting directives.
+const TOKEN_COMMAND: &str = "{command}";
+const TOKEN_DURATION: &str = "{duration}";
+const TOKEN_EXIT_CODE: &str = "{exit_code}";
+const TOKEN_CWD: &str = "{cwd}";
+const TOKEN_TAB_NAME: &str = "{tab_name}";
 
 /// Stateless notification dispatcher.
 ///
@@ -343,7 +395,7 @@ mod tests {
         let block = finished_block(Some(0), 30);
         let mut config = enabled_config(1.0);
         config.enabled = false;
-        assert!(command_finished_request(&block, "ls", &config).is_none());
+        assert!(command_finished_request(&block, "ls", "tab", &config).is_none());
     }
 
     #[test]
@@ -351,7 +403,7 @@ mod tests {
         let block = finished_block(Some(0), 30);
         let mut config = enabled_config(1.0);
         config.on_command_finished = false;
-        assert!(command_finished_request(&block, "ls", &config).is_none());
+        assert!(command_finished_request(&block, "ls", "tab", &config).is_none());
     }
 
     #[test]
@@ -359,7 +411,7 @@ mod tests {
         // 2s command, 10s threshold -> suppressed.
         let block = finished_block(Some(0), 2);
         let config = enabled_config(10.0);
-        assert!(command_finished_request(&block, "ls", &config).is_none());
+        assert!(command_finished_request(&block, "ls", "tab", &config).is_none());
     }
 
     #[test]
@@ -379,14 +431,14 @@ mod tests {
             finished_at: None,
         };
         let config = enabled_config(0.0);
-        assert!(command_finished_request(&running, "ls", &config).is_none());
+        assert!(command_finished_request(&running, "ls", "tab", &config).is_none());
     }
 
     #[test]
     fn command_finished_request_success_is_command_finished_kind() {
         let block = finished_block(Some(0), 30);
         let config = enabled_config(1.0);
-        let req = command_finished_request(&block, "cargo build", &config).expect("request");
+        let req = command_finished_request(&block, "cargo build", "tab", &config).expect("request");
         assert_eq!(req.kind, NotificationKind::CommandFinished);
         assert!(req.body.contains("cargo build"), "body: {}", req.body);
         assert!(req.body.contains("finished in"), "body: {}", req.body);
@@ -396,17 +448,19 @@ mod tests {
     fn command_finished_request_failure_is_error_kind() {
         let block = finished_block(Some(127), 30);
         let config = enabled_config(1.0);
-        let req = command_finished_request(&block, "nope", &config).expect("request");
+        let req = command_finished_request(&block, "nope", "tab", &config).expect("request");
+        // A non-zero exit drives the Error kind regardless of the template
+        // body (which uses {exit_code} rather than a "failed" verb).
         assert_eq!(req.kind, NotificationKind::Error);
         assert!(req.body.contains("exit 127"), "body: {}", req.body);
-        assert!(req.body.contains("failed"), "body: {}", req.body);
+        assert!(req.body.contains("nope"), "body: {}", req.body);
     }
 
     #[test]
     fn command_finished_request_empty_command_uses_placeholder() {
         let block = finished_block(Some(0), 30);
         let config = enabled_config(1.0);
-        let req = command_finished_request(&block, "   ", &config).expect("request");
+        let req = command_finished_request(&block, "   ", "tab", &config).expect("request");
         assert!(req.body.starts_with("Command "), "body: {}", req.body);
     }
 
@@ -425,5 +479,88 @@ mod tests {
         let mut unfocused_toasts = ToastStack::default();
         NotificationRouter::route(&osc_req("hi"), &config, false, &mut unfocused_toasts);
         assert_eq!(unfocused_toasts.len(), 0, "unfocused -> system, no toast");
+    }
+
+    fn block_with_cwd(exit_code: Option<i32>, dur_secs: u64, cwd: Option<&str>) -> CommandBlock {
+        use freminal_common::buffer_states::command_block::CommandBlockId;
+        use std::time::{Duration, SystemTime};
+        let executed = SystemTime::now();
+        CommandBlock {
+            id: CommandBlockId::next(),
+            fid: "t".to_owned(),
+            prompt_start_row: 0,
+            command_start_row: Some(0),
+            output_start_row: Some(0),
+            end_row: Some(1),
+            exit_code,
+            cwd: cwd.map(str::to_owned),
+            started_at: executed,
+            executed_at: Some(executed),
+            finished_at: Some(executed + Duration::from_secs(dur_secs)),
+        }
+    }
+
+    #[test]
+    fn template_substitutes_all_tokens() {
+        let block = block_with_cwd(Some(0), 30, Some("/home/fred"));
+        let body = render_command_finished_template(
+            "{command} | {duration} | {exit_code} | {cwd} | {tab_name}",
+            &block,
+            "cargo build",
+            "work",
+        );
+        assert_eq!(body, "cargo build | 30s | 0 | /home/fred | work");
+    }
+
+    #[test]
+    fn template_empty_command_falls_back_to_placeholder() {
+        let block = block_with_cwd(Some(0), 5, None);
+        let body = render_command_finished_template("{command}", &block, "   ", "tab");
+        assert_eq!(body, "Command");
+    }
+
+    #[test]
+    fn template_unknown_exit_code_renders_question_mark() {
+        // Shell omitted the exit code.
+        let block = block_with_cwd(None, 5, None);
+        let body = render_command_finished_template("exit {exit_code}", &block, "ls", "tab");
+        assert_eq!(body, "exit ?");
+    }
+
+    #[test]
+    fn template_unknown_cwd_renders_empty() {
+        let block = block_with_cwd(Some(0), 5, None);
+        let body = render_command_finished_template("[{cwd}]", &block, "ls", "tab");
+        assert_eq!(body, "[]");
+    }
+
+    #[test]
+    fn template_unknown_token_is_left_untouched() {
+        let block = block_with_cwd(Some(0), 5, None);
+        let body = render_command_finished_template("{command} {unknown}", &block, "ls", "tab");
+        assert_eq!(body, "ls {unknown}");
+    }
+
+    #[test]
+    fn command_finished_request_uses_custom_template() {
+        let block = block_with_cwd(Some(0), 30, Some("/srv"));
+        let config = NotificationsConfig {
+            command_finished_template: "{tab_name}: {command} ({cwd})".to_owned(),
+            ..enabled_config(1.0)
+        };
+        let req = command_finished_request(&block, "make", "build", &config).expect("request");
+        assert_eq!(req.body, "build: make (/srv)");
+        assert_eq!(req.kind, NotificationKind::CommandFinished);
+    }
+
+    #[test]
+    fn default_template_matches_documented_format() {
+        let block = block_with_cwd(Some(2), 30, None);
+        let config = enabled_config(1.0);
+        let req = command_finished_request(&block, "test", "tab", &config).expect("request");
+        // Default: "{command} finished in {duration} (exit {exit_code})".
+        assert_eq!(req.body, "test finished in 30s (exit 2)");
+        // Non-zero exit -> Error kind.
+        assert_eq!(req.kind, NotificationKind::Error);
     }
 }

--- a/freminal/src/gui/notifications.rs
+++ b/freminal/src/gui/notifications.rs
@@ -186,11 +186,23 @@ impl NotificationRouter {
     fn show_system(req: &NotificationRequest) {
         let summary = req.summary().to_owned();
         let body = req.body.clone();
+        // Error-category notifications use Critical urgency so they persist
+        // and pop as a banner; everything else is Normal. Many Linux
+        // notification daemons only raise a banner (rather than silently
+        // filing the notification in the tray) when an urgency hint is set.
+        let urgency = match req.kind {
+            NotificationKind::Error => notify_rust::Urgency::Critical,
+            NotificationKind::OscText
+            | NotificationKind::CommandFinished
+            | NotificationKind::Info => notify_rust::Urgency::Normal,
+        };
         let builder = std::thread::Builder::new().name("freminal-notify".to_owned());
         if let Err(e) = builder.spawn(move || {
             if let Err(e) = notify_rust::Notification::new()
+                .appname("freminal")
                 .summary(&summary)
                 .body(&body)
+                .urgency(urgency)
                 .show()
             {
                 tracing::warn!("failed to show desktop notification: {e}");

--- a/freminal/src/gui/notifications.rs
+++ b/freminal/src/gui/notifications.rs
@@ -1,0 +1,417 @@
+// Copyright (C) 2024-2026 Fred Clausen
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! GUI-side notification router (Task 76).
+//!
+//! Consumes notification requests originating from OSC 9 / OSC 777
+//! sequences (forwarded via `WindowManipulation::Notification`, Task 76.3)
+//! and from OSC 133 `D` command-finished events (Task 72.9), then applies
+//! the per-category routing policy from the `[notifications]` config:
+//!
+//! - **Toast leg:** push an entry onto the in-app [`ToastStack`].
+//! - **System leg:** show a desktop notification via `notify-rust` on a
+//!   short-lived background thread (the D-Bus call blocks briefly on Linux).
+//!
+//! Routing is decided per [`NotificationKind`] using the focus-aware
+//! [`NotificationRouting::wants_toast`] / [`NotificationRouting::wants_system`]
+//! helpers. The system leg additionally requires that `notify-rust` is the
+//! intended sink; the toast leg never spawns a thread.
+
+use freminal_common::buffer_states::command_block::{CommandBlock, CommandStatus};
+use freminal_common::buffer_states::window_manipulation::NotificationKind;
+use freminal_common::config::{NotificationRouting, NotificationsConfig};
+
+use super::command_blocks::format_command_duration;
+use super::toast::ToastStack;
+
+/// A fully-formed notification ready to be routed.
+///
+/// Produced by the OSC 9 / OSC 777 path (`handle_window_manipulation`) and
+/// the command-finished path (the per-pane drain in `update()`), then handed
+/// to [`NotificationRouter::route`].
+#[derive(Debug, Clone)]
+pub(super) struct NotificationRequest {
+    /// The notification category, selecting the routing policy.
+    pub kind: NotificationKind,
+    /// The notification title. `None` falls back to a kind-derived default.
+    pub title: Option<String>,
+    /// The notification body text.
+    pub body: String,
+}
+
+impl NotificationRequest {
+    /// The summary/title string shown to the user, falling back to a
+    /// category-derived default when the source supplied no title.
+    fn summary(&self) -> &str {
+        self.title.as_deref().unwrap_or(match self.kind {
+            NotificationKind::OscText | NotificationKind::Info => "Notification",
+            NotificationKind::CommandFinished => "Command finished",
+            NotificationKind::Error => "Error",
+        })
+    }
+}
+
+/// Build a command-finished [`NotificationRequest`] from a completed
+/// [`CommandBlock`], applying the `[notifications]` enable and
+/// duration-threshold gates.
+///
+/// Returns `None` (no notification) when any of the following hold:
+///
+/// - the notification system is disabled, or `on_command_finished` is off;
+/// - the command is not actually finished (`status() == Running`);
+/// - the command's duration is below `command_finished_threshold_secs`
+///   (or the duration is unknown — clock skew / missing timestamps).
+///
+/// A failed command produces an [`NotificationKind::Error`]; success or
+/// unknown-exit produces [`NotificationKind::CommandFinished`]. `command`
+/// is the extracted command text (may be empty if it scrolled out of the
+/// buffer before extraction).
+pub(super) fn command_finished_request(
+    block: &CommandBlock,
+    command: &str,
+    config: &NotificationsConfig,
+) -> Option<NotificationRequest> {
+    if !config.enabled || !config.on_command_finished {
+        return None;
+    }
+
+    let status = block.status();
+    if status == CommandStatus::Running {
+        return None;
+    }
+
+    let duration = block.duration()?;
+    if duration.as_secs_f32() < config.command_finished_threshold_secs {
+        return None;
+    }
+
+    let duration_label = format_command_duration(duration);
+    let command = command.trim();
+    let command_label = if command.is_empty() {
+        "Command".to_owned()
+    } else {
+        command.to_owned()
+    };
+
+    // A non-zero exit is an error notification; success / unknown-exit
+    // (shell omitted the code) are informational "finished" notifications.
+    // `Running` was already excluded by the status check above.
+    let (kind, body) = if let CommandStatus::Failure(code) = status {
+        (
+            NotificationKind::Error,
+            format!("{command_label} failed in {duration_label} (exit {code})"),
+        )
+    } else {
+        (
+            NotificationKind::CommandFinished,
+            format!("{command_label} finished in {duration_label}"),
+        )
+    };
+
+    Some(NotificationRequest {
+        kind,
+        title: None,
+        body,
+    })
+}
+
+/// Stateless notification dispatcher.
+///
+/// The router holds no state of its own; it is a namespace for the routing
+/// logic so the call sites read clearly and the policy is unit-testable in
+/// isolation from the egui frame loop.
+#[derive(Debug, Default, Clone, Copy)]
+pub(super) struct NotificationRouter;
+
+impl NotificationRouter {
+    /// Route a single notification request according to `config` and the
+    /// current window focus state.
+    ///
+    /// Does nothing when the notification system is disabled
+    /// ([`NotificationsConfig::enabled`] is `false`). The toast leg pushes
+    /// onto `toasts`; the system leg spawns a background thread.
+    pub(super) fn route(
+        req: &NotificationRequest,
+        config: &NotificationsConfig,
+        focused: bool,
+        toasts: &mut ToastStack,
+    ) {
+        if !config.enabled {
+            return;
+        }
+
+        let routing = Self::routing_for(req.kind, config);
+
+        if routing.wants_toast(focused) {
+            Self::push_toast(req, toasts);
+        }
+
+        if routing.wants_system(focused) {
+            Self::show_system(req);
+        }
+    }
+
+    /// Select the routing policy for a notification category.
+    const fn routing_for(
+        kind: NotificationKind,
+        config: &NotificationsConfig,
+    ) -> NotificationRouting {
+        match kind {
+            NotificationKind::Error => config.routing_error,
+            NotificationKind::CommandFinished => config.routing_command_finished,
+            // OSC text and explicit Info both follow the info policy.
+            NotificationKind::OscText | NotificationKind::Info => config.routing_info,
+        }
+    }
+
+    /// Push the notification onto the in-app toast stack. Error-category
+    /// notifications use the error styling; everything else is informational.
+    fn push_toast(req: &NotificationRequest, toasts: &mut ToastStack) {
+        let detail = (!req.body.is_empty()).then(|| req.body.clone());
+        match req.kind {
+            NotificationKind::Error => toasts.error(req.summary().to_owned(), detail),
+            NotificationKind::OscText
+            | NotificationKind::CommandFinished
+            | NotificationKind::Info => toasts.info(req.summary().to_owned(), detail),
+        }
+    }
+
+    /// Show a desktop notification on a short-lived background thread.
+    ///
+    /// `notify-rust`'s `show()` makes a synchronous D-Bus call on Linux, so
+    /// it must not run on the egui frame thread. Failures are logged and
+    /// otherwise ignored — a missing notification daemon is non-fatal.
+    fn show_system(req: &NotificationRequest) {
+        let summary = req.summary().to_owned();
+        let body = req.body.clone();
+        let builder = std::thread::Builder::new().name("freminal-notify".to_owned());
+        if let Err(e) = builder.spawn(move || {
+            if let Err(e) = notify_rust::Notification::new()
+                .summary(&summary)
+                .body(&body)
+                .show()
+            {
+                tracing::warn!("failed to show desktop notification: {e}");
+            }
+        }) {
+            tracing::warn!("failed to spawn notification thread: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn osc_req(body: &str) -> NotificationRequest {
+        NotificationRequest {
+            kind: NotificationKind::OscText,
+            title: None,
+            body: body.to_owned(),
+        }
+    }
+
+    #[test]
+    fn summary_falls_back_per_kind() {
+        let mut req = osc_req("x");
+        assert_eq!(req.summary(), "Notification");
+        req.kind = NotificationKind::CommandFinished;
+        assert_eq!(req.summary(), "Command finished");
+        req.kind = NotificationKind::Error;
+        assert_eq!(req.summary(), "Error");
+        req.kind = NotificationKind::Info;
+        assert_eq!(req.summary(), "Notification");
+    }
+
+    #[test]
+    fn summary_uses_explicit_title_when_present() {
+        let req = NotificationRequest {
+            kind: NotificationKind::OscText,
+            title: Some("Build".to_owned()),
+            body: "done".to_owned(),
+        };
+        assert_eq!(req.summary(), "Build");
+    }
+
+    #[test]
+    fn routing_for_maps_each_kind() {
+        let mut config = NotificationsConfig {
+            routing_error: NotificationRouting::Both,
+            routing_info: NotificationRouting::Toast,
+            routing_command_finished: NotificationRouting::System,
+            ..NotificationsConfig::default()
+        };
+        config.enabled = true;
+
+        assert_eq!(
+            NotificationRouter::routing_for(NotificationKind::Error, &config),
+            NotificationRouting::Both
+        );
+        assert_eq!(
+            NotificationRouter::routing_for(NotificationKind::CommandFinished, &config),
+            NotificationRouting::System
+        );
+        assert_eq!(
+            NotificationRouter::routing_for(NotificationKind::OscText, &config),
+            NotificationRouting::Toast
+        );
+        assert_eq!(
+            NotificationRouter::routing_for(NotificationKind::Info, &config),
+            NotificationRouting::Toast
+        );
+    }
+
+    #[test]
+    fn disabled_config_pushes_no_toast() {
+        let config = NotificationsConfig::default(); // enabled = false
+        let mut toasts = ToastStack::default();
+        NotificationRouter::route(&osc_req("hello"), &config, true, &mut toasts);
+        assert_eq!(toasts.len(), 0);
+    }
+
+    #[test]
+    fn enabled_toast_routing_pushes_one_toast() {
+        let config = NotificationsConfig {
+            enabled: true,
+            routing_info: NotificationRouting::Toast,
+            ..NotificationsConfig::default()
+        };
+        let mut toasts = ToastStack::default();
+        // Focused or not, Toast routing always pushes a toast.
+        NotificationRouter::route(&osc_req("hello"), &config, false, &mut toasts);
+        assert_eq!(toasts.len(), 1);
+    }
+
+    #[test]
+    fn system_only_routing_pushes_no_toast() {
+        let config = NotificationsConfig {
+            enabled: true,
+            routing_info: NotificationRouting::System,
+            ..NotificationsConfig::default()
+        };
+        let mut toasts = ToastStack::default();
+        // System-only routing never pushes a toast (the thread is best-effort
+        // and not asserted here).
+        NotificationRouter::route(&osc_req("hello"), &config, false, &mut toasts);
+        assert_eq!(toasts.len(), 0);
+    }
+
+    fn finished_block(exit_code: Option<i32>, dur_secs: u64) -> CommandBlock {
+        use freminal_common::buffer_states::command_block::CommandBlockId;
+        use std::time::{Duration, SystemTime};
+        let executed = SystemTime::now();
+        CommandBlock {
+            id: CommandBlockId::next(),
+            fid: "t".to_owned(),
+            prompt_start_row: 0,
+            command_start_row: Some(0),
+            output_start_row: Some(0),
+            end_row: Some(1),
+            exit_code,
+            cwd: None,
+            started_at: executed,
+            executed_at: Some(executed),
+            finished_at: Some(executed + Duration::from_secs(dur_secs)),
+        }
+    }
+
+    fn enabled_config(threshold: f32) -> NotificationsConfig {
+        NotificationsConfig {
+            enabled: true,
+            command_finished_threshold_secs: threshold,
+            ..NotificationsConfig::default()
+        }
+    }
+
+    #[test]
+    fn command_finished_request_gated_by_disabled() {
+        let block = finished_block(Some(0), 30);
+        let mut config = enabled_config(1.0);
+        config.enabled = false;
+        assert!(command_finished_request(&block, "ls", &config).is_none());
+    }
+
+    #[test]
+    fn command_finished_request_gated_by_on_command_finished() {
+        let block = finished_block(Some(0), 30);
+        let mut config = enabled_config(1.0);
+        config.on_command_finished = false;
+        assert!(command_finished_request(&block, "ls", &config).is_none());
+    }
+
+    #[test]
+    fn command_finished_request_gated_by_threshold() {
+        // 2s command, 10s threshold -> suppressed.
+        let block = finished_block(Some(0), 2);
+        let config = enabled_config(10.0);
+        assert!(command_finished_request(&block, "ls", &config).is_none());
+    }
+
+    #[test]
+    fn command_finished_request_running_block_is_none() {
+        use freminal_common::buffer_states::command_block::CommandBlockId;
+        let running = CommandBlock {
+            id: CommandBlockId::next(),
+            fid: "t".to_owned(),
+            prompt_start_row: 0,
+            command_start_row: Some(0),
+            output_start_row: Some(0),
+            end_row: None,
+            exit_code: None,
+            cwd: None,
+            started_at: std::time::SystemTime::now(),
+            executed_at: Some(std::time::SystemTime::now()),
+            finished_at: None,
+        };
+        let config = enabled_config(0.0);
+        assert!(command_finished_request(&running, "ls", &config).is_none());
+    }
+
+    #[test]
+    fn command_finished_request_success_is_command_finished_kind() {
+        let block = finished_block(Some(0), 30);
+        let config = enabled_config(1.0);
+        let req = command_finished_request(&block, "cargo build", &config).expect("request");
+        assert_eq!(req.kind, NotificationKind::CommandFinished);
+        assert!(req.body.contains("cargo build"), "body: {}", req.body);
+        assert!(req.body.contains("finished in"), "body: {}", req.body);
+    }
+
+    #[test]
+    fn command_finished_request_failure_is_error_kind() {
+        let block = finished_block(Some(127), 30);
+        let config = enabled_config(1.0);
+        let req = command_finished_request(&block, "nope", &config).expect("request");
+        assert_eq!(req.kind, NotificationKind::Error);
+        assert!(req.body.contains("exit 127"), "body: {}", req.body);
+        assert!(req.body.contains("failed"), "body: {}", req.body);
+    }
+
+    #[test]
+    fn command_finished_request_empty_command_uses_placeholder() {
+        let block = finished_block(Some(0), 30);
+        let config = enabled_config(1.0);
+        let req = command_finished_request(&block, "   ", &config).expect("request");
+        assert!(req.body.starts_with("Command "), "body: {}", req.body);
+    }
+
+    #[test]
+    fn system_when_unfocused_pushes_toast_only_when_focused() {
+        let config = NotificationsConfig {
+            enabled: true,
+            routing_info: NotificationRouting::SystemWhenUnfocused,
+            ..NotificationsConfig::default()
+        };
+
+        let mut focused_toasts = ToastStack::default();
+        NotificationRouter::route(&osc_req("hi"), &config, true, &mut focused_toasts);
+        assert_eq!(focused_toasts.len(), 1, "focused -> toast");
+
+        let mut unfocused_toasts = ToastStack::default();
+        NotificationRouter::route(&osc_req("hi"), &config, false, &mut unfocused_toasts);
+        assert_eq!(unfocused_toasts.len(), 0, "unfocused -> system, no toast");
+    }
+}

--- a/freminal/src/gui/rendering.rs
+++ b/freminal/src/gui/rendering.rs
@@ -509,6 +509,17 @@ pub(super) fn handle_window_manipulation(
                         ));
                 }
             }
+
+            // OSC 9 / OSC 777 desktop notification (Task 76).  The dispatch
+            // landed in 76.3; the notification router that applies the
+            // `[notifications]` routing policy (toast vs system daemon) is
+            // wired in 76.4.
+            // TODO(76.4): route through NotificationRouter.
+            WindowManipulation::Notification { kind, title, body } => {
+                tracing::debug!(
+                    "notification (pending 76.4 routing): kind={kind:?}, title={title:?}, body={body:?}"
+                );
+            }
         }
     }
     shell_set_title

--- a/freminal/src/gui/rendering.rs
+++ b/freminal/src/gui/rendering.rs
@@ -19,6 +19,7 @@ use freminal_common::themes::ThemePalette;
 use freminal_terminal_emulator::io::WindowCommand;
 
 use crate::gui::colors::internal_color_to_egui_with_alpha;
+use crate::gui::notifications::NotificationRequest;
 
 pub(super) fn set_egui_options(ctx: &egui::Context, theme: &ThemePalette, bg_opacity: f32) {
     ctx.global_style_mut(|style| {
@@ -182,6 +183,7 @@ pub(super) fn handle_window_manipulation(
     bell_since: &mut Option<Instant>,
     bell_mode: BellMode,
     flags: &WindowManipFlags,
+    notifications: &mut Vec<NotificationRequest>,
 ) -> bool {
     // Whether the shell set (or restored) a title during this frame.  Used
     // by the caller to clear any user-assigned custom tab name, so
@@ -510,15 +512,12 @@ pub(super) fn handle_window_manipulation(
                 }
             }
 
-            // OSC 9 / OSC 777 desktop notification (Task 76).  The dispatch
-            // landed in 76.3; the notification router that applies the
-            // `[notifications]` routing policy (toast vs system daemon) is
-            // wired in 76.4.
-            // TODO(76.4): route through NotificationRouter.
+            // OSC 9 / OSC 777 desktop notification (Task 76).  Collect into
+            // the out-parameter; the caller in `app_impl::update()` (where
+            // `self.config` and the toast stack are in scope) dispatches each
+            // request through the `NotificationRouter`.
             WindowManipulation::Notification { kind, title, body } => {
-                tracing::debug!(
-                    "notification (pending 76.4 routing): kind={kind:?}, title={title:?}, body={body:?}"
-                );
+                notifications.push(NotificationRequest { kind, title, body });
             }
         }
     }

--- a/freminal/src/gui/settings.rs
+++ b/freminal/src/gui/settings.rs
@@ -25,6 +25,7 @@ pub enum SettingsTab {
     Tabs,
     ShellIntegration,
     Bell,
+    Notifications,
     Security,
     Keybindings,
     Startup,
@@ -32,7 +33,7 @@ pub enum SettingsTab {
 
 impl SettingsTab {
     /// All tabs in display order.
-    const ALL: [Self; 13] = [
+    const ALL: [Self; 14] = [
         Self::Font,
         Self::Cursor,
         Self::Theme,
@@ -43,6 +44,7 @@ impl SettingsTab {
         Self::Tabs,
         Self::ShellIntegration,
         Self::Bell,
+        Self::Notifications,
         Self::Security,
         Self::Keybindings,
         Self::Startup,
@@ -60,6 +62,7 @@ impl SettingsTab {
             Self::Tabs => "Tabs",
             Self::ShellIntegration => "Shell Integration",
             Self::Bell => "Bell",
+            Self::Notifications => "Notifications",
             Self::Security => "Security",
             Self::Keybindings => "Keybindings",
             Self::Startup => "Startup",
@@ -94,6 +97,10 @@ pub enum SettingsAction {
     /// The modal was closed without Apply while opacity was being previewed —
     /// revert to the original value.
     RevertOpacity(f32),
+    /// The user clicked "Test Notification" in the Notifications tab — route
+    /// a sample notification through the current draft `[notifications]`
+    /// config so the user can verify routing without running a command.
+    TestNotification,
 }
 
 /// Result of scanning a frame's egui events for a key-binding press.
@@ -222,6 +229,12 @@ pub struct SettingsModal {
     /// `Asking`, the settings UI renders a confirmation prompt instead of
     /// actually closing.  Cleared by Save / Discard / keep-open decisions.
     pending_close: PendingClose,
+
+    /// Set by `show_notifications_tab` when the user clicks "Test
+    /// Notification".  Consumed by `show` / `show_standalone` which return it
+    /// as `SettingsAction::TestNotification` so the app can route a sample
+    /// notification through the draft `[notifications]` config.
+    pending_test_notification: bool,
 }
 
 impl SettingsModal {
@@ -247,6 +260,7 @@ impl SettingsModal {
             pending_delete_layout: None,
             baseline_toml: String::new(),
             pending_close: PendingClose::None,
+            pending_test_notification: false,
         }
     }
 
@@ -513,6 +527,10 @@ impl SettingsModal {
             return SettingsAction::DeleteLayout(path);
         }
 
+        if std::mem::take(&mut self.pending_test_notification) {
+            return SettingsAction::TestNotification;
+        }
+
         if !self.is_open && action != SettingsAction::Applied {
             let theme_changed = self.original_theme_slug != theme_before;
             let opacity_changed = (self.original_opacity - opacity_before).abs() > f32::EPSILON;
@@ -666,6 +684,10 @@ impl SettingsModal {
             return SettingsAction::DeleteLayout(path);
         }
 
+        if std::mem::take(&mut self.pending_test_notification) {
+            return SettingsAction::TestNotification;
+        }
+
         if !self.is_open && action != SettingsAction::Applied {
             let theme_changed = self.original_theme_slug != theme_before;
             let opacity_changed = (self.original_opacity - opacity_before).abs() > f32::EPSILON;
@@ -705,6 +727,14 @@ impl SettingsModal {
         &self.draft
     }
 
+    /// Returns the draft `[notifications]` config so the app can route a
+    /// "Test Notification" through exactly the settings the user is currently
+    /// editing (including unsaved changes).
+    #[must_use]
+    pub(super) const fn draft_notifications(&self) -> &config::NotificationsConfig {
+        &self.draft.notifications
+    }
+
     // -------------------------------------------------------------------------
     //  Tab dispatch
     // -------------------------------------------------------------------------
@@ -722,6 +752,7 @@ impl SettingsModal {
             SettingsTab::Tabs => self.show_tabs_tab(ui),
             SettingsTab::ShellIntegration => self.show_shell_integration_tab(ui),
             SettingsTab::Bell => self.show_bell_tab(ui),
+            SettingsTab::Notifications => self.show_notifications_tab(ui),
             SettingsTab::Security => self.show_security_tab(ui),
             SettingsTab::Keybindings => self.show_keybindings_tab(ui),
             SettingsTab::Startup => self.show_startup_tab(ui),
@@ -1396,6 +1427,151 @@ impl SettingsModal {
             "Visual: briefly flash the terminal area.\n\
              None: silently ignore the bell.",
         );
+
+        ui.add_space(12.0);
+
+        ui.checkbox(
+            &mut self.draft.bell.on_command_finished,
+            "Ring bell on command completion",
+        );
+        ui.add_space(4.0);
+        ui.colored_label(
+            egui::Color32::GRAY,
+            "Ring the bell (using the mode above) when a command finishes \
+             (OSC 133 D), even if the program emitted no bell character. \
+             Requires shell integration.",
+        );
+    }
+
+    fn show_notifications_tab(&mut self, ui: &mut Ui) {
+        ui.checkbox(
+            &mut self.draft.notifications.enabled,
+            "Enable notifications",
+        );
+        ui.add_space(4.0);
+        ui.colored_label(
+            egui::Color32::GRAY,
+            "Master switch. When off, no toasts or desktop notifications are \
+             produced, regardless of the options below.",
+        );
+
+        ui.add_space(12.0);
+        ui.heading("Sources");
+        ui.checkbox(
+            &mut self.draft.notifications.osc_9,
+            "OSC 9 (iTerm2 / WezTerm text)",
+        );
+        ui.checkbox(
+            &mut self.draft.notifications.osc_777,
+            "OSC 777 (urxvt notify;TITLE;BODY)",
+        );
+        ui.checkbox(
+            &mut self.draft.notifications.on_command_finished,
+            "Command finished (OSC 133 D)",
+        );
+
+        ui.add_space(12.0);
+        ui.horizontal(|ui| {
+            ui.label("Command threshold:");
+            ui.add(
+                DragValue::new(&mut self.draft.notifications.command_finished_threshold_secs)
+                    .speed(0.1)
+                    .range(0.0_f32..=600.0_f32)
+                    .suffix(" s"),
+            );
+        });
+        ui.add_space(4.0);
+        ui.colored_label(
+            egui::Color32::GRAY,
+            "Minimum command duration before a command-finished notification \
+             fires. Avoids spamming notifications for fast commands.",
+        );
+
+        ui.add_space(12.0);
+        ui.heading("Routing");
+        Self::notification_routing_row(ui, "Errors", &mut self.draft.notifications.routing_error);
+        Self::notification_routing_row(ui, "Info", &mut self.draft.notifications.routing_info);
+        Self::notification_routing_row(
+            ui,
+            "Command finished",
+            &mut self.draft.notifications.routing_command_finished,
+        );
+
+        ui.add_space(12.0);
+        ui.heading("Template");
+        ui.label("Command-finished notification body:");
+        ui.add(
+            egui::TextEdit::singleline(&mut self.draft.notifications.command_finished_template)
+                .desired_width(f32::INFINITY),
+        );
+        ui.add_space(4.0);
+        ui.colored_label(
+            egui::Color32::GRAY,
+            "Tokens: {command}, {duration}, {exit_code}, {cwd}, {tab_name}.",
+        );
+
+        ui.add_space(8.0);
+        if ui.button("Test Notification").clicked() {
+            self.pending_test_notification = true;
+        }
+        ui.add_space(4.0);
+        ui.colored_label(
+            egui::Color32::GRAY,
+            "Dispatches a sample notification through the routing selected \
+             above (uses the current, unsaved settings).",
+        );
+
+        ui.add_space(12.0);
+        ui.heading("Bell");
+        ui.checkbox(
+            &mut self.draft.bell.on_command_finished,
+            "Ring bell on command completion",
+        );
+        ui.add_space(4.0);
+        ui.colored_label(
+            egui::Color32::GRAY,
+            "Mirrors the toggle in the Bell tab. The bell mode is configured \
+             there.",
+        );
+    }
+
+    /// Render one labeled routing combo box. Extracted so the three routing
+    /// categories share identical UI and the per-category borrow of
+    /// `self.draft.notifications` stays scoped.
+    fn notification_routing_row(
+        ui: &mut Ui,
+        label: &str,
+        routing: &mut config::NotificationRouting,
+    ) {
+        ui.horizontal(|ui| {
+            ui.label(label);
+            ComboBox::from_id_salt(format!("notif_routing_{label}"))
+                .selected_text(notification_routing_label(*routing))
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(
+                        routing,
+                        config::NotificationRouting::Toast,
+                        notification_routing_label(config::NotificationRouting::Toast),
+                    );
+                    ui.selectable_value(
+                        routing,
+                        config::NotificationRouting::System,
+                        notification_routing_label(config::NotificationRouting::System),
+                    );
+                    ui.selectable_value(
+                        routing,
+                        config::NotificationRouting::Both,
+                        notification_routing_label(config::NotificationRouting::Both),
+                    );
+                    ui.selectable_value(
+                        routing,
+                        config::NotificationRouting::SystemWhenUnfocused,
+                        notification_routing_label(
+                            config::NotificationRouting::SystemWhenUnfocused,
+                        ),
+                    );
+                });
+        });
     }
 
     fn show_security_tab(&mut self, ui: &mut Ui) {
@@ -2085,6 +2261,15 @@ const fn bell_mode_label(mode: config::BellMode) -> &'static str {
     }
 }
 
+const fn notification_routing_label(routing: config::NotificationRouting) -> &'static str {
+    match routing {
+        config::NotificationRouting::Toast => "Toast",
+        config::NotificationRouting::System => "System",
+        config::NotificationRouting::Both => "Both",
+        config::NotificationRouting::SystemWhenUnfocused => "System when unfocused",
+    }
+}
+
 /// Returns `true` when a startup layout is configured but not present in
 /// the discovered layout list.  Extracted for unit testing since the
 /// `ComboBox` UI itself is hard to exercise in isolation.
@@ -2233,6 +2418,7 @@ mod tests {
         assert_eq!(SettingsTab::Tabs.label(), "Tabs");
         assert_eq!(SettingsTab::ShellIntegration.label(), "Shell Integration");
         assert_eq!(SettingsTab::Bell.label(), "Bell");
+        assert_eq!(SettingsTab::Notifications.label(), "Notifications");
         assert_eq!(SettingsTab::Security.label(), "Security");
         assert_eq!(SettingsTab::Keybindings.label(), "Keybindings");
         assert_eq!(SettingsTab::Startup.label(), "Startup");
@@ -2300,7 +2486,56 @@ mod tests {
 
     #[test]
     fn all_tabs_present() {
-        assert_eq!(SettingsTab::ALL.len(), 13);
+        assert_eq!(SettingsTab::ALL.len(), 14);
+    }
+
+    #[test]
+    fn notification_routing_labels() {
+        assert_eq!(
+            notification_routing_label(config::NotificationRouting::Toast),
+            "Toast"
+        );
+        assert_eq!(
+            notification_routing_label(config::NotificationRouting::System),
+            "System"
+        );
+        assert_eq!(
+            notification_routing_label(config::NotificationRouting::Both),
+            "Both"
+        );
+        assert_eq!(
+            notification_routing_label(config::NotificationRouting::SystemWhenUnfocused),
+            "System when unfocused"
+        );
+    }
+
+    #[test]
+    fn notification_settings_persist_through_draft() {
+        let mut modal = SettingsModal::new(None);
+        let cfg = Config::default();
+        modal.open(&cfg, Vec::new(), false);
+        modal.draft.notifications.enabled = true;
+        modal.draft.notifications.command_finished_template = "{command}".to_owned();
+        modal.draft.bell.on_command_finished = true;
+        let applied = modal.draft.clone();
+        assert!(applied.notifications.enabled);
+        assert_eq!(applied.notifications.command_finished_template, "{command}");
+        assert!(applied.bell.on_command_finished);
+    }
+
+    #[test]
+    fn test_notification_button_sets_pending_flag() {
+        let mut modal = SettingsModal::new(None);
+        let cfg = Config::default();
+        modal.open(&cfg, Vec::new(), false);
+        assert!(!modal.pending_test_notification);
+        // Simulate the button click side-effect.
+        modal.pending_test_notification = true;
+        // The drain in `show`/`show_standalone` takes the flag and returns the
+        // action; emulate that here.
+        let drained = std::mem::take(&mut modal.pending_test_notification);
+        assert!(drained);
+        assert!(!modal.pending_test_notification);
     }
 
     #[test]

--- a/freminal/src/gui/settings_dispatch.rs
+++ b/freminal/src/gui/settings_dispatch.rs
@@ -313,6 +313,22 @@ impl FreminalGui {
                     handle.request_repaint(wid);
                 }
             }
+            SettingsAction::TestNotification => {
+                // Route a sample notification through the draft `[notifications]`
+                // config so the user sees exactly what their current (unsaved)
+                // settings produce.  The Settings window is focused when the
+                // button is clicked, so route as focused.
+                let config = self.settings_modal.draft_notifications().clone();
+                let request = crate::gui::notifications::NotificationRequest::sample();
+                if let Ok(mut toasts) = self.toasts.try_borrow_mut() {
+                    crate::gui::notifications::NotificationRouter::route_test(
+                        &request,
+                        &config,
+                        true,
+                        &mut toasts,
+                    );
+                }
+            }
             SettingsAction::RevertTheme(_, _)
             | SettingsAction::PreviewTheme(_)
             | SettingsAction::None => {}

--- a/freminal/src/gui/toast.rs
+++ b/freminal/src/gui/toast.rs
@@ -133,6 +133,13 @@ impl ToastStack {
         self.push(ToastKind::Info, title.into(), detail);
     }
 
+    /// Number of toasts currently on the stack. Test-only helper used by the
+    /// notification router tests to assert toast-leg routing decisions.
+    #[cfg(test)]
+    pub(super) const fn len(&self) -> usize {
+        self.entries.len()
+    }
+
     fn push(&mut self, kind: ToastKind, title: String, detail: Option<String>) {
         let id = self.next_id;
         self.next_id = self.next_id.wrapping_add(1);

--- a/freminal/src/main.rs
+++ b/freminal/src/main.rs
@@ -183,7 +183,7 @@ fn main() {
         let mut filter = EnvFilter::builder()
             .with_default_directive(Level::INFO.into())
             .from_env_lossy();
-        for spec in &["winit=off", "wgpu=off", "egui=off"] {
+        for spec in &["winit=off", "wgpu=off", "egui=off", "zbus=warn"] {
             match spec.parse::<Directive>() {
                 Ok(d) => filter = filter.add_directive(d),
                 Err(e) => {
@@ -212,7 +212,7 @@ fn main() {
         let mut filter = EnvFilter::builder()
             .with_default_directive(file_default_directive)
             .from_env_lossy();
-        for spec in &["winit=off", "wgpu=off", "egui=off"] {
+        for spec in &["winit=off", "wgpu=off", "egui=off", "zbus=warn"] {
             match spec.parse::<Directive>() {
                 Ok(d) => filter = filter.add_directive(d),
                 Err(e) => {

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -105,6 +105,36 @@ let
         inherit (s.security) allow_clipboard_read;
       };
 
+      tabTitleSection = lib.filterAttrs (_: v: v != null) {
+        inherit (s.tab_title) policy separator;
+      };
+
+      shellIntegrationSection = lib.filterAttrs (_: v: v != null) {
+        inherit (s.shell_integration) set_term_program;
+      };
+
+      commandBlocksSection = lib.filterAttrs (_: v: v != null) {
+        inherit (s.command_blocks)
+          enabled
+          show_duration
+          duration_threshold_secs
+          gutter
+          ;
+      };
+
+      notificationsSection = lib.filterAttrs (_: v: v != null) {
+        inherit (s.notifications)
+          enabled
+          osc_9
+          osc_777
+          on_command_finished
+          command_finished_threshold_secs
+          routing_error
+          routing_info
+          routing_command_finished
+          ;
+      };
+
       keybindingsSection = s.keybindings;
 
       shaderSection = lib.filterAttrs (_: v: v != null) {
@@ -134,6 +164,12 @@ let
       // lib.optionalAttrs (tabsSection != { }) { tabs = tabsSection; }
       // lib.optionalAttrs (bellSection != { }) { bell = bellSection; }
       // lib.optionalAttrs (securitySection != { }) { security = securitySection; }
+      // lib.optionalAttrs (tabTitleSection != { }) { tab_title = tabTitleSection; }
+      // lib.optionalAttrs (shellIntegrationSection != { }) {
+        shell_integration = shellIntegrationSection;
+      }
+      // lib.optionalAttrs (commandBlocksSection != { }) { command_blocks = commandBlocksSection; }
+      // lib.optionalAttrs (notificationsSection != { }) { notifications = notificationsSection; }
       // lib.optionalAttrs (startupSection != { }) { startup = startupSection; }
       // lib.optionalAttrs (onboardingSection != { }) { onboarding = onboardingSection; }
       // lib.optionalAttrs (keybindingsSection != { }) { keybindings = keybindingsSection; };
@@ -507,6 +543,203 @@ in
             Allow applications to read the system clipboard via OSC 52 query.
             When true, OSC 52 queries return the clipboard contents base64-encoded.
             Null uses the default (false).
+          '';
+        };
+      };
+
+      tab_title = {
+        policy = mkOption {
+          type = types.nullOr (
+            types.enum [
+              "prefix"
+              "suffix"
+              "custom_wins"
+              "osc_wins"
+            ]
+          );
+          default = null;
+          description = ''
+            How a user-assigned custom tab name combines with a shell-set
+            (OSC 0/1/2) title.
+            "prefix"      shows "{custom}{separator}{osc}";
+            "suffix"      shows "{osc}{separator}{custom}";
+            "custom_wins" shows only the custom name when set;
+            "osc_wins"    lets the shell title clear the custom name.
+            Null uses the default ("prefix").
+          '';
+        };
+
+        separator = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = ''
+            Separator inserted between the custom name and the shell title
+            under the "prefix"/"suffix" policies.
+            Null uses the default (": ").
+          '';
+        };
+      };
+
+      shell_integration = {
+        set_term_program = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = ''
+            When true, Freminal sets TERM_PROGRAM=freminal and
+            TERM_PROGRAM_VERSION in the PTY environment and injects its
+            shell-integration scripts (OSC 133 command blocks, OSC 7 cwd).
+            Null uses the default (true).
+          '';
+        };
+      };
+
+      command_blocks = {
+        enabled = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = ''
+            Master switch for OSC 133 command-block visualization. When false,
+            markers are still parsed but no gutters, duration overlays, or
+            fold/collapse affordances appear.
+            Null uses the default (true).
+          '';
+        };
+
+        show_duration = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = ''
+            Display the duration of long-running commands next to the gutter.
+            Null uses the default (true).
+          '';
+        };
+
+        duration_threshold_secs = mkOption {
+          type = types.nullOr types.float;
+          default = null;
+          description = ''
+            Minimum command duration (seconds) before a duration label is
+            rendered, to avoid flicker on fast commands.
+            Null uses the default (2.0).
+          '';
+        };
+
+        gutter = mkOption {
+          type = types.nullOr (
+            types.enum [
+              "left"
+              "off"
+            ]
+          );
+          default = null;
+          description = ''
+            Where the per-command status gutter is drawn. "left" reserves a
+            thin colored strip on the left edge; "off" disables it.
+            Null uses the default ("left").
+          '';
+        };
+      };
+
+      notifications = {
+        enabled = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = ''
+            Master switch for the notification system. When false, no
+            notifications (toast or desktop) are produced.
+            Null uses the default (false — opt-in).
+          '';
+        };
+
+        osc_9 = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = ''
+            When true, OSC 9 (iTerm2/WezTerm) text payloads create
+            notifications.
+            Null uses the default (true).
+          '';
+        };
+
+        osc_777 = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = ''
+            When true, OSC 777 ("notify;TITLE;BODY", urxvt) payloads create
+            notifications.
+            Null uses the default (true).
+          '';
+        };
+
+        on_command_finished = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = ''
+            When true, an OSC 133 D (command finished) event fires a
+            notification.
+            Null uses the default (true).
+          '';
+        };
+
+        command_finished_threshold_secs = mkOption {
+          type = types.nullOr types.float;
+          default = null;
+          description = ''
+            Minimum command duration (seconds) before a command-finished
+            notification fires, to avoid spamming on fast commands.
+            Null uses the default (10.0).
+          '';
+        };
+
+        routing_error = mkOption {
+          type = types.nullOr (
+            types.enum [
+              "toast"
+              "system"
+              "both"
+              "system_when_unfocused"
+            ]
+          );
+          default = null;
+          description = ''
+            Routing for error-category notifications: "toast" (in-app only),
+            "system" (desktop only), "both", or "system_when_unfocused"
+            (desktop when unfocused, toast when focused).
+            Null uses the default ("both").
+          '';
+        };
+
+        routing_info = mkOption {
+          type = types.nullOr (
+            types.enum [
+              "toast"
+              "system"
+              "both"
+              "system_when_unfocused"
+            ]
+          );
+          default = null;
+          description = ''
+            Routing for informational notifications (see routing_error for the
+            value meanings).
+            Null uses the default ("toast").
+          '';
+        };
+
+        routing_command_finished = mkOption {
+          type = types.nullOr (
+            types.enum [
+              "toast"
+              "system"
+              "both"
+              "system_when_unfocused"
+            ]
+          );
+          default = null;
+          description = ''
+            Routing for command-finished notifications (see routing_error for
+            the value meanings).
+            Null uses the default ("system_when_unfocused").
           '';
         };
       };

--- a/res/freminal.ti
+++ b/res/freminal.ti
@@ -1,4 +1,11 @@
 #       Reconstructed via infocmp from file: /Applications/Freminal.app/Contents/Resources/terminfo/78/freminal
+#
+#       Notification support (Task 76): Freminal handles OSC 9 (iTerm2/WezTerm)
+#       and OSC 777 (urxvt "notify;TITLE;BODY") desktop notifications.  These
+#       are one-way, fire-and-forget sequences with no capability-query
+#       handshake, and terminfo defines no capability code for them, so there
+#       is nothing to advertise here.  Programs detect Freminal at runtime via
+#       TERM_PROGRAM=freminal (set in the PTY environment) rather than terminfo.
 xterm-freminal|freminal|Freminal,
         am, bce, ccc, hs, km, mc5i, mir, msgr, npc, xenl,
         colors#256, cols#80, it#8, lines#24, pairs#32767,

--- a/shell-integration/README.md
+++ b/shell-integration/README.md
@@ -87,6 +87,32 @@ end
 
 ---
 
+## Desktop Notifications (OSC 9 / OSC 777)
+
+Freminal raises a desktop notification (and/or an in-app toast) when a
+program emits an [OSC 9](https://iterm2.com/documentation-escape-codes.html)
+(iTerm2/WezTerm) or [OSC 777](https://github.com/tmux/tmux/wiki/Modifier-Keys)
+(urxvt `notify;TITLE;BODY`) sequence, and on command completion when
+`[notifications] on_command_finished` is enabled (see the `[notifications]`
+section of `config_example.toml`).
+
+These sequences are **one-way and fire-and-forget** — there is no
+capability-query handshake to test for. The portable way to decide whether
+to emit them is the `TERM_PROGRAM` environment variable, which Freminal sets
+to `freminal`:
+
+```sh
+if [ "${TERM_PROGRAM:-}" = "freminal" ]; then
+    notify_via_osc9() { printf '\e]9;%s\a' "$1"; }
+    notify_via_osc777() { printf '\e]777;notify;%s;%s\a' "$1" "$2"; }
+fi
+```
+
+OSC 9 takes a single body string; OSC 777 takes a title and a body. Both are
+ignored unless `[notifications] enabled = true`.
+
+---
+
 ## Compatibility Notes
 
 ### OSC 7 double-emission is harmless


### PR DESCRIPTION
## Summary

Implements **Task 76 — Notification System** for v0.9.0 (`PLAN_VERSION_090.md`). Freminal now raises in-app toasts and/or desktop notifications from OSC 9 (iTerm2/WezTerm), OSC 777 (urxvt `notify;TITLE;BODY`), and OSC 133 `D` command-finished events, with per-category routing, a configurable command-finished template, and a Settings UI.

All subtasks 76.1–76.8 are complete. Opt-in via `[notifications] enabled = true` (default off).

## Subtasks

| # | Description |
| --- | --- |
| 76.1 | Add `notify-rust` dep + `[notifications]` config section + `NotificationRouting` |
| 76.2 | Parse OSC 9 and OSC 777 into `AnsiOscType::Notify` |
| 76.3 | Forward notifications to the GUI via `WindowManipulation::Notification` |
| 76.4 | GUI `NotificationRouter` (toast + system-daemon legs) for OSC + command-finished |
| 76.4a | Fix: `[notifications]` (and `shell_integration`/`command_blocks`/`tab_title`) never loaded from user TOML (missing `ConfigPartial` fields) |
| 76.4b | Polish: silence zbus log spam; set desktop-notification urgency/appname |
| 76.4c | Config load-path audit + self-protecting guard test |
| 76.5 | Notification template (`{command}`/`{duration}`/`{exit_code}`/`{cwd}`/`{tab_name}`) + `[bell] on_command_finished` |
| 76.6 | Verify capability responders (XTGETTCAP TN, XTVERSION) + document `TERM_PROGRAM` detection |
| 76.7 | Settings UI: Notifications tab (sources, threshold, routing, template, Test Notification, bell toggle) |
| 76.8 | Docs (escape-sequence coverage/gaps + README) — absorbed into 76.2/76.6 |

## Notable design decisions

- **Handler→GUI transport** routes through `WindowManipulation::Notification` (the existing `Bell`/`SetClipboard` path) rather than a new `WindowCommand` variant, since the handler does not own a `Sender<WindowCommand>` (same constraint as 72.3).
- **76.6 deliberately did not change** `XTGETTCAP TN` (stays `xterm-256color`, matching `TERM`) or the `XTVERSION` `>|XTerm(Freminal …)` payload (the `XTerm(` prefix is load-bearing for tmux `extkeys`). The freminal identity is advertised via `TERM_PROGRAM=freminal` (72.6). Added regression guards instead.
- **76.4a/76.4c** fixed and durably guarded a latent config-loader bug (whole sections silently dropped because `ConfigPartial` was missing fields).

## Verification

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all`, and `cargo machete` all clean. Each commit leaves the tree green.