### PR TITLE
Task 106 — Pre-0.9.0 Bug Closure (Release Gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,9 +107,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, ubuntu-24.04-arm]
-        # We target the MSRV (currently 1.95.0, matching stable) plus nightly.
-        # When stable advances beyond MSRV, add the explicit MSRV version back to avoid double-compiling.
-        toolchain: ["stable", "nightly"]
+        toolchain: ["stable", "nightly", "1.95.0"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "freminal"
-version = "0.9.0-beta.6"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-buffer"
-version = "0.9.0-beta.6"
+version = "0.9.0"
 dependencies = [
  "conv2",
  "criterion",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-common"
-version = "0.9.0-beta.6"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-terminal-emulator"
-version = "0.9.0-beta.6"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-windowing"
-version = "0.9.0-beta.6"
+version = "0.9.0"
 dependencies = [
  "conv2",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["freminal", "freminal-buffer", "freminal-common", "freminal-terminal-
 default-members = ["freminal", "freminal-buffer", "freminal-common", "freminal-terminal-emulator"]
 
 [workspace.package]
-version = "0.9.0-beta.6"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.95.0"
 description = "A terminal emulator written in Rust"

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -4725,7 +4725,7 @@ regression test on the input-handling path.
 - No escape-sequence, config, or new-dependency changes — purely a windowing
   command-dispatch fix.
 
-#### 106.2 — Command-duration & gutter-extent bugs (PLANNING #2, #4)
+#### 106.2 — Command-duration & gutter-extent bugs (PLANNING #2, #4) ✅ 2026-06-15
 
 **Scope:** Two OSC 133 / gutter (Task 72/73) regressions:
 
@@ -4742,7 +4742,40 @@ regression test on the input-handling path.
 terminates at the prompt / last output line. Regression tests on the gutter
 extent and duration computation.
 
-#### 106.3 — False Ctrl-C notification on unexecuted command (PLANNING #3)
+**Completion notes (branch `task-106/bug-closure`; landed with 106.3):**
+
+- **Duration (106.2a):** `CommandBlock::duration()`
+  (`freminal-common/src/buffer_states/command_block.rs`) previously fell back
+  to `started_at` (OSC 133 A, prompt-draw time) when `executed_at` (OSC 133 C)
+  was `None`. For a Ctrl-C-on-idle-prompt block (A→D, no C) that measured
+  prompt-idle time. It now requires `executed_at` and returns `None` when no
+  `C` marker was received — there is no execution interval to report. Our own
+  bash/zsh/fish integration scripts always emit `C` before a real command, so
+  the only A→D-without-C case is an aborted prompt. Added a
+  `CommandBlock::executed()` predicate (`executed_at.is_some()`) used by both
+  the duration suppression and the notification guard.
+- **Gutter extent (106.2b):** a still-running block has no `end_row`; the
+  gutter / duration-anchor helpers substituted `running_extent`, which was
+  `visible_window_start + term_height - 1` (the pane bottom). That painted the
+  status bar all the way down even when the running command's output reached
+  only partway. New `coords::running_block_extent(snap)` returns
+  `visible_window_start + cursor_pos.y` (the cursor row = last output line so
+  far). All three `running_extent` sites in `terminal/widget.rs` (gutter fill,
+  duration-label anchor, gutter hover hit-test) now use it. A _finished_ Ctrl-C
+  block already stopped correctly because `finish_command_block` sets
+  `end_row = cursor.pos.y`; only running blocks were affected.
+- **Tests:** updated `duration_*` fixtures in `command_block.rs` to set
+  `executed_at` (so they test the C→D interval, not the removed fallback);
+  replaced `duration_falls_back_to_started_at_when_executed_at_missing` with
+  `duration_is_none_when_executed_at_missing`; added three `executed()` tests;
+  added three `running_block_extent` tests in `coords.rs` (cursor mid-screen
+  vs. pane-bottom regression guard, cursor at window top, scrolled-back).
+- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
+warnings`, `cargo fmt --all -- --check`, and `cargo machete` all clean. No
+  escape-sequence support changed (OSC 133 parsing is identical); this is a
+  renderer-side / notification-side consumption fix, so no coverage-doc update.
+
+#### 106.3 — False Ctrl-C notification on unexecuted command (PLANNING #3) ✅ 2026-06-15
 
 **Scope:** Related to 106.2. A toast / system notification fires when Ctrl-C is
 pressed on a prompt where no command ever executed. No notification should fire
@@ -4750,6 +4783,22 @@ for a command that never ran (no OSC 133 C marker).
 
 **Verification:** Ctrl-C on an idle prompt produces no notification; a real
 finished command still notifies per Task 76. Regression test.
+
+**Completion notes (branch `task-106/bug-closure`; landed with 106.2):**
+
+- As 106.2 anticipated, the fix is intertwined with the duration fix and shares
+  the `CommandBlock::executed()` predicate. `command_finished_request`
+  (`freminal/src/gui/notifications.rs`) gained an explicit
+  `if !block.executed() { return None; }` guard placed _before_ the
+  `block.duration()?` threshold check. The duration change alone would suppress
+  the notification (since `duration()` now returns `None` for unexecuted
+  blocks), but the explicit guard is robust against a zero/low
+  `command_finished_threshold_secs` and documents the intent at the call site.
+- Regression test `command_finished_request_unexecuted_ctrl_c_block_is_none`
+  builds an A→D block with `output_start_row = None` / `executed_at = None`,
+  a 30 s idle gap, and a `0.0` threshold, asserting no request is produced.
+  Existing executed-command notification tests are unaffected (their fixtures
+  already set `executed_at`).
 
 #### 106.4 — Teardown & lifecycle ordering (PLANNING #5, #6, channel errors)
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -4773,6 +4773,35 @@ most-recent-first.
 **Verification:** Most-recently-run command appears at the top; regression test
 on the palette ordering.
 
+#### 106.6 — Paste-guard modal routes to wrong pane under focus-follows-mouse ✅ 2026-06-15
+
+**Why this subtask exists:** surfaced during 106.1 review. A regression from
+the interaction of the v0.9.0 focus-follows-mouse work (Task 110) and the
+smart paste guard (Task 77).
+
+**Scope:** With focus-follows-mouse enabled, pasting flagged content into pane A
+opens the confirm-paste modal whose buttons may overlap a different pane B.
+Moving the cursor onto "Paste Anyway"/"Cancel" changes the active pane to B
+(focus follows mouse), and confirming pasted into B instead of A, because
+`send_paste_to_active_pane` resolved the _current_ active pane at confirm time.
+
+**Fix:** Capture the destination pane `(TabId, PaneId)` at dialog-open time in
+`guarded_paste_text` (mirroring how the broadcast-confirm dialog already
+carries its target tab), thread it through `PasteDialogState` /
+`PasteDialogOutcome::Paste { payload, target }`, and route the confirmed paste
+via a new `send_paste_to_target` that looks the pane up by id. If the target
+pane was closed while the modal was open the paste is dropped with a log rather
+than landing in the wrong pane. The Settings "Test Paste" preview captures the
+settings-owner window's active pane the same way. The `Safe` fast path is
+unchanged (it sends in the same frame the paste is initiated, so active == target
+by construction).
+
+**Verification:** New `dialog_preserves_target_across_open` regression test in
+`paste_guard.rs` asserts the captured target round-trips through dialog state.
+Existing dialog tests updated for the new `open`/`Paste` signatures.
+`cargo test --all`, clippy `-D warnings`, `cargo fmt --check`, and
+`cargo machete` all clean.
+
 ---
 
 ## Task 107 — Build Version Embedding ✅ Complete (2026-06-11)

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -4686,13 +4686,44 @@ disconnected-channel errors at app close).
 
 ### 106 Subtasks
 
-#### 106.1 — Right-click paste in buffer (PLANNING #1)
+#### 106.1 — Right-click paste in buffer (PLANNING #1) ✅ 2026-06-15
 
 **Scope:** Right-click paste does not work in the terminal buffer. Diagnose
 the input path and restore paste-on-right-click.
 
 **Verification:** Right-click pastes clipboard contents into the buffer;
 regression test on the input-handling path.
+
+**Completion notes (branch `task-106/bug-closure`):**
+
+- **Root cause:** the right-click context-menu "Paste" entry sends
+  `egui::ViewportCommand::RequestPaste`
+  (`freminal/src/gui/terminal/widget.rs:775`). In the custom winit/glutin
+  integration that replaced eframe (Task 66), `process_viewport_command`
+  (`freminal-windowing/src/event_loop.rs`) routed `RequestPaste` into the
+  catch-all `_ => trace!("Unhandled …")` arm, so nothing happened. Keyboard
+  paste worked because it goes through a separate keypress interceptor that
+  reads the clipboard and calls `inject_paste`.
+- **Fix:** `RequestPaste` now sets a deferred `paste_requested` flag (mirroring
+  the existing `should_close` flag). After the per-frame command loop, the
+  `RedrawRequested` handler reads the clipboard via the same cross-window
+  `windows.values_mut().find_map(state.egui.clipboard_text())` fallback the
+  keyboard interceptor uses (Wayland per-window clipboard quirk) and injects
+  `Event::Paste` into the target window. From there the existing
+  `Event::Paste` → `pending_paste` → `guarded_paste_text` path (Task 77)
+  handles bracketed-paste wrapping and the paste guard.
+- **Testability:** flag classification extracted into a pure, window-free
+  `viewport_command_flags(&cmd) -> ViewportCommandFlags` helper so it can be
+  unit-tested without a live event loop. The window-affecting arms still run
+  inline in `process_viewport_command`.
+- 3 regression tests added in `event_loop.rs::tests`:
+  `request_paste_command_sets_only_paste_flag` (the bug guard),
+  `close_command_sets_only_close_flag`, and
+  `window_affecting_commands_raise_no_flags`.
+- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D warnings`,
+  `cargo fmt --all -- --check`, and `cargo machete` all clean.
+- No escape-sequence, config, or new-dependency changes — purely a windowing
+  command-dispatch fix.
 
 #### 106.2 — Command-duration & gutter-extent bugs (PLANNING #2, #4)
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -4800,7 +4800,7 @@ finished command still notifies per Task 76. Regression test.
   Existing executed-command notification tests are unaffected (their fixtures
   already set `executed_at`).
 
-#### 106.4 — Teardown & lifecycle ordering (PLANNING #5, #6, channel errors)
+#### 106.4 — Teardown & lifecycle ordering (PLANNING #5, #6, channel errors) ✅ 2026-06-15
 
 **Scope:** Shutdown-ordering defects, addressed as one unit:
 
@@ -4813,6 +4813,52 @@ finished command still notifies per Task 76. Regression test.
 **Verification:** Clean app exit with no painter-leak warning and no
 disconnected-channel errors in the log; pane/tab close ordering verified.
 Regression coverage where the close path is unit-testable.
+
+**Completion notes (branch `task-106/bug-closure`; three commits):**
+
+- **Painter teardown (commit `d19dd06`):** the `egui_glow::Painter` (held on
+  `EguiState` in `freminal-windowing`) owns GPU objects freed only by
+  `destroy()`; the close path merely dropped it, firing the painter's
+  `Drop`-impl leak warning. The warning fired not only at app exit but on
+  every standalone-settings-window close (the settings modal is its own
+  winit window). `WindowState::destroy_egui()` now makes the window's GL
+  context current and calls `painter.destroy()` before the drop; it runs from
+  both `close_window()` (per-window close) and a new `exiting()`
+  `ApplicationHandler` hook (windows still present at irreversible event-loop
+  shutdown). `destroy()` is idempotent, so the two paths cannot double-free.
+- **Channel-shutdown classification (commit `7149c09`):** at close the PTY
+  consumer thread (owner of the `PtyRead` receiver) exits first when the GUI
+  drops the pane's input channel, while the reader thread may still receive
+  one last chunk of shell output. Its `send()` then failed and was logged
+  unconditionally at `error`. A shared `reader_shutdown: Arc<AtomicBool>` is
+  now set by the consumer thread immediately before it exits via the
+  input-channel-disconnect path; the reader consults it on send failure. Flag
+  set = expected teardown (`debug`); flag clear = the receiver vanished while
+  the reader should have kept running, a genuine ordering bug (`error`). The
+  decision is factored into a pure `classify_reader_send_failure()` helper
+  with unit tests, so demoting the log does NOT mask real anomalies. Plumbing
+  mirrors `echo_off`: `RunTerminalResult` → `FreminalPtyInputOutput` →
+  `TerminalEmulator::reader_shutdown_atomic()` → consumer thread.
+- **Close sequencing (commit `d752acc`, PLANNING #6):** two defects. (1)
+  Closing the active tab dropped its panes without sending `FocusChange(true)`
+  to the newly-visible tab's pane, unlike the close-pane and PTY-death paths —
+  a pane using focus reporting (`?1004`) was left believing it was unfocused.
+  `PerWindowState::close_tab` now notifies via `notify_active_pane_focused`,
+  but only when the closed tab was the active one (closing a background tab
+  must not move focus). (2) When a background tab's last pane died, the
+  dead-pane handler in `app_impl.rs` restored the active tab by the dead pane's
+  index rather than the user's original active tab, selecting the wrong tab
+  after a lower-indexed tab was removed. It now captures the original active
+  tab's stable `TabId` and restores by id.
+- **Tests:** `classify_reader_send_failure` (2 cases),
+  `notify_active_pane_focused_sends_focus_gained` (focus event reaches the
+  pane). The painter teardown needs a live GL context and is not unit-testable;
+  the restore-by-id invariant rests on `TabManager::close_tab`'s already-tested
+  active-index adjustment.
+- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
+warnings`, `cargo fmt --all -- --check`, and `cargo machete` all clean. No
+  escape-sequence support changed (the OSC parser is untouched), so no
+  coverage-doc update.
 
 #### 106.5 — Command history palette sort order (PLANNING #9)
 

--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -4860,13 +4860,62 @@ warnings`, `cargo fmt --all -- --check`, and `cargo machete` all clean. No
   escape-sequence support changed (the OSC parser is untouched), so no
   coverage-doc update.
 
-#### 106.5 — Command history palette sort order (PLANNING #9)
+#### 106.5 — Command history palette sort order (PLANNING #9) ✅ 2026-06-15
 
-**Scope:** The command-history palette lists oldest-first. It must sort
-most-recent-first.
+**Scope:** The command-history palette (Ctrl+Shift+M, Task 72.15) lists
+oldest-first. It must sort most-recent-first.
 
-**Verification:** Most-recently-run command appears at the top; regression test
-on the palette ordering.
+**Symptom that prompted the fix:** a command typed in the current session
+never appeared in the palette's _unfiltered_ list, yet searching for that
+exact command's text surfaced it. Diagnosis: the bug is the sort order
+itself, not a dedup/classification miss.
+
+- `merge_entries` (`freminal/src/gui/command_history.rs`) emitted the
+  shell-history seed first (oldest→newest, up to
+  `shell_history::HISTORY_SEED_CAP = 1000` entries), then this session's
+  live OSC 133 commands appended at the tail.
+- `filter_entries` caps the _rendered_ list at `MAX_VISIBLE_ENTRIES = 200`
+  via `take(200)` — but only after filtering. With an empty query the cap
+  sliced off the tail, so with a typical ≥200-entry history the live
+  entries (and the most-recent seed entries) were never reached. A
+  non-empty query scans the whole merged list before the cap, which is why
+  searching found the command.
+
+**Fix:** reverse the merge to most-recent-first. Live entries are emitted
+newest-first (this session's commands), then the seed newest-first. This
+puts recent commands at the top, inside the 200-entry cap, and pairs with
+the palette's existing default selection of index `0` (Enter recalls the
+most-recent command). Dedup was also changed from "collapse consecutive
+duplicates" to a global text dedup (first/newest occurrence wins), so a
+command both run this session and present in the history file appears
+exactly once near the top as the Live variant (carrying its exit-code
+badge) rather than twice.
+
+**Verification:** Most-recently-run command appears at the top; regression
+test on the palette ordering.
+
+**Completion notes (branch `task-106/bug-closure`):**
+
+- Single-file production change: `freminal/src/gui/command_history.rs`
+  `merge_entries`. No signature change (the `seed` / `recent` / `texts`
+  inputs are stored oldest-first and iterated `.rev()`); no `ViewState`,
+  renderer, config, or escape-sequence change.
+- Updated the `merge_entries` doc comment to describe the newest-first
+  ordering, the cap interaction, and the global dedup rationale.
+- Tests: flipped the three order-asserting tests to newest-first
+  (`merge_entries_seed_only_is_newest_first`,
+  `merge_entries_collapses_duplicates_in_seed`,
+  `merge_entries_live_newest_first_then_seed_newest_first`); added
+  `merge_entries_dedups_non_consecutive_duplicates_in_seed` (global-dedup
+  behaviour), `merge_entries_live_command_also_in_seed_appears_once_as_live`
+  (the duplicate-across-sources case), and the explicit regression guard
+  `merge_entries_recent_command_is_visible_within_cap_regression` (seed
+  larger than `MAX_VISIBLE_ENTRIES`, asserts the live command is first and
+  survives the empty-query cap).
+- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
+warnings`, `cargo fmt --all -- --check`, and `cargo machete` all clean.
+  (One `clippy::pedantic similar_names` fired on a `seen` local adjacent to
+  the `seed` parameter; renamed to `seen_texts`.)
 
 #### 106.6 — Paste-guard modal routes to wrong pane under focus-follows-mouse ✅ 2026-06-15
 

--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,7 @@
             };
           };
 
-          version = "0.9.0-beta.6";
+          version = "0.9.0";
 
           # The build sandbox strips `.git`, so the crate's build.rs `git
           # describe` can only ever yield "unknown".  Feed it a real value via
@@ -161,9 +161,9 @@
                     <key>CFBundleIdentifier</key>
                     <string>io.github.fredclausen.freminal</string>
                     <key>CFBundleVersion</key>
-                    <string>0.9.0-beta.6</string>
+                    <string>0.9.0</string>
                     <key>CFBundleShortVersionString</key>
-                    <string>0.9.0-beta.6</string>
+                    <string>0.9.0</string>
                     <key>CFBundleExecutable</key>
                     <string>freminal</string>
                     <key>CFBundleIconFile</key>

--- a/freminal-common/src/buffer_states/command_block.rs
+++ b/freminal-common/src/buffer_states/command_block.rs
@@ -156,21 +156,43 @@ impl CommandBlock {
         }
     }
 
-    /// Command execution duration if finished; `None` while still running or
-    /// if `SystemTime` arithmetic fails (clock skew).
+    /// Whether a command actually executed in this block.
+    ///
+    /// True iff `OSC 133 C` (output/execution start) was received, i.e.
+    /// [`Self::executed_at`] is `Some`.  A block where the user pressed
+    /// Ctrl-C at an idle prompt — `OSC 133 A` then `OSC 133 D` with no
+    /// intervening `C` — never executed a command and reports `false`.
+    ///
+    /// This is the signal that distinguishes a real (possibly instant)
+    /// command from an aborted prompt: the duration overlay and the
+    /// command-finished notification are both suppressed when this is
+    /// `false`.
+    #[must_use]
+    pub const fn executed(&self) -> bool {
+        self.executed_at.is_some()
+    }
+
+    /// Command execution duration if a command executed and finished; `None`
+    /// while still running, if no command executed, or if `SystemTime`
+    /// arithmetic fails (clock skew).
     ///
     /// Measured from [`Self::executed_at`] (`OSC 133 C`, command-execution
     /// start) to [`Self::finished_at`] (`OSC 133 D`).  This deliberately
     /// excludes the time the user spent typing the command at the prompt
     /// (`started_at` -> `executed_at`); measuring from `started_at` would
     /// report multi-second durations for instant commands whenever the user
-    /// paused at the prompt.  Falls back to `started_at` only when
-    /// `executed_at` is unknown (no `C` marker was received).
+    /// paused at the prompt.
+    ///
+    /// Returns `None` when no `OSC 133 C` was received ([`Self::executed`] is
+    /// `false`): such a block represents a prompt that was aborted (Ctrl-C)
+    /// before any command ran, so there is no execution interval to report.
+    /// Reporting a duration here would measure prompt-idle time, not command
+    /// time — the bug 106.2 fixes.
     #[must_use]
     pub fn duration(&self) -> Option<Duration> {
         let finished = self.finished_at?;
-        let anchor = self.executed_at.unwrap_or(self.started_at);
-        finished.duration_since(anchor).ok()
+        let executed = self.executed_at?;
+        finished.duration_since(executed).ok()
     }
 
     /// Row range covered by this block: `(start, end)`.  `end` is `None`
@@ -321,6 +343,8 @@ mod tests {
     #[test]
     fn duration_finished_after_start_is_some_positive() {
         let mut block = CommandBlock::new_running(0, None, "f1".to_owned());
+        // A command executed (C received) right at prompt start, ran 500ms.
+        block.executed_at = Some(block.started_at);
         block.finished_at = Some(block.started_at + Duration::from_millis(500));
         match block.duration() {
             Some(dur) => {
@@ -334,7 +358,8 @@ mod tests {
     #[test]
     fn duration_clock_skew_is_none() {
         let mut block = CommandBlock::new_running(0, None, "f1".to_owned());
-        // finished_at before started_at — clock skew
+        // Command executed, but finished_at is before executed_at — clock skew.
+        block.executed_at = Some(block.started_at);
         block.finished_at = Some(block.started_at - Duration::from_secs(1));
         assert!(
             block.duration().is_none(),
@@ -364,13 +389,48 @@ mod tests {
     }
 
     #[test]
-    fn duration_falls_back_to_started_at_when_executed_at_missing() {
-        // When no `OSC 133 C` was received (executed_at is None), fall back
-        // to started_at so a duration is still reported.
+    fn duration_is_none_when_executed_at_missing() {
+        // Regression for 106.2: when no `OSC 133 C` was received
+        // (executed_at is None) the prompt was aborted (Ctrl-C) before any
+        // command ran.  There is no execution interval, so duration() must
+        // report None rather than measuring prompt-idle time from
+        // started_at.
         let mut block = CommandBlock::new_running(0, None, "f1".to_owned());
         assert!(block.executed_at.is_none());
-        block.finished_at = Some(block.started_at + Duration::from_millis(250));
-        assert_eq!(block.duration(), Some(Duration::from_millis(250)));
+        // User idled 30s at the prompt then pressed Ctrl-C.
+        block.finished_at = Some(block.started_at + Duration::from_secs(30));
+        assert!(
+            block.duration().is_none(),
+            "an unexecuted (Ctrl-C) block must not report a duration"
+        );
+    }
+
+    // ── executed() ──────────────────────────────────────────────────────
+
+    #[test]
+    fn executed_false_until_output_start_received() {
+        // Fresh block: only A received.
+        let block = CommandBlock::new_running(0, None, "f1".to_owned());
+        assert!(!block.executed(), "block with no C marker has not executed");
+    }
+
+    #[test]
+    fn executed_true_once_executed_at_set() {
+        let mut block = CommandBlock::new_running(0, None, "f1".to_owned());
+        block.executed_at = Some(block.started_at + Duration::from_secs(1));
+        assert!(block.executed(), "block with a C marker has executed");
+    }
+
+    #[test]
+    fn executed_unaffected_by_finish_without_c() {
+        // A -> D with no C (Ctrl-C on idle prompt) stays "not executed".
+        let mut block = CommandBlock::new_running(0, None, "f1".to_owned());
+        block.finished_at = Some(block.started_at + Duration::from_secs(5));
+        block.exit_code = Some(130);
+        assert!(
+            !block.executed(),
+            "finishing without a C marker does not mark a block as executed"
+        );
     }
 
     #[test]

--- a/freminal-terminal-emulator/src/interface.rs
+++ b/freminal-terminal-emulator/src/interface.rs
@@ -550,6 +550,21 @@ impl TerminalEmulator {
             .map(|io| std::sync::Arc::clone(&io.echo_off))
     }
 
+    /// Return the shared PTY-reader shutdown flag.
+    ///
+    /// The PTY consumer thread sets this to `true` immediately before it
+    /// exits because the GUI dropped its input channel, so the reader thread
+    /// can treat the resulting send failure as an expected teardown rather
+    /// than an error.
+    ///
+    /// Returns `None` in headless / benchmark mode where there is no real PTY.
+    #[must_use]
+    pub fn reader_shutdown_atomic(&self) -> Option<std::sync::Arc<std::sync::atomic::AtomicBool>> {
+        self.pty_io
+            .as_ref()
+            .map(|io| std::sync::Arc::clone(&io.reader_shutdown))
+    }
+
     /// Return the OS process ID of the PTY child shell.
     ///
     /// Used by the GUI layer for CWD discovery (via a platform-specific path readback) when saving layouts and recording snapshots.

--- a/freminal-terminal-emulator/src/io/pty.rs
+++ b/freminal-terminal-emulator/src/io/pty.rs
@@ -63,6 +63,13 @@ pub struct FreminalPtyInputOutput {
     /// Used by the GUI layer for CWD discovery (via a platform-specific path readback) when saving layouts and recording snapshots.
     /// `None` on platforms where `portable_pty` cannot report the PID.
     pub child_pid: Option<u32>,
+    /// Shared shutdown flag for the PTY reader thread.
+    ///
+    /// Set to `true` by the PTY consumer thread immediately before it exits
+    /// because the GUI dropped its input channel. The reader thread reads it
+    /// to classify a failed `send` as an expected teardown rather than an
+    /// error. See [`RunTerminalResult::reader_shutdown`].
+    pub reader_shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// Return a safe temp directory path, bypassing `TMPDIR` which may be poisoned
@@ -171,6 +178,43 @@ pub struct RunTerminalResult {
     /// `None` on platforms where `portable_pty` cannot report the PID.
     /// Used by the GUI layer for CWD discovery (via a platform-specific path readback) when saving layouts and recording snapshots.
     pub child_pid: Option<u32>,
+    /// Shared shutdown flag for the PTY reader thread.
+    ///
+    /// The PTY consumer thread sets this to `true` immediately before it
+    /// exits due to the GUI dropping its input channel (pane/tab/window
+    /// teardown while the child is still alive). The reader thread reads it
+    /// when a `send` fails to distinguish an expected teardown (logged at
+    /// `debug`) from an anomalous receiver disappearance (logged at `error`).
+    pub reader_shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
+/// How the PTY reader thread should treat a failed `send` of PTY output.
+///
+/// The `PtyRead` receiver is owned by the PTY consumer thread. When a `send`
+/// fails the receiver is gone, but there are two very different reasons for
+/// that, and they must not be conflated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReaderSendFailure {
+    /// The consumer thread set the shutdown flag before exiting because the
+    /// GUI dropped the pane (pane/tab/window teardown while the child is
+    /// still alive). This is expected and should be logged at `debug`.
+    ExpectedShutdown,
+    /// The receiver disappeared while the reader was supposed to keep
+    /// running. This signals a real teardown-ordering bug and is logged at
+    /// `error`.
+    Anomalous,
+}
+
+/// Classify a failed PTY-output `send` using the shared shutdown flag.
+///
+/// Pure decision function so the reader thread's error-vs-debug branch is
+/// unit-testable without spawning a PTY.
+const fn classify_reader_send_failure(shutdown_signalled: bool) -> ReaderSendFailure {
+    if shutdown_signalled {
+        ReaderSendFailure::ExpectedShutdown
+    } else {
+        ReaderSendFailure::Anomalous
+    }
 }
 
 /// Process a single `PtyWrite` message: either write data or resize the PTY.
@@ -554,6 +598,16 @@ pub fn run_terminal(
         .try_clone_reader()
         .map_err(|e| PtyInitError::Spawn(e.to_string()))?;
 
+    // Shared shutdown flag. The PTY consumer thread (which owns the
+    // `PtyRead` receiver) sets this to `true` immediately before it exits
+    // because the GUI dropped its input channel — i.e. the pane/tab/window
+    // is being torn down while the child shell is still alive. When the
+    // reader's `send_tx.send()` then fails (the receiver is gone), this flag
+    // tells the reader the disconnect is an expected teardown rather than an
+    // anomaly, so it can exit quietly instead of logging an error.
+    let reader_shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let reader_shutdown_thread = std::sync::Arc::clone(&reader_shutdown);
+
     std::thread::Builder::new()
         .name(format!("freminal-pty-read-{pane_id}"))
         .spawn(move || {
@@ -580,7 +634,18 @@ pub fn run_terminal(
                     buf: data,
                     read_amount: amount_read,
                 }) {
-                    error!("Failed to send data to terminal: {e}");
+                    let signalled =
+                        reader_shutdown_thread.load(std::sync::atomic::Ordering::Acquire);
+                    match classify_reader_send_failure(signalled) {
+                        ReaderSendFailure::ExpectedShutdown => {
+                            debug!(
+                                "PTY read channel closed during shutdown; reader thread exiting"
+                            );
+                        }
+                        ReaderSendFailure::Anomalous => {
+                            error!("Failed to send data to terminal: {e}");
+                        }
+                    }
                     return;
                 }
             }
@@ -695,6 +760,7 @@ pub fn run_terminal(
         child_exit_rx,
         echo_off,
         child_pid,
+        reader_shutdown,
     })
 }
 
@@ -734,6 +800,7 @@ impl FreminalPtyInputOutput {
             child_exit_rx: result.child_exit_rx,
             echo_off: result.echo_off,
             child_pid: result.child_pid,
+            reader_shutdown: result.reader_shutdown,
         })
     }
 
@@ -889,5 +956,31 @@ mod locale_tests {
     #[test]
     fn locale_with_codeset_and_modifier_returned_unchanged() {
         assert_eq!(normalize_locale("en_US.UTF-8@euro"), "en_US.UTF-8@euro");
+    }
+}
+
+#[cfg(test)]
+mod reader_send_failure_tests {
+    use super::{ReaderSendFailure, classify_reader_send_failure};
+
+    #[test]
+    fn shutdown_signalled_is_expected_teardown() {
+        // The consumer thread set the flag before exiting (GUI dropped the
+        // pane). A failed send is the expected end-of-life event, not an
+        // error.
+        assert_eq!(
+            classify_reader_send_failure(true),
+            ReaderSendFailure::ExpectedShutdown
+        );
+    }
+
+    #[test]
+    fn no_shutdown_signal_is_anomalous() {
+        // The receiver vanished while the reader was supposed to keep
+        // running — a real teardown-ordering bug worth an error log.
+        assert_eq!(
+            classify_reader_send_failure(false),
+            ReaderSendFailure::Anomalous
+        );
     }
 }

--- a/freminal-windowing/src/egui_integration.rs
+++ b/freminal-windowing/src/egui_integration.rs
@@ -154,4 +154,13 @@ impl EguiState {
     pub(crate) fn modifiers(&self) -> egui::Modifiers {
         self.winit_state.egui_input().modifiers
     }
+
+    /// Free the painter's OpenGL resources.
+    ///
+    /// Must be called while this window's GL context is current and before the
+    /// painter is dropped. `egui_glow::Painter::destroy` is idempotent (guarded
+    /// by an internal `destroyed` flag), so calling it more than once is safe.
+    pub(crate) fn destroy_painter(&mut self) {
+        self.painter.destroy();
+    }
 }

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -63,6 +63,26 @@ struct WindowState {
     repaint_at: Option<Instant>,
 }
 
+impl WindowState {
+    /// Release the egui-glow painter's GPU resources before this window's
+    /// state is dropped.
+    ///
+    /// `egui_glow::Painter` owns OpenGL objects (program, textures, VBO/EBO)
+    /// that must be freed with `destroy()` while the owning GL context is
+    /// current; otherwise the painter's `Drop` impl logs a "you forgot to call
+    /// `destroy()`" resource-leak warning. This runs on every window close
+    /// (including the standalone settings window) and at event-loop exit.
+    fn destroy_egui(&mut self) {
+        if let Err(e) = self.gl.make_current() {
+            // If the context can't be made current we still call destroy()
+            // below — it is a no-op-safe GL teardown — but the GL calls may
+            // not take effect. Log so the cause is visible.
+            tracing::warn!("make_current failed during painter teardown: {e}");
+        }
+        self.egui.destroy_painter();
+    }
+}
+
 /// Main application handler that owns the `App` and all window state.
 struct Handler<A: App> {
     app: A,
@@ -202,8 +222,11 @@ impl<A: App> Handler<A> {
     }
 
     fn close_window(&mut self, winit_id: winit::window::WindowId) {
-        if let Some(state) = self.windows.remove(&winit_id) {
-            // Destroy painter before GL context
+        if let Some(mut state) = self.windows.remove(&winit_id) {
+            // Free the egui-glow painter's GPU resources while this window's
+            // GL context is still current, then drop in dependency order:
+            // egui (painter) -> gl context -> window.
+            state.destroy_egui();
             drop(state.egui);
             drop(state.gl);
             drop(state.window);
@@ -611,6 +634,21 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
         }
 
         self.update_control_flow(event_loop);
+    }
+
+    fn exiting(&mut self, _event_loop: &ActiveEventLoop) {
+        // The event loop is shutting down irreversibly. Any windows still in
+        // the map (e.g. when `exit()` was called without routing every window
+        // through `close_window`) must have their egui-glow painters torn down
+        // so they don't leak / warn on drop.
+        let ids: Vec<winit::window::WindowId> = self.windows.keys().copied().collect();
+        for winit_id in ids {
+            if let Some(state) = self.windows.get_mut(&winit_id) {
+                state.destroy_egui();
+            }
+        }
+        self.windows.clear();
+        debug!("Event loop exiting; all painters destroyed");
     }
 }
 

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -482,10 +482,42 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
 
                 // Process egui viewport commands.
                 let mut should_close = false;
+                let mut paste_requested = false;
                 for cmd in frame_output.commands {
-                    process_viewport_command(&state.window, cmd, &mut should_close);
+                    process_viewport_command(
+                        &state.window,
+                        cmd,
+                        &mut should_close,
+                        &mut paste_requested,
+                    );
                 }
 
+                // Honour `ViewportCommand::RequestPaste` (e.g. the terminal
+                // right-click "Paste" menu entry). egui-winit does not action
+                // this command itself in our custom integration — unlike
+                // eframe, which we replaced — so we read the clipboard and
+                // inject `Event::Paste` here, mirroring the keyboard paste
+                // interceptor. The cross-window `find_map` works around the
+                // Wayland per-window clipboard quirk documented there.
+                if paste_requested {
+                    let text = windows
+                        .values_mut()
+                        .find_map(|state| state.egui.clipboard_text());
+                    if let Some(text) = text {
+                        let text = text.replace("\r\n", "\n");
+                        if !text.is_empty()
+                            && let Some(state) = windows.get_mut(&winit_id)
+                        {
+                            state.egui.inject_paste(text);
+                            state.repaint_at = Some(Instant::now());
+                        }
+                    }
+                }
+
+                let Some(state) = windows.get_mut(&winit_id) else {
+                    self.update_control_flow(event_loop);
+                    return;
+                };
                 state.repaint_at = None;
 
                 // Honour egui's repaint_delay but clamp to a minimum of 16ms
@@ -582,21 +614,70 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
     }
 }
 
+/// Side-effect flags a viewport command raises that the caller must action
+/// after the per-frame command loop completes (rather than inline, because
+/// each needs `&mut` access to state the command loop has borrowed).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct ViewportCommandFlags {
+    /// The window should be closed (via `on_close_requested`).
+    should_close: bool,
+    /// A clipboard paste was requested (e.g. the right-click "Paste" menu).
+    paste_requested: bool,
+}
+
+/// Classify a viewport command into the deferred side-effect flags it raises.
+///
+/// Pure and window-free so it is unit-testable without a live event loop. The
+/// window-affecting commands (title, size, focus, …) return the default
+/// (no flags) and are actioned by [`process_viewport_command`].
+const fn viewport_command_flags(cmd: &egui::ViewportCommand) -> ViewportCommandFlags {
+    match cmd {
+        egui::ViewportCommand::Close => ViewportCommandFlags {
+            should_close: true,
+            paste_requested: false,
+        },
+        egui::ViewportCommand::RequestPaste => ViewportCommandFlags {
+            should_close: false,
+            paste_requested: true,
+        },
+        _ => ViewportCommandFlags {
+            should_close: false,
+            paste_requested: false,
+        },
+    }
+}
+
 /// Process a single egui `ViewportCommand` by mapping it to the corresponding
 /// winit `Window` API call.
 ///
 /// Commands that require closing the window set `*should_close = true`; the
 /// caller is responsible for actually closing the window after the frame
 /// completes (to avoid mutating the window map during iteration).
-fn process_viewport_command(window: &Window, cmd: egui::ViewportCommand, should_close: &mut bool) {
+///
+/// `ViewportCommand::RequestPaste` sets `*paste_requested = true` instead of
+/// being handled inline: clipboard reads need cross-window fallback on Wayland
+/// (see the keyboard paste interceptor in [`Handler::window_event`]), which
+/// requires `&mut` access to the whole window map. The caller injects the
+/// paste after the command loop completes.
+fn process_viewport_command(
+    window: &Window,
+    cmd: egui::ViewportCommand,
+    should_close: &mut bool,
+    paste_requested: &mut bool,
+) {
+    let flags = viewport_command_flags(&cmd);
+    *should_close |= flags.should_close;
+    *paste_requested |= flags.paste_requested;
+
     match cmd {
-        egui::ViewportCommand::Close => {
-            *should_close = true;
-        }
-        egui::ViewportCommand::CancelClose => {
-            // In our model, close is synchronous via on_close_requested.
-            // CancelClose is a no-op since we don't queue deferred closes.
-        }
+        // No-op inline:
+        // - `Close` / `RequestPaste` are deferred via `viewport_command_flags`
+        //   above and actioned by the caller after the command loop.
+        // - `CancelClose`: close is synchronous via `on_close_requested`, so
+        //   there is no queued deferred close to cancel.
+        egui::ViewportCommand::Close
+        | egui::ViewportCommand::RequestPaste
+        | egui::ViewportCommand::CancelClose => {}
         egui::ViewportCommand::Title(title) => {
             window.set_title(&title);
         }
@@ -680,7 +761,53 @@ pub fn run(config: WindowConfig, app: impl App + 'static) -> Result<(), Error> {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-    use super::{logical_coord_to_i32, logical_dim_to_u32};
+    use super::{
+        ViewportCommandFlags, logical_coord_to_i32, logical_dim_to_u32, viewport_command_flags,
+    };
+
+    #[test]
+    fn request_paste_command_sets_only_paste_flag() {
+        // Regression (PLANNING #1 / Task 106.1): the terminal right-click
+        // "Paste" menu sends `ViewportCommand::RequestPaste`. Before the fix
+        // this command fell through to the catch-all log-and-ignore arm, so
+        // right-click paste silently did nothing.
+        assert_eq!(
+            viewport_command_flags(&egui::ViewportCommand::RequestPaste),
+            ViewportCommandFlags {
+                should_close: false,
+                paste_requested: true,
+            }
+        );
+    }
+
+    #[test]
+    fn close_command_sets_only_close_flag() {
+        assert_eq!(
+            viewport_command_flags(&egui::ViewportCommand::Close),
+            ViewportCommandFlags {
+                should_close: true,
+                paste_requested: false,
+            }
+        );
+    }
+
+    #[test]
+    fn window_affecting_commands_raise_no_flags() {
+        // Title / focus / etc. are actioned inline against the winit window
+        // and must not set the deferred flags.
+        assert_eq!(
+            viewport_command_flags(&egui::ViewportCommand::Title("x".to_owned())),
+            ViewportCommandFlags::default()
+        );
+        assert_eq!(
+            viewport_command_flags(&egui::ViewportCommand::Focus),
+            ViewportCommandFlags::default()
+        );
+        assert_eq!(
+            viewport_command_flags(&egui::ViewportCommand::CancelClose),
+            ViewportCommandFlags::default()
+        );
+    }
 
     #[test]
     fn logical_dim_to_u32_clamps_non_positive_and_non_finite() {

--- a/freminal/Cargo.toml
+++ b/freminal/Cargo.toml
@@ -34,7 +34,7 @@ deb_depends = ["libgl1-mesa-glx"]
 # `cargo xtask bump-version` keeps this in sync, translating the SemVer
 # pre-release separator to the RPM tilde operator (e.g. "0.9.0~beta.2"), which
 # sorts older than the final release just like the SemVer pre-release does.
-version = "0.9.0~beta.6"
+version = "0.9.0"
 assets = [
   { source = "target/release/freminal", dest = "/usr/bin/freminal", mode = "755" },
 ]

--- a/freminal/src/gui/actions.rs
+++ b/freminal/src/gui/actions.rs
@@ -20,8 +20,38 @@ impl PerWindowState {
             self.renaming_tab = None;
             self.rename_buffer.clear();
         }
-        if let Err(e) = self.tabs.close_tab(index) {
-            trace!("Cannot close tab: {e}");
+        // Only the active (visible) tab closing actually transfers focus to a
+        // newly-visible pane. Closing a background tab leaves the visible pane
+        // unchanged, so it must NOT receive a spurious focus event.
+        let closing_active_tab = index == self.tabs.active_index();
+
+        match self.tabs.close_tab(index) {
+            Ok(_removed) => {
+                // The removed tab's panes are dropped here, closing their PTY
+                // channels naturally. When the active tab is closed, the tab
+                // that slides into the active slot becomes visible, so its
+                // active pane must receive focus — mirroring the close-pane and
+                // PTY-death paths. Without this, a pane whose app uses focus
+                // reporting (?1004) is left believing it is unfocused.
+                if closing_active_tab {
+                    Self::notify_active_pane_focused(self.tabs.active_tab_mut());
+                }
+            }
+            Err(e) => trace!("Cannot close tab: {e}"),
+        }
+    }
+
+    /// Send `FocusChange(true)` to the active pane of `tab`.
+    ///
+    /// Used by the tab-close path so the pane that becomes visible learns it
+    /// is focused. A send failure is logged but non-fatal (the pane may be
+    /// mid-teardown).
+    fn notify_active_pane_focused(tab: &mut super::tabs::Tab) {
+        if let Some(pane) = tab.active_pane_mut() {
+            let pane_id = pane.id;
+            if let Err(e) = pane.input_tx.send(InputEvent::FocusChange(true)) {
+                error!("Failed to send FocusChange(true) to pane {pane_id} on tab close: {e}");
+            }
         }
     }
 
@@ -849,5 +879,82 @@ impl super::FreminalGui {
         if let Err(e) = pane.input_tx.send(InputEvent::Key(wrapped.into_bytes())) {
             error!("Paste: failed to send paste to PTY: {e}");
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::gui::panes::{Pane, PaneId};
+    use crate::gui::tabs::{Tab, TabId};
+    use crate::gui::view_state::ViewState;
+    use arc_swap::ArcSwap;
+    use crossbeam_channel::Receiver;
+    use freminal_common::buffer_states::tchar::TChar;
+    use freminal_terminal_emulator::snapshot::TerminalSnapshot;
+    use std::sync::{Arc, atomic::AtomicBool};
+
+    /// Build a `Tab` whose active pane's `input_rx` is returned to the caller
+    /// so emitted `InputEvent`s can be observed.
+    fn tab_with_input_rx(id: TabId, pane_id: PaneId) -> (Tab, Receiver<InputEvent>) {
+        let arc_swap = Arc::new(ArcSwap::from_pointee(TerminalSnapshot::empty()));
+        let (input_tx, input_rx) = crossbeam_channel::unbounded();
+        let (pty_write_tx, _pty_write_rx) = crossbeam_channel::unbounded();
+        let (_window_cmd_tx, window_cmd_rx) = crossbeam_channel::unbounded();
+        let (_clipboard_tx, clipboard_rx) = crossbeam_channel::bounded(1);
+        let (_search_buffer_tx, search_buffer_rx) =
+            crossbeam_channel::bounded::<(usize, Vec<TChar>)>(1);
+        let (_pty_dead_tx, pty_dead_rx) = crossbeam_channel::bounded(1);
+        let (_command_event_tx, command_event_rx) = crossbeam_channel::unbounded();
+
+        let pane = Pane {
+            id: pane_id,
+            arc_swap,
+            input_tx,
+            pty_write_tx,
+            window_cmd_rx,
+            clipboard_rx,
+            search_buffer_rx,
+            pty_dead_rx,
+            command_event_rx,
+            recent_commands: std::collections::VecDeque::new(),
+            history_seed: crate::gui::shell_history::new_seeded_history(),
+            shell_program: None,
+            shell_histfile_last_seen: None,
+            command_texts: std::collections::HashMap::new(),
+            title: format!("pane-{pane_id}"),
+            bell_active: false,
+            pending_copy: false,
+            title_stack: Vec::new(),
+            view_state: ViewState::new(),
+            echo_off: Arc::new(AtomicBool::new(false)),
+            child_pid: None,
+            render_state: crate::gui::terminal::new_render_state(Arc::new(std::sync::Mutex::new(
+                crate::gui::renderer::WindowPostRenderer::new(),
+            ))),
+            render_cache: crate::gui::terminal::PaneRenderCache::new(),
+        };
+
+        (Tab::new(id, pane), input_rx)
+    }
+
+    #[test]
+    fn notify_active_pane_focused_sends_focus_gained() {
+        // Regression (106.4): closing the active tab must hand focus to the
+        // pane that becomes visible, mirroring the close-pane / PTY-death
+        // paths. Verify the focus-gained event actually reaches the pane.
+        let (mut tab, rx) = tab_with_input_rx(TabId::first(), PaneId::first());
+
+        PerWindowState::notify_active_pane_focused(&mut tab);
+
+        match rx.try_recv() {
+            Ok(InputEvent::FocusChange(true)) => {}
+            other => panic!("expected FocusChange(true), got {other:?}"),
+        }
+        assert!(
+            rx.try_recv().is_err(),
+            "exactly one focus event should be sent"
+        );
     }
 }

--- a/freminal/src/gui/actions.rs
+++ b/freminal/src/gui/actions.rs
@@ -785,7 +785,16 @@ impl super::FreminalGui {
         if analysis.is_safe() {
             Self::send_paste_to_active_pane(win, text);
         } else {
-            win.paste_dialog.open(text, analysis);
+            // Capture the destination pane *now*, before the confirm dialog
+            // opens. With focus-follows-mouse enabled the user moving the
+            // cursor onto the dialog's buttons changes the active pane, so we
+            // must remember where the paste was headed (Task 106 bug).
+            let tab = win.tabs.active_tab();
+            let target = super::paste_guard::PasteTarget {
+                tab_id: tab.id,
+                pane_id: tab.active_pane,
+            };
+            win.paste_dialog.open(text, analysis, target);
         }
     }
 
@@ -795,12 +804,42 @@ impl super::FreminalGui {
     /// Used both for the `Safe` fast path and when the user confirms a flagged
     /// paste via the dialog. A send failure (dead PTY) is logged, not fatal.
     pub(super) fn send_paste_to_active_pane(win: &mut PerWindowState, payload: String) {
-        use freminal_common::buffer_states::modes::rl_bracket::RlBracket;
-
         let Some(pane) = win.tabs.active_tab_mut().active_pane_mut() else {
             warn!("Paste: active tab has no active pane");
             return;
         };
+        Self::send_paste_to_pane_ref(pane, payload);
+    }
+
+    /// Send `payload` to the specific pane identified by `target`, regardless
+    /// of which pane is currently active.
+    ///
+    /// Used to resolve a confirmed flagged paste (Task 77 dialog): the target
+    /// is captured when the dialog opens so that focus moving to the dialog
+    /// buttons (e.g. under focus-follows-mouse) cannot redirect the paste to
+    /// the wrong pane (Task 106 bug). If the target pane no longer exists (it
+    /// was closed while the dialog was open) the paste is dropped with a log.
+    pub(super) fn send_paste_to_target(
+        win: &mut PerWindowState,
+        target: super::paste_guard::PasteTarget,
+        payload: String,
+    ) {
+        let Some(tab) = win.tabs.iter_mut().find(|t| t.id == target.tab_id) else {
+            warn!("Paste: target tab no longer exists; dropping paste");
+            return;
+        };
+        let Some(pane) = tab.pane_tree.find_mut(target.pane_id) else {
+            warn!("Paste: target pane no longer exists; dropping paste");
+            return;
+        };
+        Self::send_paste_to_pane_ref(pane, payload);
+    }
+
+    /// Wrap `payload` for bracketed paste (when `pane` has it enabled) and
+    /// send it to `pane`'s PTY. Shared by the active-pane and targeted paths.
+    fn send_paste_to_pane_ref(pane: &super::panes::Pane, payload: String) {
+        use freminal_common::buffer_states::modes::rl_bracket::RlBracket;
+
         let snap = pane.arc_swap.load();
         let wrapped = if snap.bracketed_paste == RlBracket::Enabled {
             format!("\x1b[200~{payload}\x1b[201~")

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -730,6 +730,12 @@ impl freminal_windowing::App for FreminalGui {
             // Try to close just the dead pane within its tab.
             let is_active_tab = tab_idx == win.tabs.active_index();
 
+            // Capture the originally-active tab's stable id so we can restore
+            // focus to *that* tab afterwards. Restoring by index is wrong:
+            // closing a tab at a lower index shifts the active tab left, and
+            // the dead pane's `tab_idx` is not the user's active tab.
+            let original_active_tab_id = win.tabs.active_tab().id;
+
             // Switch to the dead pane's tab temporarily if needed so we can
             // operate on it.
             if !is_active_tab && let Err(e) = win.tabs.switch_to(tab_idx) {
@@ -793,11 +799,16 @@ impl freminal_windowing::App for FreminalGui {
                 }
             }
 
-            // Restore the original active tab if we switched away.
+            // Restore the originally-active tab if we switched away. Look it
+            // up by stable id rather than by index, since a tab close during
+            // this iteration may have shifted indices. If the originally-active
+            // tab was itself closed, leave the active index where `close_tab`
+            // placed it.
             if !is_active_tab {
-                // The tab we were on may have been removed, so saturate.
-                let restore_idx = tab_idx.min(win.tabs.tab_count().saturating_sub(1));
-                let _ = win.tabs.switch_to(restore_idx);
+                let restore_idx = win.tabs.iter().position(|t| t.id == original_active_tab_id);
+                if let Some(restore_idx) = restore_idx {
+                    let _ = win.tabs.switch_to(restore_idx);
+                }
             }
         }
 

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -1130,8 +1130,12 @@ impl freminal_windowing::App for FreminalGui {
             // resolved (possibly edited) payload is sent to the active pane;
             // on cancel the paste is discarded.
             match win.paste_dialog.show(ctx) {
-                super::paste_guard::PasteDialogOutcome::Paste(payload) => {
-                    Self::send_paste_to_active_pane(&mut win, payload);
+                super::paste_guard::PasteDialogOutcome::Paste { payload, target } => {
+                    // Route to the pane captured when the dialog opened, not
+                    // the currently-active pane: focus-follows-mouse can change
+                    // the active pane when the cursor moves onto the dialog
+                    // buttons (Task 106 bug).
+                    Self::send_paste_to_target(&mut win, target, payload);
                 }
                 super::paste_guard::PasteDialogOutcome::Cancelled
                 | super::paste_guard::PasteDialogOutcome::Idle => {}

--- a/freminal/src/gui/command_history.rs
+++ b/freminal/src/gui/command_history.rs
@@ -228,28 +228,39 @@ fn append_row_text(row: &[TChar], out: &mut String) {
 //  Entry merging and filtering
 // ---------------------------------------------------------------------------
 
-/// Merge the shell-history seed (oldest first) with the live recent
-/// commands (oldest first) into a single de-duplicated entry list.
+/// Merge the live recent commands with the shell-history seed into a
+/// single de-duplicated, **most-recent-first** entry list.
 ///
-/// **Ordering:** seed entries come first in the order they were loaded,
-/// followed by live entries in insertion order.  This puts the most
-/// recent live commands at the bottom of the list -- closest to where
-/// the user's eye naturally lands when the modal opens with selection
-/// `0`.  Commit 3 polish may invert this; commit 2 keeps the data flow
-/// trivially predictable.
+/// **Ordering (106.5):** the most recently run command appears first.
+/// Live OSC 133 entries are emitted newest-first (this session's
+/// commands), followed by the shell-history seed newest-first.  This
+/// matters for more than aesthetics: the rendered list is capped at
+/// [`MAX_VISIBLE_ENTRIES`], and the seed can hold up to
+/// [`crate::gui::shell_history::HISTORY_SEED_CAP`] entries.  With the
+/// old oldest-first ordering, the cap sliced off the tail where this
+/// session's live commands lived, so a command just typed never
+/// appeared in the unfiltered list (it surfaced only when searched for,
+/// because filtering scans the whole list before the cap is applied).
+/// Newest-first puts recent commands at the top, inside the cap, and
+/// pairs with the palette's default selection of index `0`.
 ///
-/// **De-duplication:** a live entry whose text matches a seed entry is
-/// kept (the live variant carries an exit-code badge that the seed does
-/// not).  Consecutive duplicates within either source are collapsed,
-/// matching the spirit of `HISTCONTROL=ignoredups` -- two identical
-/// invocations back-to-back are noise.
+/// **De-duplication:** dedup is global by command text, first
+/// occurrence wins.  Because live entries are walked before seed
+/// entries, the most-recent (live) variant of a repeated command is the
+/// one kept -- it carries the exit-code badge the seed lacks -- and a
+/// command that was both run this session and present in the history
+/// file appears exactly once, near the top, rather than twice.  This
+/// also subsumes the previous `HISTCONTROL=ignoredups`-style collapse of
+/// back-to-back duplicates.
 ///
 /// `seed` is the optional shell-history seed (`None` = loader thread
-/// has not finished yet, or the shell has no recognised history file).
-/// `recent` is the pane's live `recent_commands` ring buffer.
-/// `texts` is the per-pane text cache keyed by [`CommandBlockId`];
-/// live entries without a cache hit are dropped (their text could not
-/// be extracted from the snapshot at finish time).
+/// has not finished yet, or the shell has no recognised history file);
+/// it is stored oldest-first, so it is iterated in reverse here.
+/// `recent` is the pane's live `recent_commands` ring buffer (stored
+/// oldest-first, also iterated in reverse).  `texts` is the per-pane
+/// text cache keyed by [`CommandBlockId`]; live entries without a cache
+/// hit are dropped (their text could not be extracted from the snapshot
+/// at finish time).
 #[must_use]
 pub fn merge_entries(
     seed: Option<&Vec<String>>,
@@ -257,26 +268,10 @@ pub fn merge_entries(
     texts: &HashMap<CommandBlockId, String>,
 ) -> Vec<PaletteEntry> {
     let mut out: Vec<PaletteEntry> = Vec::new();
-    let mut last_text: Option<String> = None;
+    let mut seen_texts: std::collections::HashSet<String> = std::collections::HashSet::new();
 
-    if let Some(seed_vec) = seed {
-        for cmd in seed_vec {
-            let trimmed = cmd.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            if last_text.as_deref() == Some(trimmed) {
-                continue;
-            }
-            last_text = Some(trimmed.to_owned());
-            out.push(PaletteEntry {
-                text: trimmed.to_owned(),
-                kind: EntryKind::Seed,
-            });
-        }
-    }
-
-    for block in recent {
+    // Live entries first, newest-first (the ring is stored oldest-first).
+    for block in recent.iter().rev() {
         let Some(text) = texts.get(&block.id) else {
             continue;
         };
@@ -284,10 +279,9 @@ pub fn merge_entries(
         if trimmed.is_empty() {
             continue;
         }
-        if last_text.as_deref() == Some(trimmed) {
+        if !seen_texts.insert(trimmed.to_owned()) {
             continue;
         }
-        last_text = Some(trimmed.to_owned());
         out.push(PaletteEntry {
             text: trimmed.to_owned(),
             kind: EntryKind::Live {
@@ -295,6 +289,23 @@ pub fn merge_entries(
                 status: block.status(),
             },
         });
+    }
+
+    // Then the shell-history seed, newest-first (stored oldest-first).
+    if let Some(seed_vec) = seed {
+        for cmd in seed_vec.iter().rev() {
+            let trimmed = cmd.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if !seen_texts.insert(trimmed.to_owned()) {
+                continue;
+            }
+            out.push(PaletteEntry {
+                text: trimmed.to_owned(),
+                kind: EntryKind::Seed,
+            });
+        }
     }
 
     out
@@ -711,25 +722,46 @@ mod tests {
     }
 
     #[test]
-    fn merge_entries_seed_only_preserves_order() {
+    fn merge_entries_seed_only_is_newest_first() {
+        // Seed is stored oldest-first; the palette presents it
+        // newest-first (106.5).
         let seed = vec!["ls".to_owned(), "pwd".to_owned(), "echo hi".to_owned()];
         let recent = VecDeque::new();
         let texts = HashMap::new();
         let merged = merge_entries(Some(&seed), &recent, &texts);
         assert_eq!(merged.len(), 3);
-        assert_eq!(merged[0].text, "ls");
+        assert_eq!(merged[0].text, "echo hi");
         assert_eq!(merged[1].text, "pwd");
-        assert_eq!(merged[2].text, "echo hi");
+        assert_eq!(merged[2].text, "ls");
         assert!(matches!(merged[0].kind, EntryKind::Seed));
     }
 
     #[test]
-    fn merge_entries_collapses_consecutive_duplicates_in_seed() {
+    fn merge_entries_collapses_duplicates_in_seed() {
+        // Global text dedup keeps the first (newest) occurrence.
         let seed = vec!["ls".to_owned(), "ls".to_owned(), "pwd".to_owned()];
         let recent = VecDeque::new();
         let texts = HashMap::new();
         let merged = merge_entries(Some(&seed), &recent, &texts);
         assert_eq!(merged.len(), 2);
+        // Newest-first: pwd (newest) then the single surviving ls.
+        assert_eq!(merged[0].text, "pwd");
+        assert_eq!(merged[1].text, "ls");
+    }
+
+    #[test]
+    fn merge_entries_dedups_non_consecutive_duplicates_in_seed() {
+        // Old behaviour only collapsed *consecutive* duplicates; the
+        // 106.5 global dedup also collapses an entry repeated later in
+        // history, keeping the most-recent (first-seen, newest-first)
+        // occurrence.
+        let seed = vec!["ls".to_owned(), "pwd".to_owned(), "ls".to_owned()];
+        let recent = VecDeque::new();
+        let texts = HashMap::new();
+        let merged = merge_entries(Some(&seed), &recent, &texts);
+        assert_eq!(merged.len(), 2);
+        // Walking newest-first: the trailing "ls" is seen first and kept;
+        // "pwd" next; the leading "ls" is a duplicate and dropped.
         assert_eq!(merged[0].text, "ls");
         assert_eq!(merged[1].text, "pwd");
     }
@@ -776,10 +808,13 @@ mod tests {
     }
 
     #[test]
-    fn merge_entries_seed_first_then_live_in_insertion_order() {
+    fn merge_entries_live_newest_first_then_seed_newest_first() {
+        // 106.5: live commands (this session) come first, newest-first;
+        // then the seed, newest-first.
         let seed = vec!["ls".to_owned()];
         let mut recent = VecDeque::new();
         let mut texts = HashMap::new();
+        // Pushed oldest-first into the ring: "pwd" then "make".
         for cmd in ["pwd", "make"] {
             let block = finished_block(0, Some(1), Some(2), Some(0));
             texts.insert(block.id, cmd.to_owned());
@@ -788,9 +823,64 @@ mod tests {
 
         let merged = merge_entries(Some(&seed), &recent, &texts);
         assert_eq!(merged.len(), 3);
-        assert_eq!(merged[0].text, "ls");
+        // Live newest-first: "make" (most recent), then "pwd".
+        assert_eq!(merged[0].text, "make");
+        assert!(matches!(merged[0].kind, EntryKind::Live { .. }));
         assert_eq!(merged[1].text, "pwd");
-        assert_eq!(merged[2].text, "make");
+        assert!(matches!(merged[1].kind, EntryKind::Live { .. }));
+        // Then the seed.
+        assert_eq!(merged[2].text, "ls");
+        assert!(matches!(merged[2].kind, EntryKind::Seed));
+    }
+
+    #[test]
+    fn merge_entries_live_command_also_in_seed_appears_once_as_live() {
+        // A command run this session that is also present in the history
+        // file must appear exactly once, near the top, as the Live
+        // variant (carrying the exit-code badge) -- not twice.
+        let seed = vec!["git status".to_owned(), "ls".to_owned()];
+        let mut recent = VecDeque::new();
+        let block = finished_block(0, Some(1), Some(2), Some(0));
+        let id = block.id;
+        recent.push_back(block);
+        let mut texts = HashMap::new();
+        texts.insert(id, "git status".to_owned());
+
+        let merged = merge_entries(Some(&seed), &recent, &texts);
+        // "git status" (live, newest), then seed "ls". The seed copy of
+        // "git status" is deduplicated away.
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].text, "git status");
+        assert!(matches!(merged[0].kind, EntryKind::Live { .. }));
+        assert_eq!(merged[1].text, "ls");
+        assert!(matches!(merged[1].kind, EntryKind::Seed));
+    }
+
+    #[test]
+    fn merge_entries_recent_command_is_visible_within_cap_regression() {
+        // 106.5 regression guard: a command typed this session must be
+        // visible in the *unfiltered* list even when the seed is larger
+        // than MAX_VISIBLE_ENTRIES. Previously the oldest-first ordering
+        // pushed live entries past the cap so they only surfaced when
+        // explicitly searched for.
+        let seed: Vec<String> = (0..(MAX_VISIBLE_ENTRIES * 3))
+            .map(|i| format!("old-cmd-{i}"))
+            .collect();
+        let mut recent = VecDeque::new();
+        let block = finished_block(0, Some(1), Some(2), Some(0));
+        let id = block.id;
+        recent.push_back(block);
+        let mut texts = HashMap::new();
+        texts.insert(id, "random command".to_owned());
+
+        let merged = merge_entries(Some(&seed), &recent, &texts);
+        // The live command is the very first entry...
+        assert_eq!(merged[0].text, "random command");
+        // ...and an empty-query filter (which applies the cap) still
+        // includes it.
+        let filtered = filter_entries(&merged, "");
+        assert_eq!(filtered.len(), MAX_VISIBLE_ENTRIES);
+        assert_eq!(filtered[0].text, "random command");
     }
 
     #[test]

--- a/freminal/src/gui/notifications.rs
+++ b/freminal/src/gui/notifications.rs
@@ -100,6 +100,16 @@ pub(super) fn command_finished_request(
         return None;
     }
 
+    // 106.3: a block that finished without ever executing a command (no
+    // `OSC 133 C` — e.g. Ctrl-C on an idle prompt) must not notify.  No
+    // command ran, so there is nothing to report.  This is explicit rather
+    // than relying on `duration()` returning `None` for the same case, so a
+    // zero/low `command_finished_threshold_secs` cannot resurrect the
+    // spurious notification.
+    if !block.executed() {
+        return None;
+    }
+
     let duration = block.duration()?;
     if duration.as_secs_f32() < config.command_finished_threshold_secs {
         return None;
@@ -507,6 +517,38 @@ mod tests {
         };
         let config = enabled_config(0.0);
         assert!(command_finished_request(&running, "ls", "tab", &config).is_none());
+    }
+
+    #[test]
+    fn command_finished_request_unexecuted_ctrl_c_block_is_none() {
+        // Regression for 106.3: Ctrl-C on an idle prompt produces a finished
+        // block (A -> D) that never executed a command (no `OSC 133 C`, so
+        // executed_at / output_start_row are None).  Even at a zero threshold
+        // — which would let `duration()` of an executed instant command
+        // through — no notification must fire.
+        use freminal_common::buffer_states::command_block::CommandBlockId;
+        use std::time::{Duration, SystemTime};
+        let started = SystemTime::now();
+        let ctrl_c = CommandBlock {
+            id: CommandBlockId::next(),
+            fid: "t".to_owned(),
+            prompt_start_row: 0,
+            command_start_row: Some(0),
+            // No C marker: the user aborted before any command ran.
+            output_start_row: None,
+            end_row: Some(0),
+            exit_code: Some(130),
+            cwd: None,
+            // User idled 30s at the prompt before Ctrl-C.
+            started_at: started,
+            executed_at: None,
+            finished_at: Some(started + Duration::from_secs(30)),
+        };
+        let config = enabled_config(0.0);
+        assert!(
+            command_finished_request(&ctrl_c, "", "tab", &config).is_none(),
+            "an aborted prompt that never executed a command must not notify"
+        );
     }
 
     #[test]

--- a/freminal/src/gui/paste_guard.rs
+++ b/freminal/src/gui/paste_guard.rs
@@ -25,6 +25,24 @@ use std::fmt::Write as _;
 use freminal_common::config::PasteGuardConfig;
 use regex::Regex;
 
+use super::panes::PaneId;
+use super::tabs::TabId;
+
+/// Identifies the pane a flagged paste was destined for when its confirmation
+/// dialog opened.
+///
+/// Captured at dialog-open time and carried through to confirmation so the
+/// payload lands in the originating pane even if focus moved in the meantime
+/// — e.g. with focus-follows-mouse enabled, moving the cursor onto the
+/// dialog's "Paste Anyway" button changes the active pane (Task 106 bug).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::gui) struct PasteTarget {
+    /// The tab that owned the paste when the dialog opened.
+    pub tab_id: TabId,
+    /// The pane within that tab that the paste was destined for.
+    pub pane_id: PaneId,
+}
+
 /// The classification of a paste payload produced by [`analyze`].
 ///
 /// `Safe` means no enabled trigger fired and the payload may be sent
@@ -238,8 +256,15 @@ pub(in crate::gui) enum PasteDialogOutcome {
     Cancelled,
     /// The user confirmed. The carried payload (original or edited) must be
     /// sent to the PTY by the caller (77.4), which owns bracketed-paste
-    /// wrapping and PTY routing.
-    Paste(String),
+    /// wrapping and PTY routing. `target` identifies the pane the paste was
+    /// destined for when the dialog opened, so the caller routes there rather
+    /// than to whatever pane is active at confirmation time.
+    Paste {
+        /// The paste payload (original or edited content).
+        payload: String,
+        /// The pane the paste was originally destined for.
+        target: PasteTarget,
+    },
 }
 
 /// State for a single open confirm-paste dialog.
@@ -254,6 +279,8 @@ struct PasteDialogState {
     editing: bool,
     /// Scratch buffer for the edit mode, initialised from `payload`.
     edit_buffer: String,
+    /// The pane the paste was destined for when the dialog opened.
+    target: PasteTarget,
 }
 
 /// The confirm-paste modal dialog (Task 77.3).
@@ -269,10 +296,16 @@ pub(in crate::gui) struct PasteDialog {
 }
 
 impl PasteDialog {
-    /// Open the dialog for `payload` with its precomputed `analysis`.
+    /// Open the dialog for `payload` with its precomputed `analysis`,
+    /// destined for `target`.
     ///
     /// A `Safe` analysis is ignored — the dialog is only for flagged pastes.
-    pub(in crate::gui) fn open(&mut self, payload: String, analysis: PasteAnalysis) {
+    pub(in crate::gui) fn open(
+        &mut self,
+        payload: String,
+        analysis: PasteAnalysis,
+        target: PasteTarget,
+    ) {
         if analysis.is_safe() {
             return;
         }
@@ -281,6 +314,7 @@ impl PasteDialog {
             payload,
             analysis,
             editing: false,
+            target,
         });
     }
 
@@ -374,7 +408,10 @@ impl PasteDialog {
                         } else {
                             state.payload.clone()
                         };
-                        outcome = PasteDialogOutcome::Paste(payload);
+                        outcome = PasteDialogOutcome::Paste {
+                            payload,
+                            target: state.target,
+                        };
                     }
                     if !state.editing && ui.button("Edit and Paste").clicked() {
                         state.editing = true;
@@ -393,7 +430,10 @@ impl PasteDialog {
                 } else {
                     state.payload.clone()
                 };
-                outcome = PasteDialogOutcome::Paste(payload);
+                outcome = PasteDialogOutcome::Paste {
+                    payload,
+                    target: state.target,
+                };
             }
         }
 
@@ -657,6 +697,15 @@ mod tests {
         );
     }
 
+    /// A throwaway `PasteTarget` for dialog tests. The concrete ids are
+    /// irrelevant to the open/ignore/equality assertions.
+    fn test_target() -> PasteTarget {
+        PasteTarget {
+            tab_id: TabId::first(),
+            pane_id: PaneId::first(),
+        }
+    }
+
     #[test]
     fn dialog_opens_on_flagged_analysis() {
         let mut dialog = PasteDialog::default();
@@ -667,6 +716,7 @@ mod tests {
             PasteAnalysis::Patterns {
                 matched: vec![r"\bsudo\b".to_owned()],
             },
+            test_target(),
         );
         assert!(dialog.is_open());
     }
@@ -674,7 +724,7 @@ mod tests {
     #[test]
     fn dialog_ignores_safe_analysis() {
         let mut dialog = PasteDialog::default();
-        dialog.open("harmless".to_owned(), PasteAnalysis::Safe);
+        dialog.open("harmless".to_owned(), PasteAnalysis::Safe, test_target());
         assert!(
             !dialog.is_open(),
             "a Safe analysis must never open the dialog"
@@ -686,9 +736,39 @@ mod tests {
         // Sanity-check the outcome enum used by 77.4's wire-in.
         assert_eq!(PasteDialogOutcome::Idle, PasteDialogOutcome::Idle);
         assert_ne!(
-            PasteDialogOutcome::Paste("a".to_owned()),
-            PasteDialogOutcome::Paste("b".to_owned())
+            PasteDialogOutcome::Paste {
+                payload: "a".to_owned(),
+                target: test_target(),
+            },
+            PasteDialogOutcome::Paste {
+                payload: "b".to_owned(),
+                target: test_target(),
+            }
         );
         assert_ne!(PasteDialogOutcome::Cancelled, PasteDialogOutcome::Idle);
+    }
+
+    #[test]
+    fn dialog_preserves_target_across_open() {
+        // Regression (Task 106): the destination pane is captured at open time
+        // so a confirmed paste routes to the originating pane even if focus
+        // moved (e.g. focus-follows-mouse onto the dialog buttons). A distinct
+        // target must round-trip through the dialog state unchanged.
+        let target = PasteTarget {
+            tab_id: TabId::first(),
+            pane_id: PaneId::first(),
+        };
+        let mut dialog = PasteDialog::default();
+        dialog.open(
+            "sudo rm -rf /".to_owned(),
+            PasteAnalysis::Patterns {
+                matched: vec![r"\bsudo\b".to_owned()],
+            },
+            target,
+        );
+        match dialog.state.as_ref() {
+            Some(state) => assert_eq!(state.target, target),
+            None => panic!("dialog should be open after a flagged paste"),
+        }
     }
 }

--- a/freminal/src/gui/pty.rs
+++ b/freminal/src/gui/pty.rs
@@ -10,7 +10,7 @@
 //! GUI-side channel endpoints as a [`TabChannels`].
 
 use std::path::Path;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use anyhow::Result;
@@ -230,6 +230,9 @@ pub fn spawn_pty_tab(
     let echo_off = terminal
         .echo_off_atomic()
         .unwrap_or_else(|| Arc::new(AtomicBool::new(false)));
+    let reader_shutdown = terminal
+        .reader_shutdown_atomic()
+        .unwrap_or_else(|| Arc::new(AtomicBool::new(false)));
     let child_pid = terminal.child_pid();
 
     let (input_tx, input_rx) = unbounded::<InputEvent>();
@@ -294,6 +297,7 @@ pub fn spawn_pty_tab(
         tab_cfg.recording_swap,
         tab_cfg.recording_pane_id,
         command_event_tx,
+        reader_shutdown,
     );
 
     Ok(TabChannels {
@@ -339,6 +343,7 @@ fn spawn_pty_consumer_thread(
     recording_swap: RecordingSwap,
     recording_pane_id: u32,
     command_event_tx: Sender<CommandFinishedEvent>,
+    reader_shutdown: Arc<AtomicBool>,
 ) {
     let thread_name = format!("freminal-pty-consumer-{recording_pane_id}");
     if let Err(e) = std::thread::Builder::new()
@@ -503,6 +508,13 @@ fn spawn_pty_consumer_thread(
                     }
                     recv(input_rx) -> msg => {
                         if !handle_input(&mut emulator, msg, &clipboard_tx, &search_buffer_tx) {
+                            // The GUI dropped the pane's input channel — the
+                            // pane/tab/window is being torn down while the
+                            // child shell may still be alive. Signal the PTY
+                            // reader thread so a subsequent failed `send` (the
+                            // receiver we own is about to drop) is treated as
+                            // an expected teardown, not an error.
+                            reader_shutdown.store(true, Ordering::Release);
                             return;
                         }
                     }

--- a/freminal/src/gui/settings_dispatch.rs
+++ b/freminal/src/gui/settings_dispatch.rs
@@ -361,7 +361,14 @@ impl FreminalGui {
                 } else if let Some(owner) = self.settings_owner
                     && let Some(win) = self.windows.get_mut(&owner)
                 {
-                    win.paste_dialog.open(SAMPLE.to_owned(), analysis);
+                    // Test Paste is a preview only; target the window's active
+                    // pane so a confirm would route there like a real paste.
+                    let tab = win.tabs.active_tab();
+                    let target = crate::gui::paste_guard::PasteTarget {
+                        tab_id: tab.id,
+                        pane_id: tab.active_pane,
+                    };
+                    win.paste_dialog.open(SAMPLE.to_owned(), analysis, target);
                     handle.request_repaint(owner);
                 } else {
                     self.push_error_toast(

--- a/freminal/src/gui/terminal/coords.rs
+++ b/freminal/src/gui/terminal/coords.rs
@@ -43,6 +43,23 @@ pub(super) const fn visible_window_start_for(
         .saturating_sub(scroll_offset)
 }
 
+/// Buffer-absolute row at which a still-running command block's gutter color
+/// should stop (106.2b): the cursor's current row, i.e. the last line of
+/// output the running command has produced so far.
+///
+/// A running block has no `end_row`; the gutter / duration-anchor helpers
+/// substitute this value for the missing end.  Previously this was the bottom
+/// row of the pane (`visible_window_start + term_height - 1`), which painted
+/// the gutter all the way down even when the running command's output only
+/// reached partway down the screen.  Anchoring on the cursor row stops the
+/// coloring at the last output line, as the spec requires.
+///
+/// The cursor row is screen-relative (`0..term_height`); the buffer-absolute
+/// row is `visible_window_start + cursor_pos.y`.
+pub(super) const fn running_block_extent(snap: &TerminalSnapshot) -> usize {
+    visible_window_start(snap) + snap.cursor_pos.y
+}
+
 /// Convert a screen-relative `(row, col)` — where `col` is a **display
 /// column** (a wide character occupies two columns) — to a flat index into
 /// the `visible_chars` slice.
@@ -213,6 +230,40 @@ mod visible_window_start_tests {
         // Edge case: buffer has fewer rows than visible height.
         let snap = snap_with(10, 24, 0);
         assert_eq!(visible_window_start(&snap), 0);
+    }
+
+    // ── running_block_extent (106.2b) ────────────────────────────────────
+
+    #[test]
+    fn running_extent_is_cursor_row_not_pane_bottom() {
+        // 100 total rows, 24 visible at the live bottom (window starts at 76).
+        // A running command whose cursor sits on screen row 5 has output only
+        // up to buffer row 81 — the gutter must stop there, NOT at the pane
+        // bottom (buffer row 99).
+        let mut snap = snap_with(100, 24, 0);
+        snap.cursor_pos.y = 5;
+        assert_eq!(running_block_extent(&snap), 81);
+        // Regression guard: the old (buggy) formula would have produced the
+        // pane bottom row.
+        let pane_bottom = visible_window_start(&snap) + snap.term_height - 1;
+        assert_eq!(pane_bottom, 99);
+        assert_ne!(running_block_extent(&snap), pane_bottom);
+    }
+
+    #[test]
+    fn running_extent_cursor_at_top_of_window() {
+        // Cursor on the first visible row → extent equals the window start.
+        let mut snap = snap_with(100, 24, 0);
+        snap.cursor_pos.y = 0;
+        assert_eq!(running_block_extent(&snap), visible_window_start(&snap));
+    }
+
+    #[test]
+    fn running_extent_accounts_for_scrollback() {
+        // Scrolled back 10 rows: window start is 66, cursor on screen row 3.
+        let mut snap = snap_with(100, 24, 10);
+        snap.cursor_pos.y = 3;
+        assert_eq!(running_block_extent(&snap), 69);
     }
 }
 

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -42,7 +42,7 @@ use super::{
             show_search_bar,
         },
     },
-    coords::{encode_egui_mouse_pos_as_usize, flat_index_for_cell, visible_window_start},
+    coords::{encode_egui_mouse_pos_as_usize, flat_index_for_cell, running_block_extent},
     input::write_input_to_terminal,
 };
 
@@ -207,9 +207,9 @@ fn gutter_block_id_at_pos(
     // Build the same fold-aware layout the renderer uses this frame.
     let layout = FoldLayout::new(snap, &view_state.folded_blocks);
     let rendered_row = layout.screen_to_rendered(screen_row);
-    // Running blocks extend to the live bottom row (last normally-visible row).
-    let running_extent =
-        super::coords::visible_window_start(snap) + snap.term_height.saturating_sub(1);
+    // Running blocks extend only to the cursor's row (last output line so far),
+    // not the bottom of the pane (106.2b).
+    let running_extent = super::coords::running_block_extent(snap);
 
     match layout.row_map.rendered_to_snapshot(rendered_row) {
         // A live snapshot row → containment hit-test against the blocks.
@@ -2509,8 +2509,9 @@ impl FreminalTerminalWidget {
             && !snap.command_blocks.is_empty()
         {
             let win_start = flat_window_start;
-            // Running blocks extend to the live bottom row.
-            let running_extent = visible_window_start(snap) + snap.term_height.saturating_sub(1);
+            // Running blocks extend only to the cursor's row (the last line of
+            // output produced so far), not the bottom of the pane (106.2b).
+            let running_extent = running_block_extent(snap);
             // Iterate on-screen rows (bottom-anchored); map each back through
             // rendered → snapshot → buffer.
             for screen_row_idx in 0..snap.term_height {
@@ -2583,7 +2584,7 @@ impl FreminalTerminalWidget {
                 Duration::from_secs_f32(command_blocks_config.duration_threshold_secs.max(0.0));
             let win_start = flat_window_start;
             let win_end = win_start + snap.term_height.saturating_add(snap.window_extra_rows);
-            let running_extent = visible_window_start(snap) + snap.term_height.saturating_sub(1);
+            let running_extent = running_block_extent(snap);
             let (fg_r, fg_g, fg_b) = snap.theme.foreground;
             // Muted: ~60% alpha so the label reads without overpowering
             // the underlying cell content.


### PR DESCRIPTION
## Task 106 — Pre-0.9.0 Bug Closure (Release Gate)

Closes the known bugs surfaced during v0.9.0 development, gating the
v0.9.0 release. Source: `Documents/PLANNING.MD` "Current Bugs" (#1–6, #9,
and the disconnected-channel errors at app close). Plan:
`Documents/PLAN_VERSION_090.md` Task 106.

### Subtasks in this PR

- **106.1** — Restore right-click paste in the terminal buffer.
  `RequestPaste` viewport command was falling into the windowing
  catch-all arm after the eframe→winit migration; now sets a deferred
  paste flag routed through the existing paste-guard path.
- **106.2 + 106.3** — OSC 133 / gutter regressions: command duration no
  longer measures prompt-idle time (requires OSC 133 C), running-block
  gutter extent stops at the cursor row instead of the pane bottom, and
  no false notification fires for a Ctrl-C'd unexecuted command.
- **106.4** — Teardown & lifecycle ordering: destroy the egui-glow
  painter on window/app close, classify expected PTY reader shutdown vs.
  genuine anomaly (demoting the disconnected-channel error spam), and
  correct pane/tab close focus + active-tab restore-by-id.
- **106.5** — Command history palette now sorts most-recent-first.
  Previously seed-first + a 200-entry render cap hid this session's
  commands from the unfiltered list (they surfaced only via search);
  reversed the merge to newest-first with global text dedup.
- **106.6** — Paste-guard confirm modal routes the paste to the
  originating pane (captured at dialog-open) rather than whatever pane
  focus-follows-mouse landed on at confirm time.

### Verification

`cargo test --all`, `cargo clippy --all-targets --all-features -- -D
warnings`, `cargo fmt --all -- --check`, and `cargo machete` all clean.
Each fix lands with regression tests per `testing-mandate`.

### Release gate

v0.9.0 does not ship until Tasks 106 and 109 are green.