### PR TITLE
Task 109 -- Active-pane highlight correctness (surround semantics)

### DIFF
--- a/Documents/MASTER_PLAN.md
+++ b/Documents/MASTER_PLAN.md
@@ -177,7 +177,7 @@ into v0.14.0–v0.16.0 and v0.20.0) and remaining Category C housekeeping (Tasks
 | 106 | Pre-0.9.0 Bug Closure (Release Gate)     | `PLAN_VERSION_090.md` (Task 106)              | Stub          | v0.9.0 features        |
 | 107 | Build Version Embedding                  | `PLAN_VERSION_090.md` (Task 107)              | Complete      | None                   |
 | 108 | About Modal & Attribution                | `PLAN_VERSION_090.md` (Task 108)              | Complete      | Task 107               |
-| 109 | Active-Pane Highlight Correctness (Gate) | `PLAN_VERSION_090.md` (Task 109)              | Stub          | Task 58                |
+| 109 | Active-Pane Highlight Correctness (Gate) | `PLAN_VERSION_090.md` (Task 109)              | Complete      | Task 58                |
 | 110 | Focus Follows Mouse (Toggleable)         | `PLAN_VERSION_090.md` (Task 110)              | Complete      | Task 58                |
 
 ---
@@ -631,6 +631,7 @@ Update this section as tasks complete:
 | 107  | 2026-06-11 | 2026-06-11 | 107.1-107.3 (cargo/CI/Nix version embed) on task-107/build-version-embedding     |
 | 108  | 2026-06-11 | 2026-06-11 | 108.1-108.3 (audit, ATTRIBUTIONS.md, About link) on task-108/about-modal-at      |
 | 110  | 2026-06-14 | 2026-06-14 | 110.1-110.2 on task-110/focus-follows-mouse; PR pending                          |
+| 109  | 2026-06-14 | 2026-06-14 | 109.1 audit + 109.2 surround highlight (two-pane half-fill fallback); PR pending |
 
 ---
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -5010,7 +5010,7 @@ attributions doc; modal input behavior unaffected.
 
 ---
 
-## Task 109 — Active-Pane Highlight Correctness (Release Gate)
+## Task 109 — Active-Pane Highlight Correctness (Release Gate) ✅ Complete (2026-06-14)
 
 ### 109 Summary
 
@@ -5037,7 +5037,7 @@ Source: `Documents/PLANNING.MD` #54–68.
 
 ### 109 Subtasks
 
-#### 109.1 — Highlight-geometry audit
+#### 109.1 — Highlight-geometry audit ✅
 
 **Scope:** Read-only audit of the current pane-divider highlight rendering:
 where the half-fill logic lives, how divider segments map to the focused pane,
@@ -5046,7 +5046,21 @@ and whether the color is themed.
 **Verification:** Report posted (current behavior + theming status); no code
 changes.
 
-#### 109.2 — Surround-the-active-pane highlight
+**Findings:**
+
+- The highlight was computed per _split node_ in
+  `PaneNode::split_borders` (`freminal/src/gui/panes/mod.rs`), emitting one
+  `SplitBorder` per split with `active_in_first: Option<bool>` (active pane
+  in first / second / neither subtree).
+- The renderer (`freminal/src/gui/app_impl.rs`, "tmux-style half-highlighted
+  borders") split each divider rect at its midpoint and coloured the half on
+  the active subtree's side. This is the misleading half-fill heuristic: e.g.
+  focusing Pane 1 in the 3-pane example highlighted only the _left half_ of
+  the horizontal divider, not the full segment bordering Pane 1.
+- **Theming status: hardcoded.** Active = `Color32::from_rgb(100, 160, 255)`,
+  inactive = `Color32::from_gray(80)`, broadcast = a yellow pair. Not themed.
+
+#### 109.2 — Surround-the-active-pane highlight ✅
 
 **Scope:** Replace the half-divider scheme with surround semantics per the
 109 Decisions; exclude outer window edges. Theme the color if the audit found
@@ -5056,6 +5070,48 @@ it hardcoded.
 highlights exactly the dividers bordering the active pane, full segments, no
 outer edges; color matches the active theme. Regression coverage on the
 divider-to-pane mapping where unit-testable.
+
+**Completion notes (2026-06-14):**
+
+- **Final rule: surround for 3+ panes; half-fill the single divider for
+  exactly-two-pane tabs.**
+  - **3+ panes:** every edge of the active pane that is an interior divider is
+    highlighted full-length; the rest of each divider is inactive. Each pane's
+    own edges light up, so adjacent panes stay distinguishable. 3 stacked
+    full-width panes: top active → only its bottom edge; middle active → its
+    top AND bottom edges; bottom active → only its top edge. 3-pane example
+    (Pane 1 full-width on top, Panes 2/3 side-by-side below): Pane 1 → full
+    horizontal divider; Pane 2 → left portion of the horizontal divider + full
+    vertical divider; Pane 3 → right portion + full vertical divider.
+  - **Exactly 2 panes:** the two panes share one full-span divider, so
+    surrounding either lights the same line and the focused pane would be
+    indistinguishable. That single divider is **half-filled** on the active
+    pane's side (the classic tmux behaviour) — top/bottom halves for a
+    side-by-side split (vertical line), left/right halves for a stacked split
+    (horizontal line), selected by `SplitBorder::active_in_first`. The
+    exactly-two-pane test is `pane_layout.len() == 2` in the renderer.
+  - Outer window edges are never dividers, so they are never highlighted (the
+    "exclude outer edges" requirement holds by construction).
+  - (Interim attempts: pure surround everywhere left the two-side-by-side case
+    ambiguous; a per-divider "simple two-pane" classifier wrongly split the
+    3-pane P2/P3 vertical bar. The agreed trigger is whole-tab pane count == 2.)
+- **Theming:** the active-pane highlight uses the active theme's bright-blue
+  (`ThemePalette.ansi[12]`) — the themed equivalent of the original hardcoded
+  `(100, 160, 255)`, kept distinct from the command-block status-gutter colors
+  (green/red/yellow). Inactive stays gray. Broadcast mode keeps its yellow
+  pair.
+- **New API** in `freminal/src/gui/panes/mod.rs`:
+  - `active_highlight_segment(border, active_rect, epsilon) -> Option<Rect>` —
+    pure function returning the sub-segment of the divider along the active
+    pane's edge (or `None`).
+- **Renderer:** `app_impl.rs` per-divider loop draws each divider inactive,
+  then redraws the active-pane edge segment in the active color.
+- **Tests:** 7 unit tests in `panes::tests` covering the 3-pane example
+  (Pane 1 full / Pane 2 left-segment+full-vertical / Pane 3 right-segment+
+  full-vertical / None), and the 3-stacked worked example (top → bottom edge
+  only; middle → both edges; bottom → top edge only).
+- **Verification:** `cargo test --all` green; `cargo clippy --all-targets
+--all-features -- -D warnings` clean; `cargo machete` clean.
 
 ---
 

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -1776,29 +1776,53 @@ impl freminal_windowing::App for FreminalGui {
 
             // ── Pane borders ─────────────────────────────────────────
             //
-            // Draw tmux-style half-highlighted borders: each split border is
-            // divided at the midpoint along its length. The half adjacent to
-            // the active pane's subtree is drawn in the active color; the
-            // other half gets the inactive color. This makes it visually
-            // clear which pane owns each shared edge.
+            // Draw "surround the active pane" highlighted borders (Task 109).
+            // Every edge of the active pane that is an interior divider is
+            // highlighted full-length in the active color; the rest of each
+            // divider is inactive. Outer window edges are never dividers, so
+            // they are never highlighted. Each pane's own edges light up, so
+            // stacked / nested panes stay distinguishable (a middle stacked
+            // pane lights its top AND bottom; its neighbours light only the
+            // shared edge).
+            //
+            // The one exception is a tab with EXACTLY two panes: they share a
+            // single full-span divider, so surrounding either pane lights the
+            // same line and the focused pane is indistinguishable. In that
+            // case the divider is half-filled on the active pane's side
+            // (the classic tmux behaviour).
             let broadcast_active = win.tabs.active_tab().broadcast_input;
             if has_multiple_panes && zoomed_pane.is_none() {
                 let painter = ui.painter();
                 // Broadcast mode (Task 74) tints every split border yellow so
                 // the user has a constant visual reminder that keystrokes are
                 // fanning out to every pane.  Otherwise the active pane's
-                // edges are blue and the rest gray.
+                // edges use the theme's bright-blue (ansi[12]) — the themed
+                // equivalent of the original hardcoded blue, distinct from the
+                // command-block status-gutter colors (green/red/yellow) — and
+                // the rest are gray.
                 let (inactive_color, active_color) = if broadcast_active {
                     (
                         egui::Color32::from_rgb(180, 150, 40),
                         egui::Color32::from_rgb(240, 200, 60),
                     )
                 } else {
+                    let theme = freminal_common::themes::by_slug(
+                        self.config.theme.active_slug(win.os_dark_mode),
+                    )
+                    .unwrap_or(&freminal_common::themes::CATPPUCCIN_MOCHA);
+                    let (br, bg, bb) = theme.ansi[12];
                     (
                         egui::Color32::from_gray(80),
-                        egui::Color32::from_rgb(100, 160, 255),
+                        egui::Color32::from_rgb(br, bg, bb),
                     )
                 };
+
+                // Rect of the currently focused pane; used to decide which
+                // divider segments border it.
+                let active_rect = pane_layout
+                    .iter()
+                    .find(|(id, _)| *id == active_pane_id)
+                    .map(|(_, r)| *r);
 
                 let border_rects = win
                     .tabs
@@ -1807,51 +1831,71 @@ impl freminal_windowing::App for FreminalGui {
                     .split_borders(available_rect, active_pane_id)
                     .unwrap_or_default();
 
+                // Tolerance for matching a divider coordinate to a pane edge.
+                let edge_epsilon: f32 = 1.0;
+
+                // Exactly-two-pane tabs share a single divider; half-fill it
+                // on the active pane's side rather than surrounding (which
+                // would be ambiguous). `pane_layout` holds every leaf rect.
+                let exactly_two_panes = pane_layout.len() == 2;
+
+                let stroke = |from, to, color| {
+                    painter.line_segment([from, to], egui::Stroke::new(border_width, color));
+                };
+
                 for border in &border_rects {
                     let r = border.rect;
 
-                    // Determine which halves are active/inactive.
-                    // active_in_first == Some(true)  → first half active
-                    // active_in_first == Some(false) → second half active
-                    // active_in_first == None        → both inactive
-                    let (first_color, second_color) = match border.active_in_first {
-                        Some(true) => (active_color, inactive_color),
-                        Some(false) => (inactive_color, active_color),
-                        None => (inactive_color, inactive_color),
-                    };
+                    if exactly_two_panes {
+                        // Half-fill: the active pane's side gets the active
+                        // color; the other half stays inactive. `active_in_first`
+                        // is true when the active pane is the first child
+                        // (top for a vertical line, left for a horizontal line).
+                        let (first_color, second_color) = match border.active_in_first {
+                            Some(true) => (active_color, inactive_color),
+                            Some(false) => (inactive_color, active_color),
+                            None => (inactive_color, inactive_color),
+                        };
+                        match border.direction {
+                            panes::SplitDirection::Horizontal => {
+                                // Vertical line — split top/bottom.
+                                let mid_y = f32::midpoint(r.min.y, r.max.y);
+                                stroke(r.left_top(), egui::pos2(r.min.x, mid_y), first_color);
+                                stroke(egui::pos2(r.min.x, mid_y), r.left_bottom(), second_color);
+                            }
+                            panes::SplitDirection::Vertical => {
+                                // Horizontal line — split left/right.
+                                let mid_x = f32::midpoint(r.min.x, r.max.x);
+                                stroke(r.left_top(), egui::pos2(mid_x, r.min.y), first_color);
+                                stroke(egui::pos2(mid_x, r.min.y), r.right_top(), second_color);
+                            }
+                        }
+                        continue;
+                    }
 
+                    // 3+ panes: surround. The whole divider is drawn inactive
+                    // first…
                     match border.direction {
                         panes::SplitDirection::Horizontal => {
-                            // Vertical dividing line — split top/bottom.
-                            // First child is left → "first half" = top.
-                            let mid_y = f32::midpoint(r.min.y, r.max.y);
-                            let top = egui::Rect::from_min_max(r.min, egui::pos2(r.max.x, mid_y));
-                            let bot = egui::Rect::from_min_max(egui::pos2(r.min.x, mid_y), r.max);
-
-                            painter.line_segment(
-                                [top.left_top(), top.left_bottom()],
-                                egui::Stroke::new(border_width, first_color),
-                            );
-                            painter.line_segment(
-                                [bot.left_top(), bot.left_bottom()],
-                                egui::Stroke::new(border_width, second_color),
-                            );
+                            stroke(r.left_top(), r.left_bottom(), inactive_color);
                         }
                         panes::SplitDirection::Vertical => {
-                            // Horizontal dividing line — split left/right.
-                            // First child is top → "first half" = left.
-                            let mid_x = f32::midpoint(r.min.x, r.max.x);
-                            let left = egui::Rect::from_min_max(r.min, egui::pos2(mid_x, r.max.y));
-                            let right = egui::Rect::from_min_max(egui::pos2(mid_x, r.min.y), r.max);
+                            stroke(r.left_top(), r.right_top(), inactive_color);
+                        }
+                    }
 
-                            painter.line_segment(
-                                [left.left_top(), left.right_top()],
-                                egui::Stroke::new(border_width, first_color),
-                            );
-                            painter.line_segment(
-                                [right.left_top(), right.right_top()],
-                                egui::Stroke::new(border_width, second_color),
-                            );
+                    // …then the segment along the active pane's edge is
+                    // redrawn full-length in the active color.
+                    if let Some(seg) = active_rect
+                        .and_then(|ar| panes::active_highlight_segment(border, ar, edge_epsilon))
+                    {
+                        match border.direction {
+                            panes::SplitDirection::Horizontal => {
+                                stroke(seg.left_top(), seg.left_bottom(), active_color);
+                            }
+                            panes::SplitDirection::Vertical => {
+                                stroke(seg.left_top(), seg.right_top(), active_color);
+                            }
                         }
                     }
                 }

--- a/freminal/src/gui/panes/mod.rs
+++ b/freminal/src/gui/panes/mod.rs
@@ -476,6 +476,84 @@ pub struct SplitBorder {
     pub active_in_first: Option<bool>,
 }
 
+/// The sub-segment of a split divider that should be highlighted to
+/// _surround_ the active pane (Task 109).
+///
+/// Returns the portion of `border.rect` that lies along an edge of
+/// `active_rect`, drawn full-length in the active color, or `None` when the
+/// divider does not border the active pane.
+///
+/// The semantics are "surround the active pane": every edge of the active
+/// pane that is an interior divider is highlighted, full segment. A stacked
+/// pane's bottom edge, a middle pane's top AND bottom edges, etc. each light
+/// up independently, which is what makes adjacent panes distinguishable. A
+/// divider shared between a full-width pane and a subdivided region below
+/// highlights the full divider when the full-width pane is active, but only
+/// the overlapping sub-segment when one of the smaller panes is active.
+///
+/// This is used for tabs with 3+ panes. The exactly-two-pane case is handled
+/// separately by the renderer (see `app_impl.rs`): two panes share a single
+/// full-span divider, so surrounding either lights the same line — the
+/// renderer half-fills that one divider on the active pane's side instead.
+///
+/// Because dividers are emitted only for interior split nodes, the outer
+/// edges of the window are never dividers and so are never highlighted —
+/// satisfying the "exclude the outer window edges" requirement implicitly.
+///
+/// `epsilon` absorbs sub-pixel rounding between the split-line coordinate
+/// and the active pane's edge coordinate (both derive from the same
+/// `split_rect` math, but float rounding can differ by a fraction).
+#[must_use]
+pub fn active_highlight_segment(
+    border: &SplitBorder,
+    active_rect: Rect,
+    epsilon: f32,
+) -> Option<Rect> {
+    let r = border.rect;
+    match border.direction {
+        // Vertical dividing line (Horizontal split): the divider runs along
+        // the y axis. It borders the active pane only when the divider's x
+        // sits on the pane's left or right edge.
+        SplitDirection::Horizontal => {
+            let divider_x = r.center().x;
+            let borders_pane = (divider_x - active_rect.min.x).abs() <= epsilon
+                || (divider_x - active_rect.max.x).abs() <= epsilon;
+            if !borders_pane {
+                return None;
+            }
+            let top = r.min.y.max(active_rect.min.y);
+            let bottom = r.max.y.min(active_rect.max.y);
+            if bottom - top <= epsilon {
+                return None;
+            }
+            Some(Rect::from_min_max(
+                egui::pos2(r.min.x, top),
+                egui::pos2(r.max.x, bottom),
+            ))
+        }
+        // Horizontal dividing line (Vertical split): the divider runs along
+        // the x axis. It borders the active pane only when the divider's y
+        // sits on the pane's top or bottom edge.
+        SplitDirection::Vertical => {
+            let divider_y = r.center().y;
+            let borders_pane = (divider_y - active_rect.min.y).abs() <= epsilon
+                || (divider_y - active_rect.max.y).abs() <= epsilon;
+            if !borders_pane {
+                return None;
+            }
+            let left = r.min.x.max(active_rect.min.x);
+            let right = r.max.x.min(active_rect.max.x);
+            if right - left <= epsilon {
+                return None;
+            }
+            Some(Rect::from_min_max(
+                egui::pos2(left, r.min.y),
+                egui::pos2(right, r.max.y),
+            ))
+        }
+    }
+}
+
 // ── PaneNode (internal) ─────────────────────────────────────────────
 
 /// Minimum fraction for a split ratio, preventing invisible panes.
@@ -2463,5 +2541,169 @@ mod tests {
             .find(|b| b.direction == SplitDirection::Vertical)
             .unwrap();
         assert_eq!(v_border.active_in_first, Some(false));
+    }
+
+    // ── active_highlight_segment (Task 109) ──────────────────────────
+    //
+    // The 3-pane example from the plan:
+    //   |----------------|
+    //   | Pane 1         |   (top, full width)
+    //   |----------------|   <- horizontal divider H at y=300
+    //   | Pane 2 | Pane 3|   (bottom, split by vertical divider V at x=400)
+    //   |----------------|
+    //
+    // Window 800x600, top/bottom split at y=300, bottom split at x=400.
+    //   Pane 1 rect: (0,0)-(800,300)
+    //   Pane 2 rect: (0,300)-(400,600)
+    //   Pane 3 rect: (400,300)-(800,600)
+    //   H divider rect: (0,299.5)-(800,300.5)  direction Vertical
+    //   V divider rect: (399.5,300)-(400.5,600) direction Horizontal
+
+    fn h_divider() -> SplitBorder {
+        SplitBorder {
+            direction: SplitDirection::Vertical,
+            first_child_pane: PaneId(1),
+            rect: Rect::from_min_max(egui::pos2(0.0, 299.5), egui::pos2(800.0, 300.5)),
+            parent_extent: 600.0,
+            active_in_first: None,
+        }
+    }
+
+    fn v_divider() -> SplitBorder {
+        SplitBorder {
+            direction: SplitDirection::Horizontal,
+            first_child_pane: PaneId(2),
+            rect: Rect::from_min_max(egui::pos2(399.5, 300.0), egui::pos2(400.5, 600.0)),
+            parent_extent: 800.0,
+            active_in_first: None,
+        }
+    }
+
+    const PANE1: fn() -> Rect =
+        || Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(800.0, 300.0));
+    const PANE2: fn() -> Rect =
+        || Rect::from_min_max(egui::pos2(0.0, 300.0), egui::pos2(400.0, 600.0));
+    const PANE3: fn() -> Rect =
+        || Rect::from_min_max(egui::pos2(400.0, 300.0), egui::pos2(800.0, 600.0));
+
+    #[test]
+    fn highlight_pane1_full_horizontal_divider() {
+        // Focusing Pane 1: full horizontal divider (its bottom edge, full
+        // width). The vertical divider does not border P1.
+        let seg = active_highlight_segment(&h_divider(), PANE1(), 1.0).unwrap();
+        assert!((seg.min.x - 0.0).abs() < 0.01);
+        assert!((seg.max.x - 800.0).abs() < 0.01, "full width expected");
+
+        assert!(
+            active_highlight_segment(&v_divider(), PANE1(), 1.0).is_none(),
+            "V divider must not be highlighted for Pane 1"
+        );
+    }
+
+    #[test]
+    fn highlight_pane2_left_segment_and_full_vertical() {
+        // Focusing Pane 2 (bottom-left): the horizontal divider only borders
+        // its top-left, so the highlighted segment is the left portion; the
+        // vertical divider is its full right edge.
+        let h = active_highlight_segment(&h_divider(), PANE2(), 1.0).unwrap();
+        assert!((h.min.x - 0.0).abs() < 0.01);
+        assert!((h.max.x - 400.0).abs() < 0.01, "left segment expected");
+
+        let v = active_highlight_segment(&v_divider(), PANE2(), 1.0).unwrap();
+        assert!((v.min.y - 300.0).abs() < 0.01);
+        assert!((v.max.y - 600.0).abs() < 0.01, "full height expected");
+    }
+
+    #[test]
+    fn highlight_pane3_right_segment_and_full_vertical() {
+        // Focusing Pane 3 (bottom-right): right portion of the horizontal
+        // divider + the full vertical divider (its left edge).
+        let h = active_highlight_segment(&h_divider(), PANE3(), 1.0).unwrap();
+        assert!((h.min.x - 400.0).abs() < 0.01, "right segment expected");
+        assert!((h.max.x - 800.0).abs() < 0.01);
+
+        let v = active_highlight_segment(&v_divider(), PANE3(), 1.0).unwrap();
+        assert!((v.min.y - 300.0).abs() < 0.01);
+        assert!((v.max.y - 600.0).abs() < 0.01, "full height expected");
+    }
+
+    #[test]
+    fn highlight_returns_none_when_divider_does_not_touch_pane() {
+        let detached = Rect::from_min_max(egui::pos2(10.0, 10.0), egui::pos2(100.0, 100.0));
+        assert!(active_highlight_segment(&h_divider(), detached, 1.0).is_none());
+        assert!(active_highlight_segment(&v_divider(), detached, 1.0).is_none());
+    }
+
+    // ── Three stacked full-width panes (the user's worked example) ───
+    //
+    // Window 800x600, two horizontal dividers at y=200 and y=400:
+    //   Top:    (0,0)-(800,200)
+    //   Middle: (0,200)-(800,400)
+    //   Bottom: (0,400)-(800,600)
+    //   Upper divider: (0,199.5)-(800,200.5), direction Vertical
+    //   Lower divider: (0,399.5)-(800,400.5), direction Vertical
+    //
+    // Expectation: top active -> only its bottom edge (upper divider);
+    // middle active -> both edges (upper AND lower divider); bottom active ->
+    // only its top edge (lower divider).
+
+    fn three_stacked() -> (SplitBorder, SplitBorder, Rect, Rect, Rect) {
+        let upper = SplitBorder {
+            direction: SplitDirection::Vertical,
+            first_child_pane: PaneId(0),
+            rect: Rect::from_min_max(egui::pos2(0.0, 199.5), egui::pos2(800.0, 200.5)),
+            parent_extent: 600.0,
+            active_in_first: None,
+        };
+        let lower = SplitBorder {
+            direction: SplitDirection::Vertical,
+            first_child_pane: PaneId(1),
+            rect: Rect::from_min_max(egui::pos2(0.0, 399.5), egui::pos2(800.0, 400.5)),
+            parent_extent: 600.0,
+            active_in_first: None,
+        };
+        let top = Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(800.0, 200.0));
+        let middle = Rect::from_min_max(egui::pos2(0.0, 200.0), egui::pos2(800.0, 400.0));
+        let bottom = Rect::from_min_max(egui::pos2(0.0, 400.0), egui::pos2(800.0, 600.0));
+        (upper, lower, top, middle, bottom)
+    }
+
+    #[test]
+    fn three_stacked_top_active_lights_only_bottom_edge() {
+        let (upper, lower, top, _m, _b) = three_stacked();
+        assert!(
+            active_highlight_segment(&upper, top, 1.0).is_some(),
+            "top pane's bottom edge (upper divider) must light"
+        );
+        assert!(
+            active_highlight_segment(&lower, top, 1.0).is_none(),
+            "top pane does not border the lower divider"
+        );
+    }
+
+    #[test]
+    fn three_stacked_middle_active_lights_both_edges() {
+        let (upper, lower, _t, middle, _b) = three_stacked();
+        assert!(
+            active_highlight_segment(&upper, middle, 1.0).is_some(),
+            "middle pane's top edge (upper divider) must light"
+        );
+        assert!(
+            active_highlight_segment(&lower, middle, 1.0).is_some(),
+            "middle pane's bottom edge (lower divider) must light"
+        );
+    }
+
+    #[test]
+    fn three_stacked_bottom_active_lights_only_top_edge() {
+        let (upper, lower, _t, _m, bottom) = three_stacked();
+        assert!(
+            active_highlight_segment(&upper, bottom, 1.0).is_none(),
+            "bottom pane does not border the upper divider"
+        );
+        assert!(
+            active_highlight_segment(&lower, bottom, 1.0).is_some(),
+            "bottom pane's top edge (lower divider) must light"
+        );
     }
 }


### PR DESCRIPTION
## Task 109 — Active-Pane Highlight Correctness (release gate)

Replaces the misleading tmux-style half-divider highlight in muxed sessions
with **surround-the-active-pane** semantics, and themes the highlight color.

Plan: `Documents/PLAN_VERSION_090.md` Task 109. Source bug: `PLANNING.MD` #54–68.

### 109.1 — Highlight-geometry audit

- The highlight was computed per *split node* and the renderer split each
  divider at its midpoint, colouring the half on the active subtree's side —
  the misleading heuristic (focusing Pane 1 lit only the *left half* of the
  horizontal divider).
- The colors were **hardcoded** (`(100, 160, 255)` active / `gray(80)`
  inactive), not themed.

### 109.2 — Surround-the-active-pane highlight

- **3+ panes:** every interior-divider edge of the active pane is highlighted
  full-length; the rest is inactive. Each pane's own edges light up, so
  stacked/nested panes stay distinguishable.
  - 3-pane example (Pane 1 full-width on top, Panes 2/3 below): Pane 1 → full
    horizontal divider; Pane 2 → left portion + full vertical; Pane 3 → right
    portion + full vertical.
  - 3 stacked panes: top → bottom edge; middle → both edges; bottom → top edge.
- **Exactly 2 panes:** the pair shares one full-span divider (surround would be
  ambiguous), so that single divider is **half-filled** on the active pane's
  side (classic tmux behaviour), keyed off `SplitBorder::active_in_first`.
- **Outer window edges** are never dividers, so they are never highlighted.
- **Themed:** active color now uses the theme bright-blue (`ansi[12]`) — the
  themed equivalent of the former hardcoded blue, kept distinct from the
  command-block status-gutter colors (green/red/yellow).

### Implementation

- New pure, unit-tested `active_highlight_segment()` in `panes/mod.rs`.
- Renderer in `app_impl.rs` branches on `pane_layout.len() == 2` (half-fill)
  vs surround.

### Verification

- `cargo test --all` — green (0 failures); +7 highlight unit tests.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo machete` — clean.

This is one of the two v0.9.0 release gates (the other is Task 106).