### PR TITLE
fix: 106.7 -- blank window on bash shell spawn + visible failure mode

### DIFF
--- a/Documents/PLAN_VERSION_090.md
+++ b/Documents/PLAN_VERSION_090.md
@@ -4948,6 +4948,56 @@ Existing dialog tests updated for the new `open`/`Paste` signatures.
 
 ---
 
+#### 106.7 — Blank window on bash shell spawn + no visible failure mode ✅ 2026-06-15
+
+**Why this subtask exists:** reported from a Bazzite user running the AppImage
+nightly. Freminal opened a blank, unusable window; the log ended at
+`tab_spawning: layout: failed to spawn pane 'Pane(1)': failed to initialize
+PTY`. v0.8.0 worked on the same machine, so this was a v0.9.0 regression.
+
+**Root cause (two distinct bugs):**
+
+1. **Spawn failure (bash-only, deterministic).** The Task 72.8b spawn-time
+   shell-integration injection adds `--posix` for bash via
+   `cmd.arg("--posix")` on a `portable_pty` `new_default_prog()` builder. The
+   moment any arg is pushed the builder stops being a default-prog builder, so
+   `as_command()` treats `args[0]` (`"--posix"`) as the **executable** and
+   tries to resolve it on `PATH` — which fails, so no shell spawns. zsh/fish
+   users were unaffected because their injection branches add no args (the
+   bug went unnoticed because the maintainer runs zsh). Not sandboxing: the
+   reporter simply runs bash, the Bazzite/Fedora default.
+2. **No visible failure mode.** When the only/last pane's spawn fails, the
+   layout/session-restore path produced no `TabManager`, so
+   `build_window_from_pending_layout` returned before inserting a
+   `PerWindowState`. A window with no `PerWindowState` renders nothing —
+   `update()` early-returns — leaving a blank, unrecoverable surface (the
+   error toast it tried to push had no window to render in). The default-PTY
+   path instead closed the only window, abruptly quitting with no explanation.
+
+**Fix:**
+
+- `inject_shell_integration_env` now takes the resolved shell program and, for
+  bash, promotes the builder to `[shell, "--posix"]` via
+  `CommandBuilder::replace_default_prog` instead of `cmd.arg("--posix")`, so
+  the shell stays `args[0]`.
+- New app-level `fatal_error: Option<(String, String)>` on `FreminalGui` with
+  `set_fatal_error` / `has_live_window` / `render_fatal_error`. When the
+  only/last shell fails (no live panes anywhere), `update()` renders a centered
+  error panel (title + detail + single **Exit** button) for the
+  `PerWindowState`-less window instead of returning blank. Both the default-PTY
+  and layout/session-restore first-window paths set it. The detail text points
+  the user at `[shell_integration] set_term_program = false` as a workaround.
+- Non-fatal sub-pane failures (other shells alive) keep the existing behavior:
+  error toast + skip the broken pane (verified no half-built pane leaks).
+
+**Verification:** New `shell_integration_injection_tests` in `io/pty.rs` prove
+bash keeps the shell as `args[0]` (never the `--posix` flag) and zsh/fish stay
+default-prog builders — the test fails against the pre-fix `&["--posix"]`
+behavior. `cargo test --all`, clippy `-D warnings`, and `cargo machete` all
+clean.
+
+---
+
 ## Task 107 — Build Version Embedding ✅ Complete (2026-06-11)
 
 ### 107 Summary

--- a/freminal-terminal-emulator/src/io/pty.rs
+++ b/freminal-terminal-emulator/src/io/pty.rs
@@ -319,23 +319,49 @@ fn detect_shell(program: &str) -> Option<Shell> {
 /// passed, (b) `set_term_program` is enabled, and (c) the program path
 /// matches a recognised shell.
 ///
-/// Returns the list of additional args (if any) that must be appended
-/// to `cmd` BEFORE spawning — currently only bash needs this (`--posix`).
-/// Args are returned rather than applied directly so callers retain
-/// control over `cmd.args()` error propagation.
+/// `shell_program` is the resolved shell executable path (from `--shell`,
+/// a layout override, or `$SHELL`).  It is required so that shells which
+/// need extra spawn-time arguments (currently only bash, which needs
+/// `--posix`) can be promoted from a *default-prog* builder to an explicit
+/// `[shell, args...]` builder.
+///
+/// # The default-prog / explicit-arg trap
+///
+/// A [`CommandBuilder`] created via `new_default_prog()` resolves its
+/// program lazily at spawn time (it runs `$SHELL` as a login shell).  The
+/// moment any argument is pushed via `arg()`, the builder is no longer a
+/// default-prog builder and `args[0]` is treated as the *executable*.  So
+/// naively calling `cmd.arg("--posix")` makes `portable_pty` try to spawn
+/// a program literally named `--posix`, which fails with "doesn't exist on
+/// the filesystem" — producing a blank window for every bash user.  To add
+/// args we must therefore seed `args[0]` with the real shell path via
+/// [`CommandBuilder::replace_default_prog`].
 fn inject_shell_integration_env(
     cmd: &mut CommandBuilder,
     shell: Shell,
     resources: &Path,
-) -> &'static [&'static str] {
+    shell_program: &str,
+) {
     match shell {
         Shell::Bash => {
             // bash sources `$ENV` when invoked in POSIX mode but not in
             // its normal interactive mode.  We launch with `--posix` so
             // the file is sourced; the script's first action is to
             // disable POSIX mode again.
+            //
+            // `--posix` is an *argument*, so the builder must carry the
+            // resolved shell as `args[0]`.  Use `replace_default_prog`
+            // (not `arg`) so `args[0]` is the shell, not the flag.  If the
+            // builder is somehow no longer a default-prog builder, fall
+            // back to appending the flag to whatever program is set.
             cmd.env("ENV", resources.join("bash").join("freminal-init.bash"));
-            &["--posix"]
+            if cmd.is_default_prog() {
+                if let Err(e) = cmd.replace_default_prog([shell_program, "--posix"]) {
+                    error!("failed to set bash shell-integration argv: {e}");
+                }
+            } else if let Err(e) = cmd.arg("--posix") {
+                error!("failed to append --posix to bash argv: {e}");
+            }
         }
         Shell::Zsh => {
             // Preserve any existing $ZDOTDIR via a sentinel env var.
@@ -348,7 +374,6 @@ fn inject_shell_integration_env(
                 cmd.env("__FREMINAL_ZSH_ZDOTDIR", existing);
             }
             cmd.env("ZDOTDIR", resources.join("zsh"));
-            &[]
         }
         Shell::Fish => {
             // Prepend our resources directory to $XDG_DATA_DIRS so fish
@@ -357,7 +382,6 @@ fn inject_shell_integration_env(
                 .unwrap_or_else(|_| String::from("/usr/local/share:/usr/share"));
             let combined = format!("{}:{existing}", resources.display());
             cmd.env("XDG_DATA_DIRS", combined);
-            &[]
         }
     }
 }
@@ -475,25 +499,21 @@ pub fn run_terminal(
     //
     // Falls back silently when the resources directory can't be resolved
     // (e.g. unusual platforms or stripped installs).
-    let injected_extra_args: &'static [&'static str] = if spawning_shell && set_term_program {
-        if let (Some(prog), Some(resources)) = (
+    //
+    // `inject_shell_integration_env` mutates `cmd` directly — for bash it
+    // must promote the default-prog builder to `[shell, "--posix"]` rather
+    // than appending `--posix` as a bare arg (which would make
+    // `portable_pty` spawn a program literally named `--posix`; see the
+    // function's docs).
+    if spawning_shell
+        && set_term_program
+        && let (Some(prog), Some(resources)) = (
             shell_program.as_deref(),
             freminal_common::config::shell_integration_dir(),
-        ) {
-            if let Some(shell) = detect_shell(prog) {
-                inject_shell_integration_env(&mut cmd, shell, resources.path())
-            } else {
-                &[]
-            }
-        } else {
-            &[]
-        }
-    } else {
-        &[]
-    };
-    for arg in injected_extra_args {
-        cmd.arg(arg)
-            .map_err(|e| PtyInitError::Spawn(e.to_string()))?;
+        )
+        && let Some(shell) = detect_shell(prog)
+    {
+        inject_shell_integration_env(&mut cmd, shell, resources.path(), prog);
     }
     cmd.env("__CFBundleIdentifier", "io.github.fredclausen.freminal");
 
@@ -981,6 +1001,104 @@ mod reader_send_failure_tests {
         assert_eq!(
             classify_reader_send_failure(false),
             ReaderSendFailure::Anomalous
+        );
+    }
+}
+
+#[cfg(test)]
+mod shell_integration_injection_tests {
+    use super::{Shell, detect_shell, inject_shell_integration_env};
+    use portable_pty::CommandBuilder;
+    use std::path::Path;
+
+    #[test]
+    fn detect_shell_matches_basename() {
+        assert_eq!(detect_shell("/usr/bin/bash"), Some(Shell::Bash));
+        assert_eq!(detect_shell("/bin/bash"), Some(Shell::Bash));
+        assert_eq!(detect_shell("/usr/bin/zsh"), Some(Shell::Zsh));
+        assert_eq!(detect_shell("/usr/bin/fish"), Some(Shell::Fish));
+        assert_eq!(detect_shell("/bin/sh"), None);
+        assert_eq!(detect_shell("/usr/bin/nu"), None);
+    }
+
+    /// Regression test for the blank-window-on-bash bug.
+    ///
+    /// bash needs `--posix` as a spawn-time argument.  The naive
+    /// implementation called `cmd.arg("--posix")` on a default-prog
+    /// builder, which makes `args[0] == "--posix"` — `portable_pty` then
+    /// tries to spawn a program literally named `--posix`, fails with
+    /// "doesn't exist on the filesystem", and the pane never starts (blank
+    /// window).  zsh users were unaffected because their branch adds no
+    /// args.  The fix promotes the builder to `[shell, "--posix"]` so the
+    /// shell stays `args[0]`.
+    #[test]
+    fn bash_injection_keeps_shell_as_argv0_not_posix_flag() {
+        let mut cmd = CommandBuilder::new_default_prog();
+        assert!(cmd.is_default_prog());
+
+        inject_shell_integration_env(
+            &mut cmd,
+            Shell::Bash,
+            Path::new("/tmp/freminal-resources"),
+            "/usr/bin/bash",
+        );
+
+        let argv = cmd.get_argv();
+        assert_eq!(
+            argv.first().map(|a| a.to_str()),
+            Some(Some("/usr/bin/bash")),
+            "args[0] must be the shell executable, never the --posix flag"
+        );
+        assert_eq!(
+            argv.get(1).map(|a| a.to_str()),
+            Some(Some("--posix")),
+            "--posix must be the second argv element"
+        );
+        // The ENV var that makes the integration script auto-load must be set.
+        assert!(
+            cmd.get_env("ENV").is_some(),
+            "bash integration must set $ENV to the init script"
+        );
+    }
+
+    /// zsh injection must not add any args (so the builder remains a
+    /// default-prog builder and spawns the login shell normally).
+    #[test]
+    fn zsh_injection_adds_no_args_and_sets_zdotdir() {
+        let mut cmd = CommandBuilder::new_default_prog();
+        inject_shell_integration_env(
+            &mut cmd,
+            Shell::Zsh,
+            Path::new("/tmp/freminal-resources"),
+            "/usr/bin/zsh",
+        );
+        assert!(
+            cmd.is_default_prog(),
+            "zsh injection must leave the builder as a default-prog builder"
+        );
+        assert!(
+            cmd.get_env("ZDOTDIR").is_some(),
+            "zsh integration must set $ZDOTDIR"
+        );
+    }
+
+    /// fish injection must not add any args either.
+    #[test]
+    fn fish_injection_adds_no_args_and_sets_xdg_data_dirs() {
+        let mut cmd = CommandBuilder::new_default_prog();
+        inject_shell_integration_env(
+            &mut cmd,
+            Shell::Fish,
+            Path::new("/tmp/freminal-resources"),
+            "/usr/bin/fish",
+        );
+        assert!(
+            cmd.is_default_prog(),
+            "fish injection must leave the builder as a default-prog builder"
+        );
+        assert!(
+            cmd.get_env("XDG_DATA_DIRS").is_some(),
+            "fish integration must set $XDG_DATA_DIRS"
         );
     }
 }

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -463,6 +463,13 @@ impl freminal_windowing::App for FreminalGui {
         // All other windows remain in the map, so shader/bg propagation
         // to "other windows" simply iterates self.windows.
         let Some(mut win) = self.windows.remove(&window_id) else {
+            // This window has no PerWindowState — normally a transient state
+            // during teardown, but if the only/last shell failed to spawn it
+            // is permanent.  Rather than leave a blank surface, render the
+            // fatal-error panel (with an Exit button) when one is set.
+            if self.fatal_error.is_some() {
+                self.render_fatal_error(ctx);
+            }
             return;
         };
 
@@ -2118,13 +2125,16 @@ impl FreminalGui {
             Ok(channels) => channels,
             Err(e) => {
                 error!("Failed to spawn initial PTY: {e}");
-                self.push_error_toast(
+                // This is the first/only window and it has no other live
+                // panes — a failed spawn here is fatal.  Record it so the
+                // window renders the fatal-error panel (with an Exit button)
+                // instead of a blank surface.  We deliberately do NOT close
+                // the window: closing the only window would quit the app
+                // before the user can read why.
+                self.set_fatal_error(
                     "Failed to start shell",
-                    Some(format!("The shell could not be started: {e}")),
+                    format!("The shell could not be started:\n\n{e}"),
                 );
-                // Without a PTY there is nothing to show in this window.
-                // Close it so the user is not left with a black rectangle.
-                handle.close_window(window_id);
                 return;
             }
         };
@@ -2172,6 +2182,37 @@ impl FreminalGui {
             repaint_handle,
         );
         self.windows.insert(window_id, win);
+    }
+
+    /// Render the fatal-error panel for a window that has no
+    /// [`PerWindowState`] because the only/last shell failed to spawn.
+    ///
+    /// Shows the stored title, the underlying error detail, and a single
+    /// "Exit" button that quits the application.  Replaces what would
+    /// otherwise be a blank, unrecoverable window.
+    fn render_fatal_error(&self, ctx: &egui::Context) {
+        let Some((title, detail)) = self.fatal_error.as_ref() else {
+            return;
+        };
+        // Match the rest of the GUI: build a root Ui covering the window and
+        // reserve space from it via `show_inside` (the non-deprecated API).
+        let mut root_ui = egui::Ui::new(
+            ctx.clone(),
+            egui::Id::new("freminal_fatal_error_root"),
+            egui::UiBuilder::default(),
+        );
+        CentralPanel::default().show_inside(&mut root_ui, |ui| {
+            ui.vertical_centered(|ui| {
+                ui.add_space(48.0);
+                ui.heading(title);
+                ui.add_space(12.0);
+                ui.label(detail);
+                ui.add_space(24.0);
+                if ui.button("Exit").clicked() {
+                    std::process::exit(1);
+                }
+            });
+        });
     }
 
     /// Construct a `PerWindowState` with default field values for all
@@ -2282,6 +2323,22 @@ impl FreminalGui {
 
         if let Some(cmds) = cmds_opt {
             self.inject_layout_commands(&cmds);
+        } else if !self.has_live_window() {
+            // The first window's tabs could not be built (every pane spawn
+            // failed) and no other window holds a live pane.  Without this
+            // the window would be left blank and unrecoverable.  Record a
+            // fatal error so the next frame renders the Exit panel.  A more
+            // specific per-pane spawn error has already been surfaced as a
+            // toast by `spawn_pane_from_leaf`; this is the catch-all that
+            // guarantees a visible, actionable failure state.
+            self.set_fatal_error(
+                "Failed to start session",
+                "No shell could be started for the restored session or \
+                 layout.\n\nThis usually means the shell program could not \
+                 be launched. Check your shell configuration, or try \
+                 launching with shell integration disabled \
+                 ([shell_integration] set_term_program = false).",
+            );
         }
     }
 

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -292,6 +292,19 @@ struct FreminalGui {
     /// close through, then removes the entry.  Avoids re-prompting on the
     /// `ViewportCommand::Close` round trip a Force Close triggers.
     force_close_windows: std::collections::HashSet<WindowId>,
+
+    /// Set when the application's only/last shell failed to spawn and there
+    /// are no live panes anywhere, leaving nothing to render.
+    ///
+    /// When `Some`, every window without a [`PerWindowState`] renders a
+    /// centered fatal-error panel (title + detail + an "Exit" button)
+    /// instead of a blank surface.  This prevents the "blank window on a
+    /// failed shell spawn" failure mode: a window whose tabs could not be
+    /// built is otherwise unrenderable and unrecoverable.
+    ///
+    /// `(title, detail)` — `title` is a short headline, `detail` carries
+    /// the underlying spawn error for the user to act on.
+    fatal_error: Option<(String, String)>,
 }
 
 impl FreminalGui {
@@ -418,6 +431,7 @@ impl FreminalGui {
             pending_open_keybindings: false,
             toasts: std::cell::RefCell::new(toast::ToastStack::default()),
             force_close_windows: std::collections::HashSet::new(),
+            fatal_error: None,
         };
 
         if !layout_errors.is_empty() {
@@ -460,6 +474,29 @@ impl FreminalGui {
             Err(_) => {
                 tracing::warn!("toast stack was already borrowed; dropping error toast");
             }
+        }
+    }
+
+    /// Returns `true` when at least one open window currently holds a live
+    /// [`PerWindowState`] (i.e. there is something renderable with a PTY).
+    ///
+    /// Used to decide whether a failed shell spawn is *fatal* (no panes
+    /// anywhere -> show the fatal-error panel) or merely *non-fatal* (other
+    /// shells alive -> show a toast and skip the broken pane).  The
+    /// settings window is intentionally not a `PerWindowState`, so it does
+    /// not count as a live terminal window here.
+    pub(super) fn has_live_window(&self) -> bool {
+        !self.windows.is_empty()
+    }
+
+    /// Record a fatal startup failure so the next frame renders the
+    /// fatal-error panel (title + detail + Exit) instead of a blank window.
+    ///
+    /// Only the first failure is retained; subsequent calls are ignored so
+    /// the earliest, most actionable message survives.
+    pub(super) fn set_fatal_error(&mut self, title: impl Into<String>, detail: impl Into<String>) {
+        if self.fatal_error.is_none() {
+            self.fatal_error = Some((title.into(), detail.into()));
         }
     }
 


### PR DESCRIPTION
## Summary

Closes a v0.9.0 regression reported by a Bazzite AppImage user: Freminal
opened a **blank, unusable window**, with the log ending at
`tab_spawning: layout: failed to spawn pane 'Pane(1)': failed to initialize PTY`.
v0.8.0 worked on the same machine.

Two distinct bugs, both fixed here (plan subtask **106.7**):

### 1. Spawn failure (bash-only, deterministic) — not sandboxing

The Task 72.8b spawn-time shell-integration injection adds `--posix` for bash
via `cmd.arg("--posix")` on a `portable_pty` `new_default_prog()` builder. The
moment any arg is pushed, the builder stops being a default-prog builder, so
`as_command()` treats `args[0]` (`"--posix"`) as the **executable** and tries
to resolve it on `PATH` — which fails, so no shell spawns.

- zsh/fish users were unaffected (their injection branches add no args), which
  is why it went unnoticed — the maintainer runs zsh.
- The reporter simply runs **bash**, the Bazzite/Fedora default. Not an
  AppImage/sandbox issue.

**Fix:** promote the bash builder to `[shell, "--posix"]` via
`CommandBuilder::replace_default_prog` so the resolved shell stays `args[0]`.

### 2. No visible failure mode (the blank window)

When the only/last pane's spawn failed, the layout/session-restore path
produced no `TabManager` and never inserted a `PerWindowState`. A window with
no `PerWindowState` renders nothing (`update()` early-returns), leaving a
blank, unrecoverable surface — even the error toast had no window to render in.
The default-PTY path instead closed the only window, quitting abruptly.

**Fix:** new app-level `fatal_error` state. When no live panes exist anywhere,
`update()` renders a centered error panel (title + detail + single **Exit**
button) instead of a blank surface. The detail text points the user at the
`[shell_integration] set_term_program = false` workaround. Non-fatal sub-pane
failures (other shells alive) keep the existing behavior: error toast + skip
the broken pane.

## Testing

- New `shell_integration_injection_tests` in `io/pty.rs` prove bash keeps the
  shell as `args[0]` (never the `--posix` flag) and zsh/fish stay default-prog
  builders — fails against the pre-fix `&["--posix"]` behavior.
- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D warnings`,
  and `cargo machete` all clean.

## User-side confirmation (current build, no rebuild needed)

Setting `[shell_integration] set_term_program = false` in `config.toml` (or
launching `freminal -- bash`) bypasses the injection and yields a working
shell — confirming the diagnosis. Note `--shell /usr/bin/bash` does **not**
fix it (injection still runs).