### PR TITLE
feat: Task 110 — Focus Follows Mouse (toggleable)

### DIFF
--- a/Documents/MASTER_PLAN.md
+++ b/Documents/MASTER_PLAN.md
@@ -178,7 +178,7 @@ into v0.14.0–v0.16.0 and v0.20.0) and remaining Category C housekeeping (Tasks
 | 107 | Build Version Embedding                  | `PLAN_VERSION_090.md` (Task 107)              | Complete      | None                   |
 | 108 | About Modal & Attribution                | `PLAN_VERSION_090.md` (Task 108)              | Complete      | Task 107               |
 | 109 | Active-Pane Highlight Correctness (Gate) | `PLAN_VERSION_090.md` (Task 109)              | Stub          | Task 58                |
-| 110 | Focus Follows Mouse (Toggleable)         | `PLAN_VERSION_090.md` (Task 110)              | Stub          | Task 58                |
+| 110 | Focus Follows Mouse (Toggleable)         | `PLAN_VERSION_090.md` (Task 110)              | Complete      | Task 58                |
 
 ---
 
@@ -630,6 +630,7 @@ Update this section as tasks complete:
 | 98   | 2026-06-11 | 2026-06-11 | All subtasks (98.1-98.9) on task-74-75-98/v090-finish (combined PR); PR pending  |
 | 107  | 2026-06-11 | 2026-06-11 | 107.1-107.3 (cargo/CI/Nix version embed) on task-107/build-version-embedding     |
 | 108  | 2026-06-11 | 2026-06-11 | 108.1-108.3 (audit, ATTRIBUTIONS.md, About link) on task-108/about-modal-at      |
+| 110  | 2026-06-14 | 2026-06-14 | 110.1-110.2 on task-110/focus-follows-mouse; PR pending                          |
 
 ---
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -33,7 +33,7 @@ top of the correctness debts identified in the post-v0.7.0 audit.
 | 107 | Build Version Embedding                  | Small        | Complete | None            | `task-107/build-version-embedding` |
 | 108 | About Modal & Attribution                | Small        | Complete | Task 107        | `task-108/about-modal-attribution` |
 | 109 | Active-Pane Highlight Correctness (Gate) | Small–Medium | Stub     | Task 58         | TBD                                |
-| 110 | Focus Follows Mouse (Toggleable)         | Small        | Stub     | Task 58         | TBD                                |
+| 110 | Focus Follows Mouse (Toggleable)         | Small        | Complete | Task 58         | `task-110/focus-follows-mouse`     |
 
 ### Execution order
 
@@ -5059,7 +5059,7 @@ divider-to-pane mapping where unit-testable.
 
 ---
 
-## Task 110 — Focus Follows Mouse (Toggleable)
+## Task 110 — Focus Follows Mouse (Toggleable) ✅ Complete (2026-06-14)
 
 ### 110 Summary
 
@@ -5090,6 +5090,23 @@ settings UI, `config_example.toml` documentation).
 **Verification:** Setting the option in `config.toml` round-trips and is
 reflected in the settings UI; default is focus-follows-mouse.
 
+**Completion notes (commit `1b605fd2`, 2026-06-14):**
+
+- Added `focus_follows_mouse: bool` to `TabsConfig` (`[tabs]` section),
+  defaulting to `true`. No `ConfigPartial`/`apply_partial` change needed —
+  `[tabs]` is an existing section deserialized as a unit with
+  `#[serde(default)]`.
+- Placed in `[tabs]` alongside `confirm_broadcast` (the other pane/tab
+  behavior toggle); there is no `[mouse]`/`[panes]`/`[behavior]` section.
+- Full `freminal-config-options` wiring: struct field + `Default`,
+  `config_example.toml` documentation, settings UI checkbox in the Tabs
+  tab ("Pane Focus" section), and the Nix home-manager module mirror
+  (`tabsSection` inherit + `mkOption`).
+- `default_tabs_config` and `tabs_config_roundtrip` tests extended to
+  cover the new field.
+- `cargo test -p freminal-common`, workspace clippy, `nixfmt`/`statix`/
+  `deadnix` all clean.
+
 #### 110.2 — Pane focus on mouse-over
 
 **Scope:** When enabled, mousing over a pane sets it as the focused (keyboard
@@ -5098,6 +5115,26 @@ target) pane. Tab switching unaffected (stays click-to-focus).
 **Verification:** Mousing across panes moves keyboard focus without a click
 when enabled; click-to-focus behavior restored when disabled. Regression test
 on the focus-selection path.
+
+**Completion notes (commit `1f689e97`, 2026-06-14):**
+
+- Extended the existing click-to-focus block in `app_impl.rs` (per-pane
+  render loop) so a non-active pane is focused either by a left-click or
+  (when `focus_follows_mouse` is enabled) by the pointer hovering its
+  content rect. Hover is detected via
+  `ui.ctx().pointer_hover_pos()` tested against `content_rect`.
+- The focus transfer reuses the exact same `FocusChange` channel sends as
+  click-to-focus; only the _focused_ (keyboard target) pane changes — no
+  in-flight mouse input is retargeted. Tab switching is unaffected.
+- Single-pane sessions are naturally a no-op (the sole pane is always
+  active). The pointer is over at most one pane at a time, so no intra-frame
+  flicker.
+- The decision is factored into a pure `should_focus_inactive_pane(...)`
+  helper in `freminal/src/gui/panes/mod.rs` with 3 unit tests (click,
+  hover-gated-by-ffm, no-interaction). `is_active` is checked at the call
+  site to keep the helper to three bool params (avoids
+  `fn_params_excessive_bools`/`struct_excessive_bools`).
+- `cargo test --all`, workspace clippy, and `cargo machete` all clean.
 
 ---
 

--- a/config_example.toml
+++ b/config_example.toml
@@ -203,6 +203,13 @@ limit = 4000
 # Default: false
 # confirm_broadcast = false
 
+# Whether keyboard focus follows the mouse across split panes. When true,
+# mousing into a pane in a split-pane session focuses it (makes it the keyboard
+# target) without requiring a click. When false, panes are focused only by
+# clicking. Tab switching is always click-to-focus regardless of this setting.
+# Default: true
+# focus_follows_mouse = true
+
 ## ##############################################################################
 # TAB TITLE SETTINGS
 ## ##############################################################################

--- a/freminal-common/src/config.rs
+++ b/freminal-common/src/config.rs
@@ -413,6 +413,12 @@ pub struct TabsConfig {
     /// prompts "You are about to broadcast keyboard input to N panes.
     /// Continue?". Disabling broadcast never prompts. Default: `false`.
     pub confirm_broadcast: bool,
+    /// Whether keyboard focus follows the mouse across split panes (Task
+    /// 110). When `true` (default), mousing into a pane in a muxed session
+    /// focuses it without a click. When `false`, panes are focused only by
+    /// clicking (the legacy behavior). Tab switching is always click-to-focus
+    /// regardless of this setting.
+    pub focus_follows_mouse: bool,
 }
 
 impl Default for TabsConfig {
@@ -421,6 +427,7 @@ impl Default for TabsConfig {
             show_single_tab: false,
             position: TabBarPosition::Top,
             confirm_broadcast: false,
+            focus_follows_mouse: true,
         }
     }
 }
@@ -2737,6 +2744,10 @@ copy = "Ctrl+Shift+C"
         let cfg = Config::default();
         assert!(!cfg.tabs.show_single_tab);
         assert_eq!(cfg.tabs.position, TabBarPosition::Top);
+        assert!(
+            cfg.tabs.focus_follows_mouse,
+            "focus_follows_mouse should default to true (Task 110)"
+        );
     }
 
     #[test]
@@ -2782,6 +2793,8 @@ position = "bottom"
         cfg.tabs.show_single_tab = true;
         cfg.tabs.position = TabBarPosition::Bottom;
         cfg.tabs.confirm_broadcast = true;
+        // Flip away from the `true` default to prove the field round-trips.
+        cfg.tabs.focus_follows_mouse = false;
 
         let toml_str = toml::to_string_pretty(&cfg).expect("Config should serialize");
         let deserialized: Config =
@@ -2789,6 +2802,7 @@ position = "bottom"
         assert!(deserialized.tabs.show_single_tab);
         assert_eq!(deserialized.tabs.position, TabBarPosition::Bottom);
         assert!(deserialized.tabs.confirm_broadcast);
+        assert!(!deserialized.tabs.focus_follows_mouse);
     }
 
     #[test]

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -1623,9 +1623,24 @@ impl freminal_windowing::App for FreminalGui {
                     }
                 }
 
-                // Click-to-focus: if a non-active pane was left-clicked, transfer
-                // keyboard focus to it and send FocusChange events to both panes.
-                if left_clicked && !is_active {
+                // Focus transfer (Task 110): a non-active pane is focused either
+                // by an explicit left-click or (when focus-follows-mouse is
+                // enabled) by the mouse hovering it. Following the mouse only
+                // changes the *focused* (keyboard target) pane; it does not
+                // retarget in-flight mouse input. Tab switching is unaffected.
+                // The pointer is over at most one pane at a time, so this cannot
+                // flicker between panes within a frame.
+                let pointer_over_content = ui
+                    .ctx()
+                    .pointer_hover_pos()
+                    .is_some_and(|pos| content_rect.contains(pos));
+                let should_focus = !is_active
+                    && crate::gui::panes::should_focus_inactive_pane(
+                        left_clicked,
+                        self.config.tabs.focus_follows_mouse,
+                        pointer_over_content,
+                    );
+                if should_focus {
                     let tab = win.tabs.active_tab_mut();
                     let old_active = tab.active_pane;
                     // Notify the previously-active pane that it lost focus.

--- a/freminal/src/gui/panes/mod.rs
+++ b/freminal/src/gui/panes/mod.rs
@@ -1450,12 +1450,59 @@ fn split_rect(rect: Rect, direction: SplitDirection, ratio: f32) -> (Rect, Rect)
     }
 }
 
+/// Decide whether a **non-active** pane should receive keyboard focus this
+/// frame (Task 110).
+///
+/// The caller is responsible for only invoking this for non-active panes (the
+/// active pane never re-focuses itself). A non-active pane is focused when
+/// either:
+///
+/// - it was explicitly left-clicked (`left_clicked`), or
+/// - focus-follows-mouse is enabled (`focus_follows_mouse`) and the pointer is
+///   currently over the pane's content rect (`pointer_over_content`).
+///
+/// Following the mouse only changes the *focused* (keyboard target) pane; it
+/// never retargets in-flight mouse input.
+#[must_use]
+pub const fn should_focus_inactive_pane(
+    left_clicked: bool,
+    focus_follows_mouse: bool,
+    pointer_over_content: bool,
+) -> bool {
+    left_clicked || (focus_follows_mouse && pointer_over_content)
+}
+
 // ── Tests ────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    // ── should_focus_pane tests (Task 110) ───────────────────────────
+
+    #[test]
+    fn click_focuses_inactive_pane_regardless_of_ffm() {
+        // A left-click on a non-active pane always transfers focus, even when
+        // focus-follows-mouse is disabled and the pointer is not over it.
+        assert!(should_focus_inactive_pane(true, false, false));
+        assert!(should_focus_inactive_pane(true, true, true));
+    }
+
+    #[test]
+    fn hover_focuses_inactive_pane_only_when_ffm_enabled() {
+        // Hover over a non-active pane focuses it only when focus-follows-mouse
+        // is enabled.
+        assert!(should_focus_inactive_pane(false, true, true));
+        assert!(!should_focus_inactive_pane(false, false, true));
+    }
+
+    #[test]
+    fn no_focus_when_inactive_and_no_interaction() {
+        // A non-active pane with no click and no pointer-over does not focus.
+        assert!(!should_focus_inactive_pane(false, true, false));
+        assert!(!should_focus_inactive_pane(false, false, false));
+    }
 
     // ── PaneId tests ─────────────────────────────────────────────────
 

--- a/freminal/src/gui/settings.rs
+++ b/freminal/src/gui/settings.rs
@@ -1327,6 +1327,24 @@ impl SettingsModal {
         ui.separator();
         ui.add_space(4.0);
 
+        ui.label("Pane Focus:");
+        ui.add_space(4.0);
+        ui.checkbox(
+            &mut self.draft.tabs.focus_follows_mouse,
+            "Focus follows mouse",
+        );
+        ui.add_space(2.0);
+        ui.colored_label(
+            egui::Color32::GRAY,
+            "When enabled, mousing into a split pane gives it keyboard focus \
+             without a click. When disabled, panes are focused only by \
+             clicking. Tab switching is always click-to-focus.",
+        );
+
+        ui.add_space(8.0);
+        ui.separator();
+        ui.add_space(4.0);
+
         self.show_broadcast_input_section(ui);
     }
 

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -94,7 +94,12 @@ let
       };
 
       tabsSection = lib.filterAttrs (_: v: v != null) {
-        inherit (s.tabs) show_single_tab position confirm_broadcast;
+        inherit (s.tabs)
+          show_single_tab
+          position
+          confirm_broadcast
+          focus_follows_mouse
+          ;
       };
 
       bellSection = lib.filterAttrs (_: v: v != null) {
@@ -544,6 +549,17 @@ in
             Whether enabling broadcast input (sending keystrokes to every
             pane in a tab) requires a confirmation dialog the first time it
             is turned on for a tab. Null uses the default (false).
+          '';
+        };
+
+        focus_follows_mouse = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = ''
+            Whether keyboard focus follows the mouse across split panes.
+            When true, mousing into a pane focuses it without a click; when
+            false, panes are focused only by clicking. Tab switching is
+            always click-to-focus. Null uses the default (true).
           '';
         };
       };


### PR DESCRIPTION
## Task 110 — Focus Follows Mouse (Toggleable)

Part of v0.9.0 (`PLAN_VERSION_090.md`). Active-pane focus now follows the
mouse by default: mousing into a split pane focuses it (makes it the keyboard
target) without a click. Tab switching stays click-to-focus. User-toggleable
back to the legacy click-to-focus model via config.

### Subtasks

- **110.1** — `focus_follows_mouse` config option in `[tabs]` (default `true`),
  with full wiring: `TabsConfig` field + `Default`, `config_example.toml`
  documentation, Settings UI checkbox in the Tabs tab, and the Nix
  home-manager module mirror.
- **110.2** — Hover-to-focus behavior: mousing over a non-active pane transfers
  keyboard focus when enabled, emitting the same `FocusChange` channel events
  as click-to-focus. Only the *focused* (keyboard target) pane changes — no
  in-flight mouse input is retargeted. Decision factored into a pure
  `should_focus_inactive_pane()` helper with unit tests.

### Design notes

- Placed in `[tabs]` alongside `confirm_broadcast` (the other pane/tab behavior
  toggle); there is no `[mouse]`/`[panes]`/`[behavior]` section.
- Default is focus-follows-mouse (`true`) per the 110 Decisions.
- Single-pane sessions are a no-op (the sole pane is always active). The
  pointer is over at most one pane at a time, so no intra-frame flicker.

### Verification

- `cargo test --all` — green
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo machete` — clean
- `nixfmt` / `statix` / `deadnix` on the home-manager module — clean
- Full pre-commit hook suite passing on every commit