### PR TITLE
feat: Task 107 -- build version embedding (cargo, CI, Nix)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,6 +17,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        # Full history + tags are required so the build script's
+        # `git describe --tags` produces a real version instead of "unknown".
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Install system dependencies
         run: |
@@ -67,6 +72,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        # Full history + tags are required so the build script's
+        # `git describe --tags` produces a real version instead of "unknown".
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Install system dependencies
         run: |
@@ -117,6 +127,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        # Full history + tags are required so the build script's
+        # `git describe --tags` produces a real version instead of "unknown".
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -176,6 +191,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        # Full history + tags are required so the build script's
+        # `git describe --tags` produces a real version instead of "unknown".
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "freminal"
-version = "0.9.0-beta.5"
+version = "0.9.0-beta.6"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-buffer"
-version = "0.9.0-beta.5"
+version = "0.9.0-beta.6"
 dependencies = [
  "conv2",
  "criterion",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-common"
-version = "0.9.0-beta.5"
+version = "0.9.0-beta.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-terminal-emulator"
-version = "0.9.0-beta.5"
+version = "0.9.0-beta.6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-windowing"
-version = "0.9.0-beta.5"
+version = "0.9.0-beta.6"
 dependencies = [
  "conv2",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["freminal", "freminal-buffer", "freminal-common", "freminal-terminal-
 default-members = ["freminal", "freminal-buffer", "freminal-common", "freminal-terminal-emulator"]
 
 [workspace.package]
-version = "0.9.0-beta.5"
+version = "0.9.0-beta.6"
 edition = "2024"
 rust-version = "1.95.0"
 description = "A terminal emulator written in Rust"

--- a/Documents/MASTER_PLAN.md
+++ b/Documents/MASTER_PLAN.md
@@ -175,7 +175,7 @@ into v0.14.0–v0.16.0 and v0.20.0) and remaining Category C housekeeping (Tasks
 | 104 | Kitty Text Sizing (OSC 66)               | `PLAN_VERSION_130.md` (Task 104)              | Planned       | Task 13                |
 | 105 | Kitty Drag & Drop (OSC 72)               | `PLAN_VERSION_DND.md` (Task 105)              | Deferred      | Task 102 (consent UX)  |
 | 106 | Pre-0.9.0 Bug Closure (Release Gate)     | `PLAN_VERSION_090.md` (Task 106)              | Stub          | v0.9.0 features        |
-| 107 | Build Version Embedding                  | `PLAN_VERSION_090.md` (Task 107)              | Stub          | None                   |
+| 107 | Build Version Embedding                  | `PLAN_VERSION_090.md` (Task 107)              | Complete      | None                   |
 | 108 | About Modal & Attribution                | `PLAN_VERSION_090.md` (Task 108)              | Stub          | Task 107               |
 | 109 | Active-Pane Highlight Correctness (Gate) | `PLAN_VERSION_090.md` (Task 109)              | Stub          | Task 58                |
 | 110 | Focus Follows Mouse (Toggleable)         | `PLAN_VERSION_090.md` (Task 110)              | Stub          | Task 58                |
@@ -628,6 +628,7 @@ Update this section as tasks complete:
 | 74   | 2026-06-11 | 2026-06-11 | All subtasks (74.1-74.5) on task-74-75-98/v090-finish (combined PR); PR pending  |
 | 75   | 2026-06-11 | 2026-06-11 | env round-trip tests + docs on task-74-75-98/v090-finish (combined PR)           |
 | 98   | 2026-06-11 | 2026-06-11 | All subtasks (98.1-98.9) on task-74-75-98/v090-finish (combined PR); PR pending  |
+| 107  | 2026-06-11 | 2026-06-11 | 107.1-107.3 (cargo/CI/Nix version embed) on task-107/build-version-embedding     |
 
 ---
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -18,22 +18,22 @@ top of the correctness debts identified in the post-v0.7.0 audit.
 
 ## Task Summary
 
-| #   | Feature                                  | Scope        | Status   | Depends On      | Branch                           |
-| --- | ---------------------------------------- | ------------ | -------- | --------------- | -------------------------------- |
-| 72  | OSC 133 Command Blocks                   | Large        | Complete | v0.8.0          | `task-72/osc-133-command-blocks` |
-| 73  | Command Gutters (exit-status indicator)  | Medium       | Complete | Task 72         | `task-73/command-gutters`        |
-| 74  | Broadcast Input to Panes                 | Medium       | Complete | v0.8.0, Task 58 | `task-74-75-98/v090-finish`      |
-| 75  | Verify per-pane env round-trip           | Small        | Complete | v0.8.0          | `task-74-75-98/v090-finish`      |
-| 76  | Notification System (OSC 9 / OSC 777)    | Medium       | Complete | v0.8.0, Task 72 | `task-76/notifications`          |
-| 77  | Smart Paste Guard                        | Small–Medium | Complete | v0.8.0          | `task-77/paste-guard`            |
-| 94  | Tab Title Precedence (prefix default)    | Small        | Complete | v0.8.0 (71.1)   | `task-94/tab-title-precedence`   |
-| 95  | Persist Custom Tab Names in Layouts      | Small        | Complete | v0.8.0, Task 61 | `task-95/persist-tab-names`      |
-| 98  | Block Close on Running Commands          | Small–Medium | Complete | Task 72         | `task-74-75-98/v090-finish`      |
-| 106 | Pre-0.9.0 Bug Closure (Release Gate)     | Medium       | Stub     | v0.9.0 features | TBD                              |
-| 107 | Build Version Embedding                  | Small        | Stub     | None            | TBD                              |
-| 108 | About Modal & Attribution                | Small        | Stub     | Task 107        | TBD                              |
-| 109 | Active-Pane Highlight Correctness (Gate) | Small–Medium | Stub     | Task 58         | TBD                              |
-| 110 | Focus Follows Mouse (Toggleable)         | Small        | Stub     | Task 58         | TBD                              |
+| #   | Feature                                  | Scope        | Status   | Depends On      | Branch                             |
+| --- | ---------------------------------------- | ------------ | -------- | --------------- | ---------------------------------- |
+| 72  | OSC 133 Command Blocks                   | Large        | Complete | v0.8.0          | `task-72/osc-133-command-blocks`   |
+| 73  | Command Gutters (exit-status indicator)  | Medium       | Complete | Task 72         | `task-73/command-gutters`          |
+| 74  | Broadcast Input to Panes                 | Medium       | Complete | v0.8.0, Task 58 | `task-74-75-98/v090-finish`        |
+| 75  | Verify per-pane env round-trip           | Small        | Complete | v0.8.0          | `task-74-75-98/v090-finish`        |
+| 76  | Notification System (OSC 9 / OSC 777)    | Medium       | Complete | v0.8.0, Task 72 | `task-76/notifications`            |
+| 77  | Smart Paste Guard                        | Small–Medium | Complete | v0.8.0          | `task-77/paste-guard`              |
+| 94  | Tab Title Precedence (prefix default)    | Small        | Complete | v0.8.0 (71.1)   | `task-94/tab-title-precedence`     |
+| 95  | Persist Custom Tab Names in Layouts      | Small        | Complete | v0.8.0, Task 61 | `task-95/persist-tab-names`        |
+| 98  | Block Close on Running Commands          | Small–Medium | Complete | Task 72         | `task-74-75-98/v090-finish`        |
+| 106 | Pre-0.9.0 Bug Closure (Release Gate)     | Medium       | Stub     | v0.9.0 features | TBD                                |
+| 107 | Build Version Embedding                  | Small        | Complete | None            | `task-107/build-version-embedding` |
+| 108 | About Modal & Attribution                | Small        | Stub     | Task 107        | TBD                                |
+| 109 | Active-Pane Highlight Correctness (Gate) | Small–Medium | Stub     | Task 58         | TBD                                |
+| 110 | Focus Follows Mouse (Toggleable)         | Small        | Stub     | Task 58         | TBD                                |
 
 ### Execution order
 
@@ -4744,7 +4744,7 @@ on the palette ordering.
 
 ---
 
-## Task 107 — Build Version Embedding
+## Task 107 — Build Version Embedding ✅ Complete (2026-06-11)
 
 ### 107 Summary
 
@@ -4766,9 +4766,31 @@ Source: `Documents/PLANNING.MD` #7, #8 (the same underlying gap).
 - **Feeds Task 108:** the embedded version string is consumed by the About
   modal (sequence 107 → 108).
 
+### 107 Activation findings (2026-06-11)
+
+The vergen + `git describe` infrastructure already existed before activation
+(`freminal-terminal-emulator/build.rs` → `VERGEN_GIT_DESCRIBE` →
+`freminal_terminal_emulator::GIT_DESCRIBE`, consumed by the About modal at
+`menu.rs:374` and by `TERM_PROGRAM_VERSION` at `io/pty.rs`). Both PLANNING #7
+and #8 share **one root cause**: `VERGEN_GIT_DESCRIBE` resolving to `"unknown"`.
+There are **three** build paths that each independently produce `"unknown"`,
+not the two the summary implies:
+
+1. **Local `cargo build`** — `build.rs` had only `rerun-if-changed=build.rs`,
+   no trigger tied to git HEAD/refs, so the describe value cached and went
+   stale (could stick at `"unknown"` from a first build before tags existed).
+   Fixed by 107.1.
+2. **CI-distributed binaries** — `deploy.yaml` checkouts used
+   `actions/checkout@v6` with no `fetch-depth: 0` / `fetch-tags: true`, so
+   `git describe --tags` failed in the shallow, tagless clone. Fixed by 107.2.
+3. **Nix flake** — `src = pkgs.lib.cleanSource ./.` strips `.git`, and the
+   build sandbox is git-less, so `git describe` can only yield `"unknown"`.
+   This is how the NixOS desktop actually installs freminal. Fixed by 107.3
+   (a third subtask added at activation).
+
 ### 107 Subtasks
 
-#### 107.1 — Build-time metadata generation
+#### 107.1 — Build-time metadata generation ✅
 
 **Scope:** Add `build.rs` metadata generation (commit hash, build time) exposed
 as compile-time constants. Add the build-tool dependency per
@@ -4777,13 +4799,74 @@ as compile-time constants. Add the build-tool dependency per
 **Verification:** A debug `cargo build` and a CI build both produce
 non-`unknown` metadata; constant is readable from the binary.
 
-#### 107.2 — Surface metadata in version output
+**Completion notes (2026-06-11):**
+
+- vergen and the `git describe --tags --always --dirty` shell-out already
+  existed in `freminal-terminal-emulator/build.rs`; no new build-tool
+  dependency was needed. The actual fix was that `build.rs` had no
+  `rerun-if-changed` trigger tied to git state, so the emitted
+  `VERGEN_GIT_DESCRIBE` cached and went stale.
+- Added `emit_git_rerun_directives()`: resolves `HEAD`, `packed-refs`, and
+  `refs` via `git rev-parse --git-path <name>` (worktree- and
+  submodule-correct, not a hardcoded `../.git/...`) and emits
+  `cargo:rerun-if-changed` for each. Best-effort: missing `git` / `.git`
+  skips the directive (only costs a stale value, never a failed build).
+- Verified by clean rebuilds: directives emitted (`../.git/HEAD`,
+  `../.git/packed-refs`, `../.git/refs`) and the value resolves to the real
+  `git describe` output instead of `"unknown"`.
+
+#### 107.2 — Surface metadata in version output ✅
 
 **Scope:** Wire the embedded constant into the version string reported to
 fastfetch / `--version` and into the value the About modal will read.
 
 **Verification:** `freminal --version` and the fastfetch-visible string report
 real metadata; no `(unknown)`.
+
+**Completion notes (2026-06-11):**
+
+- The surfacing wiring already existed and is correct: the About modal reads
+  `freminal_terminal_emulator::GIT_DESCRIBE` (`menu.rs:374`) and
+  `TERM_PROGRAM_VERSION` (what fastfetch reads) is
+  `"<cargo-version> (<git-describe>)"` (`io/pty.rs`). The `(unknown)` was the
+  describe value, not the wiring.
+- The distributed-binary `"unknown"` was fixed in the build pipeline: all four
+  build-job checkouts in `.github/workflows/deploy.yaml` (linux-amd64,
+  linux-arm64, windows, macos) now carry `fetch-depth: 0` + `fetch-tags: true`,
+  mirroring the already-correct `nightly.yml`. The `release` job downloads
+  artifacts only and needs no checkout change.
+
+#### 107.3 — Nix flake version embedding ✅
+
+**Why this subtask exists:** added at activation (2026-06-11). The Nix flake is
+the third `"unknown"` source (see Activation findings). `cleanSource` strips
+`.git` and the sandbox is git-less, so the in-build `git describe` can never
+succeed. This is the install path for the NixOS desktop, so it must carry a
+real version too.
+
+**Scope:** `freminal-terminal-emulator/build.rs`, `flake.nix`.
+
+- `build.rs` gains an **override layer**: if `VERGEN_GIT_DESCRIBE` is already
+  set and non-empty in the build environment, honour it verbatim and skip the
+  git shell-out (with `cargo:rerun-if-env-changed=VERGEN_GIT_DESCRIBE`). The
+  git shell-out remains the fallback when the env var is absent, so cargo and
+  CI builds are unaffected.
+- `flake.nix` sets `env.VERGEN_GIT_DESCRIBE = "v${version}-${self.shortRev or
+self.dirtyShortRev or "nix"}"`. `self.shortRev` is defined for a clean flake
+  source (the consumed-as-input desktop case), `self.dirtyShortRev` covers a
+  dirty working tree, `"nix"` is the last-resort fallback. `self`'s rev fields
+  survive `cleanSource` because they derive from the flake source path, not
+  from `src`.
+
+**Verification:**
+
+- `cargo build` with `VERGEN_GIT_DESCRIBE` set → value honoured verbatim,
+  git skipped; without it → git fallback. Both confirmed.
+- `nix build .#freminal` → the wrapped binary embeds
+  `Version 0.9.0-beta.6` / `Build v0.9.0-beta.6-<rev>-dirty` and
+  `TERM_PROGRAM_VERSION = "0.9.0-beta.6 (v0.9.0-beta.6-<rev>-dirty)"`. No
+  `(unknown)`.
+- `nixfmt`, `statix check`, `deadnix --fail` all clean on `flake.nix`.
 
 ---
 

--- a/flake.nix
+++ b/flake.nix
@@ -96,12 +96,25 @@
               exec = "freminal";
             };
           };
+
+          version = "0.9.0-beta.6";
+
+          # The build sandbox strips `.git`, so the crate's build.rs `git
+          # describe` can only ever yield "unknown".  Feed it a real value via
+          # the `VERGEN_GIT_DESCRIBE` env override (build.rs honours a pre-set
+          # value verbatim).  `self.shortRev` is defined for a clean flake
+          # source; `self.dirtyShortRev` covers a dirty working tree; "nix" is
+          # the last-resort fallback when neither is available.
+          gitDescribe = "v${version}-${self.shortRev or self.dirtyShortRev or "nix"}";
         in
         {
           freminal = rustPlatform.buildRustPackage {
             pname = "freminal";
-            version = "0.9.0-beta.5";
+            inherit version;
             src = pkgs.lib.cleanSource ./.;
+
+            # Embedded build version — see `gitDescribe` above.
+            env.VERGEN_GIT_DESCRIBE = gitDescribe;
 
             cargoLock.lockFile = ./Cargo.lock;
 
@@ -148,9 +161,9 @@
                     <key>CFBundleIdentifier</key>
                     <string>io.github.fredclausen.freminal</string>
                     <key>CFBundleVersion</key>
-                    <string>0.9.0-beta.5</string>
+                    <string>0.9.0-beta.6</string>
                     <key>CFBundleShortVersionString</key>
-                    <string>0.9.0-beta.5</string>
+                    <string>0.9.0-beta.6</string>
                     <key>CFBundleExecutable</key>
                     <string>freminal</string>
                     <key>CFBundleIconFile</key>

--- a/freminal-terminal-emulator/build.rs
+++ b/freminal-terminal-emulator/build.rs
@@ -25,24 +25,89 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .add_instructions(&si)?
         .emit()?;
 
-    // Emit VERGEN_GIT_DESCRIBE via the `git` CLI.  This avoids pulling in a
-    // heavy git-library dependency (vergen v9 requires vergen-gix/vergen-git2
-    // for git info).  The describe output looks like "v0.6.0-42-gabc1234" or
-    // just "v0.6.0" when exactly on a tag.  Falls back to the short SHA if
-    // `git describe` fails (e.g. shallow clone with no tags).
-    let git_describe = Command::new("git")
-        .args(["describe", "--tags", "--always", "--dirty"])
-        .output()
+    // Re-run this build script whenever the git state changes (a new commit,
+    // a new tag, a branch switch) so `VERGEN_GIT_DESCRIBE` never goes stale.
+    // Without these directives Cargo caches the build-script output and the
+    // About modal / `TERM_PROGRAM_VERSION` keep reporting whatever the git
+    // state was on the very first build (often "unknown" if tags were not yet
+    // present).  Resolving the paths via `git rev-parse --git-path` makes this
+    // correct in linked worktrees and submodules, not just plain clones.
+    emit_git_rerun_directives();
+
+    // Resolve VERGEN_GIT_DESCRIBE.
+    //
+    // Override layer: if the build environment already provides a non-empty
+    // `VERGEN_GIT_DESCRIBE`, honour it verbatim and skip the git shell-out.
+    // This is the escape hatch for build systems that strip `.git` and run
+    // git-less in a sandbox — the Nix flake passes the value in from
+    // `self.shortRev` because `git describe` inside the Nix sandbox can only
+    // ever produce "unknown".  Re-run if that variable changes.
+    println!("cargo:rerun-if-env-changed=VERGEN_GIT_DESCRIBE");
+
+    // Fallback layer: emit VERGEN_GIT_DESCRIBE via the `git` CLI.  This avoids
+    // pulling in a heavy git-library dependency (vergen v9 requires
+    // vergen-gix/vergen-git2 for git info).  The describe output looks like
+    // "v0.6.0-42-gabc1234" or just "v0.6.0" when exactly on a tag.  Falls back
+    // to "unknown" if `git describe` fails (e.g. shallow clone with no tags).
+    let git_describe = std::env::var("VERGEN_GIT_DESCRIBE")
         .ok()
-        .filter(|o| o.status.success())
-        .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_owned())
-        .unwrap_or_else(|| "unknown".to_owned());
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| {
+            Command::new("git")
+                .args(["describe", "--tags", "--always", "--dirty"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .map(|s| s.trim().to_owned())
+                .unwrap_or_else(|| "unknown".to_owned())
+        });
     println!("cargo:rustc-env=VERGEN_GIT_DESCRIBE={git_describe}");
 
     rebuild_terminfo()?;
 
     Ok(())
+}
+
+/// Emit `cargo:rerun-if-changed` directives for the git ref files that govern
+/// `git describe` output, so the build script re-runs when the commit or tag
+/// set changes.
+///
+/// The relevant files are `HEAD` (current commit / branch), `packed-refs`
+/// (packed tags and branches), and the loose `refs/` tree (unpacked branches
+/// and tags).  Their real on-disk locations are resolved through
+/// `git rev-parse --git-path`, which yields the correct paths even inside a
+/// linked worktree (where `HEAD` lives in the worktree but `packed-refs` lives
+/// in the common git dir) or a submodule.
+///
+/// Best-effort: if `git` is unavailable or any path cannot be resolved (e.g. a
+/// tarball build with no `.git`), the directive for that path is skipped.  A
+/// missing trigger only costs a stale `VERGEN_GIT_DESCRIBE`, never a failed
+/// build.
+fn emit_git_rerun_directives() {
+    for relative in ["HEAD", "packed-refs", "refs"] {
+        if let Some(path) = git_path(relative) {
+            // `rerun-if-changed` on a non-existent path is harmless and is
+            // re-evaluated each build, so unpacked-refs dirs that appear later
+            // still trigger a rebuild.
+            println!("cargo:rerun-if-changed={path}");
+        }
+    }
+}
+
+/// Resolve a git internal path (e.g. `HEAD`, `packed-refs`, `refs`) to its real
+/// on-disk location via `git rev-parse --git-path`, returning `None` if `git`
+/// is unavailable, the command fails, or the output is not valid UTF-8.
+fn git_path(relative: &str) -> Option<String> {
+    Command::new("git")
+        .args(["rev-parse", "--git-path", relative])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
 }
 
 /// Compile `res/freminal.ti` into `res/terminfo.tar` using `tic` and the Rust

--- a/freminal/Cargo.toml
+++ b/freminal/Cargo.toml
@@ -34,7 +34,7 @@ deb_depends = ["libgl1-mesa-glx"]
 # `cargo xtask bump-version` keeps this in sync, translating the SemVer
 # pre-release separator to the RPM tilde operator (e.g. "0.9.0~beta.2"), which
 # sorts older than the final release just like the SemVer pre-release does.
-version = "0.9.0~beta.5"
+version = "0.9.0~beta.6"
 assets = [
   { source = "target/release/freminal", dest = "/usr/bin/freminal", mode = "755" },
 ]


### PR DESCRIPTION
## Task 107 — Build Version Embedding (v0.9.0)

Closes the `Build unknown` / fastfetch `(unknown)` version gaps (PLANNING #7, #8).

### Root cause

The About modal and `TERM_PROGRAM_VERSION` (what fastfetch reads) both surface
`VERGEN_GIT_DESCRIBE`. The vergen + `git describe` infrastructure already
existed; the bug was that the describe value resolved to `"unknown"` on **three
independent build paths**, each for a different reason.

### Fixes

- **107.1 — cargo.** `build.rs` had only `rerun-if-changed=build.rs`, no trigger
  tied to git state, so the describe value cached and went stale (could stick at
  `"unknown"`). Adds `rerun-if-changed` for `HEAD`, `packed-refs`, and `refs`,
  resolved via `git rev-parse --git-path` (correct in worktrees/submodules).
- **107.2 — CI distributed binaries.** `deploy.yaml`'s four build-job checkouts
  used a shallow, tagless clone, so `git describe --tags` failed. Adds
  `fetch-depth: 0` + `fetch-tags: true` (mirroring the already-correct
  `nightly.yml`). The `release` job downloads artifacts only and needs no change.
- **107.3 — Nix flake (added at activation).** `cleanSource` strips `.git` and
  the build sandbox is git-less, so the in-build `git describe` can never
  succeed — and this is the NixOS install path. `build.rs` now honours a pre-set
  `VERGEN_GIT_DESCRIBE` env var verbatim (git shell-out remains the fallback);
  `flake.nix` supplies it from `self.shortRev or self.dirtyShortRev or "nix"`.

Also bumps the workspace version to `0.9.0-beta.6`.

### Verification

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all` — all pass
- `cargo machete` — clean
- `cargo fmt --all -- --check` — clean
- `nixfmt` / `statix check` / `deadnix --fail` on `flake.nix` — clean
- `nix build .#freminal` — wrapped binary embeds
  `Build v0.9.0-beta.6-<rev>-dirty` and
  `TERM_PROGRAM_VERSION = "0.9.0-beta.6 (v0.9.0-beta.6-<rev>-dirty)"`; no `(unknown)`
- Override layer confirmed both ways: env var set → honoured verbatim, git
  skipped; env var absent → git fallback

Plan: `Documents/PLAN_VERSION_090.md` (Task 107, marked Complete).