### PR TITLE
feat: Task 108 -- About modal & attribution

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -1,0 +1,74 @@
+# Attributions
+
+Freminal is licensed under the [MIT License](LICENSE). It also vendors source
+code and bundles font and image assets from third parties whose licenses
+require attribution. Those components and their licenses are listed below.
+
+This document is the single source of truth for attribution: the README and
+the in-app About dialog both point here rather than duplicating license text.
+
+## Vendored source code
+
+### portable-pty
+
+- **Upstream:** WezTerm — <https://github.com/wezterm/wezterm> (crate `pty/`)
+- **Version:** 0.9.1
+- **License:** MIT — Copyright (c) 2018 Wez Furlong
+- **Location:** vendored in-tree at [`portable-pty/`](portable-pty/); the full
+  license text is in [`portable-pty/LICENSE`](portable-pty/LICENSE) and the
+  local modifications are logged in
+  [`portable-pty/vendored.md`](portable-pty/vendored.md).
+
+## Bundled fonts
+
+The following fonts are embedded into the freminal binary at compile time. The
+full upstream license texts are bundled under [`res/fonts/`](res/fonts/).
+
+### Hack
+
+- **Upstream:** <https://github.com/source-foundry/Hack>
+- **License:** MIT (Hack project) plus the Bitstream Vera License for the
+  Bitstream-derived components — Copyright 2018 Source Foundry Authors;
+  Bitstream Vera Sans Mono Copyright 2003 Bitstream Inc.
+- **License text:** [`res/fonts/Hack-LICENSE.md`](res/fonts/Hack-LICENSE.md)
+- **Files:** `res/Hack-{Regular,Bold,Italic,BoldItalic}.ttf`
+
+### MesloLGS Nerd Font Mono
+
+- **Upstream:** Nerd Fonts — <https://github.com/ryanoasis/nerd-fonts>
+  (Meslo LG patched); base typeface Meslo LG by André Berg —
+  <https://github.com/andreberg/Meslo-Font>
+- **License:** SIL Open Font License 1.1 for the bundled patched font files
+  (Copyright (c) 2014 Ryan L McIntyre); the underlying Meslo LG typeface is
+  Apache-2.0; the Nerd Fonts patcher source (not bundled) is MIT.
+- **License text:**
+  [`res/fonts/MesloLGS-NerdFont-LICENSE.md`](res/fonts/MesloLGS-NerdFont-LICENSE.md)
+- **Files:** `res/MesloLGSNerdFontMono-{Regular,Bold,Italic,BoldItalic}.ttf`
+
+## Bundled images
+
+All bundled image assets are first-party to the freminal project and are
+covered by freminal's own [MIT License](LICENSE):
+
+- Application/window icon — `assets/icon.png`
+- Logo — `assets/logo.png`
+- macOS bundle icon — `assets/macos/freminal.icns`
+
+## Color themes
+
+Freminal ships color palettes adapted from a number of community theme
+projects (Catppuccin, Dracula, Nord, Solarized, Gruvbox, Tokyo Night,
+Kanagawa, Rosé Pine, Everforest, Ayu, One Dark/Light, Material, Monokai Pro,
+WezTerm, Ghostty, and the xterm defaults). Each palette is attributed at its
+definition site in
+[`freminal-common/src/themes.rs`](freminal-common/src/themes.rs) with its
+upstream source and license (most are MIT). Only numeric color values are
+reproduced; no upstream theme source is vendored.
+
+## Rust dependencies
+
+Freminal depends on a graph of permissively licensed Rust crates resolved
+through Cargo. These are not enumerated individually here; their licenses are
+constrained by the allowlist in [`deny.toml`](deny.toml) and enforced by
+`cargo deny`. A full software bill of materials can be generated with
+`cargo deny list` or `cargo license`.

--- a/Documents/MASTER_PLAN.md
+++ b/Documents/MASTER_PLAN.md
@@ -176,7 +176,7 @@ into v0.14.0–v0.16.0 and v0.20.0) and remaining Category C housekeeping (Tasks
 | 105 | Kitty Drag & Drop (OSC 72)               | `PLAN_VERSION_DND.md` (Task 105)              | Deferred      | Task 102 (consent UX)  |
 | 106 | Pre-0.9.0 Bug Closure (Release Gate)     | `PLAN_VERSION_090.md` (Task 106)              | Stub          | v0.9.0 features        |
 | 107 | Build Version Embedding                  | `PLAN_VERSION_090.md` (Task 107)              | Complete      | None                   |
-| 108 | About Modal & Attribution                | `PLAN_VERSION_090.md` (Task 108)              | Stub          | Task 107               |
+| 108 | About Modal & Attribution                | `PLAN_VERSION_090.md` (Task 108)              | Complete      | Task 107               |
 | 109 | Active-Pane Highlight Correctness (Gate) | `PLAN_VERSION_090.md` (Task 109)              | Stub          | Task 58                |
 | 110 | Focus Follows Mouse (Toggleable)         | `PLAN_VERSION_090.md` (Task 110)              | Stub          | Task 58                |
 
@@ -629,6 +629,7 @@ Update this section as tasks complete:
 | 75   | 2026-06-11 | 2026-06-11 | env round-trip tests + docs on task-74-75-98/v090-finish (combined PR)           |
 | 98   | 2026-06-11 | 2026-06-11 | All subtasks (98.1-98.9) on task-74-75-98/v090-finish (combined PR); PR pending  |
 | 107  | 2026-06-11 | 2026-06-11 | 107.1-107.3 (cargo/CI/Nix version embed) on task-107/build-version-embedding     |
+| 108  | 2026-06-11 | 2026-06-11 | 108.1-108.3 (audit, ATTRIBUTIONS.md, About link) on task-108/about-modal-at      |
 
 ---
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -4894,13 +4894,63 @@ Source: `Documents/PLANNING.MD` #50–52.
 
 ### 108 Subtasks
 
-#### 108.1 — Attribution audit
+#### 108.1 — Attribution audit ✅ (2026-06-11)
 
 **Scope:** Read-only audit of vendored code and bundled assets requiring
 attribution (portable-pty, bundled fonts, any other MIT/BSD/OFL dependency or
 asset). Produce the list in this plan document before writing the doc.
 
 **Verification:** Audit list posted; no code changes.
+
+**Audit findings.** Three classes of attributable material ship inside the
+freminal binary or repo. Whole-crate-tree permissive dependencies (the MIT/
+BSD/ISC/etc. graph resolved through Cargo) are governed by `deny.toml`'s
+license allowlist and are out of scope for a hand-maintained NOTICE — the
+attribution doc covers the **deliberately vendored / bundled** set below.
+
+**(a) Vendored source code:**
+
+- **`portable-pty`** — upstream WezTerm (`wezterm/wezterm`, `pty/`), version
+  0.9.1, **MIT**, © 2018 Wez Furlong. Vendored in-tree at `portable-pty/`;
+  local changes logged in `portable-pty/vendored.md`; `LICENSE` present.
+
+**(b) Bundled font assets** (embedded via `include_bytes!`, no license file
+currently shipped alongside — **gap: 108.2 must add the license texts**):
+
+- **Hack** — `res/Hack-{Regular,Bold,Italic,BoldItalic}.ttf`, upstream
+  `source-foundry/Hack`, **MIT-style** (Hack Open Font License: MIT for the
+  font software, with a bitmap-rendering exception).
+- **MesloLGS Nerd Font Mono** —
+  `res/MesloLGSNerdFontMono-{Regular,Bold,Italic,BoldItalic}.ttf`, upstream
+  `ryanoasis/nerd-fonts` (Meslo patched), **Apache-2.0** (base Meslo /
+  Apple-derived) **+ MIT** (Nerd Fonts glyph patches).
+
+**(c) Bundled image assets** (all first-party to the freminal project, MIT):
+
+- Application/window icon — `assets/icon.png`.
+- Logo — `assets/logo.png`.
+- macOS bundle icon — `assets/macos/freminal.icns`.
+
+**(d) Color theme palettes** — already attributed inline in
+`freminal-common/src/themes.rs` with `Source:` / `License:` doc comments
+(Catppuccin, Dracula, Nord, Solarized, Gruvbox, Tokyo Night, Kanagawa,
+Rosé Pine, Everforest, Ayu, One Dark/Light, Material, Monokai Pro, WezTerm,
+Ghostty, xterm). Most are MIT; a few are "color values widely published for
+terminal use". 108.2 should consolidate these into the attributions doc by
+reference rather than re-listing every palette.
+
+**Decisions for 108.2 (from this audit):**
+
+- The attributions doc lists (a), (b), (c) explicitly with license + upstream
+  link; (d) is covered by a single paragraph pointing at the inline
+  `themes.rs` attributions (single source of truth — no duplication).
+- **The font license texts are not currently bundled.** 108.2 must add the
+  upstream `LICENSE.md` (Hack) and `LICENSE` (Nerd Fonts / Meslo) under `res/`
+  (e.g. `res/fonts/`) so the distributed binary's source tree carries them, and
+  reference them from `ATTRIBUTIONS.md`.
+- Crate-tree transitive deps are NOT enumerated by hand; the doc states they
+  are permissive-licensed and governed by `deny.toml`, with a note that a full
+  SBOM can be produced via `cargo deny`/`cargo license`.
 
 #### 108.2 — Attributions document + README link
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -31,7 +31,7 @@ top of the correctness debts identified in the post-v0.7.0 audit.
 | 98  | Block Close on Running Commands          | Small–Medium | Complete | Task 72         | `task-74-75-98/v090-finish`        |
 | 106 | Pre-0.9.0 Bug Closure (Release Gate)     | Medium       | Stub     | v0.9.0 features | TBD                                |
 | 107 | Build Version Embedding                  | Small        | Complete | None            | `task-107/build-version-embedding` |
-| 108 | About Modal & Attribution                | Small        | Stub     | Task 107        | TBD                                |
+| 108 | About Modal & Attribution                | Small        | Complete | Task 107        | `task-108/about-modal-attribution` |
 | 109 | Active-Pane Highlight Correctness (Gate) | Small–Medium | Stub     | Task 58         | TBD                                |
 | 110 | Focus Follows Mouse (Toggleable)         | Small        | Stub     | Task 58         | TBD                                |
 
@@ -4870,7 +4870,7 @@ self.dirtyShortRev or "nix"}"`. `self.shortRev` is defined for a clean flake
 
 ---
 
-## Task 108 — About Modal & Attribution
+## Task 108 — About Modal & Attribution ✅ Complete (2026-06-11)
 
 ### 108 Summary
 
@@ -4983,13 +4983,30 @@ README links to it; markdownlint passes.
 - markdownlint clean on all new/changed markdown (repo config). No code
   changes; `cargo` verification is unaffected (docs/assets only).
 
-#### 108.3 — About-modal attribution + build version
+#### 108.3 — About-modal attribution + build version ✅ (2026-06-11)
 
 **Scope:** Surface the embedded build version (Task 107) in the About modal and
 add a link/reference to the attributions doc.
 
 **Verification:** About modal shows a real build identifier and links to the
 attributions doc; modal input behavior unaffected.
+
+**Completion notes:**
+
+- The build identifier was already surfaced in the About modal by Task 107:
+  `show_about_window` (`freminal/src/gui/menu.rs`) shows `Version` (cargo
+  version) and `Build` (`freminal_terminal_emulator::GIT_DESCRIBE`), which now
+  resolves to a real value on all three build paths after Task 107. No change
+  needed for the version half of 108.3.
+- Added a `ui.hyperlink_to("Third-party attributions", …)` line pointing at
+  `ATTRIBUTIONS.md` on the project GitHub. A hyperlink opens the system browser
+  and needs no keyboard focus, so `freminal-modal-input-suppression` does not
+  apply beyond what already exists — the About window is already registered in
+  `ui_overlay_open` (`app_impl.rs:1224`) and adds no `TextEdit`/typing widget.
+- `cargo clippy -p freminal --all-targets --all-features -- -D warnings` clean;
+  `cargo test -p freminal` green. The live-egui focus path has no automated
+  test (per the skill); the modal behavior is unchanged because no focusable
+  text widget was added.
 
 ---
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -4922,8 +4922,12 @@ currently shipped alongside — **gap: 108.2 must add the license texts**):
   font software, with a bitmap-rendering exception).
 - **MesloLGS Nerd Font Mono** —
   `res/MesloLGSNerdFontMono-{Regular,Bold,Italic,BoldItalic}.ttf`, upstream
-  `ryanoasis/nerd-fonts` (Meslo patched), **Apache-2.0** (base Meslo /
-  Apple-derived) **+ MIT** (Nerd Fonts glyph patches).
+  `ryanoasis/nerd-fonts` (Meslo patched). The bundled patched font files are
+  **OFL-1.1** (as distributed by Nerd Fonts); the underlying Meslo LG typeface
+  is Apache-2.0; the Nerd Fonts patcher source (not bundled) is MIT.
+  Corrected from the initial audit guess of "Apache-2.0 + MIT" after reading
+  the upstream `nerd-fonts/LICENSE` — patched font files are OFL-1.1, which is
+  why `deny.toml` already allows OFL-1.1.
 
 **(c) Bundled image assets** (all first-party to the freminal project, MIT):
 
@@ -4952,13 +4956,32 @@ reference rather than re-listing every palette.
   are permissive-licensed and governed by `deny.toml`, with a note that a full
   SBOM can be produced via `cargo deny`/`cargo license`.
 
-#### 108.2 — Attributions document + README link
+#### 108.2 — Attributions document + README link ✅ (2026-06-11)
 
 **Scope:** Author `ATTRIBUTIONS.md` from the 108.1 audit; link it from
 `README.md`. Follows `markdown-lint-discipline`.
 
 **Verification:** Doc lists every attributed component with license + link;
 README links to it; markdownlint passes.
+
+**Completion notes:**
+
+- Authored `ATTRIBUTIONS.md` at the repo root covering: portable-pty (MIT,
+  vendored), the two bundled fonts (with bundled license texts), the
+  first-party image assets (MIT), the theme palettes (by reference to the
+  inline `themes.rs` attributions, no duplication), and a note that the Rust
+  dependency graph is permissive and governed by `deny.toml`.
+- Bundled the upstream font license texts under `res/fonts/`:
+  `Hack-LICENSE.md` (MIT + Bitstream Vera, fetched verbatim from
+  `source-foundry/Hack`) and `MesloLGS-NerdFont-LICENSE.md` (SIL OFL 1.1,
+  fetched verbatim from `ryanoasis/nerd-fonts`, with an Apache-2.0/MIT
+  provenance note). This closes the "no font license shipped" gap from 108.1.
+- README "License" section now links to `ATTRIBUTIONS.md`.
+- The 108.1 Meslo license note was corrected (OFL-1.1 for the bundled patched
+  files, not the originally-guessed "Apache-2.0 + MIT") after reading the
+  upstream `nerd-fonts/LICENSE`.
+- markdownlint clean on all new/changed markdown (repo config). No code
+  changes; `cargo` verification is unaffected (docs/assets only).
 
 #### 108.3 — About-modal attribution + build version
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ Pre-commit hooks run these automatically. `--no-verify` is forbidden.
 
 Licensed under the [MIT License](LICENSE).
 
+Freminal vendors and bundles third-party code, fonts, and assets whose
+licenses require attribution. See [ATTRIBUTIONS.md](ATTRIBUTIONS.md) for the
+full list.
+
 ---
 
 © 2024–2026 Fred Clausen — MIT License.

--- a/freminal/src/gui/menu.rs
+++ b/freminal/src/gui/menu.rs
@@ -377,6 +377,18 @@ impl super::FreminalGui {
                     ui.label("A modern terminal emulator written in Rust.");
                     ui.add_space(2.0);
                     ui.label("Licensed under the MIT License.");
+                    ui.add_space(2.0);
+                    // Attribution for vendored code and bundled fonts/assets
+                    // lives in ATTRIBUTIONS.md (the single source of truth);
+                    // link to it rather than duplicating license text here.
+                    // A hyperlink opens the system browser and needs no
+                    // keyboard focus, so it does not affect modal input
+                    // suppression (the About window is already registered in
+                    // `ui_overlay_open`).
+                    ui.hyperlink_to(
+                        "Third-party attributions",
+                        "https://github.com/fredsystems/freminal/blob/main/ATTRIBUTIONS.md",
+                    );
                     ui.add_space(10.0);
                     if ui.button("Close").clicked() {
                         self.about_window_open = false;

--- a/res/fonts/Hack-LICENSE.md
+++ b/res/fonts/Hack-LICENSE.md
@@ -1,0 +1,54 @@
+# Hack — Licensing
+
+Freminal bundles the Hack font files (`res/Hack-*.ttf`). The full upstream
+license text follows verbatim.
+
+- Upstream: <https://github.com/source-foundry/Hack>
+
+```text
+The work in the Hack project is Copyright 2018 Source Foundry Authors and licensed under the MIT License
+
+The work in the DejaVu project was committed to the public domain.
+
+Bitstream Vera Sans Mono Copyright 2003 Bitstream Inc. and licensed under the Bitstream Vera License with Reserved Font Names "Bitstream" and "Vera"
+
+### MIT License
+
+Copyright (c) 2018 Source Foundry Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+### BITSTREAM VERA LICENSE
+
+Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license ("Fonts") and associated documentation files (the "Font Software"), to reproduce and distribute the Font Software, including without limitation the rights to use, copy, merge, publish, distribute, and/or sell copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:
+
+The above copyright and trademark notices and this permission notice shall be included in all copies of one or more of the Font Software typefaces.
+
+The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or characters may be added to the Fonts, only if the fonts are renamed to names not containing either the words "Bitstream" or the word "Vera".
+
+This License becomes null and void to the extent applicable to Fonts or Font Software that has been modified and is distributed under the "Bitstream Vera" names.
+
+The Font Software may be sold as part of a larger software package but no copy of one or more of the Font Software typefaces may be sold by itself.
+
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL BITSTREAM OR THE GNOME FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.
+
+Except as contained in this notice, the names of Gnome, the Gnome Foundation, and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Font Software without prior written authorization from the Gnome Foundation or Bitstream Inc., respectively. For further information, contact: fonts at gnome dot org.
+```

--- a/res/fonts/MesloLGS-NerdFont-LICENSE.md
+++ b/res/fonts/MesloLGS-NerdFont-LICENSE.md
@@ -1,0 +1,110 @@
+# MesloLGS Nerd Font Mono — Licensing
+
+Freminal bundles the Nerd Fonts-patched MesloLGS Mono font files
+(`MesloLGSNerdFontMono-*.ttf`). The patched font files are distributed by the
+Nerd Fonts project under the **SIL Open Font License, Version 1.1**. The
+underlying Meslo LG typeface (by André Berg, a customized version of Apple's
+Menlo, itself derived from Bitstream Vera Sans Mono) is licensed under the
+**Apache License 2.0**. The Nerd Fonts patcher source code (not bundled here)
+is MIT-licensed.
+
+- Nerd Fonts: <https://github.com/ryanoasis/nerd-fonts>
+- Meslo LG: <https://github.com/andreberg/Meslo-Font>
+
+The full text of the SIL Open Font License 1.1 governing the bundled font files
+follows.
+
+```text
+Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+```


### PR DESCRIPTION
## Task 108 — About Modal & Attribution (v0.9.0)

Adds license/credit compliance for vendored code and bundled assets, and
surfaces it from the About modal. Source: PLANNING #50–52.

> **Depends on #350 (Task 107).** The About modal's build-version display
> comes from Task 107's `GIT_DESCRIBE`. This branch was cut from `main` before
> #350 merged, so the plan-doc tables here show Task 107 as Stub and there may
> be a small table conflict to resolve after #350 lands. No code dependency
> beyond the already-present `GIT_DESCRIBE` constant.

### 108.1 — Attribution audit (docs only)

Read-only audit posted in `PLAN_VERSION_090.md`. Identified three attributable
classes: vendored `portable-pty` (MIT), bundled fonts (Hack, MesloLGS Nerd
Font Mono), first-party image assets (MIT), and theme palettes (already
attributed inline in `themes.rs`). Flagged the gap that **no font license
texts were bundled**.

### 108.2 — Attributions document + bundled font licenses

- `ATTRIBUTIONS.md` at repo root — single source of truth.
- Bundled upstream font license texts under `res/fonts/`:
  `Hack-LICENSE.md` (MIT + Bitstream Vera), `MesloLGS-NerdFont-LICENSE.md`
  (SIL OFL 1.1) — closing the 108.1 gap.
- README License section links to `ATTRIBUTIONS.md`.
- **Correction:** the bundled MesloLGS patched files are OFL-1.1 (not the
  "Apache-2.0 + MIT" guessed in 108.1), confirmed against `nerd-fonts/LICENSE`
  (OFL-1.1 is already in `deny.toml`).

### 108.3 — About-modal attribution link

- The build version was already shown in the About modal via Task 107; no
  change needed there.
- Added a `ui.hyperlink_to("Third-party attributions", …)` to `ATTRIBUTIONS.md`.
  A hyperlink opens the browser and adds no focusable text widget, so
  `freminal-modal-input-suppression` is unaffected (the About window is already
  registered in `ui_overlay_open`).

### Verification

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test -p freminal` — green
- `cargo machete` — clean
- markdownlint (repo config) — clean on all new/changed markdown
- All pre-commit hooks pass (no `--no-verify`)

Plan: `Documents/PLAN_VERSION_090.md` (Task 108, marked Complete).