### PR TITLE
Task 77: Smart Paste Guard

### DIFF
--- a/.opencode/skills/freminal-modal-input-suppression/SKILL.md
+++ b/.opencode/skills/freminal-modal-input-suppression/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: freminal-modal-input-suppression
+description: Use ONLY when working in the freminal repository AND adding, editing, or debugging a GUI modal, dialog, overlay, popup, or any in-window widget that contains a focusable input (a TextEdit, search box, name field, filter box, etc.). Triggers on "my dialog doesn't accept typing", "focus bounces back to the terminal", "the modal renders but I can't type in it", "Escape/Enter does nothing in the dialog", or creating a new egui::Window/Area on the terminal surface. Codifies the ui_overlay_open registration + lock_focus(true) + per-frame request_focus pattern that every working modal uses, and that every new modal forgets.
+---
+
+# Freminal: a new modal must register with `ui_overlay_open` or it can't be typed in
+
+This is the single most-repeated GUI bug in freminal. A new modal/overlay
+renders fine, but **keystrokes go to the terminal (the PTY) instead of the
+modal's text field** — focus appears to "bounce back" to the terminal. It has
+been (re)fixed for the settings modal, the buffer-search overlay, the
+command-history palette, the tab-rename editor, the save-layout prompt, and the
+paste-guard confirm dialog (Task 77).
+
+The cause is always the same: the terminal widget aggressively grabs egui
+keyboard focus and forwards every key event to the PTY. Unless the new modal
+**opts the active pane out of that behaviour**, the modal's `TextEdit` never
+keeps focus.
+
+## The two-part fix (do both, every time)
+
+### Part 1 — register the modal in `ui_overlay_open`
+
+`FreminalGui::update()` computes a single boolean,
+`ui_overlay_open`, in `freminal/src/gui/app_impl.rs` (search for
+`let ui_overlay_open =`). It currently OR-s together every overlay's
+"is open" predicate:
+
+```rust
+let ui_overlay_open = any_menu_open
+    || self.pending_save_layout.is_some()
+    || self.about_window_open
+    || self.welcome.is_open()
+    || win.renaming_tab.is_some()
+    || win.paste_dialog.is_open();   // each modal adds its own line
+```
+
+**Add your modal's open-predicate to this expression.** That is the whole
+gate. `ui_overlay_open` is passed into every pane's
+`terminal_widget.show(...)`, where it becomes `suppress_input` (in
+`freminal/src/gui/terminal/widget.rs`, search `let suppress_input =`). When
+`suppress_input` is true the widget:
+
+1. **skips the focus-lock grab** — the block that calls
+   `response.request_focus()` + `set_focus_lock_filter(...)` on the
+   `terminal_focus` id is gated on `!suppress_input`. Skipping it releases the
+   terminal's hold on Tab / arrows / Escape so egui can route them to your
+   modal.
+2. **bypasses `write_input_to_terminal` entirely** — the big
+   `if suppress_input || ... { /* reset, send nothing */ } else { ui.input(... write_input_to_terminal ...) }`
+   block means the PTY receives no key or mouse events that frame.
+
+There is a deliberate **one-frame trailing suppression**
+(`overlay_was_open_last_frame`) so the click that dismisses a modal does not
+leak to the terminal as a pointer event. You do not need to touch it; just
+make sure your open-predicate flips to `false` the frame the modal closes.
+
+A few overlays gate at the pane level instead of through `ui_overlay_open`
+(buffer search and command history are checked directly as
+`view_state.search_state.is_open` / `view_state.command_history.is_open` inside
+`widget.rs` because their state lives on `ViewState`, not `PerWindowState`).
+Either location works; the rule is that **some predicate the widget can see
+must be true while your modal is open**. For a modal whose state lives on
+`PerWindowState` or `FreminalGui`, `ui_overlay_open` is the right place.
+
+### Part 2 — make the modal's `TextEdit` hold focus
+
+Registering with `ui_overlay_open` stops the terminal from stealing focus, but
+your field still has to _take and keep_ it. Requesting focus once on open is
+**not enough** — egui can hand focus back. Mirror the search / command-history
+pattern exactly:
+
+```rust
+let response = ui.add(
+    egui::TextEdit::multiline(&mut state.edit_buffer)   // or ::singleline
+        .font(egui::TextStyle::Monospace)
+        .desired_width(f32::INFINITY)
+        // Hold focus so Tab / clicks inside the dialog don't bounce focus away.
+        .lock_focus(true),
+);
+// Pull focus EVERY frame it lacks it — not just on the first frame.
+if !response.has_focus() {
+    response.request_focus();
+}
+```
+
+Reference implementations to copy from:
+
+- `freminal/src/gui/search.rs` — `show_search_bar` (`.lock_focus(true)` +
+  per-frame `request_focus`).
+- `freminal/src/gui/command_history.rs` — `show_command_history_palette` (same
+  pattern, plus consuming Up/Down/Enter/Escape via `ui.input` so they never
+  reach the PTY).
+
+Do **not** keep a `just_opened` / `just_entered_edit` bool to request focus
+"only once" — that is the anti-pattern that causes the bounce. The per-frame
+`if !has_focus { request_focus() }` is the correct idiom and makes such a flag
+dead state (clippy will flag it).
+
+## Keyboard shortcuts inside the modal
+
+Read Escape / Enter / Ctrl+Enter via `ctx.input(|i| i.key_pressed(...))` (or
+`ui.input`). Because the terminal's focus-lock is released (Part 1) and the
+PTY is not being fed (Part 1), those keys are free for the modal. Resolve
+button clicks before keyboard shortcuts in the same frame so a click wins if
+both happen.
+
+## How to verify
+
+1. Build and run. Open the modal.
+2. Type into its field — characters must appear in the field, **not** in the
+   terminal behind it.
+3. Press Escape — the modal cancels; the terminal does not receive an Escape.
+4. With a text field focused, press Tab — focus stays in the field
+   (that is what `lock_focus(true)` buys you).
+
+There is no automated test for the full focus path (it needs a live egui
+context). The boolean state machine for the one-frame trailing suppression is
+unit-tested in `widget.rs` (`mod overlay_suppress_input_tests`,
+`suppress_input_state_machine`); extend or mirror that if you change the
+suppression logic itself, but the per-modal registration is verified manually.
+
+## Why this keeps happening (and the smell to watch for)
+
+Nothing in the type system forces a new modal to register with
+`ui_overlay_open`. A modal added without it compiles, renders, and looks
+finished — the bug only shows when you try to type. **Whenever you add an
+`egui::Window` / `egui::Area` / popup on the terminal surface that contains a
+focusable widget, treat "register in `ui_overlay_open`" and "lock_focus +
+per-frame request_focus" as part of the definition of done**, the same way a
+new config option is not done until it is wired through `ConfigPartial` (see
+`freminal-config-options`).
+
+## When to stop and ask
+
+- Your modal's open-state lives somewhere the terminal widget cannot see
+  (neither `PerWindowState`, `FreminalGui`, nor `ViewState`). Surface this —
+  the gate needs a predicate the widget can read.
+- You believe the modal genuinely should let some keys fall through to the
+  terminal (a rare, deliberate design). Confirm with the user; the default is
+  full suppression.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,6 +1578,7 @@ dependencies = [
  "directories",
  "predicates",
  "proptest",
+ "regex",
  "serde",
  "tempfile",
  "test-log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "freminal"
-version = "0.9.0-beta.2"
+version = "0.9.0-beta.3"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-buffer"
-version = "0.9.0-beta.2"
+version = "0.9.0-beta.3"
 dependencies = [
  "conv2",
  "criterion",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-common"
-version = "0.9.0-beta.2"
+version = "0.9.0-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-terminal-emulator"
-version = "0.9.0-beta.2"
+version = "0.9.0-beta.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-windowing"
-version = "0.9.0-beta.2"
+version = "0.9.0-beta.3"
 dependencies = [
  "conv2",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["freminal", "freminal-buffer", "freminal-common", "freminal-terminal-
 default-members = ["freminal", "freminal-buffer", "freminal-common", "freminal-terminal-emulator"]
 
 [workspace.package]
-version = "0.9.0-beta.2"
+version = "0.9.0-beta.3"
 edition = "2024"
 rust-version = "1.95.0"
 description = "A terminal emulator written in Rust"

--- a/Documents/MASTER_PLAN.md
+++ b/Documents/MASTER_PLAN.md
@@ -107,7 +107,7 @@ Panes) was subsumed by Task 58. Task 56 (Session Restore) was subsumed by Task 6
 | 74  | Broadcast Input to Panes                 | `PLAN_VERSION_090.md` (Task 74)               | Stub          | v0.8.0, Task 58        |
 | 75  | Workspace-Scoped Environment             | `PLAN_VERSION_090.md` (Task 75)               | Stub          | v0.8.0, Task 61        |
 | 76  | Notification System (OSC 9 / OSC 777)    | `PLAN_VERSION_090.md` (Task 76)               | Pending merge | v0.8.0, Task 72        |
-| 77  | Smart Paste Guard                        | `PLAN_VERSION_090.md` (Task 77)               | Stub          | v0.8.0                 |
+| 77  | Smart Paste Guard                        | `PLAN_VERSION_090.md` (Task 77)               | Pending merge | v0.8.0                 |
 | 78  | Profiles + Quick Profile Switching       | `PLAN_VERSION_100.md` (Task 78)               | Stub          | v0.8.0                 |
 | 79  | Theme Preview + Color Picker             | `PLAN_VERSION_100.md` (Task 79)               | Stub          | v0.8.0                 |
 | 80  | Font Ligatures Per-Profile Toggle        | `PLAN_VERSION_100.md` (Task 80)               | Stub          | Task 78                |
@@ -460,62 +460,63 @@ egui's `fonts_mut`), cell size is integer pixels, and the terminal area is drawn
 
 Update this section as tasks complete:
 
-| Task | Started    | Completed  | Notes                                                                           |
-| ---- | ---------- | ---------- | ------------------------------------------------------------------------------- |
-| 1    | 2026-03-10 | 2026-03-10 | 5 commits on task-01/glyph-atlas                                                |
-| 2    | 2026-03-09 | 2026-03-09 | 8 commits on task-02/cli-config                                                 |
-| 3    | 2026-03-10 | 2026-03-10 | Menu bar + tabbed settings modal                                                |
-| 4    | 2026-03-15 | 2026-03-15 | All 8 subtasks on tasks/5-11-12-13-4                                            |
-| 5    | 2026-03-12 | 2026-03-12 | All 8 subtasks complete on tasks/5-11-12-13-4                                   |
-| 6    | 2026-03-16 | 2026-03-16 | All 13 subtasks complete; 71.6%→75.8% (+4.2pp)                                  |
-| 7    | 2026-03-09 | 2026-03-09 | All 30 subtasks complete                                                        |
-| 8    | 2026-03-09 | 2026-03-09 | All 7 subtasks complete                                                         |
-| 9    | 2026-03-11 | 2026-03-11 | 12 subtasks on task-09/tmux-compat-logging                                      |
-| 10   | 2026-03-11 | 2026-03-11 | All subtasks complete                                                           |
-| 11   | 2026-03-12 | 2026-03-12 | All 9 subtasks complete on tasks/5-11-12-13-4                                   |
-| 12   | 2026-03-12 | 2026-03-12 | All 4 subtasks complete on tasks/5-11-12-13-4                                   |
-| 13   | 2026-03-14 | 2026-03-14 | All 9 subtasks complete on tasks/5-11-12-13-4                                   |
-| 14   | 2026-03-15 | 2026-03-15 | Mode noise, URL hover, scrollback selection                                     |
-| 15   | 2026-03-16 | 2026-03-16 | All 6 subtasks complete on tasks/15-16-17                                       |
-| 16   | 2026-03-16 | 2026-03-16 | All 4 subtasks complete on tasks/15-16-17                                       |
-| 17   | 2026-03-16 | 2026-03-16 | All 3 subtasks complete on tasks/15-16-17                                       |
-| 18   |            |            |                                                                                 |
-| 19   |            |            |                                                                                 |
-| 20   | 2026-03-17 | 2026-03-17 | All 12 subtasks on task-20/dec-mode-coverage                                    |
-| 21   | 2026-03-31 | 2026-03-31 | All 6 subtasks on task-21/tab-stops                                             |
-| 22   | 2026-04-04 | 2026-04-04 | Phase B complete — 248 tests, 7 bugs fixed, compliance report written           |
-| 23   | 2026-04-01 | 2026-04-01 | All 7 subtasks complete on task-23/blinking-text                                |
-| 24   | 2026-04-05 | 2026-04-05 | All 7 subtasks complete on task-24/benchmark-improvements                       |
-| 25   | 2026-04-01 | 2026-04-01 | All 10 subtasks complete on task-25/code-quality                                |
-| 26   | 2026-04-01 | 2026-04-01 | All 6 subtasks on task-26/bool-to-enum                                          |
-| 27   | 2026-04-02 | 2026-04-02 | All 9 subtasks complete on task-27/fixme-audit                                  |
-| 28   | 2026-04-03 | 2026-04-03 | All 10 subtasks complete on task-28/comment-audit                               |
-| 29   | 2026-04-06 | 2026-04-06 | All 12 subtasks complete on task-29/god-file-refactor                           |
-| 30   | 2026-04-03 | 2026-04-03 | All 8 subtasks complete on task-30/clippy-allow-audit                           |
-| 31   | 2026-04-02 | 2026-04-02 | 13 dead items deleted, 15 demoted to pub(crate)                                 |
-| 32   | 2026-04-06 | 2026-04-06 | All 9 subtasks complete on task-32/playback-feature-flag                        |
-| 33   | 2026-04-01 | 2026-04-01 | All subtasks completed.                                                         |
-| 34   | 2026-04-02 | 2026-04-02 | All 12 subtasks complete on task-34/background-opacity                          |
-| 35   | 2026-04-05 | 2026-04-05 | All 10 subtasks on task-35/kitty-keyboard-protocol                              |
-| 53   | 2026-04-15 | 2026-04-15 | All 7 subtasks complete on task-53/multiple-windows                             |
-| 54   | 2026-04-11 | 2026-04-11 | All 6 subtasks complete on task-54-55/background-images-and-shaders             |
-| 55   | 2026-04-11 | 2026-04-11 | All 8 subtasks complete on task-54-55/background-images-and-shaders             |
-| 58   | 2026-04-09 | 2026-04-10 | All 14 subtasks complete on task-58/built-in-muxing                             |
-| 62   | 2026-04-16 | 2026-04-16 | All subtasks complete on task-62/freminal-windowing                             |
-| 63   | 2026-04-16 | 2026-04-16 | All subtasks complete on task-63/single-window-migration                        |
-| 64   | 2026-04-16 | 2026-04-16 | All subtasks complete on task-64/multi-window-parity                            |
-| 65   | 2026-04-16 | 2026-04-16 | Already implemented during Tasks 62-63; verified complete                       |
-| 66   | 2026-04-16 | 2026-04-16 | Removed eframe workspace dep, cleaned stale references                          |
-| 68   | 2026-04-19 | 2026-04-19 | macOS idle CPU fix + Windows split-pane resize fix                              |
-| 69   | 2026-04-17 | 2026-04-17 | Glyphs, settings gaps, search positioning, settings window                      |
-| 59   | 2026-04-19 | 2026-04-20 | All 12 subtasks complete on task-59/frec-v2-recording                           |
-| 61   | 2026-04-20 | 2026-04-20 | All 12 subtasks complete on task-61/saved-layouts                               |
-| 70   | 2026-04-21 | 2026-04-22 | All subtasks A–O complete; merged to main via PR #324 (`c537ae1`)               |
-| 71   | 2026-04-22 | 2026-05-17 | 21 subtasks + 6 post-MT bug fixes on task-71/ux-polish-sweep; PR pending        |
-| 72   | 2026-05-17 | 2026-06-04 | 16 subtasks (72.1-72.16) complete on task-72/osc-133-command-blocks; PR pending |
-| 94   | 2026-06-04 | 2026-06-04 | All 7 subtasks complete; merged via PR #343                                     |
-| 95   | 2026-06-04 | 2026-06-04 | All 5 subtasks complete; merged via PR #343                                     |
-| 76   | 2026-06-09 | 2026-06-09 | All subtasks (76.1-76.8) complete on task-76/notifications; PR pending          |
+| Task | Started    | Completed  | Notes                                                                            |
+| ---- | ---------- | ---------- | -------------------------------------------------------------------------------- |
+| 1    | 2026-03-10 | 2026-03-10 | 5 commits on task-01/glyph-atlas                                                 |
+| 2    | 2026-03-09 | 2026-03-09 | 8 commits on task-02/cli-config                                                  |
+| 3    | 2026-03-10 | 2026-03-10 | Menu bar + tabbed settings modal                                                 |
+| 4    | 2026-03-15 | 2026-03-15 | All 8 subtasks on tasks/5-11-12-13-4                                             |
+| 5    | 2026-03-12 | 2026-03-12 | All 8 subtasks complete on tasks/5-11-12-13-4                                    |
+| 6    | 2026-03-16 | 2026-03-16 | All 13 subtasks complete; 71.6%→75.8% (+4.2pp)                                   |
+| 7    | 2026-03-09 | 2026-03-09 | All 30 subtasks complete                                                         |
+| 8    | 2026-03-09 | 2026-03-09 | All 7 subtasks complete                                                          |
+| 9    | 2026-03-11 | 2026-03-11 | 12 subtasks on task-09/tmux-compat-logging                                       |
+| 10   | 2026-03-11 | 2026-03-11 | All subtasks complete                                                            |
+| 11   | 2026-03-12 | 2026-03-12 | All 9 subtasks complete on tasks/5-11-12-13-4                                    |
+| 12   | 2026-03-12 | 2026-03-12 | All 4 subtasks complete on tasks/5-11-12-13-4                                    |
+| 13   | 2026-03-14 | 2026-03-14 | All 9 subtasks complete on tasks/5-11-12-13-4                                    |
+| 14   | 2026-03-15 | 2026-03-15 | Mode noise, URL hover, scrollback selection                                      |
+| 15   | 2026-03-16 | 2026-03-16 | All 6 subtasks complete on tasks/15-16-17                                        |
+| 16   | 2026-03-16 | 2026-03-16 | All 4 subtasks complete on tasks/15-16-17                                        |
+| 17   | 2026-03-16 | 2026-03-16 | All 3 subtasks complete on tasks/15-16-17                                        |
+| 18   |            |            |                                                                                  |
+| 19   |            |            |                                                                                  |
+| 20   | 2026-03-17 | 2026-03-17 | All 12 subtasks on task-20/dec-mode-coverage                                     |
+| 21   | 2026-03-31 | 2026-03-31 | All 6 subtasks on task-21/tab-stops                                              |
+| 22   | 2026-04-04 | 2026-04-04 | Phase B complete — 248 tests, 7 bugs fixed, compliance report written            |
+| 23   | 2026-04-01 | 2026-04-01 | All 7 subtasks complete on task-23/blinking-text                                 |
+| 24   | 2026-04-05 | 2026-04-05 | All 7 subtasks complete on task-24/benchmark-improvements                        |
+| 25   | 2026-04-01 | 2026-04-01 | All 10 subtasks complete on task-25/code-quality                                 |
+| 26   | 2026-04-01 | 2026-04-01 | All 6 subtasks on task-26/bool-to-enum                                           |
+| 27   | 2026-04-02 | 2026-04-02 | All 9 subtasks complete on task-27/fixme-audit                                   |
+| 28   | 2026-04-03 | 2026-04-03 | All 10 subtasks complete on task-28/comment-audit                                |
+| 29   | 2026-04-06 | 2026-04-06 | All 12 subtasks complete on task-29/god-file-refactor                            |
+| 30   | 2026-04-03 | 2026-04-03 | All 8 subtasks complete on task-30/clippy-allow-audit                            |
+| 31   | 2026-04-02 | 2026-04-02 | 13 dead items deleted, 15 demoted to pub(crate)                                  |
+| 32   | 2026-04-06 | 2026-04-06 | All 9 subtasks complete on task-32/playback-feature-flag                         |
+| 33   | 2026-04-01 | 2026-04-01 | All subtasks completed.                                                          |
+| 34   | 2026-04-02 | 2026-04-02 | All 12 subtasks complete on task-34/background-opacity                           |
+| 35   | 2026-04-05 | 2026-04-05 | All 10 subtasks on task-35/kitty-keyboard-protocol                               |
+| 53   | 2026-04-15 | 2026-04-15 | All 7 subtasks complete on task-53/multiple-windows                              |
+| 54   | 2026-04-11 | 2026-04-11 | All 6 subtasks complete on task-54-55/background-images-and-shaders              |
+| 55   | 2026-04-11 | 2026-04-11 | All 8 subtasks complete on task-54-55/background-images-and-shaders              |
+| 58   | 2026-04-09 | 2026-04-10 | All 14 subtasks complete on task-58/built-in-muxing                              |
+| 62   | 2026-04-16 | 2026-04-16 | All subtasks complete on task-62/freminal-windowing                              |
+| 63   | 2026-04-16 | 2026-04-16 | All subtasks complete on task-63/single-window-migration                         |
+| 64   | 2026-04-16 | 2026-04-16 | All subtasks complete on task-64/multi-window-parity                             |
+| 65   | 2026-04-16 | 2026-04-16 | Already implemented during Tasks 62-63; verified complete                        |
+| 66   | 2026-04-16 | 2026-04-16 | Removed eframe workspace dep, cleaned stale references                           |
+| 68   | 2026-04-19 | 2026-04-19 | macOS idle CPU fix + Windows split-pane resize fix                               |
+| 69   | 2026-04-17 | 2026-04-17 | Glyphs, settings gaps, search positioning, settings window                       |
+| 59   | 2026-04-19 | 2026-04-20 | All 12 subtasks complete on task-59/frec-v2-recording                            |
+| 61   | 2026-04-20 | 2026-04-20 | All 12 subtasks complete on task-61/saved-layouts                                |
+| 70   | 2026-04-21 | 2026-04-22 | All subtasks A–O complete; merged to main via PR #324 (`c537ae1`)                |
+| 71   | 2026-04-22 | 2026-05-17 | 21 subtasks + 6 post-MT bug fixes on task-71/ux-polish-sweep; PR pending         |
+| 72   | 2026-05-17 | 2026-06-04 | 16 subtasks (72.1-72.16) complete on task-72/osc-133-command-blocks; PR pending  |
+| 94   | 2026-06-04 | 2026-06-04 | All 7 subtasks complete; merged via PR #343                                      |
+| 95   | 2026-06-04 | 2026-06-04 | All 5 subtasks complete; merged via PR #343                                      |
+| 76   | 2026-06-09 | 2026-06-09 | All subtasks (76.1-76.8) complete on task-76/notifications; PR pending           |
+| 77   | 2026-06-09 | 2026-06-10 | All subtasks (77.1-77.6) + benchmark complete on task-77/paste-guard; PR pending |
 
 ---
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -3225,7 +3225,7 @@ true`; already pinned to `1.12.3` in the workspace deps).
 warnings`, `cargo fmt --check`, `cargo machete`, and the Nix lint
   stack (`nixfmt`/`statix`/`deadnix`) all clean.
 
-#### 77.2 — Paste analyzer
+#### 77.2 — Paste analyzer ✅ 2026-06-09
 
 **Scope:** New module `freminal/src/gui/paste_guard.rs`.
 
@@ -3240,6 +3240,36 @@ warnings`, `cargo fmt --check`, `cargo machete`, and the Nix lint
   `PasteGuardConfig` (use `OnceCell` or rebuild on hot-reload).
 
 **Verification:** Unit tests for each trigger and combination thereof.
+
+**Completion notes (commit `ee15974`, 2026-06-09):**
+
+- New module `freminal/src/gui/paste_guard.rs` with the `PasteAnalysis`
+  enum (all five variants as specified) and a pure
+  `analyze(payload, config, compiled) -> PasteAnalysis`.
+- **Cache placement differs from the plan.** The plan suggested caching
+  the compiled regexes on `PasteGuardConfig` via `OnceCell`.
+  `PasteGuardConfig` lives in `freminal-common`, derives
+  `Clone`/`Serialize`/`Deserialize`, and is hot-reloaded by value, so
+  hanging a `OnceCell<Vec<Regex>>` off it fights the derives. Instead a
+  GUI-side `PasteGuard` struct owns `compiled: Vec<Regex>`;
+  `PasteGuard::rebuild(&config)` recompiles and returns the invalid
+  patterns for the caller to toast (77.6) while keeping the valid
+  siblings. `analyze` is the pure free function the `PasteGuard::analyze`
+  method delegates to, so the hot path never compiles a regex.
+- Control-char trigger flags genuine C0/C1 controls (ESC, BEL, ...) but
+  ignores `\n` (the multiline trigger's job), `\r`, and `\t`, which
+  appear in legitimate pasted text. Flagged chars are de-duplicated in
+  first-seen order.
+- `Multiple` is always a flat list (never nests `Multiple` or `Safe`),
+  ordered multiline → control chars → patterns.
+- 13 unit tests cover every trigger, the disabled master switch, dedup
+  ordering, trailing-newline line counting, and partial-compile recovery.
+- **Temporary `#[allow(dead_code)]` on `mod paste_guard;`** with a
+  `TODO(77.4)` comment: the module has no production caller until the
+  wire-in lands. Removed in 77.4. Permitted by the AGENTS.md temporary-
+  refactor exception; user-approved.
+- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
+warnings`, `cargo fmt --check`, and `cargo machete` all clean.
 
 #### 77.3 — Preview dialog
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -3329,7 +3329,7 @@ Paste(String) }` and closes the dialog on resolve. The dialog is
 - `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
 warnings`, `cargo fmt --check`, and `cargo machete` all clean.
 
-#### 77.4 — Wire into paste handling
+#### 77.4 — Wire into paste handling ✅ 2026-06-09
 
 **Scope:** `freminal/src/gui/terminal/input.rs` (line 210 `KeyAction::Paste`
 and line 1191 `Event::Paste`).
@@ -3345,6 +3345,47 @@ and line 1191 `Event::Paste`).
 
 **Verification:** Integration test: paste multi-line text → dialog appears
 → confirm → PTY receives bytes.
+
+**Completion notes (commit `962a210`, 2026-06-09):**
+
+- **Interception point differs from the plan.** The plan said to call
+  `paste_guard::analyze` inline at the two `input.rs` paste sites. Those
+  sites (`dispatch_binding_action`, `write_input_to_terminal`) run deep
+  in the input loop with no access to `&Config`, the `PasteGuard` cache,
+  or `PerWindowState.paste_dialog`. Instead all three paste sites
+  (keybinding, Edit-menu, and egui `Event::Paste`) now **defer
+  `KeyAction::Paste`** up to `dispatch_deferred_action`, which runs at
+  the `update()` layer with full `self` + `win` access. User-approved
+  design.
+- New `FreminalGui::guarded_paste(win)`: ignores the request if a dialog
+  is already open (no dialog stacking), reads the clipboard via
+  `arboard`, normalises CRLF, calls `PasteGuard::analyze`, and either
+  sends straight to the active pane (`Safe`) or opens
+  `win.paste_dialog`.
+- New `FreminalGui::send_paste_to_active_pane(win, payload)`: applies
+  bracketed-paste wrapping (when the active pane has it enabled) and
+  sends `InputEvent::Key`. Used by both the `Safe` fast path and the
+  dialog `Paste` resolution.
+- `update()` renders `win.paste_dialog.show(ctx)` next to the
+  save-layout prompt; a `Paste(payload)` outcome calls
+  `send_paste_to_active_pane`, `Cancelled`/`Idle` discard.
+- `Event::Paste` now reads the clipboard in the deferred handler instead
+  of forwarding the event text — unifying all paste origins on one
+  guarded clipboard-read path (the content is identical for a normal
+  Ctrl/Cmd+V).
+- `PasteGuard` cache lives on `FreminalGui`, built at startup and
+  rebuilt in `apply_new_config` next to `binding_map`. Invalid user
+  patterns are surfaced via `push_error_toast` and skipped.
+- **Removed both temporary `#[allow(dead_code)]` markers** (the 77.2
+  module-level one and the 77.3 `paste_dialog`-field one); everything is
+  now wired and read. The unused `PasteDialog::close()` speculatively
+  added in 77.3 was deleted rather than left dead.
+- An automated end-to-end paste→dialog→confirm→PTY integration test is
+  not feasible without an egui context + a live PTY; the analyzer,
+  dialog state, and banner logic are unit-covered (18 tests) and the
+  full flow is manual-tested. `cargo test --all`, `cargo clippy
+--all-targets --all-features -- -D warnings`, `cargo fmt --check`, and
+  `cargo machete` all clean.
 
 #### 77.5 — KeyAction::PasteUnsafe
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -3146,7 +3146,7 @@ for dangerous patterns. Per-config toggle to disable.
 
 ### 77 Subtasks
 
-#### 77.1 — Config schema
+#### 77.1 — Config schema ✅ 2026-06-09
 
 **Scope:** `freminal-common/src/config.rs`, `config_example.toml`.
 
@@ -3185,6 +3185,45 @@ for dangerous patterns. Per-config toggle to disable.
   malformed patterns via the existing toast system.
 
 **Verification:** Round-trip TOML test. Regex compile-time validation test.
+
+**Completion notes (commit `4eeb8b8`, 2026-06-09):**
+
+- `PasteGuardConfig` added next to `SecurityConfig` in
+  `freminal-common/src/config.rs`. Fields: `enabled`, `multiline`,
+  `control_chars`, `patterns` (all `bool`), `pattern_list: Vec<String>`.
+- **Default change vs. the plan:** `patterns` defaults to `true`
+  (dangerous-command detection on out of the box) rather than the
+  `false` the plan originally specified. Requested by the user at task
+  start. All other defaults match the plan (`enabled`/`multiline`/
+  `control_chars = true`).
+- The default `pattern_list` is produced by a private
+  `default_paste_guard_patterns()` helper using the seven patterns from
+  the plan (`rm -rf`, `curl|sh`, `wget|sh`, `sudo`, `doas`, `dd of=/dev/`,
+  `mkfs.`).
+- Regex validation is exposed as
+  `PasteGuardConfig::invalid_patterns() -> Vec<(String, String)>`
+  rather than enforced at load time. Rationale: `freminal-common` is a
+  library crate with no UI surface and no `anyhow`; the load path
+  (`apply_partial`) cannot raise a toast. The GUI consumes
+  `invalid_patterns()` in 77.2/77.6 and surfaces malformed patterns via
+  the existing toast system, skipping them at match time.
+- `regex` added to `freminal-common/Cargo.toml` (`regex.workspace =
+true`; already pinned to `1.12.3` in the workspace deps).
+- `#[allow(clippy::struct_excessive_bools)]` with a justifying comment
+  on the struct, matching the established `NotificationsConfig` pattern
+  (four documented TOML toggles; an enum would distort the schema).
+- Full merge-wiring per the config-options checklist: `Config` field +
+  `Default`, `ConfigPartial` field, `apply_partial` arm, the
+  `every_config_section_survives_partial_merge` guard test (mutation +
+  assertion + no-`..` destructure entry), `config_example.toml`
+  documentation, and the Nix home-manager module mirror (let-binding,
+  merge arm, five `mkOption`s including a `listOf str` for
+  `pattern_list`).
+- 4 new unit tests: defaults, TOML round-trip, all-default-patterns-
+  compile, and malformed-pattern reporting.
+- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
+warnings`, `cargo fmt --check`, `cargo machete`, and the Nix lint
+  stack (`nixfmt`/`statix`/`deadnix`) all clean.
 
 #### 77.2 — Paste analyzer
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -3387,6 +3387,22 @@ and line 1191 `Event::Paste`).
 --all-targets --all-features -- -D warnings`, `cargo fmt --check`, and
   `cargo machete` all clean.
 
+**Follow-up fix (commit `9dbc433`, 2026-06-10): paste regression.**
+The initial 77.4 wire-in broke paste entirely. Root cause: the
+windowing layer (`freminal-windowing/src/event_loop.rs`) already
+intercepts paste shortcuts (Ctrl+V **and** Ctrl+Shift+V — the modifier
+check is `command && "v"`, case-insensitive), reads the clipboard via
+the reliable egui-winit/smithay path, and injects `Event::Paste(text)`
+to work around Wayland multi-window clipboard breakage. The wire-in
+made the `Event::Paste` arm discard that known-good text and defer a
+second `arboard` read, which fails (`clipboard … empty`) on the common
+path. Fix: `Event::Paste` now stashes its text in
+`ViewState::pending_paste`, drained in `update()` and fed to a new
+`guarded_paste_text` (analyze → send or open dialog) with no clipboard
+read. `arboard` (`guarded_paste`) is retained only for the menu-Paste /
+explicit-keybinding path that does not flow through the windowing
+interceptor.
+
 #### 77.5 — KeyAction::PasteUnsafe
 
 **Scope:** `freminal-common/src/keybindings.rs`, dispatch.

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -3403,6 +3403,20 @@ read. `arboard` (`guarded_paste`) is retained only for the menu-Paste /
 explicit-keybinding path that does not flow through the windowing
 interceptor.
 
+**Follow-up fix (commit `7dbf538`, 2026-06-10): dialog focus.**
+The dialog rendered but never captured keyboard input — focus bounced
+back to the terminal, so the Edit-and-Paste field was untypable (the
+recurring modal-focus bug class also fixed for settings/search/command
+history). Two fixes, matching the established pattern: (1) add
+`win.paste_dialog.is_open()` to the `ui_overlay_open` flag in
+`update()` (`app_impl.rs`) — that flag gates the terminal widget's
+focus-lock and its `write_input_to_terminal` call, so the active pane
+stops stealing focus and forwarding keystrokes while the dialog is
+open; (2) give the edit-mode `TextEdit` `.lock_focus(true)` and
+re-request focus every frame it lacks it (mirroring `show_search_bar`
+and `show_command_history_palette`). The redundant `just_entered_edit`
+flag was removed.
+
 #### 77.5 — KeyAction::PasteUnsafe
 
 **Scope:** `freminal-common/src/keybindings.rs`, dispatch.

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -25,7 +25,7 @@ top of the correctness debts identified in the post-v0.7.0 audit.
 | 74  | Broadcast Input to Panes                | Medium       | Pending  | v0.8.0, Task 58 | `task-74/broadcast-input`        |
 | 75  | Verify per-pane env round-trip          | Small        | Pending  | v0.8.0          | `task-75/pane-env-roundtrip`     |
 | 76  | Notification System (OSC 9 / OSC 777)   | Medium       | Complete | v0.8.0, Task 72 | `task-76/notifications`          |
-| 77  | Smart Paste Guard                       | Small–Medium | Pending  | v0.8.0          | `task-77/paste-guard`            |
+| 77  | Smart Paste Guard                       | Small–Medium | Complete | v0.8.0          | `task-77/paste-guard`            |
 | 94  | Tab Title Precedence (prefix default)   | Small        | Complete | v0.8.0 (71.1)   | `task-94/tab-title-precedence`   |
 | 95  | Persist Custom Tab Names in Layouts     | Small        | Complete | v0.8.0, Task 61 | `task-95/persist-tab-names`      |
 | 98  | Block Close on Running Commands         | Small–Medium | Pending  | Task 72         | `task-98/block-close-on-running` |
@@ -3458,7 +3458,7 @@ confirmation)"`, `FromStr`, and `ALL` membership); a new
 - `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
 warnings`, `cargo fmt --check`, and `cargo machete` all clean.
 
-#### 77.6 — Settings UI
+#### 77.6 — Settings UI ✅ 2026-06-10
 
 **Scope:** Existing Security settings tab (`freminal/src/gui/settings.rs`).
 
@@ -3474,15 +3474,51 @@ warnings`, `cargo fmt --check`, and `cargo machete` all clean.
 **Verification:** Round-trip persistence. Pattern editor accepts/rejects
 malformed regex correctly.
 
+**Completion notes (commit `15107b7`, 2026-06-10):**
+
+- A "Paste Guard" section added to the Security settings tab
+  (`show_paste_guard_section`): master enable toggle; multi-line /
+  control-character / pattern per-trigger toggles (disabled via
+  `add_enabled_ui` when the guard / pattern matching is off); an
+  editable pattern list with per-row remove (`➖`) and an "Add pattern"
+  (`➕`) button. Invalid regexes render in red (`text_color_opt`) with a
+  hover note that they are ignored at match time (live
+  `regex::Regex::new(...).is_ok()` check per row).
+- A "Test Paste" button mirrors the Notifications tab's "Test
+  Notification": sets `pending_test_paste`, drained in
+  `show`/`show_standalone` as `SettingsAction::TestPaste`, handled in
+  `handle_settings_action` by building a temporary `PasteGuard` from
+  `draft_paste_guard()` (the unsaved draft), analyzing a sample payload,
+  and opening the confirm dialog on the `settings_owner` window. If the
+  draft would not intercept the sample, an info toast says so instead.
+- Per-section persistence relies on the existing `[paste_guard]`
+  `ConfigPartial`/`apply_partial` wiring from 77.1; the Settings tab
+  edits `self.draft.paste_guard` directly, saved on Apply like every
+  other section.
+- `SettingsModal` gained a justified `#[allow(clippy::struct_excessive_bools)]`
+  (several independent one-shot UI flags).
+- Tests: `test_paste_button_sets_pending_flag`,
+  `draft_paste_guard_reflects_edits`. The egui render path is
+  manual-tested. `cargo test --all`, clippy, fmt, machete all clean.
+
 ### 77 Open Questions Resolved
 
 All resolved.
 
-### 77 Benchmarks
+### 77 Benchmarks ✅ 2026-06-10
 
 `paste_guard::analyze` runs in the GUI thread on a paste event. For a 1MB
 paste with all triggers and 20 patterns, it must complete in < 50ms.
 Add a benchmark in a new `freminal/benches/paste_guard_bench.rs`.
+
+**Done (commit `406f7d8`).** `freminal/benches/paste_guard_bench.rs`
+(Criterion) covers `analyze_1mb_all_triggers`, `analyze_typical_paste`,
+and `rebuild_patterns`. Measured: the 1 MB / all-triggers / 20-pattern
+worst case is **~688 µs** — roughly 70× under the 50 ms budget; a
+typical ~2 KB paste is ~1.8 µs; rebuilding the 20-pattern cache is
+~745 µs. To make the analyzer reachable from the separate-crate bench,
+`mod paste_guard` and the analyzer API were promoted to `pub` (matching
+`gui::atlas` / `gui::shaping`); the dialog types stay `pub(in crate::gui)`.
 
 ---
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -3271,7 +3271,7 @@ warnings`, `cargo fmt --check`, `cargo machete`, and the Nix lint
 - `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
 warnings`, `cargo fmt --check`, and `cargo machete` all clean.
 
-#### 77.3 — Preview dialog
+#### 77.3 — Preview dialog ✅ 2026-06-09
 
 **Scope:** `freminal/src/gui/paste_guard.rs` (UI) and integration with the
 existing modal pattern (look at the existing Settings modal infra in
@@ -3292,6 +3292,42 @@ existing modal pattern (look at the existing Settings modal infra in
 
 **Verification:** Manual visual test. Snapshot test of the analyzer
 classifications.
+
+**Completion notes (commit `d62faaf`, 2026-06-09):**
+
+- `PasteDialog` added to `freminal/src/gui/paste_guard.rs`: a centered,
+  non-resizable `egui::Window` titled "Confirm Paste" following the
+  established `show_save_layout_prompt` / `show_confirm_close_prompt`
+  modal pattern.
+- Banner is produced by a pure, unit-tested `banner_text(&PasteAnalysis)
+-> String` (e.g. "Multi-line paste — 17 lines, 420 bytes",
+  "Dangerous patterns detected: …", control chars rendered as `U+XXXX`,
+  and a flattened "Multiple triggers — …").
+- **Content area:** a scrollable monospace preview. Read-only mode uses
+  a disabled multiline `TextEdit` (monospace + selectable without
+  edits); "Edit and Paste" flips it to an editable `TextEdit` bound to a
+  scratch `edit_buffer`, focused once on entry. The plan mentioned
+  optional renderer syntax highlighting "or plain monospace if that's
+  too invasive" — plain monospace was chosen.
+- **Buttons:** Cancel, Paste Anyway, Edit and Paste. **Keyboard:**
+  Escape = Cancel, Ctrl+Enter = Paste Anyway (clicks in the same frame
+  take precedence over shortcuts).
+- `show()` returns `PasteDialogOutcome { Idle | Cancelled |
+Paste(String) }` and closes the dialog on resolve. The dialog is
+  **target-agnostic** — it yields only the resolved text. Bracketed-
+  paste wrapping and the `InputEvent::Key` send stay in 77.4, which
+  owns the `input_tx` and pane routing.
+- State lives on `PerWindowState::paste_dialog` (paste targets a
+  window's active pane). That field carries a temporary
+  `#[allow(dead_code)]` + `TODO(77.4)` until `update()` renders it and
+  the paste path opens it; the module-level allow from 77.2 also
+  remains until 77.4.
+- 8 new unit tests (banner formatting incl. flattened `Multiple`,
+  open/close/`is_open`, the `Safe`-never-opens rule, outcome equality).
+  The egui render path itself is exercised manually, per the plan's
+  "manual visual test"; the testable state logic is unit-covered.
+- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
+warnings`, `cargo fmt --check`, and `cargo machete` all clean.
 
 #### 77.4 — Wire into paste handling
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -3417,7 +3417,7 @@ re-request focus every frame it lacks it (mirroring `show_search_bar`
 and `show_command_history_palette`). The redundant `just_entered_edit`
 flag was removed.
 
-#### 77.5 — KeyAction::PasteUnsafe
+#### 77.5 — KeyAction::PasteUnsafe ✅ 2026-06-10
 
 **Scope:** `freminal-common/src/keybindings.rs`, dispatch.
 
@@ -3427,6 +3427,36 @@ flag was removed.
 - Document the action as "Paste without confirmation".
 
 **Verification:** Round-trip keybinding test.
+
+**Completion notes (commit `2ab8caa`, 2026-06-10):**
+
+- **Default binding is `Ctrl+Shift+Alt+V`, not the plan's
+  `Ctrl+Shift+V`** (which collides with `Paste`). One modifier beyond
+  the normal paste combo, so the bypass is deliberate. User-approved.
+- Full four-step keybinding ritual: `KeyAction::PasteUnsafe` variant
+  (with `name() = "paste_unsafe"`, `display_label() = "Paste (no
+confirmation)"`, `FromStr`, and `ALL` membership); a new
+  `BindingModifiers::CTRL_SHIFT_ALT` constant; the default binding in
+  `register_misc_bindings`; and the action list in `config_example.toml`.
+- **Dispatch reality vs. the plan.** The windowing paste interceptor
+  (`event_loop.rs`) fires for _any_ `command + v`, including
+  `Ctrl+Shift+Alt+V`, and converts it to an `Event::Paste` — so the
+  `BindingMap` entry never sees the bypass combo on that (common) path.
+  The bypass intent is therefore detected at the `Event::Paste` arm via
+  the **Alt modifier** (`input.modifiers.alt`) and carried through a new
+  `ViewState::PendingPaste { text, bypass_guard }` (replacing the bare
+  `Option<String>` from the 77.4 fix). `update()` sends a bypassing
+  paste straight to the active pane (`send_paste_to_active_pane`),
+  otherwise runs the guard. The `BindingMap` entry plus a new
+  `unguarded_paste` (arboard) handler in `dispatch_deferred_action`
+  cover the menu and any platform/config where the interceptor does not
+  fire.
+- Tests: `default_paste_unsafe_binding` (asserts the bypass combo maps
+  to `PasteUnsafe` and stays distinct from `Paste`),
+  `paste_unsafe_name_round_trips`, and the updated guard counts
+  (`ALL` = 60 actions, default map = 47 bindings).
+- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
+warnings`, `cargo fmt --check`, and `cargo machete` all clean.
 
 #### 77.6 — Settings UI
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -18,17 +18,17 @@ top of the correctness debts identified in the post-v0.7.0 audit.
 
 ## Task Summary
 
-| #   | Feature                                 | Scope        | Status        | Depends On      | Branch                           |
-| --- | --------------------------------------- | ------------ | ------------- | --------------- | -------------------------------- |
-| 72  | OSC 133 Command Blocks                  | Large        | Pending merge | v0.8.0          | `task-72/osc-133-command-blocks` |
-| 73  | Command Gutters (exit-status indicator) | Medium       | Pending       | Task 72         | `task-73/command-gutters`        |
-| 74  | Broadcast Input to Panes                | Medium       | Pending       | v0.8.0, Task 58 | `task-74/broadcast-input`        |
-| 75  | Verify per-pane env round-trip          | Small        | Pending       | v0.8.0          | `task-75/pane-env-roundtrip`     |
-| 76  | Notification System (OSC 9 / OSC 777)   | Medium       | Pending merge | v0.8.0, Task 72 | `task-76/notifications`          |
-| 77  | Smart Paste Guard                       | Small–Medium | Pending       | v0.8.0          | `task-77/paste-guard`            |
-| 94  | Tab Title Precedence (prefix default)   | Small        | Complete      | v0.8.0 (71.1)   | `task-94/tab-title-precedence`   |
-| 95  | Persist Custom Tab Names in Layouts     | Small        | Complete      | v0.8.0, Task 61 | `task-95/persist-tab-names`      |
-| 98  | Block Close on Running Commands         | Small–Medium | Pending       | Task 72         | `task-98/block-close-on-running` |
+| #   | Feature                                 | Scope        | Status   | Depends On      | Branch                           |
+| --- | --------------------------------------- | ------------ | -------- | --------------- | -------------------------------- |
+| 72  | OSC 133 Command Blocks                  | Large        | Complete | v0.8.0          | `task-72/osc-133-command-blocks` |
+| 73  | Command Gutters (exit-status indicator) | Medium       | Complete | Task 72         | `task-73/command-gutters`        |
+| 74  | Broadcast Input to Panes                | Medium       | Pending  | v0.8.0, Task 58 | `task-74/broadcast-input`        |
+| 75  | Verify per-pane env round-trip          | Small        | Pending  | v0.8.0          | `task-75/pane-env-roundtrip`     |
+| 76  | Notification System (OSC 9 / OSC 777)   | Medium       | Complete | v0.8.0, Task 72 | `task-76/notifications`          |
+| 77  | Smart Paste Guard                       | Small–Medium | Pending  | v0.8.0          | `task-77/paste-guard`            |
+| 94  | Tab Title Precedence (prefix default)   | Small        | Complete | v0.8.0 (71.1)   | `task-94/tab-title-precedence`   |
+| 95  | Persist Custom Tab Names in Layouts     | Small        | Complete | v0.8.0, Task 61 | `task-95/persist-tab-names`      |
+| 98  | Block Close on Running Commands         | Small–Medium | Pending  | Task 72         | `task-98/block-close-on-running` |
 
 ### Execution order
 
@@ -111,7 +111,7 @@ extend or rewrite it.
 
 ---
 
-## Task 72 — OSC 133 Command Blocks
+## Task 72 — OSC 133 Command Blocks ✅ Complete (2026-06-04)
 
 ### 72 Summary
 
@@ -1784,7 +1784,7 @@ Each subtask's commit message must contain a before/after table. Regressions
 
 ---
 
-## Task 73 — Command Gutters
+## Task 73 — Command Gutters ✅ Complete (2026-06-08)
 
 ### 73 Summary
 
@@ -2463,7 +2463,7 @@ None. No code change.
 
 ---
 
-## Task 76 — Notification System (OSC 9 / OSC 777)
+## Task 76 — Notification System (OSC 9 / OSC 777) ✅ Complete (2026-06-09)
 
 ### 76 Summary
 

--- a/agents.md
+++ b/agents.md
@@ -79,24 +79,25 @@ The `freminal-numeric-conversions` skill expands the `as`-casts /
 
 ## Skills you will need in this repo
 
-| Skill                            | When it fires                                                                                                                                 |
-| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `freminal-architecture`          | Architecture-affecting changes (GUI/PTY split, snapshot transport, crate boundaries).                                                         |
-| `freminal-orchestrator-protocol` | About to spawn sub-agents. The action-class / scope / stop-condition discipline is mandatory.                                                 |
-| `freminal-bench-table`           | Touching render / PTY / buffer / parser / `build_snapshot`. Names which bench file covers what (procedure lives in `performance-benchmarks`). |
-| `freminal-frec-decoder`          | Analyzing `.frec` / `.bin` recording files. Use `sequence_decoder.py`, not ad-hoc parsers.                                                    |
-| `freminal-escape-sequence-docs`  | Adding / removing / altering escape sequence support. Dual-doc update required.                                                               |
-| `freminal-numeric-conversions`   | Numeric type conversions. `conv2` crate; no raw `as` in production.                                                                           |
-| `freminal-config-options`        | Adding / renaming / removing a config option (`Config` field in `config.rs`). Mandatory `ConfigPartial` / `apply_partial` wiring checklist.   |
-| `rust-best-practices`            | Any Rust edit. Panic-free production, clippy maxed, no bypass.                                                                                |
-| `performance-benchmarks`         | Generic before/after capture procedure and 15% regression threshold (used together with `freminal-bench-table`).                              |
-| `flake-dev-shell-discipline`     | About to need a system tool not in the dev shell. Add to `flake.nix`, stop, wait for `nix develop`.                                           |
-| `precommit-fix-loop`             | When a commit is rejected by pre-commit hooks.                                                                                                |
-| `commit-discipline`              | Before any commit / PR. Plan-subtask numbering convention is freminal-specific.                                                               |
-| `testing-mandate`                | Before declaring any task done.                                                                                                               |
-| `no-summary-documents`           | Before creating any new markdown file (no PHASE_X_SUMMARY.md, no IMPLEMENTATION_PROGRESS.md, etc.).                                           |
-| `markdown-lint-discipline`       | Before writing or editing any `.md` file. Common markdownlint pitfalls (MD031, MD040, table widths).                                          |
-| `flaky-tests-are-bugs`           | A test fails sporadically. Root-cause it; no retries / `#[ignore]` / longer timeouts.                                                         |
+| Skill                              | When it fires                                                                                                                                     |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `freminal-architecture`            | Architecture-affecting changes (GUI/PTY split, snapshot transport, crate boundaries).                                                             |
+| `freminal-orchestrator-protocol`   | About to spawn sub-agents. The action-class / scope / stop-condition discipline is mandatory.                                                     |
+| `freminal-bench-table`             | Touching render / PTY / buffer / parser / `build_snapshot`. Names which bench file covers what (procedure lives in `performance-benchmarks`).     |
+| `freminal-frec-decoder`            | Analyzing `.frec` / `.bin` recording files. Use `sequence_decoder.py`, not ad-hoc parsers.                                                        |
+| `freminal-escape-sequence-docs`    | Adding / removing / altering escape sequence support. Dual-doc update required.                                                                   |
+| `freminal-numeric-conversions`     | Numeric type conversions. `conv2` crate; no raw `as` in production.                                                                               |
+| `freminal-config-options`          | Adding / renaming / removing a config option (`Config` field in `config.rs`). Mandatory `ConfigPartial` / `apply_partial` wiring checklist.       |
+| `freminal-modal-input-suppression` | Adding / debugging a GUI modal, dialog, or overlay with a text field. Register in `ui_overlay_open` + `lock_focus(true)` or it can't be typed in. |
+| `rust-best-practices`              | Any Rust edit. Panic-free production, clippy maxed, no bypass.                                                                                    |
+| `performance-benchmarks`           | Generic before/after capture procedure and 15% regression threshold (used together with `freminal-bench-table`).                                  |
+| `flake-dev-shell-discipline`       | About to need a system tool not in the dev shell. Add to `flake.nix`, stop, wait for `nix develop`.                                               |
+| `precommit-fix-loop`               | When a commit is rejected by pre-commit hooks.                                                                                                    |
+| `commit-discipline`                | Before any commit / PR. Plan-subtask numbering convention is freminal-specific.                                                                   |
+| `testing-mandate`                  | Before declaring any task done.                                                                                                                   |
+| `no-summary-documents`             | Before creating any new markdown file (no PHASE_X_SUMMARY.md, no IMPLEMENTATION_PROGRESS.md, etc.).                                               |
+| `markdown-lint-discipline`         | Before writing or editing any `.md` file. Common markdownlint pitfalls (MD031, MD040, table widths).                                              |
+| `flaky-tests-are-bugs`             | A test fails sporadically. Root-cause it; no retries / `#[ignore]` / longer timeouts.                                                             |
 
 ---
 

--- a/config_example.toml
+++ b/config_example.toml
@@ -441,6 +441,7 @@ limit = 4000
 #   Clipboard:
 #     copy            = "Ctrl+Shift+C"
 #     paste           = "Ctrl+Shift+V"
+#     paste_unsafe    = "Ctrl+Shift+Alt+V"  # paste, skipping the paste-guard dialog
 #     select_all      = (unbound)
 #
 #   Search:

--- a/config_example.toml
+++ b/config_example.toml
@@ -250,6 +250,44 @@ limit = 4000
 # password_indicator = true
 
 ## ##############################################################################
+# PASTE GUARD
+## ##############################################################################
+[paste_guard]
+# Master switch. When false, no paste is ever intercepted regardless of the
+# per-trigger toggles below.
+# Default: true (safer-by-default).
+# enabled = true
+
+# Confirm any paste containing a newline.
+# Default: true.
+# multiline = true
+
+# Confirm any paste containing control characters (ESC, BEL, etc.) other than
+# the newline covered by `multiline` and the bracketed-paste markers Freminal
+# wraps the payload with.
+# Default: true.
+# control_chars = true
+
+# When true, additionally match the payload against `pattern_list` and escalate
+# the warning when a dangerous pattern is found.
+# Default: true.
+# patterns = true
+
+# Regex patterns (Rust regex syntax) treated as dangerous. Matched only when
+# `patterns` is true. Malformed patterns are reported (via a toast) at load
+# time and skipped at match time.
+# Default:
+# pattern_list = [
+#     "\\brm\\s+-rf?\\b",
+#     "\\bcurl\\b[^|]+\\|\\s*(sh|bash|zsh|fish)\\b",
+#     "\\bwget\\b[^|]+\\|\\s*(sh|bash|zsh|fish)\\b",
+#     "\\bsudo\\b",
+#     "\\bdoas\\b",
+#     "\\bdd\\s+.*of=/dev/",
+#     "\\bmkfs\\.",
+# ]
+
+## ##############################################################################
 # SHELL INTEGRATION (OSC 133)
 ## ##############################################################################
 [shell_integration]

--- a/flake.nix
+++ b/flake.nix
@@ -100,7 +100,7 @@
         {
           freminal = rustPlatform.buildRustPackage {
             pname = "freminal";
-            version = "0.9.0-beta.2";
+            version = "0.9.0-beta.3";
             src = pkgs.lib.cleanSource ./.;
 
             cargoLock.lockFile = ./Cargo.lock;
@@ -148,9 +148,9 @@
                     <key>CFBundleIdentifier</key>
                     <string>io.github.fredclausen.freminal</string>
                     <key>CFBundleVersion</key>
-                    <string>0.9.0-beta.2</string>
+                    <string>0.9.0-beta.3</string>
                     <key>CFBundleShortVersionString</key>
-                    <string>0.9.0-beta.2</string>
+                    <string>0.9.0-beta.3</string>
                     <key>CFBundleExecutable</key>
                     <string>freminal</string>
                     <key>CFBundleIconFile</key>

--- a/freminal-common/Cargo.toml
+++ b/freminal-common/Cargo.toml
@@ -19,6 +19,7 @@ categories.workspace = true
 clap.workspace = true
 conv2.workspace = true
 directories.workspace = true
+regex.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 toml.workspace = true

--- a/freminal-common/src/config.rs
+++ b/freminal-common/src/config.rs
@@ -35,6 +35,7 @@ pub struct Config {
     pub tab_title: TabTitleConfig,
     pub bell: BellConfig,
     pub security: SecurityConfig,
+    pub paste_guard: PasteGuardConfig,
     pub shell_integration: ShellIntegrationConfig,
     pub command_blocks: CommandBlocksConfig,
     pub notifications: NotificationsConfig,
@@ -78,6 +79,7 @@ impl Default for Config {
             tab_title: TabTitleConfig::default(),
             bell: BellConfig::default(),
             security: SecurityConfig::default(),
+            paste_guard: PasteGuardConfig::default(),
             shell_integration: ShellIntegrationConfig::default(),
             command_blocks: CommandBlocksConfig::default(),
             notifications: NotificationsConfig::default(),
@@ -541,6 +543,107 @@ impl Default for SecurityConfig {
             allow_clipboard_read: false,
             password_indicator: true,
         }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+//  Paste Guard
+// ------------------------------------------------------------------------------------------------
+
+/// The default set of dangerous-command regex patterns matched against paste
+/// payloads when [`PasteGuardConfig::patterns`] is enabled.
+///
+/// Patterns use Rust [`regex`] syntax. They are intentionally conservative:
+/// each targets a command that is irreversible or privilege-escalating, so a
+/// false positive merely shows a confirmation dialog rather than silently
+/// running the command.
+fn default_paste_guard_patterns() -> Vec<String> {
+    vec![
+        r"\brm\s+-rf?\b".to_owned(),
+        r"\bcurl\b[^|]+\|\s*(sh|bash|zsh|fish)\b".to_owned(),
+        r"\bwget\b[^|]+\|\s*(sh|bash|zsh|fish)\b".to_owned(),
+        r"\bsudo\b".to_owned(),
+        r"\bdoas\b".to_owned(),
+        r"\bdd\s+.*of=/dev/".to_owned(),
+        r"\bmkfs\.".to_owned(),
+    ]
+}
+
+/// Configuration for the smart paste guard.
+///
+/// When a paste is "interesting" (multi-line, contains control characters, or
+/// matches a dangerous pattern) the GUI shows a confirmation dialog before
+/// sending the payload to the PTY. Each trigger can be toggled independently;
+/// the master [`enabled`](Self::enabled) switch disables the guard entirely.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+// Four independent TOML config toggles (master switch + three per-trigger
+// enables). Each maps directly to a documented `[paste_guard]` key; collapsing
+// them into an enum would distort the config schema and add noise.
+#[allow(clippy::struct_excessive_bools)]
+pub struct PasteGuardConfig {
+    /// Master switch. When `false`, no paste is ever intercepted regardless of
+    /// the per-trigger toggles below.
+    ///
+    /// Default: `true` (safer-by-default).
+    pub enabled: bool,
+
+    /// Confirm any paste containing a newline (`\n`).
+    ///
+    /// Default: `true`.
+    pub multiline: bool,
+
+    /// Confirm any paste containing control characters (ESC, BEL, etc.) other
+    /// than the line feeds covered by [`multiline`](Self::multiline) and the
+    /// bracketed-paste markers freminal wraps the payload with.
+    ///
+    /// Default: `true`.
+    pub control_chars: bool,
+
+    /// When `true`, additionally match the payload against
+    /// [`pattern_list`](Self::pattern_list) and escalate the warning when a
+    /// dangerous pattern is found.
+    ///
+    /// Default: `true`.
+    pub patterns: bool,
+
+    /// Regex patterns (Rust [`regex`] syntax) treated as dangerous. Matched
+    /// only when [`patterns`](Self::patterns) is `true`.
+    ///
+    /// Defaults to [`default_paste_guard_patterns`].
+    pub pattern_list: Vec<String>,
+}
+
+impl Default for PasteGuardConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            multiline: true,
+            control_chars: true,
+            patterns: true,
+            pattern_list: default_paste_guard_patterns(),
+        }
+    }
+}
+
+impl PasteGuardConfig {
+    /// Validate every entry in [`pattern_list`](Self::pattern_list), returning
+    /// one `(pattern, error_message)` pair per pattern that fails to compile as
+    /// a Rust [`regex`].
+    ///
+    /// An empty result means every pattern compiled successfully. The caller
+    /// (GUI) is expected to surface any returned errors to the user (e.g. via
+    /// the toast system) and skip the offending patterns at match time. This
+    /// crate has no UI surface, so validation is reported rather than enforced.
+    #[must_use]
+    pub fn invalid_patterns(&self) -> Vec<(String, String)> {
+        self.pattern_list
+            .iter()
+            .filter_map(|pattern| match regex::Regex::new(pattern) {
+                Ok(_) => None,
+                Err(err) => Some((pattern.clone(), err.to_string())),
+            })
+            .collect()
     }
 }
 
@@ -1215,6 +1318,7 @@ struct ConfigPartial {
     pub tab_title: Option<TabTitleConfig>,
     pub bell: Option<BellConfig>,
     pub security: Option<SecurityConfig>,
+    pub paste_guard: Option<PasteGuardConfig>,
     pub shell_integration: Option<ShellIntegrationConfig>,
     pub command_blocks: Option<CommandBlocksConfig>,
     pub notifications: Option<NotificationsConfig>,
@@ -1264,6 +1368,9 @@ impl Config {
         }
         if let Some(security) = partial.security {
             self.security = security;
+        }
+        if let Some(paste_guard) = partial.paste_guard {
+            self.paste_guard = paste_guard;
         }
         if let Some(shell_integration) = partial.shell_integration {
             self.shell_integration = shell_integration;
@@ -1821,6 +1928,68 @@ size = 14.0
         assert!(!parsed.command_blocks.show_duration);
         assert!((parsed.command_blocks.duration_threshold_secs - 5.5_f32).abs() < f32::EPSILON);
         assert_eq!(parsed.command_blocks.gutter, GutterPosition::Off);
+    }
+
+    #[test]
+    fn paste_guard_defaults_are_safer_by_default() {
+        let cfg = PasteGuardConfig::default();
+        assert!(cfg.enabled);
+        assert!(cfg.multiline);
+        assert!(cfg.control_chars);
+        // Pattern matching is enabled by default (dangerous-command detection
+        // is on out of the box).
+        assert!(cfg.patterns);
+        assert_eq!(cfg.pattern_list, default_paste_guard_patterns());
+        assert!(!cfg.pattern_list.is_empty());
+    }
+
+    #[test]
+    fn paste_guard_round_trips_through_toml() {
+        let mut cfg = Config::default();
+        cfg.paste_guard.enabled = false;
+        cfg.paste_guard.multiline = false;
+        cfg.paste_guard.control_chars = false;
+        cfg.paste_guard.patterns = false;
+        cfg.paste_guard.pattern_list = vec![r"\bgit\s+push\b".to_owned()];
+
+        let toml = toml::to_string_pretty(&cfg).expect("serialise config");
+        let parsed: Config = toml::from_str(&toml).expect("re-parse");
+
+        assert!(!parsed.paste_guard.enabled);
+        assert!(!parsed.paste_guard.multiline);
+        assert!(!parsed.paste_guard.control_chars);
+        assert!(!parsed.paste_guard.patterns);
+        assert_eq!(parsed.paste_guard.pattern_list, vec![r"\bgit\s+push\b"]);
+    }
+
+    #[test]
+    fn paste_guard_default_patterns_all_compile() {
+        let cfg = PasteGuardConfig::default();
+        let invalid = cfg.invalid_patterns();
+        assert!(
+            invalid.is_empty(),
+            "default paste-guard patterns must all compile: {invalid:?}"
+        );
+    }
+
+    #[test]
+    fn paste_guard_invalid_patterns_are_reported() {
+        let cfg = PasteGuardConfig {
+            // `[` opens an unterminated character class; `(` an unclosed group.
+            pattern_list: vec![r"\bsudo\b".to_owned(), "[".to_owned(), "(".to_owned()],
+            ..PasteGuardConfig::default()
+        };
+
+        let invalid = cfg.invalid_patterns();
+        assert_eq!(
+            invalid.len(),
+            2,
+            "exactly the two malformed patterns: {invalid:?}"
+        );
+        let bad: Vec<&str> = invalid.iter().map(|(p, _)| p.as_str()).collect();
+        assert!(bad.contains(&"["));
+        assert!(bad.contains(&"("));
+        assert!(!bad.contains(&r"\bsudo\b"));
     }
 
     #[test]
@@ -2656,6 +2825,7 @@ mode = "none"
         original.tab_title.policy = TabTitlePolicy::OscWins;
         original.bell.mode = BellMode::None;
         original.security.allow_clipboard_read = !Config::default().security.allow_clipboard_read;
+        original.paste_guard.patterns = !Config::default().paste_guard.patterns;
         original.shell_integration.set_term_program =
             !Config::default().shell_integration.set_term_program;
         original.command_blocks.enabled = !Config::default().command_blocks.enabled;
@@ -2721,6 +2891,10 @@ mode = "none"
             "security section dropped"
         );
         assert_eq!(
+            loaded.paste_guard.patterns, original.paste_guard.patterns,
+            "paste_guard section dropped"
+        );
+        assert_eq!(
             loaded.shell_integration.set_term_program, original.shell_integration.set_term_program,
             "shell_integration section dropped"
         );
@@ -2768,6 +2942,7 @@ mode = "none"
             tab_title: _,
             bell: _,
             security: _,
+            paste_guard: _,
             shell_integration: _,
             command_blocks: _,
             notifications: _,

--- a/freminal-common/src/keybindings.rs
+++ b/freminal-common/src/keybindings.rs
@@ -22,6 +22,7 @@
 //! |--------------------|------------------|
 //! | `Ctrl+Shift+C`     | Copy             |
 //! | `Ctrl+Shift+V`     | Paste            |
+//! | `Ctrl+Shift+Alt+V` | Paste (no guard) |
 //! | `Ctrl+Shift+T`     | New Tab          |
 //! | `Ctrl+Shift+W`     | Close Tab        |
 //! | `Ctrl+Shift+,`     | Open Settings    |
@@ -460,6 +461,13 @@ impl BindingModifiers {
         shift: false,
         alt: true,
     };
+
+    /// Ctrl + Shift + Alt.
+    pub const CTRL_SHIFT_ALT: Self = Self {
+        ctrl: true,
+        shift: true,
+        alt: true,
+    };
 }
 
 impl fmt::Display for BindingModifiers {
@@ -688,6 +696,9 @@ pub enum KeyAction {
     Copy,
     /// Paste the system clipboard contents into the terminal.
     Paste,
+    /// Paste the system clipboard contents directly, bypassing the smart
+    /// paste guard's confirmation dialog (Task 77).
+    PasteUnsafe,
     /// Select all visible terminal content.
     SelectAll,
 
@@ -868,6 +879,7 @@ impl KeyAction {
             Self::RenameTab => "rename_tab",
             Self::Copy => "copy",
             Self::Paste => "paste",
+            Self::PasteUnsafe => "paste_unsafe",
             Self::SelectAll => "select_all",
             Self::OpenSearch => "open_search",
             Self::SearchNext => "search_next",
@@ -938,6 +950,7 @@ impl KeyAction {
             Self::RenameTab => "Rename Tab",
             Self::Copy => "Copy",
             Self::Paste => "Paste",
+            Self::PasteUnsafe => "Paste (no confirmation)",
             Self::SelectAll => "Select All",
             Self::OpenSearch => "Open Search",
             Self::SearchNext => "Search Next",
@@ -1005,6 +1018,7 @@ impl KeyAction {
         Self::RenameTab,
         Self::Copy,
         Self::Paste,
+        Self::PasteUnsafe,
         Self::SelectAll,
         Self::OpenSearch,
         Self::SearchNext,
@@ -1084,6 +1098,7 @@ impl FromStr for KeyAction {
             "rename_tab" => Ok(Self::RenameTab),
             "copy" => Ok(Self::Copy),
             "paste" => Ok(Self::Paste),
+            "paste_unsafe" => Ok(Self::PasteUnsafe),
             "select_all" => Ok(Self::SelectAll),
             "open_search" => Ok(Self::OpenSearch),
             "search_next" => Ok(Self::SearchNext),
@@ -1313,6 +1328,13 @@ fn register_misc_bindings(map: &mut BindingMap) {
     map.bind(
         KeyCombo::new(BindingKey::V, BindingModifiers::CTRL_SHIFT),
         KeyAction::Paste,
+    );
+    // Paste bypassing the smart paste guard's confirmation dialog (Task 77).
+    // Ctrl+Shift+Alt+V is one modifier beyond the normal Paste combo so the
+    // "unsafe" variant is deliberate and not fat-fingered.
+    map.bind(
+        KeyCombo::new(BindingKey::V, BindingModifiers::CTRL_SHIFT_ALT),
+        KeyAction::PasteUnsafe,
     );
     // Copy the last completed command's output (OSC 133 D-bounded region).
     // Ctrl+Shift+Y is free on all platforms — bash readline binds Ctrl+Y to
@@ -1828,7 +1850,7 @@ mod tests {
         // roundtrip test above covers ALL, and name() is exhaustive.
         assert_eq!(
             KeyAction::ALL.len(),
-            59,
+            60,
             "KeyAction::ALL should contain all variants"
         );
     }
@@ -1853,6 +1875,25 @@ mod tests {
         let map = BindingMap::default();
         let combo = KeyCombo::new(BindingKey::V, BindingModifiers::CTRL_SHIFT);
         assert_eq!(map.lookup(&combo), Some(KeyAction::Paste));
+    }
+
+    #[test]
+    fn default_paste_unsafe_binding() {
+        let map = BindingMap::default();
+        let combo = KeyCombo::new(BindingKey::V, BindingModifiers::CTRL_SHIFT_ALT);
+        assert_eq!(map.lookup(&combo), Some(KeyAction::PasteUnsafe));
+        // The bypass combo must be distinct from the normal Paste combo.
+        let paste_combo = KeyCombo::new(BindingKey::V, BindingModifiers::CTRL_SHIFT);
+        assert_eq!(map.lookup(&paste_combo), Some(KeyAction::Paste));
+    }
+
+    #[test]
+    fn paste_unsafe_name_round_trips() {
+        assert_eq!(KeyAction::PasteUnsafe.name(), "paste_unsafe");
+        assert_eq!(
+            "paste_unsafe".parse::<KeyAction>(),
+            Ok(KeyAction::PasteUnsafe)
+        );
     }
 
     #[test]
@@ -2182,7 +2223,7 @@ mod tests {
         // The default map should have a known number of bindings.
         // This catches silent additions or removals.
         let map = BindingMap::default();
-        // Count: Copy(1) + Paste(1) + NewTab(1) + NextTab(1)
+        // Count: Copy(1) + Paste(1) + PasteUnsafe(1) + NewTab(1) + NextTab(1)
         //        + PrevTab(1) + SwitchToTab1-9(9) + ZoomIn(2) + ZoomOut(1)
         //        + ZoomReset(1) + OpenSettings(1) + OpenSearch(1)
         //        + PrevCommand(1) + NextCommand(1) + ScrollPageUp(1)
@@ -2192,11 +2233,11 @@ mod tests {
         //        + FocusPaneLeft/Down/Up/Right(4) + ResizePaneLeft/Down/Up/Right(4)
         //        + ZoomPane(1) + NewWindow(1) + ClearScrollback(1)
         //        + ToggleRecording(1) + UnfoldAll(1)
-        //        + CopyLastCommandOutput(1) + ShowCommandHistory(1) = 46
+        //        + CopyLastCommandOutput(1) + ShowCommandHistory(1) = 47
         assert_eq!(
             map.len(),
-            46,
-            "default binding map should have exactly 46 bindings"
+            47,
+            "default binding map should have exactly 47 bindings"
         );
     }
 

--- a/freminal/Cargo.toml
+++ b/freminal/Cargo.toml
@@ -34,7 +34,7 @@ deb_depends = ["libgl1-mesa-glx"]
 # `cargo xtask bump-version` keeps this in sync, translating the SemVer
 # pre-release separator to the RPM tilde operator (e.g. "0.9.0~beta.2"), which
 # sorts older than the final release just like the SemVer pre-release does.
-version = "0.9.0~beta.2"
+version = "0.9.0~beta.3"
 assets = [
   { source = "target/release/freminal", dest = "/usr/bin/freminal", mode = "755" },
 ]

--- a/freminal/Cargo.toml
+++ b/freminal/Cargo.toml
@@ -41,6 +41,10 @@ assets = [
 
 [[bench]]
 harness = false
+name = "paste_guard_bench"
+
+[[bench]]
+harness = false
 name = "render_loop_bench"
 
 [dependencies]

--- a/freminal/benches/paste_guard_bench.rs
+++ b/freminal/benches/paste_guard_bench.rs
@@ -1,0 +1,135 @@
+// Copyright (C) 2024-2026 Fred Clausen
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Smart paste guard analyzer benchmarks (Task 77).
+//!
+//! [`PasteGuard::analyze`] runs on the GUI thread for every paste, so a
+//! pathological payload (a very large clipboard with every trigger enabled and
+//! many regex patterns) must not stall the UI. The plan's budget is **< 50 ms
+//! for a 1 MB paste with all triggers and 20 patterns**.
+//!
+//! These benchmarks measure the analyzer on:
+//!
+//! 1. `analyze_1mb_all_triggers` — the worst case: 1 MB, multi-line, embedded
+//!    control characters, and 20 dangerous-command patterns.
+//! 2. `analyze_typical_paste` — a realistic ~2 KB multi-line snippet.
+//! 3. `rebuild_patterns` — recompiling the 20-pattern cache (config apply /
+//!    hot-reload cost).
+//!
+//! Pattern compilation is excluded from the per-paste path: the `analyze`
+//! benches build the `PasteGuard` once outside the timed closure.
+
+use std::time::Duration;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use freminal::gui::paste_guard::PasteGuard;
+use freminal_common::config::PasteGuardConfig;
+use std::hint::black_box;
+
+fn configure() -> Criterion {
+    Criterion::default()
+        .sample_size(20)
+        .warm_up_time(Duration::from_millis(300))
+        .measurement_time(Duration::from_secs(3))
+        .with_plots()
+}
+
+/// A config with all triggers on and 20 dangerous-command patterns (the 7
+/// defaults plus 13 more), matching the plan's worst-case budget.
+fn config_20_patterns() -> PasteGuardConfig {
+    // The default config already has every trigger enabled and the 7 default
+    // patterns, so we only need to pad the pattern list out to 20.
+    let mut cfg = PasteGuardConfig::default();
+    debug_assert!(cfg.enabled && cfg.multiline && cfg.control_chars && cfg.patterns);
+    // Start from the 7 defaults, then pad to 20 with additional realistic
+    // dangerous-command patterns.
+    cfg.pattern_list.extend(
+        [
+            r"\bchmod\s+-R?\s*777\b",
+            r"\bchown\s+-R\b",
+            r"\bgit\s+push\s+--force\b",
+            r"\bgit\s+reset\s+--hard\b",
+            r"\bkill\s+-9\b",
+            r"\bshutdown\b",
+            r"\breboot\b",
+            r"\bmkfs\b",
+            r"\bfdisk\b",
+            r"\bparted\b",
+            r"\bnpm\s+publish\b",
+            r"\bdocker\s+system\s+prune\b",
+            r"\bterraform\s+destroy\b",
+        ]
+        .iter()
+        .map(|s| (*s).to_owned()),
+    );
+    debug_assert_eq!(cfg.pattern_list.len(), 20);
+    cfg
+}
+
+/// Build a payload of approximately `target_bytes` bytes: many lines of shell-
+/// like text, a couple of embedded control characters, and a dangerous command
+/// near the end so the pattern scan does not short-circuit early.
+fn payload_of_size(target_bytes: usize) -> String {
+    let mut out = String::with_capacity(target_bytes + 64);
+    let line = "echo benchmark output line with some lorem ipsum filler text\n";
+    while out.len() < target_bytes {
+        out.push_str(line);
+    }
+    // An embedded control char (BEL) so the control-char trigger fires.
+    out.push('\u{0007}');
+    // A dangerous command at the very end so every pattern is scanned.
+    out.push_str("\nsudo rm -rf /tmp/example\n");
+    out
+}
+
+fn bench_analyze_1mb_all_triggers(c: &mut Criterion) {
+    let cfg = config_20_patterns();
+    let guard = PasteGuard::new(&cfg);
+    let payload = payload_of_size(1024 * 1024);
+
+    c.bench_function("analyze_1mb_all_triggers", |b| {
+        b.iter(|| {
+            let result = guard.analyze(black_box(&payload), black_box(&cfg));
+            black_box(result);
+        });
+    });
+}
+
+fn bench_analyze_typical_paste(c: &mut Criterion) {
+    let cfg = config_20_patterns();
+    let guard = PasteGuard::new(&cfg);
+    let payload = payload_of_size(2 * 1024);
+
+    c.bench_function("analyze_typical_paste", |b| {
+        b.iter(|| {
+            let result = guard.analyze(black_box(&payload), black_box(&cfg));
+            black_box(result);
+        });
+    });
+}
+
+fn bench_rebuild_patterns(c: &mut Criterion) {
+    let cfg = config_20_patterns();
+
+    c.bench_function("rebuild_patterns", |b| {
+        b.iter(|| {
+            let mut guard = PasteGuard::default();
+            let errors = guard.rebuild(black_box(&cfg));
+            black_box(errors);
+            black_box(guard);
+        });
+    });
+}
+
+criterion_group!(
+    name = benches;
+    config = configure();
+    targets =
+        bench_analyze_1mb_all_triggers,
+        bench_analyze_typical_paste,
+        bench_rebuild_patterns,
+);
+
+criterion_main!(benches);

--- a/freminal/src/gui/actions.rs
+++ b/freminal/src/gui/actions.rs
@@ -691,6 +691,12 @@ impl super::FreminalGui {
 
         // Read clipboard directly via arboard, bypassing egui-winit's
         // per-window clipboard (which fails on Wayland child windows).
+        //
+        // This is the menu-Paste / explicit-keybinding path. The far more
+        // common paste path is the windowing layer intercepting the paste
+        // shortcut and injecting an `Event::Paste` with already-read text;
+        // that goes through `guarded_paste_text` instead (see `update()`),
+        // which is why we must NOT rely on arboard for the common case.
         let text = match arboard::Clipboard::new().and_then(|mut cb| cb.get_text()) {
             Ok(text) if !text.is_empty() => text.replace("\r\n", "\n"),
             Ok(_) => return,
@@ -699,6 +705,24 @@ impl super::FreminalGui {
                 return;
             }
         };
+
+        self.guarded_paste_text(win, text);
+    }
+
+    /// Run the smart paste guard on an already-obtained `text` payload.
+    ///
+    /// Shared by the arboard path ([`guarded_paste`]) and the
+    /// windowing-injected `Event::Paste` path. A `Safe` analysis sends
+    /// straight to the active pane; anything flagged opens the confirm dialog.
+    ///
+    /// [`guarded_paste`]: Self::guarded_paste
+    pub(super) fn guarded_paste_text(&self, win: &mut PerWindowState, text: String) {
+        if win.paste_dialog.is_open() {
+            return;
+        }
+        if text.is_empty() {
+            return;
+        }
 
         let analysis = self.paste_guard.analyze(&text, &self.config.paste_guard);
 

--- a/freminal/src/gui/actions.rs
+++ b/freminal/src/gui/actions.rs
@@ -588,6 +588,7 @@ impl super::FreminalGui {
                 }
             }
             KeyAction::Paste => self.guarded_paste(win),
+            KeyAction::PasteUnsafe => Self::unguarded_paste(win),
             KeyAction::Copy
             | KeyAction::SelectAll
             | KeyAction::ToggleMenuBar
@@ -707,6 +708,25 @@ impl super::FreminalGui {
         };
 
         self.guarded_paste_text(win, text);
+    }
+
+    /// Paste the clipboard directly, bypassing the smart paste guard
+    /// (`KeyAction::PasteUnsafe`).
+    ///
+    /// This is the arboard path for the bypass action on platforms/configs
+    /// where the windowing paste interceptor does not fire (the common path
+    /// detects the bypass via the Alt modifier on `Event::Paste` and routes
+    /// through `send_paste_to_active_pane` directly).
+    pub(super) fn unguarded_paste(win: &mut PerWindowState) {
+        let text = match arboard::Clipboard::new().and_then(|mut cb| cb.get_text()) {
+            Ok(text) if !text.is_empty() => text.replace("\r\n", "\n"),
+            Ok(_) => return,
+            Err(e) => {
+                error!("Paste (unsafe): clipboard read failed: {e}");
+                return;
+            }
+        };
+        Self::send_paste_to_active_pane(win, text);
     }
 
     /// Run the smart paste guard on an already-obtained `text` payload.

--- a/freminal/src/gui/actions.rs
+++ b/freminal/src/gui/actions.rs
@@ -266,7 +266,6 @@ impl super::FreminalGui {
         action: freminal_common::keybindings::KeyAction,
         all_deferred_actions: &mut Vec<freminal_common::keybindings::KeyAction>,
     ) {
-        use freminal_common::buffer_states::modes::rl_bracket::RlBracket;
         use freminal_common::keybindings::KeyAction;
 
         match action {
@@ -293,28 +292,11 @@ impl super::FreminalGui {
                 }
             }
             KeyAction::Paste => {
-                let Some(pane) = win.tabs.active_tab_mut().active_pane_mut() else {
-                    warn!("Menu Paste: active tab has no active pane");
-                    return;
-                };
-                let snap = pane.arc_swap.load();
-                match arboard::Clipboard::new().and_then(|mut cb| cb.get_text()) {
-                    Ok(text) if !text.is_empty() => {
-                        let text = text.replace("\r\n", "\n");
-                        let payload = if snap.bracketed_paste == RlBracket::Enabled {
-                            format!("\x1b[200~{text}\x1b[201~")
-                        } else {
-                            text
-                        };
-                        if let Err(e) = pane.input_tx.send(InputEvent::Key(payload.into_bytes())) {
-                            error!("Menu Paste: failed to send paste to PTY: {e}");
-                        }
-                    }
-                    Ok(_) => {}
-                    Err(e) => {
-                        error!("Menu Paste: clipboard read failed: {e}");
-                    }
-                }
+                // Defer to `dispatch_deferred_action` so the smart paste guard
+                // (Task 77) can analyze the clipboard with access to the live
+                // config and the per-window confirm dialog. Unifies the menu
+                // paste path with the keybinding and egui-event paste paths.
+                all_deferred_actions.push(KeyAction::Paste);
             }
             KeyAction::SelectAll => {
                 let Some(pane) = win.tabs.active_tab_mut().active_pane_mut() else {
@@ -605,8 +587,8 @@ impl super::FreminalGui {
                     }
                 }
             }
+            KeyAction::Paste => self.guarded_paste(win),
             KeyAction::Copy
-            | KeyAction::Paste
             | KeyAction::SelectAll
             | KeyAction::ToggleMenuBar
             | KeyAction::ScrollPageUp
@@ -689,6 +671,64 @@ impl super::FreminalGui {
                 // parse error.  See `reload_config_from_disk` for details.
                 self.reload_config_from_disk(handle);
             }
+        }
+    }
+
+    /// Handle a paste request that has been deferred to the GUI layer so the
+    /// smart paste guard (Task 77) can run with access to the live config and
+    /// the per-window confirm dialog.
+    ///
+    /// Reads the system clipboard, normalises line endings, and analyses the
+    /// payload. A `Safe` result is sent straight to the active pane; anything
+    /// flagged opens the confirm dialog instead (resolved later in `update()`).
+    pub(super) fn guarded_paste(&self, win: &mut PerWindowState) {
+        // A confirm dialog is already up for this window; ignore the new
+        // paste request rather than stacking a second dialog or clobbering
+        // the pending payload. The user must resolve the open one first.
+        if win.paste_dialog.is_open() {
+            return;
+        }
+
+        // Read clipboard directly via arboard, bypassing egui-winit's
+        // per-window clipboard (which fails on Wayland child windows).
+        let text = match arboard::Clipboard::new().and_then(|mut cb| cb.get_text()) {
+            Ok(text) if !text.is_empty() => text.replace("\r\n", "\n"),
+            Ok(_) => return,
+            Err(e) => {
+                error!("Paste: clipboard read failed: {e}");
+                return;
+            }
+        };
+
+        let analysis = self.paste_guard.analyze(&text, &self.config.paste_guard);
+
+        if analysis.is_safe() {
+            Self::send_paste_to_active_pane(win, text);
+        } else {
+            win.paste_dialog.open(text, analysis);
+        }
+    }
+
+    /// Wrap `payload` for bracketed paste (when the active pane has it enabled)
+    /// and send it to the active pane's PTY.
+    ///
+    /// Used both for the `Safe` fast path and when the user confirms a flagged
+    /// paste via the dialog. A send failure (dead PTY) is logged, not fatal.
+    pub(super) fn send_paste_to_active_pane(win: &mut PerWindowState, payload: String) {
+        use freminal_common::buffer_states::modes::rl_bracket::RlBracket;
+
+        let Some(pane) = win.tabs.active_tab_mut().active_pane_mut() else {
+            warn!("Paste: active tab has no active pane");
+            return;
+        };
+        let snap = pane.arc_swap.load();
+        let wrapped = if snap.bracketed_paste == RlBracket::Enabled {
+            format!("\x1b[200~{payload}\x1b[201~")
+        } else {
+            payload
+        };
+        if let Err(e) = pane.input_tx.send(InputEvent::Key(wrapped.into_bytes())) {
+            error!("Paste: failed to send paste to PTY: {e}");
         }
     }
 }

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -222,6 +222,7 @@ impl freminal_windowing::App for FreminalGui {
                         dragging_tab: None,
                         last_tab_rects: Vec::new(),
                         pending_menu_actions: Vec::new(),
+                        paste_dialog: super::paste_guard::PasteDialog::default(),
                     };
                     self.windows.insert(window_id, win);
 
@@ -1938,6 +1939,7 @@ impl FreminalGui {
             dragging_tab: None,
             last_tab_rects: Vec::new(),
             pending_menu_actions: Vec::new(),
+            paste_dialog: super::paste_guard::PasteDialog::default(),
         }
     }
 

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -1122,7 +1122,8 @@ impl freminal_windowing::App for FreminalGui {
                 || self.pending_save_layout.is_some()
                 || self.about_window_open
                 || self.welcome.is_open()
-                || win.renaming_tab.is_some();
+                || win.renaming_tab.is_some()
+                || win.paste_dialog.is_open();
 
             // ── Pane border drag-to-resize ───────────────────────────
             //

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -1717,15 +1717,20 @@ impl freminal_windowing::App for FreminalGui {
             }
 
             // Drain a pending paste injected by the windowing layer's
-            // `Event::Paste` (Task 77). Run the smart paste guard on the
-            // already-read text; do not re-read the clipboard here.
+            // `Event::Paste` (Task 77). Use the already-read text; do not
+            // re-read the clipboard here. `bypass_guard` (the PasteUnsafe
+            // action, Ctrl+Shift+Alt+V) sends directly without analysis.
             let pending_paste = win
                 .tabs
                 .active_tab_mut()
                 .active_pane_mut()
                 .and_then(|pane| pane.view_state.pending_paste.take());
-            if let Some(text) = pending_paste {
-                self.guarded_paste_text(&mut win, text);
+            if let Some(pending) = pending_paste {
+                if pending.bypass_guard {
+                    Self::send_paste_to_active_pane(&mut win, pending.text);
+                } else {
+                    self.guarded_paste_text(&mut win, pending.text);
+                }
             }
 
             // Handle deferred close-pane (needs `ui` for ViewportCommand::Close).

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -1079,6 +1079,18 @@ impl freminal_windowing::App for FreminalGui {
                 all_deferred_actions.push(freminal_common::keybindings::KeyAction::SaveLayout);
             }
 
+            // Smart paste guard confirm dialog (Task 77).  Shown whenever a
+            // flagged paste is pending for this window.  On confirm, the
+            // resolved (possibly edited) payload is sent to the active pane;
+            // on cancel the paste is discarded.
+            match win.paste_dialog.show(ctx) {
+                super::paste_guard::PasteDialogOutcome::Paste(payload) => {
+                    Self::send_paste_to_active_pane(&mut win, payload);
+                }
+                super::paste_guard::PasteDialogOutcome::Cancelled
+                | super::paste_guard::PasteDialogOutcome::Idle => {}
+            }
+
             // Floating "About Freminal" dialog.  Shown whenever the user
             // clicked "About Freminal" in the Help menu.  Self-dismissing
             // via its own Close button or title-bar X.

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -1715,6 +1715,18 @@ impl freminal_windowing::App for FreminalGui {
                 self.dispatch_deferred_action(action, &mut win, window_id, handle);
             }
 
+            // Drain a pending paste injected by the windowing layer's
+            // `Event::Paste` (Task 77). Run the smart paste guard on the
+            // already-read text; do not re-read the clipboard here.
+            let pending_paste = win
+                .tabs
+                .active_tab_mut()
+                .active_pane_mut()
+                .and_then(|pane| pane.view_state.pending_paste.take());
+            if let Some(text) = pending_paste {
+                self.guarded_paste_text(&mut win, text);
+            }
+
             // Handle deferred close-pane (needs `ui` for ViewportCommand::Close).
             if win.pending_close_pane {
                 win.pending_close_pane = false;

--- a/freminal/src/gui/layout_ops.rs
+++ b/freminal/src/gui/layout_ops.rs
@@ -630,6 +630,7 @@ impl FreminalGui {
             dragging_tab: None,
             last_tab_rects: Vec::new(),
             pending_menu_actions: Vec::new(),
+            paste_dialog: super::paste_guard::PasteDialog::default(),
         };
         self.windows.insert(window_id, win);
 

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -42,6 +42,11 @@ mod hot_reload;
 mod layout_ops;
 mod menu;
 mod notifications;
+// TODO(77.4): remove this `allow` once the analyzer is wired into the paste
+// handling path in `terminal/input.rs`. The module is fully unit-tested but
+// has no production caller until then.
+#[allow(dead_code)]
+mod paste_guard;
 mod platform;
 mod recording;
 mod rendering;

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -42,7 +42,7 @@ mod hot_reload;
 mod layout_ops;
 mod menu;
 mod notifications;
-mod paste_guard;
+pub mod paste_guard;
 mod platform;
 mod recording;
 mod rendering;

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -42,10 +42,6 @@ mod hot_reload;
 mod layout_ops;
 mod menu;
 mod notifications;
-// TODO(77.4): remove this `allow` once the analyzer is wired into the paste
-// handling path in `terminal/input.rs`. The module is fully unit-tested but
-// has no production caller until then.
-#[allow(dead_code)]
 mod paste_guard;
 mod platform;
 mod recording;
@@ -137,6 +133,12 @@ struct FreminalGui {
     /// new settings. Passed into the terminal widget on every frame so that
     /// bound key combos are intercepted before PTY dispatch.
     binding_map: freminal_common::keybindings::BindingMap,
+
+    /// Smart paste guard with its compiled dangerous-command pattern cache
+    /// (Task 77). Rebuilt from `config.paste_guard` when the user applies new
+    /// settings. Consulted on every paste to decide whether to show the
+    /// confirm dialog.
+    paste_guard: paste_guard::PasteGuard,
 
     /// Monotonic generator for `PaneId` values.
     ///
@@ -315,6 +317,8 @@ impl FreminalGui {
             freminal_common::keybindings::BindingMap::default()
         });
 
+        let paste_guard = paste_guard::PasteGuard::new(&config.paste_guard);
+
         // Load persisted app state (currently just the first-run flag).
         // Lives in `$XDG_STATE_HOME/freminal/state.toml` so NixOS
         // home-manager users with a read-only `config.toml` can still
@@ -369,6 +373,7 @@ impl FreminalGui {
         let app = Self {
             windows: HashMap::new(),
             binding_map,
+            paste_guard,
             config,
             args,
             settings_modal: SettingsModal::new(config_path.clone()),

--- a/freminal/src/gui/paste_guard.rs
+++ b/freminal/src/gui/paste_guard.rs
@@ -297,13 +297,6 @@ impl PasteDialog {
         self.state.is_some()
     }
 
-    /// Discard any open dialog without producing an outcome.
-    ///
-    /// Used by 77.4 when the target pane closes out from under an open dialog.
-    pub(in crate::gui) fn close(&mut self) {
-        self.state = None;
-    }
-
     /// Render the dialog for one frame and return the resulting outcome.
     ///
     /// Returns [`PasteDialogOutcome::Idle`] when the dialog is closed or still
@@ -666,7 +659,7 @@ mod tests {
     }
 
     #[test]
-    fn dialog_opens_and_closes() {
+    fn dialog_opens_on_flagged_analysis() {
         let mut dialog = PasteDialog::default();
         assert!(!dialog.is_open());
 
@@ -677,9 +670,6 @@ mod tests {
             },
         );
         assert!(dialog.is_open());
-
-        dialog.close();
-        assert!(!dialog.is_open());
     }
 
     #[test]

--- a/freminal/src/gui/paste_guard.rs
+++ b/freminal/src/gui/paste_guard.rs
@@ -258,9 +258,6 @@ struct PasteDialogState {
     editing: bool,
     /// Scratch buffer for the edit mode, initialised from `payload`.
     edit_buffer: String,
-    /// `true` only on the first frame after opening, used to focus the edit
-    /// field exactly once when entering edit mode.
-    just_entered_edit: bool,
 }
 
 /// The confirm-paste modal dialog (Task 77.3).
@@ -288,7 +285,6 @@ impl PasteDialog {
             payload,
             analysis,
             editing: false,
-            just_entered_edit: false,
         });
     }
 
@@ -340,11 +336,19 @@ impl PasteDialog {
                                 egui::TextEdit::multiline(&mut state.edit_buffer)
                                     .font(egui::TextStyle::Monospace)
                                     .desired_width(f32::INFINITY)
-                                    .desired_rows(10),
+                                    .desired_rows(10)
+                                    // Hold focus so Tab and clicks inside the
+                                    // dialog do not bounce focus back to the
+                                    // terminal.
+                                    .lock_focus(true),
                             );
-                            if state.just_entered_edit {
+                            // Pull focus every frame the editor lacks it — same
+                            // pattern as the search and command-history
+                            // overlays. Requesting only once on entry is not
+                            // enough; egui can hand focus back to the terminal's
+                            // focus-lock interactable otherwise.
+                            if !response.has_focus() {
                                 response.request_focus();
-                                state.just_entered_edit = false;
                             }
                         } else {
                             // Read-only: a disabled multiline TextEdit keeps the
@@ -378,7 +382,6 @@ impl PasteDialog {
                     }
                     if !state.editing && ui.button("Edit and Paste").clicked() {
                         state.editing = true;
-                        state.just_entered_edit = true;
                     }
                 });
             });

--- a/freminal/src/gui/paste_guard.rs
+++ b/freminal/src/gui/paste_guard.rs
@@ -1,0 +1,402 @@
+// Copyright (C) 2024-2026 Fred Clausen
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Smart paste guard analyzer (Task 77).
+//!
+//! Classifies a paste payload against the `[paste_guard]` config so the GUI
+//! can decide whether to send it straight to the PTY or first show a
+//! confirmation dialog (77.3, wired in 77.4).
+//!
+//! Two pieces live here:
+//!
+//! - [`analyze`] — a pure function that classifies a payload into a
+//!   [`PasteAnalysis`]. It takes the already-compiled dangerous-command
+//!   patterns so the hot path never re-compiles regexes.
+//! - [`PasteGuard`] — owns the compiled pattern cache. Rebuilt from
+//!   [`PasteGuardConfig`] at startup and on config hot-reload;
+//!   [`PasteGuard::rebuild`] returns the patterns that failed to compile so
+//!   the caller can surface them (e.g. via the toast stack) and the guard
+//!   silently skips them at match time.
+
+use freminal_common::config::PasteGuardConfig;
+use regex::Regex;
+
+/// The classification of a paste payload produced by [`analyze`].
+///
+/// `Safe` means no enabled trigger fired and the payload may be sent
+/// directly. Every other variant means the confirmation dialog should be
+/// shown, carrying enough detail to explain *why* to the user.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::gui) enum PasteAnalysis {
+    /// No enabled trigger fired; send the payload without confirmation.
+    Safe,
+    /// The payload contains at least one newline.
+    Multiline {
+        /// Number of lines in the payload (one more than the newline count).
+        line_count: usize,
+        /// Total byte length of the payload.
+        byte_count: usize,
+    },
+    /// The payload contains control characters other than the line breaks
+    /// and tabs that appear routinely in legitimate text.
+    ControlChars {
+        /// The distinct flagged control characters, in first-seen order.
+        chars: Vec<char>,
+    },
+    /// The payload matched one or more dangerous-command patterns.
+    Patterns {
+        /// The source pattern strings that matched, in config order.
+        matched: Vec<String>,
+    },
+    /// More than one trigger fired. `triggers` never contains `Safe` or a
+    /// nested `Multiple`; it is a flat list of the individual triggers in a
+    /// stable order (multiline, control chars, patterns).
+    Multiple {
+        /// The individual triggers that fired.
+        triggers: Vec<Self>,
+    },
+}
+
+impl PasteAnalysis {
+    /// Whether the payload may be sent without confirmation.
+    pub(in crate::gui) const fn is_safe(&self) -> bool {
+        matches!(self, Self::Safe)
+    }
+}
+
+/// Returns `true` for control characters the guard should flag.
+///
+/// Newline (`\n`) is handled by the multiline trigger, and carriage return
+/// (`\r`) and tab (`\t`) appear routinely in legitimate pasted text, so none
+/// of those count here. Everything else `char::is_control` reports — ESC,
+/// BEL, NUL, the other C0 controls, and the C1 controls — is flagged.
+fn is_flagged_control(c: char) -> bool {
+    c.is_control() && c != '\n' && c != '\r' && c != '\t'
+}
+
+/// Classify `payload` against the enabled triggers in `config`.
+///
+/// `compiled` is the cache of successfully-compiled dangerous-command
+/// patterns (see [`PasteGuard`]); it is consulted only when
+/// [`PasteGuardConfig::patterns`] is enabled. This function performs no
+/// allocation-heavy work beyond collecting the (small) trigger detail and
+/// never compiles a regex, so it is safe to call on the GUI thread for every
+/// paste.
+///
+/// When `config.enabled` is `false` the result is always [`PasteAnalysis::Safe`].
+pub(in crate::gui) fn analyze(
+    payload: &str,
+    config: &PasteGuardConfig,
+    compiled: &[Regex],
+) -> PasteAnalysis {
+    if !config.enabled {
+        return PasteAnalysis::Safe;
+    }
+
+    let mut triggers: Vec<PasteAnalysis> = Vec::new();
+
+    if config.multiline && payload.contains('\n') {
+        // `lines()` would undercount a trailing newline; count breaks + 1.
+        let newlines = payload.matches('\n').count();
+        triggers.push(PasteAnalysis::Multiline {
+            line_count: newlines + 1,
+            byte_count: payload.len(),
+        });
+    }
+
+    if config.control_chars {
+        let mut chars: Vec<char> = Vec::new();
+        for c in payload.chars() {
+            if is_flagged_control(c) && !chars.contains(&c) {
+                chars.push(c);
+            }
+        }
+        if !chars.is_empty() {
+            triggers.push(PasteAnalysis::ControlChars { chars });
+        }
+    }
+
+    if config.patterns {
+        let matched: Vec<String> = compiled
+            .iter()
+            .filter(|re| re.is_match(payload))
+            .map(|re| re.as_str().to_owned())
+            .collect();
+        if !matched.is_empty() {
+            triggers.push(PasteAnalysis::Patterns { matched });
+        }
+    }
+
+    match triggers.len() {
+        0 => PasteAnalysis::Safe,
+        1 => {
+            // Exactly one trigger: unwrap it out of the vec.
+            triggers.into_iter().next().unwrap_or(PasteAnalysis::Safe)
+        }
+        _ => PasteAnalysis::Multiple { triggers },
+    }
+}
+
+/// Owns the compiled dangerous-command pattern cache.
+///
+/// The cache is rebuilt from [`PasteGuardConfig::pattern_list`] at startup and
+/// whenever the config is hot-reloaded. Patterns that fail to compile are
+/// skipped (and reported by [`PasteGuard::rebuild`]) so a single malformed
+/// user pattern never disables the guard.
+#[derive(Debug, Default)]
+pub(in crate::gui) struct PasteGuard {
+    compiled: Vec<Regex>,
+}
+
+impl PasteGuard {
+    /// Build a guard from `config`, discarding any compile errors.
+    ///
+    /// Prefer [`PasteGuard::rebuild`] on an existing guard when you need to
+    /// surface compile errors to the user.
+    pub(in crate::gui) fn new(config: &PasteGuardConfig) -> Self {
+        let mut guard = Self::default();
+        let _ = guard.rebuild(config);
+        guard
+    }
+
+    /// Recompile the pattern cache from `config`, returning one
+    /// `(pattern, error_message)` pair for every pattern that failed to
+    /// compile. An empty result means every pattern compiled.
+    ///
+    /// Successfully-compiled patterns are always installed even when some
+    /// siblings fail, so the guard stays maximally effective.
+    pub(in crate::gui) fn rebuild(&mut self, config: &PasteGuardConfig) -> Vec<(String, String)> {
+        let mut compiled = Vec::with_capacity(config.pattern_list.len());
+        let mut errors = Vec::new();
+        for pattern in &config.pattern_list {
+            match Regex::new(pattern) {
+                Ok(re) => compiled.push(re),
+                Err(err) => errors.push((pattern.clone(), err.to_string())),
+            }
+        }
+        self.compiled = compiled;
+        errors
+    }
+
+    /// Classify `payload` using the cached patterns and `config`.
+    pub(in crate::gui) fn analyze(
+        &self,
+        payload: &str,
+        config: &PasteGuardConfig,
+    ) -> PasteAnalysis {
+        analyze(payload, config, &self.compiled)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_all_on() -> PasteGuardConfig {
+        PasteGuardConfig {
+            enabled: true,
+            multiline: true,
+            control_chars: true,
+            patterns: true,
+            pattern_list: vec![r"\brm\s+-rf?\b".to_owned(), r"\bsudo\b".to_owned()],
+        }
+    }
+
+    #[test]
+    fn safe_single_line_plain_text() {
+        let cfg = config_all_on();
+        let guard = PasteGuard::new(&cfg);
+        assert_eq!(guard.analyze("echo hello", &cfg), PasteAnalysis::Safe);
+    }
+
+    #[test]
+    fn disabled_master_switch_is_always_safe() {
+        let cfg = PasteGuardConfig {
+            enabled: false,
+            ..config_all_on()
+        };
+        let guard = PasteGuard::new(&cfg);
+        // Multi-line + dangerous pattern, but the guard is off.
+        assert_eq!(
+            guard.analyze("sudo rm -rf /\nsecond line", &cfg),
+            PasteAnalysis::Safe
+        );
+    }
+
+    #[test]
+    fn multiline_trigger() {
+        let cfg = PasteGuardConfig {
+            patterns: false,
+            control_chars: false,
+            ..config_all_on()
+        };
+        let guard = PasteGuard::new(&cfg);
+        let payload = "line one\nline two\nline three";
+        assert_eq!(
+            guard.analyze(payload, &cfg),
+            PasteAnalysis::Multiline {
+                line_count: 3,
+                byte_count: payload.len(),
+            }
+        );
+    }
+
+    #[test]
+    fn multiline_counts_trailing_newline_as_extra_line() {
+        let cfg = PasteGuardConfig {
+            patterns: false,
+            control_chars: false,
+            ..config_all_on()
+        };
+        let guard = PasteGuard::new(&cfg);
+        assert_eq!(
+            guard.analyze("only\n", &cfg),
+            PasteAnalysis::Multiline {
+                line_count: 2,
+                byte_count: 5,
+            }
+        );
+    }
+
+    #[test]
+    fn multiline_disabled_does_not_fire() {
+        let cfg = PasteGuardConfig {
+            multiline: false,
+            patterns: false,
+            control_chars: false,
+            ..config_all_on()
+        };
+        let guard = PasteGuard::new(&cfg);
+        assert_eq!(guard.analyze("a\nb\nc", &cfg), PasteAnalysis::Safe);
+    }
+
+    #[test]
+    fn control_chars_trigger_on_esc_and_bel() {
+        let cfg = PasteGuardConfig {
+            multiline: false,
+            patterns: false,
+            ..config_all_on()
+        };
+        let guard = PasteGuard::new(&cfg);
+        match guard.analyze("safe\x1b\x07text", &cfg) {
+            PasteAnalysis::ControlChars { chars } => {
+                assert_eq!(chars, vec!['\x1b', '\x07']);
+            }
+            other => panic!("expected ControlChars, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn control_chars_ignores_tab_and_carriage_return() {
+        let cfg = PasteGuardConfig {
+            multiline: false,
+            patterns: false,
+            ..config_all_on()
+        };
+        let guard = PasteGuard::new(&cfg);
+        // Tab and CR are routine in legitimate text and must not trigger.
+        assert_eq!(guard.analyze("a\tb\rc", &cfg), PasteAnalysis::Safe);
+    }
+
+    #[test]
+    fn control_chars_deduplicates_in_first_seen_order() {
+        let cfg = PasteGuardConfig {
+            multiline: false,
+            patterns: false,
+            ..config_all_on()
+        };
+        let guard = PasteGuard::new(&cfg);
+        match guard.analyze("\x07\x1b\x07\x1b", &cfg) {
+            PasteAnalysis::ControlChars { chars } => {
+                assert_eq!(chars, vec!['\x07', '\x1b']);
+            }
+            other => panic!("expected ControlChars, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn patterns_trigger_records_matched_sources() {
+        let cfg = PasteGuardConfig {
+            multiline: false,
+            control_chars: false,
+            ..config_all_on()
+        };
+        let guard = PasteGuard::new(&cfg);
+        match guard.analyze("please sudo rm -rf /tmp/x", &cfg) {
+            PasteAnalysis::Patterns { matched } => {
+                assert!(matched.contains(&r"\brm\s+-rf?\b".to_owned()));
+                assert!(matched.contains(&r"\bsudo\b".to_owned()));
+            }
+            other => panic!("expected Patterns, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn patterns_disabled_does_not_fire() {
+        let cfg = PasteGuardConfig {
+            multiline: false,
+            control_chars: false,
+            patterns: false,
+            ..config_all_on()
+        };
+        let guard = PasteGuard::new(&cfg);
+        assert_eq!(guard.analyze("sudo rm -rf /", &cfg), PasteAnalysis::Safe);
+    }
+
+    #[test]
+    fn multiple_triggers_are_flattened() {
+        let cfg = config_all_on();
+        let guard = PasteGuard::new(&cfg);
+        // Multi-line + control char + dangerous pattern.
+        match guard.analyze("sudo something\nrm -rf /\x1b", &cfg) {
+            PasteAnalysis::Multiple { triggers } => {
+                assert_eq!(triggers.len(), 3);
+                assert!(matches!(triggers[0], PasteAnalysis::Multiline { .. }));
+                assert!(matches!(triggers[1], PasteAnalysis::ControlChars { .. }));
+                assert!(matches!(triggers[2], PasteAnalysis::Patterns { .. }));
+                // The flattened list never nests Multiple or Safe.
+                assert!(
+                    !triggers
+                        .iter()
+                        .any(|t| matches!(t, PasteAnalysis::Multiple { .. } | PasteAnalysis::Safe))
+                );
+            }
+            other => panic!("expected Multiple, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rebuild_reports_invalid_patterns_and_keeps_valid_ones() {
+        let cfg = PasteGuardConfig {
+            multiline: false,
+            control_chars: false,
+            pattern_list: vec![r"\bsudo\b".to_owned(), "[".to_owned()],
+            ..config_all_on()
+        };
+        let mut guard = PasteGuard::default();
+        let errors = guard.rebuild(&cfg);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].0, "[");
+        // The valid `sudo` pattern still matches despite the malformed sibling.
+        match guard.analyze("sudo reboot", &cfg) {
+            PasteAnalysis::Patterns { matched } => {
+                assert_eq!(matched, vec![r"\bsudo\b".to_owned()]);
+            }
+            other => panic!("expected Patterns, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn is_safe_helper() {
+        assert!(PasteAnalysis::Safe.is_safe());
+        assert!(
+            !PasteAnalysis::Multiline {
+                line_count: 2,
+                byte_count: 4
+            }
+            .is_safe()
+        );
+    }
+}

--- a/freminal/src/gui/paste_guard.rs
+++ b/freminal/src/gui/paste_guard.rs
@@ -31,7 +31,7 @@ use regex::Regex;
 /// directly. Every other variant means the confirmation dialog should be
 /// shown, carrying enough detail to explain *why* to the user.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(in crate::gui) enum PasteAnalysis {
+pub enum PasteAnalysis {
     /// No enabled trigger fired; send the payload without confirmation.
     Safe,
     /// The payload contains at least one newline.
@@ -63,7 +63,8 @@ pub(in crate::gui) enum PasteAnalysis {
 
 impl PasteAnalysis {
     /// Whether the payload may be sent without confirmation.
-    pub(in crate::gui) const fn is_safe(&self) -> bool {
+    #[must_use]
+    pub const fn is_safe(&self) -> bool {
         matches!(self, Self::Safe)
     }
 }
@@ -88,11 +89,8 @@ fn is_flagged_control(c: char) -> bool {
 /// paste.
 ///
 /// When `config.enabled` is `false` the result is always [`PasteAnalysis::Safe`].
-pub(in crate::gui) fn analyze(
-    payload: &str,
-    config: &PasteGuardConfig,
-    compiled: &[Regex],
-) -> PasteAnalysis {
+#[must_use]
+pub fn analyze(payload: &str, config: &PasteGuardConfig, compiled: &[Regex]) -> PasteAnalysis {
     if !config.enabled {
         return PasteAnalysis::Safe;
     }
@@ -148,7 +146,7 @@ pub(in crate::gui) fn analyze(
 /// skipped (and reported by [`PasteGuard::rebuild`]) so a single malformed
 /// user pattern never disables the guard.
 #[derive(Debug, Default)]
-pub(in crate::gui) struct PasteGuard {
+pub struct PasteGuard {
     compiled: Vec<Regex>,
 }
 
@@ -157,7 +155,8 @@ impl PasteGuard {
     ///
     /// Prefer [`PasteGuard::rebuild`] on an existing guard when you need to
     /// surface compile errors to the user.
-    pub(in crate::gui) fn new(config: &PasteGuardConfig) -> Self {
+    #[must_use]
+    pub fn new(config: &PasteGuardConfig) -> Self {
         let mut guard = Self::default();
         let _ = guard.rebuild(config);
         guard
@@ -169,7 +168,7 @@ impl PasteGuard {
     ///
     /// Successfully-compiled patterns are always installed even when some
     /// siblings fail, so the guard stays maximally effective.
-    pub(in crate::gui) fn rebuild(&mut self, config: &PasteGuardConfig) -> Vec<(String, String)> {
+    pub fn rebuild(&mut self, config: &PasteGuardConfig) -> Vec<(String, String)> {
         let mut compiled = Vec::with_capacity(config.pattern_list.len());
         let mut errors = Vec::new();
         for pattern in &config.pattern_list {
@@ -183,11 +182,8 @@ impl PasteGuard {
     }
 
     /// Classify `payload` using the cached patterns and `config`.
-    pub(in crate::gui) fn analyze(
-        &self,
-        payload: &str,
-        config: &PasteGuardConfig,
-    ) -> PasteAnalysis {
+    #[must_use]
+    pub fn analyze(&self, payload: &str, config: &PasteGuardConfig) -> PasteAnalysis {
         analyze(payload, config, &self.compiled)
     }
 }

--- a/freminal/src/gui/paste_guard.rs
+++ b/freminal/src/gui/paste_guard.rs
@@ -20,6 +20,8 @@
 //!   the caller can surface them (e.g. via the toast stack) and the guard
 //!   silently skips them at match time.
 
+use std::fmt::Write as _;
+
 use freminal_common::config::PasteGuardConfig;
 use regex::Regex;
 
@@ -187,6 +189,226 @@ impl PasteGuard {
         config: &PasteGuardConfig,
     ) -> PasteAnalysis {
         analyze(payload, config, &self.compiled)
+    }
+}
+
+/// A one-line, human-readable explanation of why the paste was flagged,
+/// shown in the dialog banner.
+///
+/// Pure and unit-tested; the dialog renderer only formats this string.
+fn banner_text(analysis: &PasteAnalysis) -> String {
+    match analysis {
+        // `Safe` never reaches the dialog, but give a sane string rather than
+        // panicking if it somehow does.
+        PasteAnalysis::Safe => "Paste".to_owned(),
+        PasteAnalysis::Multiline {
+            line_count,
+            byte_count,
+        } => {
+            format!("Multi-line paste — {line_count} lines, {byte_count} bytes")
+        }
+        PasteAnalysis::ControlChars { chars } => {
+            let rendered = chars
+                .iter()
+                .map(|c| format!("U+{:04X}", u32::from(*c)))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("Control characters detected: {rendered}")
+        }
+        PasteAnalysis::Patterns { matched } => {
+            format!("Dangerous patterns detected: {}", matched.join(", "))
+        }
+        PasteAnalysis::Multiple { triggers } => {
+            let parts = triggers
+                .iter()
+                .map(banner_text)
+                .collect::<Vec<_>>()
+                .join("; ");
+            let mut out = String::from("Multiple triggers — ");
+            // `write!` into a String is infallible; ignore the Result without
+            // an `unwrap` to satisfy the panic-free policy.
+            let _ = write!(out, "{parts}");
+            out
+        }
+    }
+}
+
+/// The result of rendering the confirm-paste dialog for one frame.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::gui) enum PasteDialogOutcome {
+    /// The dialog is closed, or open and awaiting a decision. Nothing to do.
+    Idle,
+    /// The user cancelled. The pending paste must be discarded.
+    Cancelled,
+    /// The user confirmed. The carried payload (original or edited) must be
+    /// sent to the PTY by the caller (77.4), which owns bracketed-paste
+    /// wrapping and PTY routing.
+    Paste(String),
+}
+
+/// State for a single open confirm-paste dialog.
+#[derive(Debug, Clone)]
+struct PasteDialogState {
+    /// The raw, unwrapped paste payload as analysed.
+    payload: String,
+    /// Why the paste was flagged (drives the banner).
+    analysis: PasteAnalysis,
+    /// `true` once the user clicked "Edit and Paste"; the content area becomes
+    /// an editable `TextEdit` bound to `edit_buffer`.
+    editing: bool,
+    /// Scratch buffer for the edit mode, initialised from `payload`.
+    edit_buffer: String,
+    /// `true` only on the first frame after opening, used to focus the edit
+    /// field exactly once when entering edit mode.
+    just_entered_edit: bool,
+}
+
+/// The confirm-paste modal dialog (Task 77.3).
+///
+/// Lives on `PerWindowState`. Opened by the paste path (77.4) when the
+/// analyzer flags a payload, rendered every frame while open via [`show`],
+/// and resolved when the user confirms, cancels, or presses a shortcut.
+///
+/// [`show`]: PasteDialog::show
+#[derive(Debug, Default)]
+pub(in crate::gui) struct PasteDialog {
+    state: Option<PasteDialogState>,
+}
+
+impl PasteDialog {
+    /// Open the dialog for `payload` with its precomputed `analysis`.
+    ///
+    /// A `Safe` analysis is ignored — the dialog is only for flagged pastes.
+    pub(in crate::gui) fn open(&mut self, payload: String, analysis: PasteAnalysis) {
+        if analysis.is_safe() {
+            return;
+        }
+        self.state = Some(PasteDialogState {
+            edit_buffer: payload.clone(),
+            payload,
+            analysis,
+            editing: false,
+            just_entered_edit: false,
+        });
+    }
+
+    /// Whether the dialog is currently open.
+    pub(in crate::gui) const fn is_open(&self) -> bool {
+        self.state.is_some()
+    }
+
+    /// Discard any open dialog without producing an outcome.
+    ///
+    /// Used by 77.4 when the target pane closes out from under an open dialog.
+    pub(in crate::gui) fn close(&mut self) {
+        self.state = None;
+    }
+
+    /// Render the dialog for one frame and return the resulting outcome.
+    ///
+    /// Returns [`PasteDialogOutcome::Idle`] when the dialog is closed or still
+    /// awaiting a decision. On `Cancelled` or `Paste`, the dialog closes
+    /// itself before returning.
+    ///
+    /// Keyboard shortcuts: `Escape` cancels; `Ctrl+Enter` pastes the current
+    /// payload (edited content when in edit mode).
+    pub(in crate::gui) fn show(&mut self, ctx: &egui::Context) -> PasteDialogOutcome {
+        let Some(state) = self.state.as_mut() else {
+            return PasteDialogOutcome::Idle;
+        };
+
+        let mut outcome = PasteDialogOutcome::Idle;
+
+        let escape = ctx.input(|i| i.key_pressed(egui::Key::Escape));
+        let ctrl_enter = ctx.input(|i| i.modifiers.command && i.key_pressed(egui::Key::Enter));
+
+        egui::Window::new("Confirm Paste")
+            .collapsible(false)
+            .resizable(false)
+            .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+            .show(ctx, |ui| {
+                ui.set_max_width(560.0);
+
+                // Trigger banner.
+                ui.label(
+                    egui::RichText::new(banner_text(&state.analysis))
+                        .strong()
+                        .color(egui::Color32::from_rgb(0xE0, 0x6C, 0x4B)),
+                );
+                ui.add_space(6.0);
+
+                // Content area: read-only preview, or editable buffer.
+                egui::ScrollArea::vertical()
+                    .max_height(280.0)
+                    .auto_shrink([false, true])
+                    .show(ui, |ui| {
+                        if state.editing {
+                            let response = ui.add(
+                                egui::TextEdit::multiline(&mut state.edit_buffer)
+                                    .font(egui::TextStyle::Monospace)
+                                    .desired_width(f32::INFINITY)
+                                    .desired_rows(10),
+                            );
+                            if state.just_entered_edit {
+                                response.request_focus();
+                                state.just_entered_edit = false;
+                            }
+                        } else {
+                            // Read-only: a disabled multiline TextEdit keeps the
+                            // monospace + selectable behaviour without allowing
+                            // edits.
+                            let mut view = state.payload.as_str();
+                            ui.add_enabled(
+                                false,
+                                egui::TextEdit::multiline(&mut view)
+                                    .font(egui::TextStyle::Monospace)
+                                    .desired_width(f32::INFINITY)
+                                    .desired_rows(10),
+                            );
+                        }
+                    });
+
+                ui.add_space(8.0);
+
+                ui.horizontal(|ui| {
+                    // Cancel is the default (safest) action.
+                    if ui.button("Cancel").clicked() {
+                        outcome = PasteDialogOutcome::Cancelled;
+                    }
+                    if ui.button("Paste Anyway").clicked() {
+                        let payload = if state.editing {
+                            state.edit_buffer.clone()
+                        } else {
+                            state.payload.clone()
+                        };
+                        outcome = PasteDialogOutcome::Paste(payload);
+                    }
+                    if !state.editing && ui.button("Edit and Paste").clicked() {
+                        state.editing = true;
+                        state.just_entered_edit = true;
+                    }
+                });
+            });
+
+        // Keyboard shortcuts resolve after rendering so a click in the same
+        // frame still wins if both happen (clicks set `outcome` above).
+        if outcome == PasteDialogOutcome::Idle {
+            if escape {
+                outcome = PasteDialogOutcome::Cancelled;
+            } else if ctrl_enter {
+                let payload = if state.editing {
+                    state.edit_buffer.clone()
+                } else {
+                    state.payload.clone()
+                };
+                outcome = PasteDialogOutcome::Paste(payload);
+            }
+        }
+
+        if outcome != PasteDialogOutcome::Idle {
+            self.state = None;
+        }
+        outcome
     }
 }
 
@@ -398,5 +620,86 @@ mod tests {
             }
             .is_safe()
         );
+    }
+
+    #[test]
+    fn banner_text_for_each_variant() {
+        assert_eq!(
+            banner_text(&PasteAnalysis::Multiline {
+                line_count: 17,
+                byte_count: 420,
+            }),
+            "Multi-line paste — 17 lines, 420 bytes"
+        );
+        assert_eq!(
+            banner_text(&PasteAnalysis::ControlChars {
+                chars: vec!['\x1b', '\x07'],
+            }),
+            "Control characters detected: U+001B, U+0007"
+        );
+        assert_eq!(
+            banner_text(&PasteAnalysis::Patterns {
+                matched: vec![r"\bsudo\b".to_owned(), r"\brm\s+-rf?\b".to_owned()],
+            }),
+            r"Dangerous patterns detected: \bsudo\b, \brm\s+-rf?\b"
+        );
+        assert_eq!(banner_text(&PasteAnalysis::Safe), "Paste");
+    }
+
+    #[test]
+    fn banner_text_flattens_multiple() {
+        let banner = banner_text(&PasteAnalysis::Multiple {
+            triggers: vec![
+                PasteAnalysis::Multiline {
+                    line_count: 2,
+                    byte_count: 8,
+                },
+                PasteAnalysis::Patterns {
+                    matched: vec![r"\bsudo\b".to_owned()],
+                },
+            ],
+        });
+        assert_eq!(
+            banner,
+            r"Multiple triggers — Multi-line paste — 2 lines, 8 bytes; Dangerous patterns detected: \bsudo\b"
+        );
+    }
+
+    #[test]
+    fn dialog_opens_and_closes() {
+        let mut dialog = PasteDialog::default();
+        assert!(!dialog.is_open());
+
+        dialog.open(
+            "sudo rm -rf /".to_owned(),
+            PasteAnalysis::Patterns {
+                matched: vec![r"\bsudo\b".to_owned()],
+            },
+        );
+        assert!(dialog.is_open());
+
+        dialog.close();
+        assert!(!dialog.is_open());
+    }
+
+    #[test]
+    fn dialog_ignores_safe_analysis() {
+        let mut dialog = PasteDialog::default();
+        dialog.open("harmless".to_owned(), PasteAnalysis::Safe);
+        assert!(
+            !dialog.is_open(),
+            "a Safe analysis must never open the dialog"
+        );
+    }
+
+    #[test]
+    fn dialog_outcome_equality() {
+        // Sanity-check the outcome enum used by 77.4's wire-in.
+        assert_eq!(PasteDialogOutcome::Idle, PasteDialogOutcome::Idle);
+        assert_ne!(
+            PasteDialogOutcome::Paste("a".to_owned()),
+            PasteDialogOutcome::Paste("b".to_owned())
+        );
+        assert_ne!(PasteDialogOutcome::Cancelled, PasteDialogOutcome::Idle);
     }
 }

--- a/freminal/src/gui/settings.rs
+++ b/freminal/src/gui/settings.rs
@@ -101,6 +101,10 @@ pub enum SettingsAction {
     /// a sample notification through the current draft `[notifications]`
     /// config so the user can verify routing without running a command.
     TestNotification,
+    /// The user clicked "Test Paste" in the Security tab — open the confirm
+    /// dialog with sample content using the current draft `[paste_guard]`
+    /// config so the user can preview the guard without pasting for real.
+    TestPaste,
 }
 
 /// Result of scanning a frame's egui events for a key-binding press.
@@ -149,6 +153,11 @@ enum KeyRecordingState {
 }
 
 /// Persistent state for the settings modal.
+// Several independent UI flags (window-open, per-tab "pending action" one-shots
+// like test-notification / test-paste, recording state). Each is a distinct,
+// unrelated boolean; collapsing them into a state machine would obscure rather
+// than clarify the modal's state.
+#[allow(clippy::struct_excessive_bools)]
 pub struct SettingsModal {
     /// Whether the modal window is currently visible.
     pub is_open: bool,
@@ -235,6 +244,12 @@ pub struct SettingsModal {
     /// as `SettingsAction::TestNotification` so the app can route a sample
     /// notification through the draft `[notifications]` config.
     pending_test_notification: bool,
+
+    /// Set by `show_security_tab` when the user clicks "Test Paste".  Consumed
+    /// by `show` / `show_standalone` which return it as
+    /// `SettingsAction::TestPaste` so the app can open the confirm dialog with
+    /// sample content using the draft `[paste_guard]` config.
+    pending_test_paste: bool,
 }
 
 impl SettingsModal {
@@ -261,6 +276,7 @@ impl SettingsModal {
             baseline_toml: String::new(),
             pending_close: PendingClose::None,
             pending_test_notification: false,
+            pending_test_paste: false,
         }
     }
 
@@ -531,6 +547,10 @@ impl SettingsModal {
             return SettingsAction::TestNotification;
         }
 
+        if std::mem::take(&mut self.pending_test_paste) {
+            return SettingsAction::TestPaste;
+        }
+
         if !self.is_open && action != SettingsAction::Applied {
             let theme_changed = self.original_theme_slug != theme_before;
             let opacity_changed = (self.original_opacity - opacity_before).abs() > f32::EPSILON;
@@ -688,6 +708,10 @@ impl SettingsModal {
             return SettingsAction::TestNotification;
         }
 
+        if std::mem::take(&mut self.pending_test_paste) {
+            return SettingsAction::TestPaste;
+        }
+
         if !self.is_open && action != SettingsAction::Applied {
             let theme_changed = self.original_theme_slug != theme_before;
             let opacity_changed = (self.original_opacity - opacity_before).abs() > f32::EPSILON;
@@ -733,6 +757,14 @@ impl SettingsModal {
     #[must_use]
     pub(super) const fn draft_notifications(&self) -> &config::NotificationsConfig {
         &self.draft.notifications
+    }
+
+    /// The draft `[paste_guard]` config, so the "Test Paste" button can preview
+    /// the confirm dialog using the settings the user is currently editing
+    /// (including unsaved changes).
+    #[must_use]
+    pub(super) const fn draft_paste_guard(&self) -> &config::PasteGuardConfig {
+        &self.draft.paste_guard
     }
 
     // -------------------------------------------------------------------------
@@ -1600,6 +1632,92 @@ impl SettingsModal {
             "Show a \u{1f510} lock icon in the tab bar when the foreground \
              process disables terminal echo (e.g. password prompts from \
              sudo, ssh, passwd).",
+        );
+
+        ui.add_space(16.0);
+        ui.separator();
+        ui.add_space(8.0);
+        self.show_paste_guard_section(ui);
+    }
+
+    /// The Paste Guard subsection of the Security tab (Task 77).
+    fn show_paste_guard_section(&mut self, ui: &mut Ui) {
+        ui.heading("Paste Guard");
+        ui.add_space(4.0);
+        ui.colored_label(
+            egui::Color32::GRAY,
+            "Show a confirmation dialog before pasting risky content. \
+             Bypass for a single paste with Ctrl+Shift+Alt+V.",
+        );
+        ui.add_space(8.0);
+
+        ui.checkbox(&mut self.draft.paste_guard.enabled, "Enable paste guard");
+
+        // The per-trigger toggles are only meaningful while the guard is on.
+        ui.add_enabled_ui(self.draft.paste_guard.enabled, |ui| {
+            ui.add_space(4.0);
+            ui.checkbox(
+                &mut self.draft.paste_guard.multiline,
+                "Confirm multi-line pastes",
+            );
+            ui.checkbox(
+                &mut self.draft.paste_guard.control_chars,
+                "Confirm pastes containing control characters",
+            );
+            ui.checkbox(
+                &mut self.draft.paste_guard.patterns,
+                "Confirm pastes matching dangerous patterns",
+            );
+
+            // Pattern list editor — only relevant when pattern matching is on.
+            ui.add_enabled_ui(self.draft.paste_guard.patterns, |ui| {
+                ui.add_space(8.0);
+                ui.label("Dangerous patterns (Rust regex):");
+                ui.add_space(2.0);
+
+                // Index of a row to delete, applied after the loop so we do
+                // not mutate the Vec while iterating it.
+                let mut remove_index: Option<usize> = None;
+                for (idx, pattern) in self.draft.paste_guard.pattern_list.iter_mut().enumerate() {
+                    ui.horizontal(|ui| {
+                        if ui.button("\u{2796}").on_hover_text("Remove").clicked() {
+                            remove_index = Some(idx);
+                        }
+                        let valid = regex::Regex::new(pattern).is_ok();
+                        let edit = egui::TextEdit::singleline(pattern)
+                            .desired_width(f32::INFINITY)
+                            .font(egui::TextStyle::Monospace)
+                            .text_color_opt(
+                                (!valid).then_some(egui::Color32::from_rgb(0xE0, 0x6C, 0x4B)),
+                            );
+                        ui.add(edit).on_hover_text(if valid {
+                            "Valid regex"
+                        } else {
+                            "Invalid regex \u{2014} this pattern is ignored at match time"
+                        });
+                    });
+                }
+                if let Some(idx) = remove_index {
+                    self.draft.paste_guard.pattern_list.remove(idx);
+                }
+
+                ui.add_space(2.0);
+                if ui.button("\u{2795} Add pattern").clicked() {
+                    self.draft.paste_guard.pattern_list.push(String::new());
+                }
+            });
+        });
+
+        ui.add_space(8.0);
+        if ui.button("Test Paste").clicked() {
+            self.pending_test_paste = true;
+        }
+        ui.add_space(4.0);
+        ui.colored_label(
+            egui::Color32::GRAY,
+            "Opens the confirm dialog with sample content using the current \
+             (unsaved) settings, so you can preview the guard without pasting \
+             for real.",
         );
     }
 
@@ -2536,6 +2654,38 @@ mod tests {
         let drained = std::mem::take(&mut modal.pending_test_notification);
         assert!(drained);
         assert!(!modal.pending_test_notification);
+    }
+
+    #[test]
+    fn test_paste_button_sets_pending_flag() {
+        let mut modal = SettingsModal::new(None);
+        let cfg = Config::default();
+        modal.open(&cfg, Vec::new(), false);
+        assert!(!modal.pending_test_paste);
+        // Simulate the button click side-effect.
+        modal.pending_test_paste = true;
+        // The drain in `show`/`show_standalone` takes the flag and returns
+        // `SettingsAction::TestPaste`; emulate that here.
+        let drained = std::mem::take(&mut modal.pending_test_paste);
+        assert!(drained);
+        assert!(!modal.pending_test_paste);
+    }
+
+    #[test]
+    fn draft_paste_guard_reflects_edits() {
+        let mut modal = SettingsModal::new(None);
+        let cfg = Config::default();
+        modal.open(&cfg, Vec::new(), false);
+        assert!(modal.draft_paste_guard().enabled);
+        // Edits to the draft are visible through the accessor used by the
+        // "Test Paste" dispatch.
+        modal.draft.paste_guard.enabled = false;
+        modal.draft.paste_guard.pattern_list = vec![r"\bgit\s+push\b".to_owned()];
+        assert!(!modal.draft_paste_guard().enabled);
+        assert_eq!(
+            modal.draft_paste_guard().pattern_list,
+            vec![r"\bgit\s+push\b"]
+        );
     }
 
     #[test]

--- a/freminal/src/gui/settings_dispatch.rs
+++ b/freminal/src/gui/settings_dispatch.rs
@@ -340,6 +340,36 @@ impl FreminalGui {
                     );
                 }
             }
+            SettingsAction::TestPaste => {
+                // Open the confirm dialog with sample content using the draft
+                // `[paste_guard]` config, so the user previews exactly what
+                // their current (unsaved) settings produce. Routed to the
+                // terminal window that owns the Settings window.
+                const SAMPLE: &str = "echo first line\nsudo rm -rf /tmp/example\necho third line";
+                let cfg = self.settings_modal.draft_paste_guard().clone();
+                let guard = crate::gui::paste_guard::PasteGuard::new(&cfg);
+                let analysis = guard.analyze(SAMPLE, &cfg);
+                if analysis.is_safe() {
+                    self.push_info_toast(
+                        "Test Paste",
+                        Some(
+                            "With these settings the sample paste would NOT be \
+                             intercepted."
+                                .to_owned(),
+                        ),
+                    );
+                } else if let Some(owner) = self.settings_owner
+                    && let Some(win) = self.windows.get_mut(&owner)
+                {
+                    win.paste_dialog.open(SAMPLE.to_owned(), analysis);
+                    handle.request_repaint(owner);
+                } else {
+                    self.push_error_toast(
+                        "Test Paste",
+                        Some("No terminal window available to show the dialog.".to_owned()),
+                    );
+                }
+            }
             SettingsAction::RevertTheme(_, _)
             | SettingsAction::PreviewTheme(_)
             | SettingsAction::None => {}

--- a/freminal/src/gui/settings_dispatch.rs
+++ b/freminal/src/gui/settings_dispatch.rs
@@ -117,6 +117,17 @@ impl FreminalGui {
 
         self.config = new_cfg;
 
+        // Rebuild the paste-guard pattern cache from the new config and report
+        // any patterns that fail to compile (skipped at match time).
+        let invalid = self.paste_guard.rebuild(&self.config.paste_guard);
+        for (pattern, err) in invalid {
+            error!("Paste guard: ignoring invalid pattern `{pattern}`: {err}");
+            self.push_error_toast(
+                "Invalid paste-guard pattern",
+                Some(format!("`{pattern}` — {err}")),
+            );
+        }
+
         // Apply background image to all panes in all windows.
         let new_bg_path = self.config.ui.background_image.clone();
         for win in self.windows.values() {

--- a/freminal/src/gui/terminal/input.rs
+++ b/freminal/src/gui/terminal/input.rs
@@ -10,7 +10,7 @@ use crate::gui::{
         FreminalMousePosition, PreviousMouseState, handle_pointer_button, handle_pointer_moved,
         handle_pointer_scroll,
     },
-    view_state::{CellCoord, ViewState},
+    view_state::{CellCoord, PendingPaste, ViewState},
 };
 
 use conv2::ConvUtil;
@@ -1475,11 +1475,20 @@ pub(super) fn write_input_to_terminal(
             Event::Paste(text) => {
                 // The windowing layer already read the clipboard (via the
                 // reliable egui-winit path) and injected this event. Stash the
-                // text for the smart paste guard (Task 77), which runs in
-                // `update()` with access to the config and confirm dialog.
-                // Do NOT re-read the clipboard via arboard here — that path is
-                // unreliable on Wayland and would discard this known-good text.
-                view_state.pending_paste = Some(text.clone());
+                // text for handling in `update()` with access to the config and
+                // confirm dialog. Do NOT re-read the clipboard via arboard here
+                // — that path is unreliable on Wayland and would discard this
+                // known-good text.
+                //
+                // The windowing paste interceptor fires for any `command + v`,
+                // including the `PasteUnsafe` combo (Ctrl+Shift+Alt+V), so the
+                // BindingMap entry never sees it on that path. Detect the
+                // bypass intent here by the Alt modifier: Alt held ==
+                // PasteUnsafe (skip the guard).
+                view_state.pending_paste = Some(PendingPaste {
+                    text: text.clone(),
+                    bypass_guard: input.modifiers.alt,
+                });
                 continue;
             }
             Event::PointerGone => {

--- a/freminal/src/gui/terminal/input.rs
+++ b/freminal/src/gui/terminal/input.rs
@@ -1472,13 +1472,14 @@ pub(super) fn write_input_to_terminal(
                 previous_key = Some(*key);
                 continue;
             }
-            Event::Paste(_text) => {
-                // Route egui paste events through the smart paste guard
-                // (Task 77) rather than sending inline. The guard reads the
-                // clipboard itself in `dispatch_deferred_action`, so the event
-                // text is not forwarded here; deferring `KeyAction::Paste`
-                // unifies this path with the Ctrl+Shift+V / menu paste paths.
-                deferred_actions.push(KeyAction::Paste);
+            Event::Paste(text) => {
+                // The windowing layer already read the clipboard (via the
+                // reliable egui-winit path) and injected this event. Stash the
+                // text for the smart paste guard (Task 77), which runs in
+                // `update()` with access to the config and confirm dialog.
+                // Do NOT re-read the clipboard via arboard here — that path is
+                // unreliable on Wayland and would discard this known-good text.
+                view_state.pending_paste = Some(text.clone());
                 continue;
             }
             Event::PointerGone => {

--- a/freminal/src/gui/terminal/input.rs
+++ b/freminal/src/gui/terminal/input.rs
@@ -19,7 +19,7 @@ use egui::{Event, InputState, Key, Modifiers, PointerButton, Rect};
 use freminal_common::buffer_states::command_block::{CommandBlock, CommandBlockId};
 use freminal_common::buffer_states::modes::{
     application_escape_key::ApplicationEscapeKey, decarm::Decarm, decbkm::Decbkm, decckm::Decckm,
-    keypad::KeypadMode, lnm::Lnm, mouse::MouseTrack, rl_bracket::RlBracket,
+    keypad::KeypadMode, lnm::Lnm, mouse::MouseTrack,
 };
 use freminal_common::keybindings::{BindingKey, BindingMap, BindingModifiers, KeyAction, KeyCombo};
 use freminal_common::send_or_log;
@@ -448,29 +448,11 @@ pub(super) fn dispatch_binding_action(
     deferred_actions: &mut Vec<KeyAction>,
 ) {
     match action {
-        KeyAction::Paste => {
-            // Read clipboard directly via arboard, bypassing egui-winit's
-            // per-window clipboard (which fails on Wayland child windows).
-            match arboard::Clipboard::new().and_then(|mut cb| cb.get_text()) {
-                Ok(text) if !text.is_empty() => {
-                    let text = text.replace("\r\n", "\n");
-                    let payload = if snap.bracketed_paste == RlBracket::Enabled {
-                        format!("\x1b[200~{text}\x1b[201~")
-                    } else {
-                        text
-                    };
-                    send_or_log!(
-                        input_tx,
-                        InputEvent::Key(payload.into_bytes()),
-                        "Failed to send paste to PTY consumer"
-                    );
-                }
-                Ok(_) => {}
-                Err(e) => {
-                    error!("Clipboard read failed: {e}");
-                }
-            }
-        }
+        // `KeyAction::Paste` is intentionally NOT handled here. It is deferred
+        // to `dispatch_deferred_action` (via the `other` arm below) so the
+        // smart paste guard (Task 77) can analyze the clipboard with access to
+        // the live config and the per-window confirm dialog, which are not
+        // reachable at this input-layer call site.
         KeyAction::Copy if let Some((start, end)) = view_state.selection.normalised() => {
             if let Err(e) = input_tx.send(InputEvent::ExtractSelection {
                 start_row: start.row,
@@ -1490,13 +1472,14 @@ pub(super) fn write_input_to_terminal(
                 previous_key = Some(*key);
                 continue;
             }
-            Event::Paste(text) => {
-                if snap.bracketed_paste == RlBracket::Enabled {
-                    // ESC [ 200 ~, followed by the pasted text, followed by ESC [ 201 ~.
-                    collect_text(&format!("\x1b[200~{}{}", text, "\x1b[201~"))
-                } else {
-                    collect_text(text)
-                }
+            Event::Paste(_text) => {
+                // Route egui paste events through the smart paste guard
+                // (Task 77) rather than sending inline. The guard reads the
+                // clipboard itself in `dispatch_deferred_action`, so the event
+                // text is not forwarded here; deferring `KeyAction::Paste`
+                // unifies this path with the Ctrl+Shift+V / menu paste paths.
+                deferred_actions.push(KeyAction::Paste);
+                continue;
             }
             Event::PointerGone => {
                 view_state.mouse_position = None;

--- a/freminal/src/gui/view_state.rs
+++ b/freminal/src/gui/view_state.rs
@@ -328,6 +328,20 @@ impl CommandHistoryState {
 
 /// GUI-local view state for the terminal widget.
 ///
+/// A paste payload awaiting handling by the GUI layer (Task 77).
+///
+/// Stashed by `write_input_to_terminal` when an `Event::Paste` arrives (the
+/// windowing layer reads the clipboard reliably and injects the event) and
+/// drained in `update()`.
+#[derive(Debug, Clone)]
+pub struct PendingPaste {
+    /// The clipboard text to paste (already read by the windowing layer).
+    pub text: String,
+    /// When `true`, skip the smart paste guard entirely and send directly —
+    /// the user invoked the `PasteUnsafe` action (Ctrl+Shift+Alt+V).
+    pub bypass_guard: bool,
+}
+
 /// Everything here belongs to the render thread only.  The PTY thread never
 /// reads or writes any of these fields.
 ///
@@ -376,16 +390,17 @@ pub struct ViewState {
     /// while mouse tracking is off (no mouse-aware TUI application running).
     pub selection: SelectionState,
 
-    /// Pending paste text from an egui `Event::Paste`, awaiting smart-paste-
-    /// guard analysis (Task 77).
+    /// Pending paste from an egui `Event::Paste`, awaiting handling by the GUI
+    /// layer (Task 77).
     ///
     /// The windowing layer intercepts paste shortcuts, reads the clipboard via
     /// the reliable egui-winit path, and injects `Event::Paste(text)`. The
-    /// text is stashed here by `write_input_to_terminal` and drained in
-    /// `update()`, where the guard runs with access to the config and the
-    /// confirm dialog. Using the injected text avoids a second, unreliable
-    /// `arboard` clipboard read on this path.
-    pub pending_paste: Option<String>,
+    /// payload is stashed here by `write_input_to_terminal` and drained in
+    /// `update()`, where (unless `bypass_guard` is set) the smart paste guard
+    /// runs with access to the config and the confirm dialog. Using the
+    /// injected text avoids a second, unreliable `arboard` clipboard read on
+    /// this path.
+    pub pending_paste: Option<PendingPaste>,
 
     /// Set of OSC 133 command blocks the user has folded in this pane.
     ///

--- a/freminal/src/gui/view_state.rs
+++ b/freminal/src/gui/view_state.rs
@@ -376,6 +376,17 @@ pub struct ViewState {
     /// while mouse tracking is off (no mouse-aware TUI application running).
     pub selection: SelectionState,
 
+    /// Pending paste text from an egui `Event::Paste`, awaiting smart-paste-
+    /// guard analysis (Task 77).
+    ///
+    /// The windowing layer intercepts paste shortcuts, reads the clipboard via
+    /// the reliable egui-winit path, and injects `Event::Paste(text)`. The
+    /// text is stashed here by `write_input_to_terminal` and drained in
+    /// `update()`, where the guard runs with access to the config and the
+    /// confirm dialog. Using the injected text avoids a second, unreliable
+    /// `arboard` clipboard read on this path.
+    pub pending_paste: Option<String>,
+
     /// Set of OSC 133 command blocks the user has folded in this pane.
     ///
     /// Folding is a pure view-layer concept — the underlying buffer is
@@ -526,6 +537,7 @@ impl Default for ViewState {
             previous_scroll_amount: 0.0,
             previous_mouse_state: None,
             selection: SelectionState::default(),
+            pending_paste: None,
             folded_blocks: HashSet::new(),
             text_blink_cycle: 0,
             text_blink_last_tick: Instant::now(),

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -142,4 +142,14 @@ pub(super) struct PerWindowState {
     /// here.  Drained and dispatched at the top of the active pane's input
     /// processing each frame.
     pub(super) pending_menu_actions: Vec<freminal_common::keybindings::KeyAction>,
+
+    /// Smart paste guard confirmation dialog for this window (Task 77).
+    ///
+    /// Opened by the paste path when the analyzer flags a payload, rendered
+    /// every frame while open, and resolved when the user confirms or cancels.
+    /// Wired into the paste flow in 77.4.
+    // TODO(77.4): remove this `allow` once `update()` renders the dialog and
+    // the paste path opens it. The field has no reader until then.
+    #[allow(dead_code)]
+    pub(super) paste_dialog: super::paste_guard::PasteDialog,
 }

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -145,11 +145,7 @@ pub(super) struct PerWindowState {
 
     /// Smart paste guard confirmation dialog for this window (Task 77).
     ///
-    /// Opened by the paste path when the analyzer flags a payload, rendered
+    /// Opened by `guarded_paste` when the analyzer flags a payload, rendered
     /// every frame while open, and resolved when the user confirms or cancels.
-    /// Wired into the paste flow in 77.4.
-    // TODO(77.4): remove this `allow` once `update()` renders the dialog and
-    // the paste path opens it. The field has no reader until then.
-    #[allow(dead_code)]
     pub(super) paste_dialog: super::paste_guard::PasteDialog,
 }

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -105,6 +105,16 @@ let
         inherit (s.security) allow_clipboard_read;
       };
 
+      pasteGuardSection = lib.filterAttrs (_: v: v != null) {
+        inherit (s.paste_guard)
+          enabled
+          multiline
+          control_chars
+          patterns
+          pattern_list
+          ;
+      };
+
       tabTitleSection = lib.filterAttrs (_: v: v != null) {
         inherit (s.tab_title) policy separator;
       };
@@ -164,6 +174,7 @@ let
       // lib.optionalAttrs (tabsSection != { }) { tabs = tabsSection; }
       // lib.optionalAttrs (bellSection != { }) { bell = bellSection; }
       // lib.optionalAttrs (securitySection != { }) { security = securitySection; }
+      // lib.optionalAttrs (pasteGuardSection != { }) { paste_guard = pasteGuardSection; }
       // lib.optionalAttrs (tabTitleSection != { }) { tab_title = tabTitleSection; }
       // lib.optionalAttrs (shellIntegrationSection != { }) {
         shell_integration = shellIntegrationSection;
@@ -543,6 +554,59 @@ in
             Allow applications to read the system clipboard via OSC 52 query.
             When true, OSC 52 queries return the clipboard contents base64-encoded.
             Null uses the default (false).
+          '';
+        };
+      };
+
+      paste_guard = {
+        enabled = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = ''
+            Master switch for the paste guard. When false, no paste is ever
+            intercepted regardless of the per-trigger toggles below.
+            Null uses the default (true).
+          '';
+        };
+
+        multiline = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = ''
+            Confirm any paste containing a newline.
+            Null uses the default (true).
+          '';
+        };
+
+        control_chars = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = ''
+            Confirm any paste containing control characters (ESC, BEL, etc.)
+            other than the newline covered by multiline and the bracketed-paste
+            markers Freminal wraps the payload with.
+            Null uses the default (true).
+          '';
+        };
+
+        patterns = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = ''
+            When true, additionally match the payload against pattern_list and
+            escalate the warning when a dangerous pattern is found.
+            Null uses the default (true).
+          '';
+        };
+
+        pattern_list = mkOption {
+          type = types.nullOr (types.listOf types.str);
+          default = null;
+          description = ''
+            Regex patterns (Rust regex syntax) treated as dangerous. Matched
+            only when patterns is true. Malformed patterns are reported and
+            skipped at match time.
+            Null uses the default dangerous-command pattern set.
           '';
         };
       };


### PR DESCRIPTION
## Summary

Implements **Task 77 — Smart Paste Guard** (v0.9.0). A paste containing risky
content (multi-line, control characters, or a dangerous-command pattern) now
shows a confirmation dialog before being sent to the PTY, with a per-config
toggle and a one-shot bypass shortcut.

All six subtasks (77.1–77.6) plus the mandated benchmark are complete. Each
subtask has detailed completion notes in `Documents/PLAN_VERSION_090.md`.

## What's included

- **77.1 — Config schema.** New `[paste_guard]` section (`enabled`,
  `multiline`, `control_chars`, `patterns`, `pattern_list`) with full
  `ConfigPartial`/`apply_partial` merge wiring, the guard-test entry,
  `config_example.toml` docs, and the Nix home-manager module mirror. Pattern
  matching defaults **on**.
- **77.2 — Analyzer.** Pure `analyze()` classifier + `PasteGuard` compiled-regex
  cache. `PasteAnalysis` = Safe / Multiline / ControlChars / Patterns /
  Multiple.
- **77.3 — Confirm dialog.** Centered egui modal: trigger banner, scrollable
  preview, Cancel / Paste Anyway / Edit-and-Paste, Esc & Ctrl+Enter shortcuts.
- **77.4 — Wire-in.** All three paste paths (keybinding, Edit menu, egui
  `Event::Paste`) route through the guard at the `update()` layer. Includes two
  follow-up fixes found in manual testing: the arboard-vs-windowing-injected
  text regression, and the modal input-suppression/focus fix.
- **77.5 — `KeyAction::PasteUnsafe`.** Bypasses the guard, default
  **Ctrl+Shift+Alt+V** (the plan's `Ctrl+Shift+V` collided with `Paste`).
  Detected via the Alt modifier on the windowing-injected paste path.
- **77.6 — Settings UI.** Paste Guard section in the Security tab: toggles, a
  live-validated editable pattern list, and a "Test Paste" button.
- **Benchmark.** `freminal/benches/paste_guard_bench.rs`. Worst case (1 MB, all
  triggers, 20 patterns) is ~688 µs — ~70× under the 50 ms budget.

## Also in this PR

- **`freminal-modal-input-suppression` opencode skill** capturing the recurring
  modal-focus bug (register in `ui_overlay_open` + `lock_focus`), listed in
  `agents.md`.
- **Doc fix** correcting the v0.9.0 task-summary status for Tasks 72/73/76
  (they were complete but mislabeled).
- Version bump `0.9.0-beta.2` → `0.9.0-beta.3`.

## Notable design decisions (all documented in plan completion notes)

- The compiled-regex cache lives on a GUI-side `PasteGuard`, not on
  `PasteGuardConfig` (the plan's `OnceCell` suggestion fought the config
  derives).
- Paste interception happens at `update()`'s deferred dispatch, not inline at
  the input leaves (which lack config/dialog access).
- The analyzer API was promoted to `pub` so the separate-crate benchmark can
  reach it (matching `gui::atlas` / `gui::shaping`).

## Verification

`cargo test --all`, `cargo clippy --all-targets --all-features -- -D warnings`,
`cargo machete`, and `cargo fmt --check` all clean.