### PR TITLE
v0.9.0: Tasks 74, 75, 98 — broadcast input, per-pane env, close guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "freminal"
-version = "0.9.0-beta.4"
+version = "0.9.0-beta.5"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-buffer"
-version = "0.9.0-beta.4"
+version = "0.9.0-beta.5"
 dependencies = [
  "conv2",
  "criterion",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-common"
-version = "0.9.0-beta.4"
+version = "0.9.0-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-terminal-emulator"
-version = "0.9.0-beta.4"
+version = "0.9.0-beta.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-windowing"
-version = "0.9.0-beta.4"
+version = "0.9.0-beta.5"
 dependencies = [
  "conv2",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["freminal", "freminal-buffer", "freminal-common", "freminal-terminal-
 default-members = ["freminal", "freminal-buffer", "freminal-common", "freminal-terminal-emulator"]
 
 [workspace.package]
-version = "0.9.0-beta.4"
+version = "0.9.0-beta.5"
 edition = "2024"
 rust-version = "1.95.0"
 description = "A terminal emulator written in Rust"

--- a/Documents/LAYOUT_FORMAT.md
+++ b/Documents/LAYOUT_FORMAT.md
@@ -217,6 +217,23 @@ freminal --layout dev.toml ~/projects/backend
 Without variables, layouts would be project-specific (hardcoded paths). The
 `$1` positional convention follows shell scripting.
 
+### Per-Pane Environment Variables
+
+The `env` table on a leaf pane supports the same substitution forms as
+`directory`, `command`, `shell`, and `title`. Each value is substituted
+independently before the pane is spawned. This lets one layout target many
+projects while still exporting project-scoped environment variables:
+
+```toml
+[[windows.tabs.panes]]
+directory = "$1"
+env = { PROJECT_ROOT = "$1", AWS_PROFILE = "$ENV{AWS_PROFILE}" }
+```
+
+The resolved env map is layered into the pane's PTY environment beneath the
+spawn-time defaults (`TERM_PROGRAM`, etc.), so a layout can override those by
+naming the same key.
+
 ---
 
 ## Save Current Layout

--- a/Documents/MASTER_PLAN.md
+++ b/Documents/MASTER_PLAN.md
@@ -131,7 +131,7 @@ into v0.13.0–v0.15.0 and v0.19.0) and remaining Category C housekeeping (Tasks
 | 72  | OSC 133 Command Blocks                   | `PLAN_VERSION_090.md` (Task 72)               | Pending merge | v0.8.0                 |
 | 73  | Command Gutters                          | `PLAN_VERSION_090.md` (Task 73)               | Stub          | Task 72                |
 | 74  | Broadcast Input to Panes                 | `PLAN_VERSION_090.md` (Task 74)               | Pending merge | v0.8.0, Task 58        |
-| 75  | Workspace-Scoped Environment             | `PLAN_VERSION_090.md` (Task 75)               | Stub          | v0.8.0, Task 61        |
+| 75  | Workspace-Scoped Environment             | `PLAN_VERSION_090.md` (Task 75)               | Complete      | v0.8.0, Task 61        |
 | 76  | Notification System (OSC 9 / OSC 777)    | `PLAN_VERSION_090.md` (Task 76)               | Pending merge | v0.8.0, Task 72        |
 | 77  | Smart Paste Guard                        | `PLAN_VERSION_090.md` (Task 77)               | Pending merge | v0.8.0                 |
 | 78  | Profiles + Quick Profile Switching       | `PLAN_VERSION_130.md` (Task 78)               | Stub          | v0.8.0                 |
@@ -156,7 +156,7 @@ into v0.13.0–v0.15.0 and v0.19.0) and remaining Category C housekeeping (Tasks
 | 95  | Persist Custom Tab Names in Layouts      | `PLAN_VERSION_090.md` (Task 95)               | Complete      | v0.8.0 (71.1), Task 61 |
 | 96  | Per-Pane Title Bar                       | `PLAN_VERSION_130.md` (Task 96)               | Stub          | Task 58                |
 | 97  | Dynamic Tab Width & Overflow             | `PLAN_VERSION_130.md` (Task 97)               | Stub          | v0.8.0 (71.1)          |
-| 98  | Block Close on Running Commands          | `PLAN_VERSION_090.md` (Task 98)               | Stub          | Task 72                |
+| 98  | Block Close on Running Commands          | `PLAN_VERSION_090.md` (Task 98)               | Complete      | Task 72                |
 | 99  | Kitty Desktop Notifications (OSC 99)     | `PLAN_VERSION_100.md` (Task 99)               | Planned       | v0.9.0 (Task 76)       |
 | 100 | Kitty Graphics Protocol Completion       | `PLAN_VERSION_100.md` (Task 100)              | Planned       | Task 13                |
 | 101 | Kitty Keyboard Protocol Verification     | `PLAN_VERSION_100.md` (Task 101)              | Planned       | Task 35                |
@@ -611,6 +611,8 @@ Update this section as tasks complete:
 | 76   | 2026-06-09 | 2026-06-09 | All subtasks (76.1-76.8) complete on task-76/notifications; PR pending           |
 | 77   | 2026-06-09 | 2026-06-10 | All subtasks (77.1-77.6) + benchmark complete on task-77/paste-guard; PR pending |
 | 74   | 2026-06-11 | 2026-06-11 | All subtasks (74.1-74.5) on task-74-75-98/v090-finish (combined PR); PR pending  |
+| 75   | 2026-06-11 | 2026-06-11 | env round-trip tests + docs on task-74-75-98/v090-finish (combined PR)           |
+| 98   | 2026-06-11 | 2026-06-11 | All subtasks (98.1-98.9) on task-74-75-98/v090-finish (combined PR); PR pending  |
 
 ---
 

--- a/Documents/MASTER_PLAN.md
+++ b/Documents/MASTER_PLAN.md
@@ -130,7 +130,7 @@ into v0.13.0–v0.15.0 and v0.19.0) and remaining Category C housekeeping (Tasks
 | 71  | UX Completeness & Polish Sweep           | `PLAN_VERSION_080.md` (Task 71)               | Pending merge | None                   |
 | 72  | OSC 133 Command Blocks                   | `PLAN_VERSION_090.md` (Task 72)               | Pending merge | v0.8.0                 |
 | 73  | Command Gutters                          | `PLAN_VERSION_090.md` (Task 73)               | Stub          | Task 72                |
-| 74  | Broadcast Input to Panes                 | `PLAN_VERSION_090.md` (Task 74)               | Stub          | v0.8.0, Task 58        |
+| 74  | Broadcast Input to Panes                 | `PLAN_VERSION_090.md` (Task 74)               | Pending merge | v0.8.0, Task 58        |
 | 75  | Workspace-Scoped Environment             | `PLAN_VERSION_090.md` (Task 75)               | Stub          | v0.8.0, Task 61        |
 | 76  | Notification System (OSC 9 / OSC 777)    | `PLAN_VERSION_090.md` (Task 76)               | Pending merge | v0.8.0, Task 72        |
 | 77  | Smart Paste Guard                        | `PLAN_VERSION_090.md` (Task 77)               | Pending merge | v0.8.0                 |
@@ -610,6 +610,7 @@ Update this section as tasks complete:
 | 95   | 2026-06-04 | 2026-06-04 | All 5 subtasks complete; merged via PR #343                                      |
 | 76   | 2026-06-09 | 2026-06-09 | All subtasks (76.1-76.8) complete on task-76/notifications; PR pending           |
 | 77   | 2026-06-09 | 2026-06-10 | All subtasks (77.1-77.6) + benchmark complete on task-77/paste-guard; PR pending |
+| 74   | 2026-06-11 | 2026-06-11 | All subtasks (74.1-74.5) on task-74-75-98/v090-finish (combined PR); PR pending  |
 
 ---
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -4485,6 +4485,27 @@ tab_name, unknown_blocks)` plus the per-scope `FreminalGui` methods,
 **Verification:** Round-trip keybinding test; manual test of the
 key path.
 
+**Completion notes (2026-06-11):**
+
+- Added `KeyAction::ForceClose` with the full four-step ritual: variant
+  - doc comment, `name()` (`"force_close"`), `display_label()`
+    (`"Force Close"`), `ALL` entry, `FromStr` arm, and a
+    `config_example.toml` keybindings doc line. No default binding (per
+    the plan — force close must be deliberate).
+- `ALL.len()` count test bumped 61 → 62; `ForceClose` added to the
+  `unbound_actions_not_in_default_map` test. Default-binding total
+  unchanged (still 48).
+- Dispatch: the `ForceClose` deferred-action arm sets a new
+  `PerWindowState::pending_force_close` flag. The flag is drained where
+  the close dialog is resolved in `update()`: if a dialog is open it is
+  resolved as Force Close (via the new `CloseGuardDialog::force_close_now`),
+  and the captured scope's close is executed; if nothing is open the flag
+  is a harmless no-op.
+- `PerWindowState` gained a documented `#[allow(clippy::struct_excessive_bools)]`
+  (it now holds >3 independent per-frame intent flags, same rationale as
+  the `FreminalGui` aggregator).
+- `cargo test --all`, workspace clippy, and `cargo machete` clean.
+
 #### 98.9 — Settings UI
 
 **Scope:** Security settings tab (`freminal/src/gui/settings.rs`).

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -4407,6 +4407,70 @@ plus any app-quit dispatch path identified in 98.1.
 running command, trigger app quit, verify dialog appears and
 cancel preserves both windows.
 
+**Completion notes for 98.3–98.7 (2026-06-11, committed together):**
+
+These five subtasks are tightly intertwined (the dialog consumes the
+detection output; every wiring point opens the same dialog and resolves
+the same outcome enum), so they ship in one commit per
+`commit-discipline`'s "tightly intertwined subtasks" allowance.
+
+- **New module `freminal/src/gui/close_guard.rs`** holding the pure
+  detection helpers, the `RunningCommandInfo` descriptor, the
+  `CloseGuardDialog` modal, the `PendingClose` / `CloseScope` /
+  `CloseDialogOutcome` types, and the `FreminalGui` orchestration
+  methods (`guarded_close_pane`, `guarded_close_tab`,
+  `window_close_running`, and the per-scope `gather_*` helpers).
+- **Detection (98.3):** `pane_running_command` reads the pane's
+  `ArcSwap` snapshot (lock-free) and reports a running command iff the
+  most recent block is `CommandStatus::Running` **and** has an
+  `output_start_row` (OSC 133 C seen). A block with only `A` (idle
+  prompt, then Ctrl-C) is deliberately **not** counted — this is the
+  precise behavior the planning notes asked for (no spurious
+  "command running" prompt on an idle prompt). `pane_is_unknown` reports
+  panes that never saw a prompt marker, gated by `unknown_blocks`.
+  **Naming deviation:** the plan named the aggregate
+  `panes_with_running_commands(&[&Pane])` / `unknown_command_panes`;
+  the implemented surface is `gather_tab_running(panes, tab_id,
+tab_name, unknown_blocks)` plus the per-scope `FreminalGui` methods,
+  because the dialog needs the tab id/name alongside each pane and the
+  pane alone does not carry that context.
+- **Dialog (98.4):** `CloseGuardDialog` mirrors `broadcast_guard.rs`:
+  state on `PerWindowState`, registered in `ui_overlay_open`, rendered
+  every frame, Esc = Cancel, Ctrl+Enter = Force Close. List entries are
+  `"<tab name> · <command> (<elapsed>)"`. **Command label deviation:**
+  `CommandBlock` does not capture the command-line text, so the label
+  is the pane title (often the running program via OSC 0/2) or
+  `"<unknown command>"`, not the literal command. **"Close Other Panes"
+  deferred:** the optional third button is not implemented in v0.9.0 —
+  Cancel / Force Close cover the requirement; partial close is logged
+  here as a future enhancement.
+- **Pane close (98.5):** the deferred-close drain site in
+  `app_impl.rs update()` now calls `guarded_close_pane` instead of
+  `close_focused_pane`. `close_focused_pane` is unchanged and is the
+  Force Close executor.
+- **Tab close (98.6):** both the `CloseTab` keybinding deferred arm and
+  the tab-bar / menu `TabBarAction::Close(i)` route through
+  `guarded_close_tab`. Force Close calls the raw `win.close_tab(idx)`.
+- **Window close + app quit (98.7):** `on_close_requested` consults the
+  guard. A confirmed force-close is tracked in
+  `FreminalGui::force_close_windows: HashSet<WindowId>`; on the
+  `ViewportCommand::Close` round trip the entry is removed and the close
+  proceeds. Otherwise, running commands open the dialog (scope
+  `Window`) and the function returns `false` to veto the OS close.
+  **App-quit deviation:** there is no multi-window quit path in freminal
+  (see 98.1) — "Quit" closes only the focused window via
+  `ViewportCommand::Close`, which already routes through
+  `on_close_requested`. So `guard_app_quit` has no separate code path;
+  window-close guarding covers every exit. Documented in 98.1 + 98.2.
+- **Tests:** 13 unit tests in `close_guard.rs` covering the running /
+  not-running / prompt-only / finished / most-recent-only detection
+  cases, unknown detection, elapsed computation, the
+  duration/entry formatters, and the dialog open/scope. Full GUI
+  integration (real `Pane` with channels) is exercised manually; the
+  pure helpers are unit-tested directly.
+- `cargo test --all`, workspace `cargo clippy --all-targets
+--all-features -- -D warnings`, and `cargo machete` all clean.
+
 #### 98.8 — `KeyAction::ForceClose`
 
 **Scope:** `freminal-common/src/keybindings.rs`, dispatch.

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -22,13 +22,13 @@ top of the correctness debts identified in the post-v0.7.0 audit.
 | --- | --------------------------------------- | ------------ | -------- | --------------- | -------------------------------- |
 | 72  | OSC 133 Command Blocks                  | Large        | Complete | v0.8.0          | `task-72/osc-133-command-blocks` |
 | 73  | Command Gutters (exit-status indicator) | Medium       | Complete | Task 72         | `task-73/command-gutters`        |
-| 74  | Broadcast Input to Panes                | Medium       | Pending  | v0.8.0, Task 58 | `task-74/broadcast-input`        |
-| 75  | Verify per-pane env round-trip          | Small        | Pending  | v0.8.0          | `task-75/pane-env-roundtrip`     |
+| 74  | Broadcast Input to Panes                | Medium       | Complete | v0.8.0, Task 58 | `task-74-75-98/v090-finish`      |
+| 75  | Verify per-pane env round-trip          | Small        | Pending  | v0.8.0          | `task-74-75-98/v090-finish`      |
 | 76  | Notification System (OSC 9 / OSC 777)   | Medium       | Complete | v0.8.0, Task 72 | `task-76/notifications`          |
 | 77  | Smart Paste Guard                       | Small–Medium | Complete | v0.8.0          | `task-77/paste-guard`            |
 | 94  | Tab Title Precedence (prefix default)   | Small        | Complete | v0.8.0 (71.1)   | `task-94/tab-title-precedence`   |
 | 95  | Persist Custom Tab Names in Layouts     | Small        | Complete | v0.8.0, Task 61 | `task-95/persist-tab-names`      |
-| 98  | Block Close on Running Commands         | Small–Medium | Pending  | Task 72         | `task-98/block-close-on-running` |
+| 98  | Block Close on Running Commands         | Small–Medium | Pending  | Task 72         | `task-74-75-98/v090-finish`      |
 
 ### Execution order
 
@@ -2287,7 +2287,56 @@ All resolved.
 
 ---
 
-## Task 74 — Broadcast Input to Panes
+## Task 74 — Broadcast Input to Panes ✅ Complete (2026-06-11)
+
+> **Completion (branch `task-74-75-98/v090-finish`).** All five subtasks
+> implemented and committed individually. Tasks 74, 75, and 98 ship in a
+> single PR off this combined branch (per user direction); Task 74 was
+> managed end-to-end, Tasks 75 and 98 follow on the same branch.
+>
+> - **74.1** (`4b99b10c`): `Tab::broadcast_input` flag (default false),
+>   `Tab::toggle_broadcast()`, Debug field, two unit tests.
+> - **74.2** (`0a1e6aa8`): `KeyAction::ToggleBroadcastInput` with default
+>   `Ctrl+Shift+I` in `register_tab_bindings`. Dispatched in `actions.rs`
+>   (deferred path) toggling the active tab + info toast.
+>   `config_example.toml` documented. `ALL` count 60→61, default-binding
+>   count 47→48; round-trip + default-binding tests added.
+> - **74.3** (`438b197d`): fan-out. `write_input_to_terminal` and
+>   `widget.rs::show()` gain a `key_broadcast_targets: &[Sender<InputEvent>]`
+>   slice; a `broadcast_key_bytes` helper mirrors each encoded
+>   `InputEvent::Key` at the two genuine keyboard send sites (KKP release +
+>   main text/key/paste encode). Scroll-derived `send_terminal_inputs` calls
+>   are deliberately NOT broadcast. The `app_impl` render loop collects
+>   per-pane senders once per frame (senders are cheap to clone) and passes
+>   the _other_ panes' senders only to the active pane's `show()`. Tab bar
+>   prepends a satellite-antenna glyph when broadcast is on. 4 unit tests on
+>   the fan-out helper.
+> - **74.4** (`d9f576c1`): split borders tint yellow and a "BROADCAST" tag
+>   paints in each pane's top-right (avoids the password-lock icon, which
+>   lives in the tab/menu bar). Visual; verified manually.
+> - **74.5** (`544eb624`): `confirm_broadcast` bool on `TabsConfig`
+>   (default false) wired through `config_example.toml`, the Tabs settings
+>   panel (new "Broadcast Input" section: read-only shortcut +
+>   jump-to-keybindings button + confirm toggle), the Nix home-manager
+>   module, and a round-trip test. New `broadcast_guard` module provides a
+>   per-window confirm dialog (mirrors paste-guard); registered in
+>   `ui_overlay_open`. Enabling broadcast with confirmation on opens the
+>   dialog; disabling never prompts.
+>
+> **Design notes (decided during implementation):**
+>
+> - Broadcast is keyboard-only. The two real keyboard send sites are
+>   mirrored; mouse, scroll-to-arrow, mouse-tracking escapes, resize, focus,
+>   and selection events are pane-local and never fan out.
+> - Paste payloads broadcast the active pane's mode-encoded (bracketed-paste-
+>   wrapped) bytes verbatim to every pane, rather than re-deriving each
+>   pane's wrap. This is the simple, documented semantic.
+> - Tab-bar indicator glyph: `📡` (U+1F4E1). Pane label: literal
+>   "BROADCAST" tag, top-right. Both documented here per 74.3/74.4's
+>   "agent chooses, document the choice" instruction.
+> - Full verification green: `cargo test --all`, workspace clippy
+>   (`-D warnings`), `cargo fmt --all --check`, `cargo machete`, and the Nix
+>   lint stack (`nixfmt`/`statix`/`deadnix`) on the home-manager module.
 
 ### 74 Summary
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -4297,6 +4297,29 @@ egui::ViewportCommand::Close)` routes back through
 
 **Verification:** Round-trip TOML test in `config.rs` tests.
 
+**Completion notes (2026-06-11):**
+
+- Added `CloseGuardConfig { enabled, unknown_blocks, guard_app_quit }`
+  with a `Default` impl (`true`, `false`, `true`) and the full
+  `#[serde(default)]` + per-field doc comments documenting that only
+  `CommandStatus::Running` counts as "running".
+- Full new-section wiring per `freminal-config-options`: field on
+  `Config`, `Default` impl, `ConfigPartial::close_guard`,
+  `apply_partial` merge arm, and the
+  `every_config_section_survives_partial_merge` guard test (mutation,
+  assertion, and the no-`..` destructure entry).
+- Two dedicated tests: `close_guard_config_round_trips_through_toml`
+  and `close_guard_apply_partial_merges_from_toml`.
+- `config_example.toml` gained a `[close_guard]` section.
+- Nix home-manager module mirrored: `closeGuardSection` let-binding,
+  `optionalAttrs` merge arm, and three `mkOption`s. `nixfmt --check`,
+  `statix check`, `deadnix --fail` all clean.
+- **Deviation:** `guard_app_quit` is retained in the schema for
+  forward-compatibility but has no distinct gate in v0.9.0 — there is
+  no multi-window app-quit path (Quit closes only the focused window),
+  so window-close guarding already covers every exit. Documented in the
+  98.1 audit notes and in the field's doc comment.
+
 #### 98.3 — Running-command detection helper
 
 **Scope:** New module `freminal/src/gui/close_guard.rs`.

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -28,7 +28,7 @@ top of the correctness debts identified in the post-v0.7.0 audit.
 | 77  | Smart Paste Guard                       | Small–Medium | Complete | v0.8.0          | `task-77/paste-guard`            |
 | 94  | Tab Title Precedence (prefix default)   | Small        | Complete | v0.8.0 (71.1)   | `task-94/tab-title-precedence`   |
 | 95  | Persist Custom Tab Names in Layouts     | Small        | Complete | v0.8.0, Task 61 | `task-95/persist-tab-names`      |
-| 98  | Block Close on Running Commands         | Small–Medium | Pending  | Task 72         | `task-74-75-98/v090-finish`      |
+| 98  | Block Close on Running Commands         | Small–Medium | Complete | Task 72         | `task-74-75-98/v090-finish`      |
 
 ### Execution order
 
@@ -4134,7 +4134,24 @@ The following ideas surfaced during planning but are explicitly deferred:
 
 ---
 
-## Task 98 — Block Close on Running Commands
+## Task 98 — Block Close on Running Commands ✅ Complete (2026-06-11)
+
+> **Completion (branch `task-74-75-98/v090-finish`).** All nine subtasks
+> (98.1 audit → 98.9 settings UI) implemented and committed. Tasks 74, 75,
+> and 98 ship in a single PR off this combined branch per user direction.
+> Key deviations, each documented in the relevant subtask notes:
+>
+> - No multi-window app-quit path exists in freminal (Quit closes the
+>   focused window), so `guard_app_quit` has no separate gate — window-close
+>   guarding via `on_close_requested` covers every exit (98.1, 98.7).
+> - The dialog command label is the pane title (or `"<unknown command>"`),
+>   because `CommandBlock` does not capture the command-line text (98.4).
+> - The optional "Close Other Panes" dialog button is deferred — Cancel /
+>   Force Close cover the requirement (98.4).
+> - A pane counts as "running" only when its most recent OSC 133 block has
+>   seen C (output start) and not D; an idle prompt with no executed command
+>   never blocks close (98.3) — this matches the planning-notes concern
+>   about Ctrl-C on an idle prompt.
 
 ### 98 Summary
 
@@ -4517,6 +4534,22 @@ key path.
 
 **Verification:** Round-trip persistence; modal opens and reflects
 config state.
+
+**Completion notes (2026-06-11):**
+
+- Added `show_close_guard_section` to the Security tab in
+  `freminal/src/gui/settings.rs`, rendered after the Paste Guard
+  subsection. Three checkboxes bound to `self.draft.close_guard`:
+  `enabled`, `unknown_blocks`, and `guard_app_quit`. The latter two are
+  wrapped in `add_enabled_ui(self.draft.close_guard.enabled, ...)` so
+  they grey out when the guard is off, mirroring the Paste Guard
+  section's pattern.
+- No `settings_dispatch.rs` arm needed: the guard reads
+  `self.config.close_guard` fresh at each close check, so it takes
+  effect live the moment Apply writes the draft into `self.config`.
+  Persistence is covered by the 98.2 config round-trip tests.
+- No new `SettingsTab` (reuses the existing Security tab), so the tab
+  count / `ALL` assertions are unchanged.
 
 ### 98 Open Questions Resolved
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -4219,6 +4219,56 @@ or window, and every path that triggers app quit.
 
 **Verification:** Report posted; no code changes.
 
+**Completion notes (2026-06-11) — close-path audit:**
+
+Every close entry point and its current guard status (none are guarded
+today except the settings-window unsaved-changes case):
+
+| Entry point                    | Location                                 | Mechanism                                                                        |
+| ------------------------------ | ---------------------------------------- | -------------------------------------------------------------------------------- |
+| Keybinding `ClosePane`         | `input.rs` → `actions.rs` (deferred arm) | sets `win.pending_close_pane = true`; drained in `app_impl.rs update()`          |
+| Menu "Pane > Close Pane"       | `menu.rs`                                | sets `win.pending_close_pane = true`; same drain                                 |
+| Keybinding `CloseTab`          | `actions.rs` deferred dispatch           | `win.tabs.close_active_tab()` directly                                           |
+| Menu "Tab > Close Tab"         | `menu.rs`                                | `TabBarAction::Close(active)` → `dispatch_tab_bar_action` → `win.close_tab(i)`   |
+| Tab-bar "×" button             | `actions.rs` `dispatch_tab_bar_action`   | `TabBarAction::Close(i)` → `win.close_tab(i)`                                    |
+| `close_focused_pane` last-pane | `actions.rs`                             | `ViewportCommand::Close` (closes window) or `win.close_tab(idx)`                 |
+| PTY-death last-pane            | `app_impl.rs`                            | `ViewportCommand::Close` or `win.close_tab(tab_idx)` (NOT user-initiated)        |
+| Menu "Quit"                    | `menu.rs`                                | `ViewportCommand::Close` (closes only the current window — no multi-window quit) |
+| OS window-close button         | `event_loop.rs` → `on_close_requested`   | returns `bool`; `false` vetoes                                                   |
+| `ViewportCommand::Close` (all) | `event_loop.rs` → `on_close_requested`   | programmatic closes route through `on_close_requested`                           |
+
+Key architectural facts driving the implementation:
+
+- **There is no `KeyAction::Quit` and no multi-window app-quit path.**
+  "Quit" closes only the focused window via `ViewportCommand::Close`.
+  This simplifies 98.7: there is no cross-window quit to guard — each
+  window's close is independently guarded through `on_close_requested`.
+  98.2's `guard_app_quit` key is therefore retained in the schema (for
+  forward-compatibility / documentation) but has no distinct code path
+  to gate in v0.9.0; window-close guarding covers every real exit.
+- **`close_focused_pane(ui, win)` in `actions.rs` is the single
+  user-intent pane-close function.** Both the keybinding and the menu
+  set `win.pending_close_pane`, drained once per frame in `update()`.
+  98.5 guards this drain site.
+- **`PerWindowState` (`window.rs`) is the dialog home**, exactly like
+  `paste_dialog` and `broadcast_dialog`. A new `close_dialog:
+CloseGuardDialog` field plus a `pending_close: Option<PendingClose>`
+  carry the suspended close intent.
+- **Snapshot read:** `pane.arc_swap.load()` → `Arc<TerminalSnapshot>`;
+  `snap.command_blocks: Arc<[CommandBlock]>`; a pane has a running
+  command iff any block's `status() == CommandStatus::Running`.
+- **Modal pattern (5 steps):** state struct on `PerWindowState`;
+  register `.is_open()` in `ui_overlay_open` (`app_impl.rs`); call
+  `dialog.show(ctx)` each frame in `update()`; open on trigger; resolve
+  outcome. `broadcast_guard.rs` is the closest template (no text field).
+- **Force Close → window:** `ui.ctx().send_viewport_cmd(
+egui::ViewportCommand::Close)` routes back through
+  `on_close_requested`. To avoid re-prompting, the resolved
+  `pending_close` must carry a "user already confirmed" flag so
+  `on_close_requested` lets it through.
+- **IDs:** `PaneId(u64)` (global), `TabId(u64)` (per-window),
+  `WindowId(winit id)` (process-global).
+
 #### 98.2 — Config schema
 
 **Scope:** `freminal-common/src/config.rs`, `config_example.toml`.

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -23,7 +23,7 @@ top of the correctness debts identified in the post-v0.7.0 audit.
 | 72  | OSC 133 Command Blocks                  | Large        | Complete | v0.8.0          | `task-72/osc-133-command-blocks` |
 | 73  | Command Gutters (exit-status indicator) | Medium       | Complete | Task 72         | `task-73/command-gutters`        |
 | 74  | Broadcast Input to Panes                | Medium       | Complete | v0.8.0, Task 58 | `task-74-75-98/v090-finish`      |
-| 75  | Verify per-pane env round-trip          | Small        | Pending  | v0.8.0          | `task-74-75-98/v090-finish`      |
+| 75  | Verify per-pane env round-trip          | Small        | Complete | v0.8.0          | `task-74-75-98/v090-finish`      |
 | 76  | Notification System (OSC 9 / OSC 777)   | Medium       | Complete | v0.8.0, Task 72 | `task-76/notifications`          |
 | 77  | Smart Paste Guard                       | Small–Medium | Complete | v0.8.0          | `task-77/paste-guard`            |
 | 94  | Tab Title Precedence (prefix default)   | Small        | Complete | v0.8.0 (71.1)   | `task-94/tab-title-precedence`   |
@@ -2447,7 +2447,32 @@ per-frame work.
 
 ---
 
-## Task 75 — Verify Per-Pane Env Round-Trip
+## Task 75 — Verify Per-Pane Env Round-Trip ✅ Complete (2026-06-11)
+
+> **Completion (branch `task-74-75-98/v090-finish`).** Verified the existing
+> per-pane `env` plumbing round-trips through load → substitute → resolve and
+> through serialize → reparse, with explicit regression tests; documented the
+> `env` substitution behavior in `LAYOUT_FORMAT.md`. No production code
+> changed — Task 75 is verification + documentation only, exactly as the
+> reduced v0.9.0 scope intended.
+>
+> - **75.1** — three new tests in `freminal-common/src/layout.rs`:
+>   `per_pane_env_round_trips_through_load_and_resolve` (two panes, each with
+>   an `env` map mixing literal, `${named}`, and `$1` positional values;
+>   asserts the resolved leaves carry the substituted maps),
+>   `per_pane_env_appears_in_serialized_toml` (in-memory layout → TOML →
+>   reparse, confirms env keys/values survive), and
+>   `empty_pane_env_is_omitted_from_serialized_toml` (confirms the
+>   `skip_serializing_if = "HashMap::is_empty"` attribute).
+> - **75.2** — added a "Per-Pane Environment Variables" subsection to
+>   `Documents/LAYOUT_FORMAT.md` with the `env = { PROJECT_ROOT = "$1",
+AWS_PROFILE = "$ENV{AWS_PROFILE}" }` example and a note that env layers
+>   beneath spawn-time defaults.
+>
+> **Deviation:** the plan said "Update the 'Last updated' header line" in
+> `LAYOUT_FORMAT.md`, but that document has no such line (it opens directly
+> with the H1 and intro). No header line was added — introducing one solely
+> for this task would be out of step with the document's existing style.
 
 ### 75 Summary
 

--- a/config_example.toml
+++ b/config_example.toml
@@ -516,6 +516,8 @@ limit = 4000
 #     split_vertical   = "Ctrl+Shift+Pipe"   (split focused pane left | right)
 #     split_horizontal = "Ctrl+Shift+Minus"  (split focused pane top / bottom)
 #     close_pane       = "Ctrl+Shift+W"      (close focused pane; last pane closes tab)
+#     force_close      = (unbound)           (resolve the close-on-running-command
+#                                             guard dialog as "Force Close")
 #     focus_pane_left  = "Ctrl+Shift+H"      (move focus left)
 #     focus_pane_down  = "Ctrl+Shift+J"      (move focus down)
 #     focus_pane_up    = "Ctrl+Shift+K"      (move focus up)

--- a/config_example.toml
+++ b/config_example.toml
@@ -197,6 +197,12 @@ limit = 4000
 # Default: "top"
 # position = "top"
 
+# Whether enabling broadcast input (Ctrl+Shift+I — send keystrokes to every
+# pane in the tab) requires a confirmation dialog the first time it is turned
+# on for a tab. Disabling broadcast never prompts.
+# Default: false
+# confirm_broadcast = false
+
 ## ##############################################################################
 # TAB TITLE SETTINGS
 ## ##############################################################################

--- a/config_example.toml
+++ b/config_example.toml
@@ -495,6 +495,8 @@ limit = 4000
 #     resize_pane_up    = "Ctrl+Alt+K"       (shrink pane upward)
 #     resize_pane_right = "Ctrl+Alt+L"       (grow pane rightward)
 #     zoom_pane        = "Ctrl+Shift+Z"      (toggle zoom on focused pane)
+#     toggle_broadcast_input = "Ctrl+Shift+I" (broadcast keyboard input to every
+#                                              pane in the active tab)
 #
 #   Session:
 #     toggle_recording = "Ctrl+Shift+R"      (start/stop FREC v2 session recording)

--- a/config_example.toml
+++ b/config_example.toml
@@ -386,6 +386,30 @@ limit = 4000
 # command_finished_template = "{command} finished in {duration} (exit {exit_code})"
 
 ## ##############################################################################
+# CLOSE GUARD (block close on running commands)
+## ##############################################################################
+[close_guard]
+# Master switch. When false, no close-guard checks run and every pane / tab /
+# window close proceeds immediately. When true, closing a scope that contains
+# a running foreground command (per OSC 133 markers) shows a confirmation
+# dialog listing what is running.
+# Default: true.
+# enabled = true
+
+# When true, also block close for panes whose command status is unknown
+# (no OSC 133 markers ever received — e.g. a raw `sh` without shell
+# integration, or a directly-launched `vim`).
+# Default: false (unknown panes close freely, matching pre-v0.9.0 behavior).
+# unknown_blocks = false
+
+# When true, the app-quit path runs the guard. When false, app quit bypasses
+# it and only individual close-window / close-tab / close-pane actions are
+# guarded. Note: Freminal's "Quit" closes only the focused window, so every
+# exit already routes through the window-close guard regardless of this flag.
+# Default: true.
+# guard_app_quit = true
+
+## ##############################################################################
 # STARTUP & LAYOUTS
 ## ##############################################################################
 

--- a/flake.nix
+++ b/flake.nix
@@ -100,7 +100,7 @@
         {
           freminal = rustPlatform.buildRustPackage {
             pname = "freminal";
-            version = "0.9.0-beta.4";
+            version = "0.9.0-beta.5";
             src = pkgs.lib.cleanSource ./.;
 
             cargoLock.lockFile = ./Cargo.lock;
@@ -148,9 +148,9 @@
                     <key>CFBundleIdentifier</key>
                     <string>io.github.fredclausen.freminal</string>
                     <key>CFBundleVersion</key>
-                    <string>0.9.0-beta.4</string>
+                    <string>0.9.0-beta.5</string>
                     <key>CFBundleShortVersionString</key>
-                    <string>0.9.0-beta.4</string>
+                    <string>0.9.0-beta.5</string>
                     <key>CFBundleExecutable</key>
                     <string>freminal</string>
                     <key>CFBundleIconFile</key>

--- a/freminal-common/src/config.rs
+++ b/freminal-common/src/config.rs
@@ -406,6 +406,11 @@ pub struct TabsConfig {
     pub show_single_tab: bool,
     /// Position of the tab bar: `"top"` or `"bottom"`.
     pub position: TabBarPosition,
+    /// Whether toggling broadcast input *on* requires a confirmation dialog
+    /// (Task 74). When `true`, the first activation of broadcast in a tab
+    /// prompts "You are about to broadcast keyboard input to N panes.
+    /// Continue?". Disabling broadcast never prompts. Default: `false`.
+    pub confirm_broadcast: bool,
 }
 
 impl Default for TabsConfig {
@@ -413,6 +418,7 @@ impl Default for TabsConfig {
         Self {
             show_single_tab: false,
             position: TabBarPosition::Top,
+            confirm_broadcast: false,
         }
     }
 }
@@ -2712,12 +2718,14 @@ position = "bottom"
         let mut cfg = Config::default();
         cfg.tabs.show_single_tab = true;
         cfg.tabs.position = TabBarPosition::Bottom;
+        cfg.tabs.confirm_broadcast = true;
 
         let toml_str = toml::to_string_pretty(&cfg).expect("Config should serialize");
         let deserialized: Config =
             toml::from_str(&toml_str).expect("serialized TOML should round-trip");
         assert!(deserialized.tabs.show_single_tab);
         assert_eq!(deserialized.tabs.position, TabBarPosition::Bottom);
+        assert!(deserialized.tabs.confirm_broadcast);
     }
 
     #[test]

--- a/freminal-common/src/config.rs
+++ b/freminal-common/src/config.rs
@@ -36,6 +36,7 @@ pub struct Config {
     pub bell: BellConfig,
     pub security: SecurityConfig,
     pub paste_guard: PasteGuardConfig,
+    pub close_guard: CloseGuardConfig,
     pub shell_integration: ShellIntegrationConfig,
     pub command_blocks: CommandBlocksConfig,
     pub notifications: NotificationsConfig,
@@ -80,6 +81,7 @@ impl Default for Config {
             bell: BellConfig::default(),
             security: SecurityConfig::default(),
             paste_guard: PasteGuardConfig::default(),
+            close_guard: CloseGuardConfig::default(),
             shell_integration: ShellIntegrationConfig::default(),
             command_blocks: CommandBlocksConfig::default(),
             notifications: NotificationsConfig::default(),
@@ -650,6 +652,63 @@ impl PasteGuardConfig {
                 Err(err) => Some((pattern.clone(), err.to_string())),
             })
             .collect()
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+//  Close Guard
+// ------------------------------------------------------------------------------------------------
+
+/// Configuration for the close-on-running-command guard (Task 98).
+///
+/// When the user attempts to close a pane, tab, or window while one or more
+/// shells in the affected scope have a running foreground command — as
+/// reported by OSC 133 command markers — a confirmation dialog lists what is
+/// running and lets the user cancel or force-close.
+///
+/// "Running" means a [`crate::buffer_states::command_block::CommandStatus::Running`]
+/// command block: an `OSC 133 C` marker was emitted with no matching
+/// `OSC 133 D`. `Success`, `Failure`, and `Unknown` blocks do **not** block
+/// close. A pane that has never received an OSC 133 prompt marker is treated
+/// as "unknown" and only blocks close when [`unknown_blocks`](Self::unknown_blocks)
+/// is `true`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+// Three independent TOML toggles, each mapping directly to a documented
+// `[close_guard]` key; collapsing them into an enum would distort the schema.
+#[allow(clippy::struct_excessive_bools)]
+pub struct CloseGuardConfig {
+    /// Master switch. When `false`, no close-guard checks run and every close
+    /// proceeds immediately.
+    ///
+    /// Default: `true`.
+    pub enabled: bool,
+
+    /// When `true`, also block close for panes whose command status is unknown
+    /// (no OSC 133 markers ever received — e.g. a raw `sh` without shell
+    /// integration, or a directly-launched `vim`).
+    ///
+    /// Default: `false` (matches pre-v0.9.0 behavior — unknown panes close
+    /// freely).
+    pub unknown_blocks: bool,
+
+    /// When `true`, the app-quit path runs the guard. When `false`, app quit
+    /// bypasses the guard and only individual close-window / close-tab /
+    /// close-pane actions are guarded.
+    ///
+    /// Default: `true`. Note: freminal's "Quit" closes only the focused
+    /// window (there is no multi-window quit), so in practice every exit
+    /// already routes through the window-close guard regardless of this flag.
+    pub guard_app_quit: bool,
+}
+
+impl Default for CloseGuardConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            unknown_blocks: false,
+            guard_app_quit: true,
+        }
     }
 }
 
@@ -1325,6 +1384,7 @@ struct ConfigPartial {
     pub bell: Option<BellConfig>,
     pub security: Option<SecurityConfig>,
     pub paste_guard: Option<PasteGuardConfig>,
+    pub close_guard: Option<CloseGuardConfig>,
     pub shell_integration: Option<ShellIntegrationConfig>,
     pub command_blocks: Option<CommandBlocksConfig>,
     pub notifications: Option<NotificationsConfig>,
@@ -1377,6 +1437,9 @@ impl Config {
         }
         if let Some(paste_guard) = partial.paste_guard {
             self.paste_guard = paste_guard;
+        }
+        if let Some(close_guard) = partial.close_guard {
+            self.close_guard = close_guard;
         }
         if let Some(shell_integration) = partial.shell_integration {
             self.shell_integration = shell_integration;
@@ -2834,6 +2897,7 @@ mode = "none"
         original.bell.mode = BellMode::None;
         original.security.allow_clipboard_read = !Config::default().security.allow_clipboard_read;
         original.paste_guard.patterns = !Config::default().paste_guard.patterns;
+        original.close_guard.unknown_blocks = !Config::default().close_guard.unknown_blocks;
         original.shell_integration.set_term_program =
             !Config::default().shell_integration.set_term_program;
         original.command_blocks.enabled = !Config::default().command_blocks.enabled;
@@ -2903,6 +2967,10 @@ mode = "none"
             "paste_guard section dropped"
         );
         assert_eq!(
+            loaded.close_guard.unknown_blocks, original.close_guard.unknown_blocks,
+            "close_guard section dropped"
+        );
+        assert_eq!(
             loaded.shell_integration.set_term_program, original.shell_integration.set_term_program,
             "shell_integration section dropped"
         );
@@ -2951,6 +3019,7 @@ mode = "none"
             bell: _,
             security: _,
             paste_guard: _,
+            close_guard: _,
             shell_integration: _,
             command_blocks: _,
             notifications: _,
@@ -2959,6 +3028,49 @@ mode = "none"
             startup: _,
             onboarding: _,
         } = loaded;
+    }
+
+    #[test]
+    fn close_guard_config_round_trips_through_toml() {
+        let mut cfg = CloseGuardConfig::default();
+        assert!(cfg.enabled, "default enabled is true");
+        assert!(!cfg.unknown_blocks, "default unknown_blocks is false");
+        assert!(cfg.guard_app_quit, "default guard_app_quit is true");
+
+        // Flip every field and confirm the round trip preserves them.
+        cfg.enabled = false;
+        cfg.unknown_blocks = true;
+        cfg.guard_app_quit = false;
+
+        let toml = toml::to_string_pretty(&cfg).expect("serialize CloseGuardConfig");
+        let parsed: CloseGuardConfig = toml::from_str(&toml).expect("deserialize CloseGuardConfig");
+        assert!(!parsed.enabled);
+        assert!(parsed.unknown_blocks);
+        assert!(!parsed.guard_app_quit);
+    }
+
+    #[test]
+    fn close_guard_apply_partial_merges_from_toml() {
+        // Regression guard: [close_guard] must survive the ConfigPartial merge.
+        let mut cfg = Config::default();
+        assert!(cfg.close_guard.enabled, "default enabled");
+        assert!(!cfg.close_guard.unknown_blocks, "default unknown_blocks");
+
+        let partial: ConfigPartial = toml::from_str(
+            r"
+[close_guard]
+unknown_blocks = true
+",
+        )
+        .expect("valid TOML");
+        cfg.apply_partial(partial);
+        assert!(
+            cfg.close_guard.unknown_blocks,
+            "[close_guard] unknown_blocks must merge through ConfigPartial"
+        );
+        // Untouched keys keep their defaults.
+        assert!(cfg.close_guard.enabled);
+        assert!(cfg.close_guard.guard_app_quit);
     }
 
     #[test]

--- a/freminal-common/src/keybindings.rs
+++ b/freminal-common/src/keybindings.rs
@@ -818,6 +818,9 @@ pub enum KeyAction {
     SplitHorizontal,
     /// Close the focused pane (last pane closes the tab).
     ClosePane,
+    /// Resolve the close-on-running-command guard dialog as "Force Close",
+    /// bypassing the running-command check. No-op when no dialog is open.
+    ForceClose,
     /// Move focus to the pane to the left.
     FocusPaneLeft,
     /// Move focus to the pane below.
@@ -918,6 +921,7 @@ impl KeyAction {
             Self::SplitVertical => "split_vertical",
             Self::SplitHorizontal => "split_horizontal",
             Self::ClosePane => "close_pane",
+            Self::ForceClose => "force_close",
             Self::FocusPaneLeft => "focus_pane_left",
             Self::FocusPaneDown => "focus_pane_down",
             Self::FocusPaneUp => "focus_pane_up",
@@ -990,6 +994,7 @@ impl KeyAction {
             Self::SplitVertical => "Split Vertical",
             Self::SplitHorizontal => "Split Horizontal",
             Self::ClosePane => "Close Pane",
+            Self::ForceClose => "Force Close",
             Self::FocusPaneLeft => "Focus Pane Left",
             Self::FocusPaneDown => "Focus Pane Down",
             Self::FocusPaneUp => "Focus Pane Up",
@@ -1059,6 +1064,7 @@ impl KeyAction {
         Self::SplitVertical,
         Self::SplitHorizontal,
         Self::ClosePane,
+        Self::ForceClose,
         Self::FocusPaneLeft,
         Self::FocusPaneDown,
         Self::FocusPaneUp,
@@ -1140,6 +1146,7 @@ impl FromStr for KeyAction {
             "split_vertical" => Ok(Self::SplitVertical),
             "split_horizontal" => Ok(Self::SplitHorizontal),
             "close_pane" => Ok(Self::ClosePane),
+            "force_close" => Ok(Self::ForceClose),
             "focus_pane_left" => Ok(Self::FocusPaneLeft),
             "focus_pane_down" => Ok(Self::FocusPaneDown),
             "focus_pane_up" => Ok(Self::FocusPaneUp),
@@ -1870,7 +1877,7 @@ mod tests {
         // roundtrip test above covers ALL, and name() is exhaustive.
         assert_eq!(
             KeyAction::ALL.len(),
-            61,
+            62,
             "KeyAction::ALL should contain all variants"
         );
     }
@@ -2297,6 +2304,7 @@ mod tests {
             KeyAction::FoldPreviousCommand,
             KeyAction::FoldAll,
             KeyAction::CopyCommandOutputAtCursor,
+            KeyAction::ForceClose,
         ];
         for action in unbound {
             assert!(

--- a/freminal-common/src/keybindings.rs
+++ b/freminal-common/src/keybindings.rs
@@ -836,6 +836,15 @@ pub enum KeyAction {
     ResizePaneRight,
     /// Toggle zoom on the focused pane (full-tab or restore).
     ZoomPane,
+    /// Toggle broadcasting keyboard input to every pane in the active tab.
+    ///
+    /// When on, each `InputEvent::Key` payload directed at the focused pane
+    /// is also fanned out to every other leaf pane in the tab.  Mouse
+    /// events, resize events, and per-pane window commands are never
+    /// broadcast.  The toggle is per-tab and defaults to off.
+    ///
+    /// Default binding: `Ctrl+Shift+I` (mnemonic: "Input to all panes").
+    ToggleBroadcastInput,
 
     // -- Layout actions ---------------------------------------------------
     /// Open the Load Layout dialog.
@@ -918,6 +927,7 @@ impl KeyAction {
             Self::ResizePaneUp => "resize_pane_up",
             Self::ResizePaneRight => "resize_pane_right",
             Self::ZoomPane => "zoom_pane",
+            Self::ToggleBroadcastInput => "toggle_broadcast_input",
             Self::LoadLayout => "load_layout",
             Self::SaveLayout => "save_layout",
             Self::ReloadConfig => "reload_config",
@@ -989,6 +999,7 @@ impl KeyAction {
             Self::ResizePaneUp => "Resize Pane Up",
             Self::ResizePaneRight => "Resize Pane Right",
             Self::ZoomPane => "Zoom Pane",
+            Self::ToggleBroadcastInput => "Toggle Broadcast Input",
             Self::LoadLayout => "Load Layout",
             Self::SaveLayout => "Save Layout",
             Self::ReloadConfig => "Reload Config",
@@ -1057,6 +1068,7 @@ impl KeyAction {
         Self::ResizePaneUp,
         Self::ResizePaneRight,
         Self::ZoomPane,
+        Self::ToggleBroadcastInput,
         Self::LoadLayout,
         Self::SaveLayout,
         Self::ReloadConfig,
@@ -1137,6 +1149,7 @@ impl FromStr for KeyAction {
             "resize_pane_up" => Ok(Self::ResizePaneUp),
             "resize_pane_right" => Ok(Self::ResizePaneRight),
             "zoom_pane" => Ok(Self::ZoomPane),
+            "toggle_broadcast_input" => Ok(Self::ToggleBroadcastInput),
             "load_layout" => Ok(Self::LoadLayout),
             "save_layout" => Ok(Self::SaveLayout),
             "reload_config" => Ok(Self::ReloadConfig),
@@ -1316,6 +1329,13 @@ fn register_tab_bindings(map: &mut BindingMap) {
     for (key, action) in digit_actions {
         map.bind(KeyCombo::new(key, BindingModifiers::CTRL_SHIFT), action);
     }
+
+    // Broadcast keyboard input to every pane in the active tab.
+    // Ctrl+Shift+I is free on all platforms (mnemonic: "Input to all panes").
+    map.bind(
+        KeyCombo::new(BindingKey::I, BindingModifiers::CTRL_SHIFT),
+        KeyAction::ToggleBroadcastInput,
+    );
 }
 
 /// Register clipboard, zoom, UI, and scrollback bindings.
@@ -1850,7 +1870,7 @@ mod tests {
         // roundtrip test above covers ALL, and name() is exhaustive.
         assert_eq!(
             KeyAction::ALL.len(),
-            60,
+            61,
             "KeyAction::ALL should contain all variants"
         );
     }
@@ -1901,6 +1921,25 @@ mod tests {
         let map = BindingMap::default();
         let combo = KeyCombo::new(BindingKey::T, BindingModifiers::CTRL_SHIFT);
         assert_eq!(map.lookup(&combo), Some(KeyAction::NewTab));
+    }
+
+    #[test]
+    fn default_toggle_broadcast_input_binding() {
+        let map = BindingMap::default();
+        let combo = KeyCombo::new(BindingKey::I, BindingModifiers::CTRL_SHIFT);
+        assert_eq!(map.lookup(&combo), Some(KeyAction::ToggleBroadcastInput));
+    }
+
+    #[test]
+    fn toggle_broadcast_input_name_round_trips() {
+        assert_eq!(
+            KeyAction::ToggleBroadcastInput.name(),
+            "toggle_broadcast_input"
+        );
+        assert_eq!(
+            "toggle_broadcast_input".parse::<KeyAction>(),
+            Ok(KeyAction::ToggleBroadcastInput)
+        );
     }
 
     #[test]
@@ -2233,11 +2272,12 @@ mod tests {
         //        + FocusPaneLeft/Down/Up/Right(4) + ResizePaneLeft/Down/Up/Right(4)
         //        + ZoomPane(1) + NewWindow(1) + ClearScrollback(1)
         //        + ToggleRecording(1) + UnfoldAll(1)
-        //        + CopyLastCommandOutput(1) + ShowCommandHistory(1) = 47
+        //        + CopyLastCommandOutput(1) + ShowCommandHistory(1)
+        //        + ToggleBroadcastInput(1) = 48
         assert_eq!(
             map.len(),
-            47,
-            "default binding map should have exactly 47 bindings"
+            48,
+            "default binding map should have exactly 48 bindings"
         );
     }
 

--- a/freminal-common/src/layout.rs
+++ b/freminal-common/src/layout.rs
@@ -1472,6 +1472,185 @@ size = [640, 480]
         let _ = std::fs::remove_dir_all(&tmp_dir);
     }
 
+    // -----------------------------------------------------------------
+    //  Task 75.1 — per-pane env round-trip
+    // -----------------------------------------------------------------
+
+    const TWO_PANE_ENV_LAYOUT: &str = r#"
+[layout]
+name = "EnvRoundTrip"
+
+[layout.variables]
+project_dir = "/srv/project"
+
+[[tabs]]
+title = "Work"
+
+  [[tabs.panes]]
+  id = "root"
+  split = "vertical"
+  ratio = 0.5
+
+  [[tabs.panes]]
+  id = "left"
+  parent = "root"
+  position = "first"
+  active = true
+  env = { FOO = "bar", PROJECT_ROOT = "${project_dir}" }
+
+  [[tabs.panes]]
+  id = "right"
+  parent = "root"
+  position = "second"
+  env = { LANG = "en_US.UTF-8", FROM_POS = "$1" }
+"#;
+
+    /// Collect every leaf in a resolved tree, in depth-first order.
+    fn collect_leaves(node: &ResolvedNode, out: &mut Vec<ResolvedLeaf>) {
+        match node {
+            ResolvedNode::Leaf(leaf) => out.push(leaf.clone()),
+            ResolvedNode::Split { first, second, .. } => {
+                collect_leaves(first, out);
+                collect_leaves(second, out);
+            }
+        }
+    }
+
+    #[test]
+    fn per_pane_env_round_trips_through_load_and_resolve() {
+        let layout = Layout::from_str_content(Path::new("env.toml"), TWO_PANE_ENV_LAYOUT)
+            .expect("parse failed");
+
+        // Substitute with a positional arg so `$1` resolves.
+        let positional = vec!["positional-value".to_owned()];
+        let substituted = layout.apply_variables(&positional, &HashMap::new());
+        let resolved = substituted.resolve().expect("resolve failed");
+
+        let root = resolved.windows[0].tabs[0]
+            .root
+            .as_ref()
+            .expect("root should exist");
+        let mut leaves = Vec::new();
+        collect_leaves(root, &mut leaves);
+        assert_eq!(leaves.len(), 2, "expected two leaf panes");
+
+        let left = leaves
+            .iter()
+            .find(|l| l.id == "left")
+            .expect("left leaf missing");
+        assert_eq!(left.env.get("FOO").map(String::as_str), Some("bar"));
+        // `${project_dir}` resolves to the named variable's value.
+        assert_eq!(
+            left.env.get("PROJECT_ROOT").map(String::as_str),
+            Some("/srv/project")
+        );
+
+        let right = leaves
+            .iter()
+            .find(|l| l.id == "right")
+            .expect("right leaf missing");
+        assert_eq!(
+            right.env.get("LANG").map(String::as_str),
+            Some("en_US.UTF-8")
+        );
+        // `$1` resolves to the supplied positional argument.
+        assert_eq!(
+            right.env.get("FROM_POS").map(String::as_str),
+            Some("positional-value")
+        );
+    }
+
+    #[test]
+    fn per_pane_env_appears_in_serialized_toml() {
+        // Build an in-memory layout (mirrors the save path) with two panes,
+        // each carrying an env map, then serialize and confirm the keys and
+        // values survive into the TOML output and re-parse identically.
+        let layout = Layout {
+            layout: LayoutMeta {
+                name: Some("SaveEnv".to_owned()),
+                ..LayoutMeta::default()
+            },
+            windows: Vec::new(),
+            tabs: vec![LayoutTab {
+                title: Some("T".to_owned()),
+                custom_name: None,
+                active: true,
+                panes: vec![
+                    LayoutPane {
+                        id: "root".to_owned(),
+                        parent: None,
+                        position: None,
+                        split: Some(LayoutSplitDirection::Horizontal),
+                        ratio: 0.5,
+                        directory: None,
+                        command: None,
+                        shell: None,
+                        env: HashMap::new(),
+                        title: None,
+                        active: false,
+                    },
+                    LayoutPane {
+                        id: "top".to_owned(),
+                        parent: Some("root".to_owned()),
+                        position: Some(LayoutPanePosition::First),
+                        split: None,
+                        ratio: 0.5,
+                        directory: None,
+                        command: None,
+                        shell: None,
+                        env: HashMap::from([("ALPHA".to_owned(), "one".to_owned())]),
+                        title: None,
+                        active: true,
+                    },
+                    LayoutPane {
+                        id: "bottom".to_owned(),
+                        parent: Some("root".to_owned()),
+                        position: Some(LayoutPanePosition::Second),
+                        split: None,
+                        ratio: 0.5,
+                        directory: None,
+                        command: None,
+                        shell: None,
+                        env: HashMap::from([("BETA".to_owned(), "two".to_owned())]),
+                        title: None,
+                        active: false,
+                    },
+                ],
+            }],
+        };
+
+        let toml_str = layout.to_toml_string().expect("serialize failed");
+        assert!(toml_str.contains("ALPHA"), "ALPHA key missing: {toml_str}");
+        assert!(toml_str.contains("\"one\""), "ALPHA value missing");
+        assert!(toml_str.contains("BETA"), "BETA key missing");
+        assert!(toml_str.contains("\"two\""), "BETA value missing");
+
+        // Re-parse and confirm the env maps survive.
+        let reparsed =
+            Layout::from_str_content(Path::new("save_env.toml"), &toml_str).expect("reparse");
+        let panes = &reparsed.tabs[0].panes;
+        let top = panes.iter().find(|p| p.id == "top").expect("top missing");
+        assert_eq!(top.env.get("ALPHA").map(String::as_str), Some("one"));
+        let bottom = panes
+            .iter()
+            .find(|p| p.id == "bottom")
+            .expect("bottom missing");
+        assert_eq!(bottom.env.get("BETA").map(String::as_str), Some("two"));
+    }
+
+    #[test]
+    fn empty_pane_env_is_omitted_from_serialized_toml() {
+        // A leaf with no env should not emit an empty `env = {}` table,
+        // confirming the `skip_serializing_if = "HashMap::is_empty"` attr.
+        let layout =
+            Layout::from_str_content(Path::new("simple.toml"), SIMPLE_LAYOUT).expect("parse");
+        let toml_str = layout.to_toml_string().expect("serialize failed");
+        assert!(
+            !toml_str.contains("env"),
+            "empty env should be skipped: {toml_str}"
+        );
+    }
+
     #[test]
     fn validation_rejects_cycle() {
         let bad = r#"

--- a/freminal/Cargo.toml
+++ b/freminal/Cargo.toml
@@ -34,7 +34,7 @@ deb_depends = ["libgl1-mesa-glx"]
 # `cargo xtask bump-version` keeps this in sync, translating the SemVer
 # pre-release separator to the RPM tilde operator (e.g. "0.9.0~beta.2"), which
 # sorts older than the final release just like the SemVer pre-release does.
-version = "0.9.0~beta.4"
+version = "0.9.0~beta.5"
 assets = [
   { source = "target/release/freminal", dest = "/usr/bin/freminal", mode = "755" },
 ]

--- a/freminal/src/gui/actions.rs
+++ b/freminal/src/gui/actions.rs
@@ -359,6 +359,11 @@ impl super::FreminalGui {
                 }
             }
             KeyAction::NewTab => self.spawn_new_tab(win),
+            KeyAction::ForceClose => {
+                // Resolve an open close-guard dialog as Force Close. No-op
+                // when no dialog is open (handled where the flag is drained).
+                win.pending_force_close = true;
+            }
             KeyAction::CloseTab => {
                 // Route through the close guard, which either opens the
                 // confirmation dialog (running command present) or closes the

--- a/freminal/src/gui/actions.rs
+++ b/freminal/src/gui/actions.rs
@@ -588,18 +588,30 @@ impl super::FreminalGui {
                 }
             }
             KeyAction::ToggleBroadcastInput => {
+                let confirm = self.config.tabs.confirm_broadcast;
                 let tab = win.tabs.active_tab_mut();
-                let now_on = tab.toggle_broadcast();
                 let pane_count = tab.pane_tree.iter_panes().map_or(1, |p| p.len());
-                if now_on {
-                    self.push_info_toast(
-                        "Broadcast input enabled",
-                        Some(format!(
-                            "Keyboard input is now sent to all {pane_count} pane(s) in this tab."
-                        )),
-                    );
+                let currently_on = tab.broadcast_input;
+
+                // Turning broadcast ON with confirmation enabled defers the
+                // toggle to the confirm dialog. Turning it OFF (or with
+                // confirmation disabled) toggles immediately. Disabling never
+                // prompts.
+                if !currently_on && confirm {
+                    let tab_id = tab.id;
+                    win.broadcast_dialog.open(tab_id, pane_count);
                 } else {
-                    self.push_info_toast("Broadcast input disabled", None);
+                    let now_on = tab.toggle_broadcast();
+                    if now_on {
+                        self.push_info_toast(
+                            "Broadcast input enabled",
+                            Some(format!(
+                                "Keyboard input is now sent to all {pane_count} pane(s) in this tab."
+                            )),
+                        );
+                    } else {
+                        self.push_info_toast("Broadcast input disabled", None);
+                    }
                 }
             }
             KeyAction::Paste => self.guarded_paste(win),

--- a/freminal/src/gui/actions.rs
+++ b/freminal/src/gui/actions.rs
@@ -587,6 +587,21 @@ impl super::FreminalGui {
                     }
                 }
             }
+            KeyAction::ToggleBroadcastInput => {
+                let tab = win.tabs.active_tab_mut();
+                let now_on = tab.toggle_broadcast();
+                let pane_count = tab.pane_tree.iter_panes().map_or(1, |p| p.len());
+                if now_on {
+                    self.push_info_toast(
+                        "Broadcast input enabled",
+                        Some(format!(
+                            "Keyboard input is now sent to all {pane_count} pane(s) in this tab."
+                        )),
+                    );
+                } else {
+                    self.push_info_toast("Broadcast input disabled", None);
+                }
+            }
             KeyAction::Paste => self.guarded_paste(win),
             KeyAction::PasteUnsafe => Self::unguarded_paste(win),
             KeyAction::Copy

--- a/freminal/src/gui/actions.rs
+++ b/freminal/src/gui/actions.rs
@@ -195,7 +195,7 @@ impl super::FreminalGui {
                     warn!("TabBarAction::SwitchTo: active tab has no active pane");
                 }
             }
-            super::TabBarAction::Close(i) => win.close_tab(i),
+            super::TabBarAction::Close(i) => self.guarded_close_tab(win, i),
             super::TabBarAction::BeginRename(i) => {
                 // Start inline rename: seed the buffer with the current
                 // display name and mark the tab as renaming.  Clamp to a
@@ -359,17 +359,21 @@ impl super::FreminalGui {
                 }
             }
             KeyAction::NewTab => self.spawn_new_tab(win),
-            KeyAction::CloseTab if let Err(e) = win.tabs.close_active_tab() => {
-                trace!("Cannot close tab: {e}");
+            KeyAction::CloseTab => {
+                // Route through the close guard, which either opens the
+                // confirmation dialog (running command present) or closes the
+                // active tab immediately.  `guarded_close_tab` handles the
+                // last-tab case (the close silently no-ops there, matching the
+                // previous `close_active_tab` behavior).
+                let idx = win.tabs.active_index();
+                self.guarded_close_tab(win, idx);
             }
-            // `CloseTab` with no error is a no-op here; `ClearScrollback`
-            // and the fold actions are fully handled synchronously in
-            // `dispatch_binding_action` (the former resets view scroll
-            // offset and sends `InputEvent::ClearScrollback`; the latter
-            // mutate `ViewState::folded_blocks` directly) so they need no
-            // deferred-action work.
-            KeyAction::CloseTab
-            | KeyAction::ClearScrollback
+            // `ClearScrollback` and the fold actions are fully handled
+            // synchronously in `dispatch_binding_action` (the former resets
+            // view scroll offset and sends `InputEvent::ClearScrollback`; the
+            // latter mutate `ViewState::folded_blocks` directly) so they need
+            // no deferred-action work.
+            KeyAction::ClearScrollback
             | KeyAction::FoldPreviousCommand
             | KeyAction::FoldAll
             | KeyAction::UnfoldAll

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -223,6 +223,7 @@ impl freminal_windowing::App for FreminalGui {
                         last_tab_rects: Vec::new(),
                         pending_menu_actions: Vec::new(),
                         paste_dialog: super::paste_guard::PasteDialog::default(),
+                        broadcast_dialog: super::broadcast_guard::BroadcastConfirmDialog::default(),
                     };
                     self.windows.insert(window_id, win);
 
@@ -1113,6 +1114,26 @@ impl freminal_windowing::App for FreminalGui {
                 | super::paste_guard::PasteDialogOutcome::Idle => {}
             }
 
+            // Broadcast-input confirm dialog (Task 74.5).  Shown when the user
+            // tried to enable broadcast and `[tabs] confirm_broadcast` is set.
+            // On confirm, broadcast is enabled on the dialog's target tab.
+            match win.broadcast_dialog.show(ctx) {
+                super::broadcast_guard::BroadcastDialogOutcome::Confirmed(tab_id) => {
+                    if let Some(tab) = win.tabs.iter_mut().find(|t| t.id == tab_id) {
+                        tab.broadcast_input = true;
+                        let pane_count = tab.pane_tree.iter_panes().map_or(1, |p| p.len());
+                        self.push_info_toast(
+                            "Broadcast input enabled",
+                            Some(format!(
+                                "Keyboard input is now sent to all {pane_count} pane(s) in this tab."
+                            )),
+                        );
+                    }
+                }
+                super::broadcast_guard::BroadcastDialogOutcome::Cancelled
+                | super::broadcast_guard::BroadcastDialogOutcome::Idle => {}
+            }
+
             // Floating "About Freminal" dialog.  Shown whenever the user
             // clicked "About Freminal" in the Help menu.  Self-dismissing
             // via its own Close button or title-bar X.
@@ -1145,7 +1166,8 @@ impl freminal_windowing::App for FreminalGui {
                 || self.about_window_open
                 || self.welcome.is_open()
                 || win.renaming_tab.is_some()
-                || win.paste_dialog.is_open();
+                || win.paste_dialog.is_open()
+                || win.broadcast_dialog.is_open();
 
             // ── Pane border drag-to-resize ───────────────────────────
             //
@@ -2049,6 +2071,7 @@ impl FreminalGui {
             last_tab_rects: Vec::new(),
             pending_menu_actions: Vec::new(),
             paste_dialog: super::paste_guard::PasteDialog::default(),
+            broadcast_dialog: super::broadcast_guard::BroadcastConfirmDialog::default(),
         }
     }
 

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -1685,10 +1685,24 @@ impl freminal_windowing::App for FreminalGui {
             // the active pane's subtree is drawn in the active color; the
             // other half gets the inactive color. This makes it visually
             // clear which pane owns each shared edge.
+            let broadcast_active = win.tabs.active_tab().broadcast_input;
             if has_multiple_panes && zoomed_pane.is_none() {
                 let painter = ui.painter();
-                let inactive_color = egui::Color32::from_gray(80);
-                let active_color = egui::Color32::from_rgb(100, 160, 255);
+                // Broadcast mode (Task 74) tints every split border yellow so
+                // the user has a constant visual reminder that keystrokes are
+                // fanning out to every pane.  Otherwise the active pane's
+                // edges are blue and the rest gray.
+                let (inactive_color, active_color) = if broadcast_active {
+                    (
+                        egui::Color32::from_rgb(180, 150, 40),
+                        egui::Color32::from_rgb(240, 200, 60),
+                    )
+                } else {
+                    (
+                        egui::Color32::from_gray(80),
+                        egui::Color32::from_rgb(100, 160, 255),
+                    )
+                };
 
                 let border_rects = win
                     .tabs
@@ -1744,6 +1758,34 @@ impl freminal_windowing::App for FreminalGui {
                             );
                         }
                     }
+                }
+            }
+
+            // Broadcast label (Task 74): when broadcast is active, paint a
+            // small "BROADCAST" tag in the top-right corner of every visible
+            // pane.  Top-right is chosen so it never collides with the
+            // password-prompt lock icon (which lives in the tab/menu bar, not
+            // the pane area).  Drawn for the zoomed pane too.
+            if broadcast_active {
+                let painter = ui.painter();
+                let label_color = egui::Color32::from_rgb(240, 200, 60);
+                let bg = egui::Color32::from_rgba_unmultiplied(0, 0, 0, 160);
+                for (_pane_id, pane_rect) in &pane_layout {
+                    let anchor = egui::pos2(pane_rect.max.x - 4.0, pane_rect.min.y + 4.0);
+                    let galley = painter.layout_no_wrap(
+                        "BROADCAST".to_owned(),
+                        egui::FontId::monospace(10.0),
+                        label_color,
+                    );
+                    let text_rect = egui::Align2::RIGHT_TOP
+                        .anchor_size(anchor, galley.size())
+                        .expand(2.0);
+                    painter.rect_filled(text_rect, 2.0, bg);
+                    painter.galley(
+                        text_rect.left_top() + egui::vec2(2.0, 2.0),
+                        galley,
+                        label_color,
+                    );
                 }
             }
 

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -1053,6 +1053,28 @@ impl freminal_windowing::App for FreminalGui {
             let zoomed_pane = win.tabs.active_tab().zoomed_pane;
             let has_multiple_panes = win.tabs.active_tab().pane_tree.pane_count().unwrap_or(1) > 1;
 
+            // Broadcast input (Task 74): when the active tab has broadcast
+            // enabled, collect the (pane id, input sender) of every leaf pane
+            // up front. Senders are cheap to clone. The active pane's render
+            // call mirrors its keyboard input to every *other* pane in this
+            // list. Empty when broadcast is off (the common case).
+            let broadcast_senders: Vec<(panes::PaneId, crossbeam_channel::Sender<InputEvent>)> =
+                if win.tabs.active_tab().broadcast_input {
+                    win.tabs
+                        .active_tab()
+                        .pane_tree
+                        .iter_panes()
+                        .map(|panes| {
+                            panes
+                                .into_iter()
+                                .map(|p| (p.id, p.input_tx.clone()))
+                                .collect()
+                        })
+                        .unwrap_or_default()
+                } else {
+                    Vec::new()
+                };
+
             // When a pane is zoomed, render only that pane at full size.
             // Borders are hidden during zoom since there is only one visible pane.
             let (pane_layout, border_width) = if let Some(zoomed_id) = zoomed_pane {
@@ -1410,6 +1432,20 @@ impl freminal_windowing::App for FreminalGui {
                     && pane.echo_off.load(std::sync::atomic::Ordering::Relaxed);
                 let is_active = pane_id == active_pane_id;
 
+                // Broadcast input (Task 74): only the active pane fans out its
+                // keyboard input, and only to the *other* panes. Non-active
+                // panes and the broadcast-off case pass an empty slice.
+                let key_broadcast_targets: Vec<crossbeam_channel::Sender<InputEvent>> = if is_active
+                {
+                    broadcast_senders
+                        .iter()
+                        .filter(|(id, _)| *id != pane_id)
+                        .map(|(_, tx)| tx.clone())
+                        .collect()
+                } else {
+                    Vec::new()
+                };
+
                 // Build a RecordingContext for this pane if recording is active.
                 // Hold the Arc locally so the borrow in `RecordingContext.handle`
                 // remains valid for the lifetime of `rec_ctx`.
@@ -1452,6 +1488,7 @@ impl freminal_windowing::App for FreminalGui {
                             pane_id,
                             rec_ctx.as_ref(),
                             &mut pane.pending_copy,
+                            &key_broadcast_targets,
                         )
                     });
                 let (left_clicked, deferred_actions) = show_result.inner;

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -225,6 +225,7 @@ impl freminal_windowing::App for FreminalGui {
                         paste_dialog: super::paste_guard::PasteDialog::default(),
                         broadcast_dialog: super::broadcast_guard::BroadcastConfirmDialog::default(),
                         close_dialog: super::close_guard::CloseGuardDialog::default(),
+                        pending_force_close: false,
                     };
                     self.windows.insert(window_id, win);
 
@@ -1160,8 +1161,17 @@ impl freminal_windowing::App for FreminalGui {
             // pane / tab / window close is suspended pending confirmation.  On
             // Force Close the original close is executed with the guard
             // bypassed; on Cancel the close is abandoned.
+            // A pending ForceClose key action resolves an open close-guard
+            // dialog as Force Close; harmless no-op when nothing is open.
+            let force_close_requested = std::mem::take(&mut win.pending_force_close);
             if let Some(scope) = win.close_dialog.scope() {
-                match win.close_dialog.show(ctx) {
+                let outcome = if force_close_requested {
+                    win.close_dialog.force_close_now();
+                    super::close_guard::CloseDialogOutcome::ForceClose
+                } else {
+                    win.close_dialog.show(ctx)
+                };
+                match outcome {
                     super::close_guard::CloseDialogOutcome::ForceClose => match scope {
                         super::close_guard::CloseScope::Pane => {
                             Self::close_focused_pane(ui, &mut win);
@@ -2124,6 +2134,7 @@ impl FreminalGui {
             paste_dialog: super::paste_guard::PasteDialog::default(),
             broadcast_dialog: super::broadcast_guard::BroadcastConfirmDialog::default(),
             close_dialog: super::close_guard::CloseGuardDialog::default(),
+            pending_force_close: false,
         }
     }
 

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -224,6 +224,7 @@ impl freminal_windowing::App for FreminalGui {
                         pending_menu_actions: Vec::new(),
                         paste_dialog: super::paste_guard::PasteDialog::default(),
                         broadcast_dialog: super::broadcast_guard::BroadcastConfirmDialog::default(),
+                        close_dialog: super::close_guard::CloseGuardDialog::default(),
                     };
                     self.windows.insert(window_id, win);
 
@@ -281,6 +282,27 @@ impl freminal_windowing::App for FreminalGui {
             let _ = self.settings_modal.request_close();
             self.settings_modal.is_open = false;
             self.settings_owner = None;
+        }
+
+        // Close-on-running-command guard (Task 98.7).  If the user already
+        // confirmed a force-close for this window, let it through and clear
+        // the flag.  Otherwise, if any pane in the window has a running
+        // foreground command, open the confirmation dialog and veto the OS
+        // close (return false); the dialog's Force Close re-issues the close
+        // with this flag set.
+        if self.force_close_windows.remove(&window_id) {
+            // User-confirmed force close — fall through to the close logic.
+        } else if let Some(win) = self.windows.get(&window_id) {
+            let running = self.window_close_running(win);
+            if !running.is_empty()
+                && let Some(win) = self.windows.get_mut(&window_id)
+            {
+                win.close_dialog.open(super::close_guard::PendingClose {
+                    scope: super::close_guard::CloseScope::Window,
+                    running,
+                });
+                return false;
+            }
         }
 
         // Auto-save session before the last terminal window is removed.
@@ -1134,6 +1156,32 @@ impl freminal_windowing::App for FreminalGui {
                 | super::broadcast_guard::BroadcastDialogOutcome::Idle => {}
             }
 
+            // Close-on-running-command guard dialog (Task 98).  Shown while a
+            // pane / tab / window close is suspended pending confirmation.  On
+            // Force Close the original close is executed with the guard
+            // bypassed; on Cancel the close is abandoned.
+            if let Some(scope) = win.close_dialog.scope() {
+                match win.close_dialog.show(ctx) {
+                    super::close_guard::CloseDialogOutcome::ForceClose => match scope {
+                        super::close_guard::CloseScope::Pane => {
+                            Self::close_focused_pane(ui, &mut win);
+                        }
+                        super::close_guard::CloseScope::Tab(index) => {
+                            win.close_tab(index);
+                        }
+                        super::close_guard::CloseScope::Window => {
+                            // Mark this window as user-confirmed so the
+                            // on_close_requested guard lets the resulting
+                            // ViewportCommand::Close through without re-prompting.
+                            self.force_close_windows.insert(window_id);
+                            ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                        }
+                    },
+                    super::close_guard::CloseDialogOutcome::Cancelled
+                    | super::close_guard::CloseDialogOutcome::Idle => {}
+                }
+            }
+
             // Floating "About Freminal" dialog.  Shown whenever the user
             // clicked "About Freminal" in the Help menu.  Self-dismissing
             // via its own Close button or title-bar X.
@@ -1167,7 +1215,8 @@ impl freminal_windowing::App for FreminalGui {
                 || self.welcome.is_open()
                 || win.renaming_tab.is_some()
                 || win.paste_dialog.is_open()
-                || win.broadcast_dialog.is_open();
+                || win.broadcast_dialog.is_open()
+                || win.close_dialog.is_open();
 
             // ── Pane border drag-to-resize ───────────────────────────
             //
@@ -1835,9 +1884,11 @@ impl freminal_windowing::App for FreminalGui {
             }
 
             // Handle deferred close-pane (needs `ui` for ViewportCommand::Close).
+            // Routed through the close guard (Task 98): a running foreground
+            // command opens the confirmation dialog instead of closing.
             if win.pending_close_pane {
                 win.pending_close_pane = false;
-                Self::close_focused_pane(ui, &mut win);
+                self.guarded_close_pane(ui, &mut win);
             }
 
             // Handle deferred directional focus (needs layout rects).
@@ -2072,6 +2123,7 @@ impl FreminalGui {
             pending_menu_actions: Vec::new(),
             paste_dialog: super::paste_guard::PasteDialog::default(),
             broadcast_dialog: super::broadcast_guard::BroadcastConfirmDialog::default(),
+            close_dialog: super::close_guard::CloseGuardDialog::default(),
         }
     }
 

--- a/freminal/src/gui/broadcast_guard.rs
+++ b/freminal/src/gui/broadcast_guard.rs
@@ -1,0 +1,152 @@
+//! Broadcast-input confirmation dialog (Task 74.5).
+//!
+//! When the user has set `[tabs] confirm_broadcast = true`, enabling
+//! broadcast input for a tab pops a confirmation modal listing how many
+//! panes the keystrokes will fan out to. Disabling broadcast never prompts.
+//!
+//! The dialog lives on `PerWindowState`, mirroring the paste-guard dialog
+//! pattern: opened by the `ToggleBroadcastInput` dispatch, rendered every
+//! frame while open via [`BroadcastConfirmDialog::show`], and resolved when
+//! the user confirms or cancels. Like every modal on the terminal surface it
+//! must be registered in `ui_overlay_open` (see `app_impl.rs`) so Escape /
+//! Enter / clicks do not leak to the terminal.
+
+use super::tabs::TabId;
+
+/// The result of rendering the broadcast-confirm dialog for one frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::gui) enum BroadcastDialogOutcome {
+    /// The dialog is closed, or open and awaiting a decision. Nothing to do.
+    Idle,
+    /// The user cancelled. Broadcast must remain off.
+    Cancelled,
+    /// The user confirmed. Broadcast should be enabled on the carried tab.
+    Confirmed(TabId),
+}
+
+/// State for a single open broadcast-confirm dialog.
+#[derive(Debug, Clone, Copy)]
+struct BroadcastConfirmState {
+    /// The tab whose broadcast flag should be turned on if confirmed.
+    tab_id: TabId,
+    /// Number of panes the broadcast would reach (for the banner text).
+    pane_count: usize,
+}
+
+/// The broadcast-confirm modal dialog (Task 74.5).
+#[derive(Debug, Default)]
+pub(in crate::gui) struct BroadcastConfirmDialog {
+    state: Option<BroadcastConfirmState>,
+}
+
+impl BroadcastConfirmDialog {
+    /// Open the dialog for `tab_id`, which currently holds `pane_count` panes.
+    pub(in crate::gui) const fn open(&mut self, tab_id: TabId, pane_count: usize) {
+        self.state = Some(BroadcastConfirmState { tab_id, pane_count });
+    }
+
+    /// Whether the dialog is currently open.
+    pub(in crate::gui) const fn is_open(&self) -> bool {
+        self.state.is_some()
+    }
+
+    /// Render the dialog for one frame and return the resulting outcome.
+    ///
+    /// Returns [`BroadcastDialogOutcome::Idle`] when the dialog is closed or
+    /// still awaiting a decision. On `Cancelled` or `Confirmed`, the dialog
+    /// closes itself before returning.
+    ///
+    /// Keyboard shortcuts: `Escape` cancels; `Enter` confirms.
+    pub(in crate::gui) fn show(&mut self, ctx: &egui::Context) -> BroadcastDialogOutcome {
+        let Some(state) = self.state else {
+            return BroadcastDialogOutcome::Idle;
+        };
+
+        let mut outcome = BroadcastDialogOutcome::Idle;
+
+        let escape = ctx.input(|i| i.key_pressed(egui::Key::Escape));
+        let enter = ctx.input(|i| i.key_pressed(egui::Key::Enter));
+
+        egui::Window::new("Enable Broadcast Input")
+            .collapsible(false)
+            .resizable(false)
+            .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+            .show(ctx, |ui| {
+                ui.set_max_width(420.0);
+                ui.label(
+                    egui::RichText::new(format!(
+                        "You are about to broadcast keyboard input to {} pane(s) \
+                         in this tab. Continue?",
+                        state.pane_count
+                    ))
+                    .strong(),
+                );
+                ui.add_space(8.0);
+                ui.colored_label(
+                    egui::Color32::GRAY,
+                    "Every keystroke will be sent to all panes at once until you \
+                     toggle broadcast off.",
+                );
+                ui.add_space(12.0);
+                ui.horizontal(|ui| {
+                    if ui.button("Cancel").clicked() {
+                        outcome = BroadcastDialogOutcome::Cancelled;
+                    }
+                    if ui.button("Enable Broadcast").clicked() {
+                        outcome = BroadcastDialogOutcome::Confirmed(state.tab_id);
+                    }
+                });
+            });
+
+        // Keyboard shortcuts resolve only if a button click did not already.
+        if outcome == BroadcastDialogOutcome::Idle {
+            if escape {
+                outcome = BroadcastDialogOutcome::Cancelled;
+            } else if enter {
+                outcome = BroadcastDialogOutcome::Confirmed(state.tab_id);
+            }
+        }
+
+        if outcome != BroadcastDialogOutcome::Idle {
+            self.state = None;
+        }
+
+        outcome
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_dialog_is_closed() {
+        let dialog = BroadcastConfirmDialog::default();
+        assert!(!dialog.is_open());
+    }
+
+    #[test]
+    fn open_marks_dialog_open() {
+        let mut dialog = BroadcastConfirmDialog::default();
+        dialog.open(TabId::offset(3), 4);
+        assert!(dialog.is_open());
+    }
+
+    #[test]
+    fn outcome_equality() {
+        assert_eq!(BroadcastDialogOutcome::Idle, BroadcastDialogOutcome::Idle);
+        assert_eq!(
+            BroadcastDialogOutcome::Confirmed(TabId::offset(1)),
+            BroadcastDialogOutcome::Confirmed(TabId::offset(1))
+        );
+        assert_ne!(
+            BroadcastDialogOutcome::Confirmed(TabId::offset(1)),
+            BroadcastDialogOutcome::Confirmed(TabId::offset(2))
+        );
+        assert_ne!(
+            BroadcastDialogOutcome::Cancelled,
+            BroadcastDialogOutcome::Idle
+        );
+    }
+}

--- a/freminal/src/gui/close_guard.rs
+++ b/freminal/src/gui/close_guard.rs
@@ -1,0 +1,573 @@
+//! Close-on-running-command guard (Task 98).
+//!
+//! When the user attempts to close a pane, tab, or window — or quit the
+//! application — while a shell in the affected scope has a running foreground
+//! command (per OSC 133 markers), a confirmation dialog lists what is running
+//! and lets the user cancel or force-close.
+//!
+//! This module provides:
+//!
+//! - The pure detection helpers ([`pane_running_command`],
+//!   [`panes_with_running_commands`], [`unknown_command_panes`]) that read the
+//!   latest [`TerminalSnapshot`] via the pane's `ArcSwap` without locking or
+//!   mutating emulator state.
+//! - The [`RunningCommandInfo`] descriptor surfaced to the dialog.
+//! - The [`CloseGuardDialog`] modal (98.4) and the [`PendingClose`] intent
+//!   carried while the dialog is open (98.5–98.7).
+//!
+//! "Running" means a [`CommandStatus::Running`] block that has additionally
+//! received its `OSC 133 C` (output-start) marker — i.e. a command actually
+//! began executing. A block that only saw `OSC 133 A` (the prompt was drawn
+//! but nothing was run, then Ctrl-C) is *not* counted as running, which
+//! avoids spurious "command running" prompts on an idle prompt.
+
+use std::time::{Duration, SystemTime};
+
+use freminal_common::buffer_states::command_block::{CommandBlock, CommandStatus};
+
+use super::panes::{Pane, PaneId};
+use super::tabs::TabId;
+
+/// Information about one pane that has a running foreground command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::gui) struct RunningCommandInfo {
+    /// The pane running the command.
+    pub pane_id: PaneId,
+    /// The tab the pane lives in (for display).
+    pub tab_id: TabId,
+    /// Display name of the tab (for the dialog list).
+    pub tab_name: String,
+    /// A human label for the running command. Freminal's OSC 133 markers do
+    /// not carry the command text, so this is the pane title when set (often
+    /// the running program's name via OSC 0/2) or `"<unknown command>"`.
+    pub command: String,
+    /// Wall-clock time the command has been running, best-effort. `None` if
+    /// the timestamp is missing or clock skew makes the math fail.
+    pub elapsed: Option<Duration>,
+}
+
+/// The label used when no better command name is available.
+const UNKNOWN_COMMAND: &str = "<unknown command>";
+
+/// Returns `true` if `blocks`' most recent entry is an actually-executing
+/// command (status `Running` *and* an `OSC 133 C` output-start marker seen).
+///
+/// Pure over the snapshot's command-block slice so it is unit-testable without
+/// constructing a real [`Pane`].
+fn blocks_have_running_command(blocks: &[CommandBlock]) -> bool {
+    blocks
+        .last()
+        .is_some_and(|b| b.status() == CommandStatus::Running && b.output_start_row.is_some())
+}
+
+/// Returns `true` if `blocks` is empty — the pane has never received an OSC 133
+/// prompt marker, so its command status is unknown.
+const fn blocks_are_unknown(blocks: &[CommandBlock]) -> bool {
+    blocks.is_empty()
+}
+
+/// Compute the elapsed runtime of the most recent (running) block in `blocks`,
+/// measured from its execution start (`OSC 133 C`) to `now`.
+fn running_elapsed(blocks: &[CommandBlock], now: SystemTime) -> Option<Duration> {
+    let last = blocks.last()?;
+    let anchor = last.executed_at.unwrap_or(last.started_at);
+    now.duration_since(anchor).ok()
+}
+
+/// Build a [`RunningCommandInfo`] for `pane` if it has a running command.
+///
+/// Reads the pane's latest snapshot via `ArcSwap` (lock-free). Returns `None`
+/// when the pane has no actively-running command.
+pub(in crate::gui) fn pane_running_command(
+    pane: &Pane,
+    tab_id: TabId,
+    tab_name: &str,
+) -> Option<RunningCommandInfo> {
+    let snap = pane.arc_swap.load();
+    if !blocks_have_running_command(&snap.command_blocks) {
+        return None;
+    }
+
+    let command = if pane.title.trim().is_empty() {
+        UNKNOWN_COMMAND.to_owned()
+    } else {
+        pane.title.clone()
+    };
+
+    Some(RunningCommandInfo {
+        pane_id: pane.id,
+        tab_id,
+        tab_name: tab_name.to_owned(),
+        command,
+        elapsed: running_elapsed(&snap.command_blocks, SystemTime::now()),
+    })
+}
+
+/// Returns `true` if `pane` has never received an OSC 133 prompt marker (its
+/// command status is unknown). Used when `[close_guard] unknown_blocks = true`.
+pub(in crate::gui) fn pane_is_unknown(pane: &Pane) -> bool {
+    blocks_are_unknown(&pane.arc_swap.load().command_blocks)
+}
+
+/// Collect the running (and optionally unknown) commands across `panes`, all
+/// of which belong to the tab identified by `tab_id` / `tab_name`.
+///
+/// `unknown_blocks` mirrors `[close_guard] unknown_blocks`: when `true`, a
+/// pane that has never seen an OSC 133 prompt also blocks close and is listed
+/// with the `"<unknown command>"` label.
+pub(in crate::gui) fn gather_tab_running(
+    panes: &[&Pane],
+    tab_id: TabId,
+    tab_name: &str,
+    unknown_blocks: bool,
+) -> Vec<RunningCommandInfo> {
+    let mut out = Vec::new();
+    for pane in panes {
+        if let Some(info) = pane_running_command(pane, tab_id, tab_name) {
+            out.push(info);
+        } else if unknown_blocks && pane_is_unknown(pane) {
+            out.push(RunningCommandInfo {
+                pane_id: pane.id,
+                tab_id,
+                tab_name: tab_name.to_owned(),
+                command: UNKNOWN_COMMAND.to_owned(),
+                elapsed: None,
+            });
+        }
+    }
+    out
+}
+
+/// What close action a [`CloseGuardDialog`] is currently guarding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::gui) enum CloseScope {
+    /// Close the focused pane.
+    Pane,
+    /// Close the tab at the given index.
+    Tab(usize),
+    /// Close this window (and, if it is the last, quit).
+    Window,
+}
+
+/// A close action suspended while the guard dialog is open.
+#[derive(Debug, Clone)]
+pub(in crate::gui) struct PendingClose {
+    /// The scope being closed.
+    pub scope: CloseScope,
+    /// Panes (and their commands) blocking the close, for the dialog list.
+    pub running: Vec<RunningCommandInfo>,
+}
+
+/// The result of rendering the close-guard dialog for one frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::gui) enum CloseDialogOutcome {
+    /// Closed, or open and awaiting a decision. Nothing to do.
+    Idle,
+    /// The user cancelled. The close must NOT proceed.
+    Cancelled,
+    /// The user chose "Force Close". The close should proceed.
+    ForceClose,
+}
+
+/// The close-guard confirmation modal (Task 98.4).
+///
+/// Lives on `PerWindowState`, mirroring the paste-guard / broadcast-guard
+/// dialogs. Registered in `ui_overlay_open` so its keys do not leak to the
+/// terminal; rendered every frame via [`CloseGuardDialog::show`].
+#[derive(Debug, Default)]
+pub(in crate::gui) struct CloseGuardDialog {
+    pending: Option<PendingClose>,
+}
+
+impl CloseGuardDialog {
+    /// Open the dialog for a suspended close.
+    pub(in crate::gui) fn open(&mut self, pending: PendingClose) {
+        self.pending = Some(pending);
+    }
+
+    /// Whether the dialog is currently open.
+    pub(in crate::gui) const fn is_open(&self) -> bool {
+        self.pending.is_some()
+    }
+
+    /// The scope being guarded, if open.
+    pub(in crate::gui) fn scope(&self) -> Option<CloseScope> {
+        self.pending.as_ref().map(|p| p.scope)
+    }
+
+    /// Render the dialog for one frame and return the outcome. On a resolved
+    /// outcome (`Cancelled` / `ForceClose`) the dialog closes itself.
+    ///
+    /// `Escape` cancels; `Ctrl+Enter` force-closes (a deliberately awkward
+    /// chord so it is not pressed by reflex).
+    pub(in crate::gui) fn show(&mut self, ctx: &egui::Context) -> CloseDialogOutcome {
+        let Some(pending) = self.pending.as_ref() else {
+            return CloseDialogOutcome::Idle;
+        };
+
+        let mut outcome = CloseDialogOutcome::Idle;
+
+        let escape = ctx.input(|i| i.key_pressed(egui::Key::Escape));
+        let force = ctx.input(|i| i.modifiers.ctrl && i.key_pressed(egui::Key::Enter));
+
+        let count = pending.running.len();
+        let banner = format!(
+            "{count} pane{} {} a running command. Close anyway?",
+            if count == 1 { "" } else { "s" },
+            if count == 1 { "has" } else { "have" },
+        );
+
+        egui::Window::new("Close — Running Commands")
+            .collapsible(false)
+            .resizable(false)
+            .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+            .show(ctx, |ui| {
+                ui.set_max_width(480.0);
+                ui.label(egui::RichText::new(banner).strong());
+                ui.add_space(8.0);
+
+                egui::ScrollArea::vertical()
+                    .max_height(180.0)
+                    .show(ui, |ui| {
+                        for info in &pending.running {
+                            ui.label(format_running_entry(info));
+                        }
+                    });
+
+                ui.add_space(12.0);
+                ui.horizontal(|ui| {
+                    if ui.button("Cancel").clicked() {
+                        outcome = CloseDialogOutcome::Cancelled;
+                    }
+                    if ui.button("Force Close").clicked() {
+                        outcome = CloseDialogOutcome::ForceClose;
+                    }
+                });
+                ui.add_space(4.0);
+                ui.colored_label(
+                    egui::Color32::GRAY,
+                    "Esc to cancel · Ctrl+Enter to force close",
+                );
+            });
+
+        if outcome == CloseDialogOutcome::Idle {
+            if escape {
+                outcome = CloseDialogOutcome::Cancelled;
+            } else if force {
+                outcome = CloseDialogOutcome::ForceClose;
+            }
+        }
+
+        if outcome != CloseDialogOutcome::Idle {
+            self.pending = None;
+        }
+
+        outcome
+    }
+}
+
+/// Format one running-command entry for the dialog list:
+/// `"<tab name> · <command> (<elapsed>)"`.
+fn format_running_entry(info: &RunningCommandInfo) -> String {
+    let elapsed = info
+        .elapsed
+        .map_or_else(|| "running".to_owned(), format_elapsed);
+    format!("{} · {} ({elapsed})", info.tab_name, info.command)
+}
+
+/// Format a duration as a compact `"3s"` / `"2m15s"` / `"1h3m"` label.
+fn format_elapsed(d: Duration) -> String {
+    let secs = d.as_secs();
+    if secs < 60 {
+        return format!("{secs}s");
+    }
+    if secs < 3600 {
+        let (m, s) = (secs / 60, secs % 60);
+        return if s == 0 {
+            format!("{m}m")
+        } else {
+            format!("{m}m{s}s")
+        };
+    }
+    let (h, m) = (secs / 3600, (secs % 3600) / 60);
+    if m == 0 {
+        format!("{h}h")
+    } else {
+        format!("{h}h{m}m")
+    }
+}
+
+// ---------------------------------------------------------------------------
+//  Orchestration (FreminalGui methods)
+// ---------------------------------------------------------------------------
+
+impl super::FreminalGui {
+    /// Gather running commands across one tab (by index), honoring config.
+    /// Returns an empty vec when the guard is disabled or nothing is running.
+    fn gather_running_for_tab(
+        &self,
+        win: &super::window::PerWindowState,
+        tab_index: usize,
+    ) -> Vec<RunningCommandInfo> {
+        if !self.config.close_guard.enabled {
+            return Vec::new();
+        }
+        let Some(tab) = win.tabs.iter().nth(tab_index) else {
+            return Vec::new();
+        };
+        let tab_name = tab
+            .display_name(
+                self.config.tab_title.policy,
+                &self.config.tab_title.separator,
+            )
+            .into_owned();
+        let panes = tab.pane_tree.iter_panes().unwrap_or_default();
+        gather_tab_running(
+            &panes,
+            tab.id,
+            &tab_name,
+            self.config.close_guard.unknown_blocks,
+        )
+    }
+
+    /// Gather running commands across every tab in the window.
+    fn gather_running_for_window(
+        &self,
+        win: &super::window::PerWindowState,
+    ) -> Vec<RunningCommandInfo> {
+        if !self.config.close_guard.enabled {
+            return Vec::new();
+        }
+        let mut out = Vec::new();
+        for index in 0..win.tabs.tab_count() {
+            out.extend(self.gather_running_for_tab(win, index));
+        }
+        out
+    }
+
+    /// Gather the running command in the active tab's focused pane only.
+    fn gather_running_for_focused_pane(
+        &self,
+        win: &super::window::PerWindowState,
+    ) -> Vec<RunningCommandInfo> {
+        if !self.config.close_guard.enabled {
+            return Vec::new();
+        }
+        let tab = win.tabs.active_tab();
+        let tab_name = tab
+            .display_name(
+                self.config.tab_title.policy,
+                &self.config.tab_title.separator,
+            )
+            .into_owned();
+        let target = tab.active_pane;
+        let Ok(panes) = tab.pane_tree.iter_panes() else {
+            return Vec::new();
+        };
+        let Some(pane) = panes.iter().find(|p| p.id == target) else {
+            return Vec::new();
+        };
+        pane_running_command(pane, tab.id, &tab_name).map_or_else(
+            || {
+                if self.config.close_guard.unknown_blocks && pane_is_unknown(pane) {
+                    vec![RunningCommandInfo {
+                        pane_id: pane.id,
+                        tab_id: tab.id,
+                        tab_name,
+                        command: UNKNOWN_COMMAND.to_owned(),
+                        elapsed: None,
+                    }]
+                } else {
+                    Vec::new()
+                }
+            },
+            |info| vec![info],
+        )
+    }
+
+    /// Close the focused pane, guarding on running commands.  When a running
+    /// command is present, opens the confirmation dialog and suspends the
+    /// close; otherwise closes immediately.
+    pub(in crate::gui) fn guarded_close_pane(
+        &self,
+        ui: &egui::Ui,
+        win: &mut super::window::PerWindowState,
+    ) {
+        let running = self.gather_running_for_focused_pane(win);
+        if running.is_empty() {
+            Self::close_focused_pane(ui, win);
+        } else {
+            win.close_dialog.open(PendingClose {
+                scope: CloseScope::Pane,
+                running,
+            });
+        }
+    }
+
+    /// Close the tab at `index`, guarding on running commands.
+    pub(in crate::gui) fn guarded_close_tab(
+        &self,
+        win: &mut super::window::PerWindowState,
+        index: usize,
+    ) {
+        let running = self.gather_running_for_tab(win, index);
+        if running.is_empty() {
+            win.close_tab(index);
+        } else {
+            win.close_dialog.open(PendingClose {
+                scope: CloseScope::Tab(index),
+                running,
+            });
+        }
+    }
+
+    /// Returns the running commands across the whole window for a window-close
+    /// guard.  Empty when the guard is disabled or nothing is running.
+    pub(in crate::gui) fn window_close_running(
+        &self,
+        win: &super::window::PerWindowState,
+    ) -> Vec<RunningCommandInfo> {
+        self.gather_running_for_window(win)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use freminal_common::buffer_states::command_block::CommandBlock;
+
+    /// A block in the `Running` state that has executed (saw `C`).
+    fn running_executed() -> CommandBlock {
+        let mut b = CommandBlock::new_running(0, None, "fid".to_owned());
+        b.output_start_row = Some(1);
+        b.executed_at = Some(SystemTime::now());
+        b
+    }
+
+    /// A block that saw only `A` (prompt drawn, nothing executed).
+    fn running_not_executed() -> CommandBlock {
+        CommandBlock::new_running(0, None, "fid".to_owned())
+    }
+
+    /// A finished, successful block.
+    fn finished_success() -> CommandBlock {
+        let mut b = CommandBlock::new_running(0, None, "fid".to_owned());
+        b.output_start_row = Some(1);
+        b.executed_at = Some(SystemTime::now());
+        b.end_row = Some(2);
+        b.exit_code = Some(0);
+        b.finished_at = Some(SystemTime::now());
+        b
+    }
+
+    #[test]
+    fn no_blocks_means_no_running_command() {
+        assert!(!blocks_have_running_command(&[]));
+    }
+
+    #[test]
+    fn executing_block_is_running() {
+        assert!(blocks_have_running_command(&[running_executed()]));
+    }
+
+    #[test]
+    fn prompt_only_block_is_not_running() {
+        // A→(Ctrl-C) with no C must NOT count as a running command, so the
+        // user is not nagged on an idle prompt.
+        assert!(!blocks_have_running_command(&[running_not_executed()]));
+    }
+
+    #[test]
+    fn finished_block_is_not_running() {
+        assert!(!blocks_have_running_command(&[finished_success()]));
+    }
+
+    #[test]
+    fn only_the_most_recent_block_matters() {
+        // An earlier running block followed by a finished block ⇒ not running.
+        let blocks = vec![running_executed(), finished_success()];
+        assert!(!blocks_have_running_command(&blocks));
+        // A finished block followed by a running one ⇒ running.
+        let blocks = vec![finished_success(), running_executed()];
+        assert!(blocks_have_running_command(&blocks));
+    }
+
+    #[test]
+    fn empty_blocks_are_unknown() {
+        assert!(blocks_are_unknown(&[]));
+        assert!(!blocks_are_unknown(&[finished_success()]));
+        assert!(!blocks_are_unknown(&[running_executed()]));
+    }
+
+    #[test]
+    fn running_elapsed_measures_from_execution_start() {
+        let mut b = running_executed();
+        let start = SystemTime::now() - Duration::from_secs(5);
+        b.executed_at = Some(start);
+        let now = start + Duration::from_secs(5);
+        let elapsed = running_elapsed(&[b], now).expect("elapsed");
+        assert_eq!(elapsed.as_secs(), 5);
+    }
+
+    #[test]
+    fn running_elapsed_falls_back_to_started_at() {
+        let mut b = running_executed();
+        let start = SystemTime::now() - Duration::from_secs(3);
+        b.started_at = start;
+        b.executed_at = None;
+        let now = start + Duration::from_secs(3);
+        let elapsed = running_elapsed(&[b], now).expect("elapsed");
+        assert_eq!(elapsed.as_secs(), 3);
+    }
+
+    #[test]
+    fn running_elapsed_none_for_empty() {
+        assert!(running_elapsed(&[], SystemTime::now()).is_none());
+    }
+
+    fn info(tab_name: &str, command: &str, elapsed: Option<Duration>) -> RunningCommandInfo {
+        RunningCommandInfo {
+            pane_id: PaneId::first(),
+            tab_id: TabId::first(),
+            tab_name: tab_name.to_owned(),
+            command: command.to_owned(),
+            elapsed,
+        }
+    }
+
+    #[test]
+    fn format_elapsed_compact_units() {
+        assert_eq!(format_elapsed(Duration::from_secs(3)), "3s");
+        assert_eq!(format_elapsed(Duration::from_secs(59)), "59s");
+        assert_eq!(format_elapsed(Duration::from_mins(1)), "1m");
+        assert_eq!(format_elapsed(Duration::from_secs(135)), "2m15s");
+        assert_eq!(format_elapsed(Duration::from_hours(1)), "1h");
+        assert_eq!(format_elapsed(Duration::from_mins(63)), "1h3m");
+    }
+
+    #[test]
+    fn format_running_entry_includes_tab_command_and_elapsed() {
+        let entry = format_running_entry(&info("Work", "vim", Some(Duration::from_secs(5))));
+        assert_eq!(entry, "Work · vim (5s)");
+    }
+
+    #[test]
+    fn format_running_entry_missing_elapsed_reads_running() {
+        let entry = format_running_entry(&info("T", "<unknown command>", None));
+        assert_eq!(entry, "T · <unknown command> (running)");
+    }
+
+    #[test]
+    fn dialog_open_and_scope() {
+        let mut dialog = CloseGuardDialog::default();
+        assert!(!dialog.is_open());
+        assert!(dialog.scope().is_none());
+        dialog.open(PendingClose {
+            scope: CloseScope::Tab(2),
+            running: vec![info("T", "cmd", None)],
+        });
+        assert!(dialog.is_open());
+        assert_eq!(dialog.scope(), Some(CloseScope::Tab(2)));
+    }
+}

--- a/freminal/src/gui/close_guard.rs
+++ b/freminal/src/gui/close_guard.rs
@@ -195,6 +195,13 @@ impl CloseGuardDialog {
         self.pending.as_ref().map(|p| p.scope)
     }
 
+    /// Close the dialog immediately, as if the user chose Force Close. Used by
+    /// the `ForceClose` key action; the caller performs the actual close based
+    /// on the [`scope`](Self::scope) it captured before calling this.
+    pub(in crate::gui) fn force_close_now(&mut self) {
+        self.pending = None;
+    }
+
     /// Render the dialog for one frame and return the outcome. On a resolved
     /// outcome (`Cancelled` / `ForceClose`) the dialog closes itself.
     ///

--- a/freminal/src/gui/layout_ops.rs
+++ b/freminal/src/gui/layout_ops.rs
@@ -633,6 +633,7 @@ impl FreminalGui {
             paste_dialog: super::paste_guard::PasteDialog::default(),
             broadcast_dialog: super::broadcast_guard::BroadcastConfirmDialog::default(),
             close_dialog: super::close_guard::CloseGuardDialog::default(),
+            pending_force_close: false,
         };
         self.windows.insert(window_id, win);
 

--- a/freminal/src/gui/layout_ops.rs
+++ b/freminal/src/gui/layout_ops.rs
@@ -632,6 +632,7 @@ impl FreminalGui {
             pending_menu_actions: Vec::new(),
             paste_dialog: super::paste_guard::PasteDialog::default(),
             broadcast_dialog: super::broadcast_guard::BroadcastConfirmDialog::default(),
+            close_dialog: super::close_guard::CloseGuardDialog::default(),
         };
         self.windows.insert(window_id, win);
 

--- a/freminal/src/gui/layout_ops.rs
+++ b/freminal/src/gui/layout_ops.rs
@@ -631,6 +631,7 @@ impl FreminalGui {
             last_tab_rects: Vec::new(),
             pending_menu_actions: Vec::new(),
             paste_dialog: super::paste_guard::PasteDialog::default(),
+            broadcast_dialog: super::broadcast_guard::BroadcastConfirmDialog::default(),
         };
         self.windows.insert(window_id, win);
 

--- a/freminal/src/gui/menu.rs
+++ b/freminal/src/gui/menu.rs
@@ -732,6 +732,14 @@ impl super::FreminalGui {
             (false, false) => label.to_owned(),
         };
 
+        // Broadcast indicator (Task 74): prepend a satellite-antenna glyph
+        // when this tab is broadcasting keyboard input to all its panes.
+        let display_label = if tab.broadcast_input {
+            format!("\u{1f4e1} {display_label}")
+        } else {
+            display_label
+        };
+
         // Tab frame: active gets a gray fill, bell-active inactive tabs
         // get a warm amber tint, others use a transparent frame. A tab
         // that is currently being dragged renders as a translucent ghost

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -37,6 +37,7 @@ pub mod view_state;
 mod actions;
 mod app_impl;
 mod broadcast_guard;
+mod close_guard;
 mod command_blocks;
 mod command_history;
 mod hot_reload;
@@ -284,6 +285,13 @@ struct FreminalGui {
     /// cascade of `&mut self` through otherwise-read-only call sites.  The
     /// entire GUI runs on a single thread, so `RefCell` is sufficient.
     toasts: std::cell::RefCell<toast::ToastStack>,
+
+    /// Windows for which the user has already confirmed a force-close in the
+    /// close-guard dialog (Task 98).  When `on_close_requested` fires for a
+    /// window in this set it skips the running-command guard and lets the
+    /// close through, then removes the entry.  Avoids re-prompting on the
+    /// `ViewportCommand::Close` round trip a Force Close triggers.
+    force_close_windows: std::collections::HashSet<WindowId>,
 }
 
 impl FreminalGui {
@@ -409,6 +417,7 @@ impl FreminalGui {
             welcome: welcome_overlay,
             pending_open_keybindings: false,
             toasts: std::cell::RefCell::new(toast::ToastStack::default()),
+            force_close_windows: std::collections::HashSet::new(),
         };
 
         if !layout_errors.is_empty() {

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -36,6 +36,7 @@ pub mod view_state;
 
 mod actions;
 mod app_impl;
+mod broadcast_guard;
 mod command_blocks;
 mod command_history;
 mod hot_reload;

--- a/freminal/src/gui/settings.rs
+++ b/freminal/src/gui/settings.rs
@@ -1682,6 +1682,38 @@ impl SettingsModal {
         ui.separator();
         ui.add_space(8.0);
         self.show_paste_guard_section(ui);
+
+        ui.add_space(16.0);
+        ui.separator();
+        ui.add_space(8.0);
+        self.show_close_guard_section(ui);
+    }
+
+    /// The Close Guard subsection of the Security tab (Task 98.9).
+    fn show_close_guard_section(&mut self, ui: &mut Ui) {
+        ui.heading("Close Guard");
+        ui.add_space(4.0);
+        ui.colored_label(
+            egui::Color32::GRAY,
+            "Confirm before closing a pane, tab, or window that has a running \
+             foreground command (detected via OSC 133 shell integration).",
+        );
+        ui.add_space(8.0);
+
+        ui.checkbox(&mut self.draft.close_guard.enabled, "Enable close guard");
+
+        // The remaining toggles are only meaningful while the guard is on.
+        ui.add_enabled_ui(self.draft.close_guard.enabled, |ui| {
+            ui.add_space(4.0);
+            ui.checkbox(
+                &mut self.draft.close_guard.unknown_blocks,
+                "Also guard panes with unknown status (no shell integration)",
+            );
+            ui.checkbox(
+                &mut self.draft.close_guard.guard_app_quit,
+                "Guard application quit",
+            );
+        });
     }
 
     /// The Paste Guard subsection of the Security tab (Task 77).

--- a/freminal/src/gui/settings.rs
+++ b/freminal/src/gui/settings.rs
@@ -1322,6 +1322,50 @@ impl SettingsModal {
             &self.draft.tab_title.separator,
         );
         ui.colored_label(egui::Color32::GRAY, format!("Preview:  {preview}"));
+
+        ui.add_space(8.0);
+        ui.separator();
+        ui.add_space(4.0);
+
+        self.show_broadcast_input_section(ui);
+    }
+
+    /// Render the "Broadcast Input" section of the Tabs settings tab
+    /// (Task 74.5): the read-only shortcut display with a jump-to-keybindings
+    /// button, and the confirm-before-enabling toggle.
+    fn show_broadcast_input_section(&mut self, ui: &mut Ui) {
+        ui.label("Broadcast Input:");
+        ui.add_space(2.0);
+        ui.colored_label(
+            egui::Color32::GRAY,
+            "When enabled for a tab, keystrokes are sent to every pane in the \
+             tab at once. Toggle it per-tab with the keybinding below.",
+        );
+        ui.add_space(4.0);
+
+        let effective_map = self.draft.build_binding_map().unwrap_or_default();
+        let binding_text = effective_map
+            .combo_for(KeyAction::ToggleBroadcastInput)
+            .map_or_else(|| "unbound".to_owned(), |c| c.to_string());
+        ui.horizontal(|ui| {
+            ui.label("Shortcut:");
+            ui.monospace(&binding_text);
+            if ui.button("Change…").clicked() {
+                self.active_tab = SettingsTab::Keybindings;
+            }
+        });
+
+        ui.add_space(4.0);
+        ui.checkbox(
+            &mut self.draft.tabs.confirm_broadcast,
+            "Confirm before enabling broadcast",
+        );
+        ui.add_space(2.0);
+        ui.colored_label(
+            egui::Color32::GRAY,
+            "When on, the first time you enable broadcast in a tab a dialog \
+             asks you to confirm. Disabling broadcast never prompts.",
+        );
     }
 
     // Renders both the Shell Integration section and the Command Blocks

--- a/freminal/src/gui/tabs.rs
+++ b/freminal/src/gui/tabs.rs
@@ -92,6 +92,15 @@ pub struct Tab {
     /// Cleared by [`TabManager::switch_to`], [`TabManager::next_tab`], and
     /// [`TabManager::prev_tab`] when the tab becomes active again.
     pub has_pending_event: bool,
+
+    /// When `true`, keyboard input directed at the active pane is also
+    /// fanned out to every other leaf pane in this tab (Task 74).
+    ///
+    /// Mouse events, resize events, and per-pane window commands are never
+    /// broadcast.  The flag is per-tab (not per-pane) and defaults to
+    /// `false`.  Toggled via `KeyAction::ToggleBroadcastInput` or
+    /// [`Tab::toggle_broadcast`].
+    pub broadcast_input: bool,
 }
 
 impl Tab {
@@ -106,7 +115,16 @@ impl Tab {
             zoomed_pane: None,
             custom_name: None,
             has_pending_event: false,
+            broadcast_input: false,
         }
+    }
+
+    /// Toggle whether keyboard input is broadcast to all panes in this tab.
+    ///
+    /// Returns the new state of the flag.
+    pub const fn toggle_broadcast(&mut self) -> bool {
+        self.broadcast_input = !self.broadcast_input;
+        self.broadcast_input
     }
 
     /// Return the name to display for this tab under the given title policy.
@@ -199,6 +217,7 @@ impl std::fmt::Debug for Tab {
             .field("active_pane", &self.active_pane)
             .field("zoomed_pane", &self.zoomed_pane)
             .field("custom_name", &self.custom_name)
+            .field("broadcast_input", &self.broadcast_input)
             .finish_non_exhaustive()
     }
 }
@@ -520,6 +539,24 @@ mod tests {
         let mut tab = dummy_tab(TabId(0), osc);
         tab.custom_name = custom.map(str::to_owned);
         tab.display_name(policy, ": ").into_owned()
+    }
+
+    #[test]
+    fn new_tab_broadcast_input_defaults_to_false() {
+        let tab = dummy_tab(TabId(0), "Tab 1");
+        assert!(!tab.broadcast_input);
+    }
+
+    #[test]
+    fn toggle_broadcast_flips_flag_and_returns_new_state() {
+        let mut tab = dummy_tab(TabId(0), "Tab 1");
+        assert!(!tab.broadcast_input);
+
+        assert!(tab.toggle_broadcast());
+        assert!(tab.broadcast_input);
+
+        assert!(!tab.toggle_broadcast());
+        assert!(!tab.broadcast_input);
     }
 
     #[test]

--- a/freminal/src/gui/terminal/input.rs
+++ b/freminal/src/gui/terminal/input.rs
@@ -803,6 +803,26 @@ pub(super) fn send_terminal_inputs(
     );
 }
 
+/// Mirror an already-encoded keyboard byte sequence to every broadcast target.
+///
+/// Used by Task 74 broadcast-input mode: the active pane's encoded
+/// `InputEvent::Key` payload is replayed to every other leaf pane in the tab.
+/// Each pane independently applies its own bracketed-paste / cursor-key mode,
+/// so we replay the raw encoded bytes rather than re-encoding per pane.
+///
+/// A failed send to one target is logged and skipped — it never aborts the
+/// fan-out to the remaining targets.
+fn broadcast_key_bytes(targets: &[Sender<InputEvent>], bytes: &[u8]) {
+    if bytes.is_empty() {
+        return;
+    }
+    for target in targets {
+        if let Err(e) = target.send(InputEvent::Key(bytes.to_vec())) {
+            error!("Failed to broadcast key input to a pane: {e}");
+        }
+    }
+}
+
 /// Handle mouse scroll when mouse tracking is off.
 ///
 /// On the **alternate screen** (less, vim, htop, ...) scroll events are
@@ -975,6 +995,15 @@ fn release_end_col(
 /// When `is_active_pane` is `false`, only primary left-click presses are detected (to support
 /// click-to-focus in the caller). All keyboard, text, paste, copy, scroll, and mouse-tracking
 /// events are suppressed — they are never forwarded to the inactive pane's PTY.
+///
+/// ## Broadcast input (Task 74)
+///
+/// `key_broadcast_targets` lists the input senders of the *other* panes in
+/// the tab when broadcast mode is active on the active pane. Genuine keyboard
+/// input (text, control keys, KKP press/release, synthesized control
+/// sequences, and paste payloads) is mirrored to every target. Mouse,
+/// scroll-derived, resize, focus, and selection events are never mirrored.
+/// The slice is empty when broadcast is off or this is not the active pane.
 pub(super) fn write_input_to_terminal(
     input: &InputState,
     snap: &TerminalSnapshot,
@@ -991,6 +1020,7 @@ pub(super) fn write_input_to_terminal(
     is_active_pane: bool,
     recording_ctx: Option<&RecordingContext<'_>>,
     placeholder_rects: &[(Rect, CommandBlockId)],
+    key_broadcast_targets: &[Sender<InputEvent>],
 ) -> (
     bool,
     Option<PreviousMouseState>,
@@ -1079,12 +1109,16 @@ pub(super) fn write_input_to_terminal(
                     event_type: KeyEventType::Release,
                     associated_text: None,
                 };
-                send_terminal_inputs(
-                    std::slice::from_ref(&ti),
-                    input_tx,
-                    &InputModes::from_snapshot(snap),
-                    &release_meta,
-                );
+                let modes = InputModes::from_snapshot(snap);
+                send_terminal_inputs(std::slice::from_ref(&ti), input_tx, &modes, &release_meta);
+                // Broadcast (Task 74): mirror the KKP release sequence to the
+                // other panes. Each pane shares the same KKP mode here, so
+                // re-encoding with the active pane's modes is correct.
+                if !key_broadcast_targets.is_empty() {
+                    let bytes =
+                        encode_terminal_inputs(std::slice::from_ref(&ti), &modes, &release_meta);
+                    broadcast_key_bytes(key_broadcast_targets, &bytes);
+                }
                 state_changed = true;
                 continue;
             }
@@ -1981,6 +2015,11 @@ pub(super) fn write_input_to_terminal(
                 error!("Failed to send key input to PTY consumer: {e}");
             }
 
+            // Broadcast (Task 74): mirror this keyboard/paste payload to every
+            // other pane in the tab. The encoded bytes already carry the
+            // active pane's bracketed-paste / cursor-key wrapping.
+            broadcast_key_bytes(key_broadcast_targets, &encoded);
+
             // Emit recording event for keyboard input.
             if let Some(ctx) = recording_ctx {
                 // For paste events, emit ClipboardPaste instead of KeyboardInput.
@@ -2374,5 +2413,61 @@ mod scroll_window_tests {
             late >= 90,
             "rows after the fold placeholder must skip the hidden span, got {late}"
         );
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod broadcast_tests {
+    //! Tests for [`broadcast_key_bytes`] — the Task 74 keyboard-input
+    //! fan-out helper. These verify the bytes are mirrored verbatim to
+    //! every target channel and that a closed/disconnected target does
+    //! not abort the fan-out to the remaining targets.
+
+    use super::*;
+
+    #[test]
+    fn broadcasts_bytes_to_every_target() {
+        let (tx1, rx1) = crossbeam_channel::unbounded();
+        let (tx2, rx2) = crossbeam_channel::unbounded();
+        let (tx3, rx3) = crossbeam_channel::unbounded();
+
+        broadcast_key_bytes(&[tx1, tx2, tx3], b"hello");
+
+        for rx in [&rx1, &rx2, &rx3] {
+            match rx.try_recv() {
+                Ok(InputEvent::Key(bytes)) => assert_eq!(bytes, b"hello"),
+                other => panic!("expected InputEvent::Key(b\"hello\"), got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn empty_bytes_sends_nothing() {
+        let (tx, rx) = crossbeam_channel::unbounded();
+        broadcast_key_bytes(std::slice::from_ref(&tx), b"");
+        assert!(rx.try_recv().is_err(), "empty payload must not be sent");
+    }
+
+    #[test]
+    fn empty_targets_is_a_noop() {
+        // Must not panic with no targets (the common broadcast-off case).
+        broadcast_key_bytes(&[], b"data");
+    }
+
+    #[test]
+    fn disconnected_target_does_not_abort_remaining_fanout() {
+        let (tx_dead, rx_dead) = crossbeam_channel::unbounded::<InputEvent>();
+        drop(rx_dead); // Make tx_dead's send fail.
+        let (tx_live, rx_live) = crossbeam_channel::unbounded();
+
+        // Dead target first, live target second: the live target must still
+        // receive the bytes even though the first send errored.
+        broadcast_key_bytes(&[tx_dead, tx_live], b"x");
+
+        match rx_live.try_recv() {
+            Ok(InputEvent::Key(bytes)) => assert_eq!(bytes, b"x"),
+            other => panic!("expected InputEvent::Key(b\"x\"), got {other:?}"),
+        }
     }
 }

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -1280,6 +1280,9 @@ impl FreminalTerminalWidget {
     /// - `bg_image_mode` — background image fit mode from config.
     /// - `binding_map` — user key-binding map; bound combos are intercepted before PTY dispatch.
     /// - `is_active_pane` — whether this pane currently has keyboard focus.
+    /// - `key_broadcast_targets` — input senders of the other panes to mirror
+    ///   keyboard input to when broadcast mode is active (Task 74); empty when
+    ///   broadcast is off or this is not the active pane.
     // Inherently large: the main per-frame terminal widget handler — processes input, handles
     // blink/scroll/mouse, and orchestrates layout. Each section is tightly coupled.
     #[allow(clippy::too_many_lines)]
@@ -1308,6 +1311,7 @@ impl FreminalTerminalWidget {
         pane_id: crate::gui::panes::PaneId,
         recording_ctx: Option<&freminal_terminal_emulator::recording::RecordingContext<'_>>,
         pending_copy: &mut bool,
+        key_broadcast_targets: &[Sender<InputEvent>],
     ) -> (bool, Vec<freminal_common::keybindings::KeyAction>) {
         const BLINK_TICK_SECONDS: f64 = 0.50;
 
@@ -1579,6 +1583,7 @@ impl FreminalTerminalWidget {
                     is_active_pane,
                     recording_ctx,
                     &cache.placeholder_hit_rects,
+                    key_broadcast_targets,
                 )
             });
             left_mouse_button_pressed |= left_mouse_button_pressed_inner;

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -25,6 +25,12 @@ pub(super) type PendingGeometry = (Option<[u32; 2]>, Option<[i32; 2]>);
 /// owns one of these. All windows are peers — there is no root/secondary
 /// distinction. Shared state (config, args, binding map, settings modal)
 /// lives on [`super::FreminalGui`].
+// Each bool is an independent, short-lived per-frame UI intent flag
+// (pending close-pane / new-window / force-close, etc.) drained at the end of
+// the frame. They are unrelated and combining them into a state machine would
+// couple distinct intents and obscure meaning -- same rationale as the
+// `FreminalGui` aggregator's allow.
+#[allow(clippy::struct_excessive_bools)]
 pub(super) struct PerWindowState {
     /// All open terminal tabs for this window.
     pub(super) tabs: TabManager,
@@ -161,4 +167,9 @@ pub(super) struct PerWindowState {
     /// contains a running foreground command, rendered every frame while open,
     /// and resolved to Cancel or Force Close.
     pub(super) close_dialog: super::close_guard::CloseGuardDialog,
+
+    /// Set by the `ForceClose` key action; consumed in `update()` where the
+    /// close dialog is resolved.  Resolves an open close-guard dialog as
+    /// "Force Close" without the user reaching for the mouse or Ctrl+Enter.
+    pub(super) pending_force_close: bool,
 }

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -154,4 +154,11 @@ pub(super) struct PerWindowState {
     /// Opened by the `ToggleBroadcastInput` dispatch when
     /// `[tabs] confirm_broadcast` is set and broadcast is being turned on.
     pub(super) broadcast_dialog: super::broadcast_guard::BroadcastConfirmDialog,
+
+    /// Close-on-running-command confirmation dialog for this window (Task 98).
+    ///
+    /// Opened by a guarded pane / tab / window close when the affected scope
+    /// contains a running foreground command, rendered every frame while open,
+    /// and resolved to Cancel or Force Close.
+    pub(super) close_dialog: super::close_guard::CloseGuardDialog,
 }

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -148,4 +148,10 @@ pub(super) struct PerWindowState {
     /// Opened by `guarded_paste` when the analyzer flags a payload, rendered
     /// every frame while open, and resolved when the user confirms or cancels.
     pub(super) paste_dialog: super::paste_guard::PasteDialog,
+
+    /// Broadcast-input confirmation dialog for this window (Task 74).
+    ///
+    /// Opened by the `ToggleBroadcastInput` dispatch when
+    /// `[tabs] confirm_broadcast` is set and broadcast is being turned on.
+    pub(super) broadcast_dialog: super::broadcast_guard::BroadcastConfirmDialog,
 }

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -115,6 +115,14 @@ let
           ;
       };
 
+      closeGuardSection = lib.filterAttrs (_: v: v != null) {
+        inherit (s.close_guard)
+          enabled
+          unknown_blocks
+          guard_app_quit
+          ;
+      };
+
       tabTitleSection = lib.filterAttrs (_: v: v != null) {
         inherit (s.tab_title) policy separator;
       };
@@ -175,6 +183,7 @@ let
       // lib.optionalAttrs (bellSection != { }) { bell = bellSection; }
       // lib.optionalAttrs (securitySection != { }) { security = securitySection; }
       // lib.optionalAttrs (pasteGuardSection != { }) { paste_guard = pasteGuardSection; }
+      // lib.optionalAttrs (closeGuardSection != { }) { close_guard = closeGuardSection; }
       // lib.optionalAttrs (tabTitleSection != { }) { tab_title = tabTitleSection; }
       // lib.optionalAttrs (shellIntegrationSection != { }) {
         shell_integration = shellIntegrationSection;
@@ -617,6 +626,39 @@ in
             only when patterns is true. Malformed patterns are reported and
             skipped at match time.
             Null uses the default dangerous-command pattern set.
+          '';
+        };
+      };
+
+      close_guard = {
+        enabled = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = ''
+            Master switch for the close-on-running-command guard. When true,
+            closing a pane / tab / window that contains a running foreground
+            command (per OSC 133 markers) shows a confirmation dialog.
+            Null uses the default (true).
+          '';
+        };
+
+        unknown_blocks = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = ''
+            When true, also block close for panes whose command status is
+            unknown (no OSC 133 markers ever received).
+            Null uses the default (false).
+          '';
+        };
+
+        guard_app_quit = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = ''
+            When true, the app-quit path runs the close guard. When false, app
+            quit bypasses it and only individual close actions are guarded.
+            Null uses the default (true).
           '';
         };
       };

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -94,7 +94,7 @@ let
       };
 
       tabsSection = lib.filterAttrs (_: v: v != null) {
-        inherit (s.tabs) show_single_tab position;
+        inherit (s.tabs) show_single_tab position confirm_broadcast;
       };
 
       bellSection = lib.filterAttrs (_: v: v != null) {
@@ -525,6 +525,16 @@ in
           description = ''
             Position of the tab bar: "top" or "bottom".
             Null uses the default ("top").
+          '';
+        };
+
+        confirm_broadcast = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = ''
+            Whether enabling broadcast input (sending keystrokes to every
+            pane in a tab) requires a confirmation dialog the first time it
+            is turned on for a tab. Null uses the default (false).
           '';
         };
       };


### PR DESCRIPTION
Closes the remaining v0.9.0 "Modern Workflow Terminal" work on the combined
`task-74-75-98/v090-finish` branch. See `Documents/PLAN_VERSION_090.md` for the
full per-subtask breakdown and completion notes.

## Task 74 — Broadcast Input to Panes ✅

Per-tab toggle that fans out keyboard `InputEvent::Key` events to every leaf
pane in the active tab. Mouse/scroll/resize/focus events stay pane-local.

- `Tab::broadcast_input` flag + `KeyAction::ToggleBroadcastInput` (`Ctrl+Shift+I`).
- Fan-out at the two real keyboard send sites; tab-bar antenna glyph + per-pane
  "BROADCAST" indicator.
- `[tabs] confirm_broadcast` opt-in confirmation dialog (mirrors paste guard).

## Task 75 — Verify Per-Pane Env Round-Trip ✅

Verification + documentation only (no production code change). The reduced
v0.9.0 scope: confirm the existing `LayoutPane::env` plumbing round-trips and
document it.

- Regression tests: load → variable-substitute → resolve, serialize → reparse,
  and empty-env omission.
- Documented per-pane `env` substitution (`$1`, `${named}`, `$ENV{…}`) in
  `LAYOUT_FORMAT.md`.

## Task 98 — Block Close on Running Commands ✅

Confirmation dialog when closing a pane/tab/window that has a running
foreground command (detected via OSC 133 markers).

- `[close_guard]` config section (`enabled` / `unknown_blocks` /
  `guard_app_quit`) with full `ConfigPartial` merge wiring + Nix mirror.
- New `close_guard` module: lock-free snapshot detection (a pane is "running"
  only when its latest OSC 133 block saw C but not D — an idle prompt never
  blocks), Cancel / Force-Close dialog, and wiring into pane/tab/window close.
- `KeyAction::ForceClose` (unbound) + a Close Guard section in the Security
  settings tab.

### Notable deviations (documented in the plan)

- No multi-window app-quit path exists in freminal, so `guard_app_quit` has no
  separate gate — window-close guarding covers every exit.
- The dialog command label is the pane title (or `<unknown command>`) because
  `CommandBlock` does not capture the command-line text.
- The optional "Close Other Panes" dialog button is deferred.

## Verification

- `cargo test --all` — 103 suites green, 0 failures
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo machete` — clean
- `nixfmt --check` / `statix check` / `deadnix --fail` on the home-manager module — clean