### PR TITLE
fix: Task 113 -- resize/reflow scroll corruption (Bugs G, R, E)

### DIFF
--- a/Documents/PLAN_VERSION_100.md
+++ b/Documents/PLAN_VERSION_100.md
@@ -966,9 +966,18 @@ await review.
 
 ## Task 113 — Resize / Reflow Scroll Corruption
 
-> **STATUS: PENDING.** Decomposed into three subtasks (113.1–113.3). 113.1 is
+> **STATUS: IN PROGRESS.** Decomposed into three subtasks (113.1–113.3). 113.1 is
 > the root-cause fix and the priority; 113.2 and 113.3 are independent
 > amplifiers found alongside it. Each subtask leaves `cargo test --all` green.
+>
+> - **113.1 — COMPLETE.** Grow path no longer appends an unreclaimable blank
+>   tail below the live cursor; it reclaims trailing pristine `ScrollFill`
+>   padding instead, pinning the live cursor to the bottom of the (taller)
+>   window and revealing real scrollback above. Bug G smoke test passes and is
+>   kept uncommented. Added a `buffer_resize/grow_height` benchmark (no
+>   regression: p = 0.08, "No change").
+> - **113.2 — pending.** Bug R smoke test remains commented out until activated.
+> - **113.3 — pending.**
 
 ### Background — the reported bug
 
@@ -1142,6 +1151,27 @@ unreclaimable rows.
 
 Stop: report the new grow logic, the smoke-test result, and the benchmark
 before/after; await review.
+
+**Implementation note (113.1, as landed).** The grow now appends **nothing** on
+the primary buffer (rather than "append only when scrollback is insufficient").
+Instead, `resize_height` calls a new private helper
+`reclaim_trailing_blank_padding()` that pops trailing pristine `ScrollFill` rows
+(empty cells) lying strictly below the live cursor, then leaves the buffer as
+short as its content requires. The taller window reveals real scrollback above
+via the existing bottom-anchored `visible_window_start`; when no scrollback
+exists the buffer is left with `rows.len() < height` and the GUI pads the
+remainder below the live bottom — exactly mirroring `Buffer::new`, which
+deliberately starts with a single row, not `height` blank rows. This is a
+cleaner equivalent of the plan's invariant: it satisfies "the live bottom stays
+at the bottom of the window," and because no rows are ever appended below the
+cursor, a grow/shrink cycle can never accumulate a blank tail. The screen
+re-fills through the normal `handle_lf` row-push path, so the LF fast path is
+never handed a cursor sitting above a blank tail. Two `tests_gui_resize` cases
+(`resize_grow_adds_rows`, the `preserve_scrollback_anchor_*` clamp tests) encoded
+the old append-at-bottom mechanics and were rewritten to assert the new contract
+(cursor stays pinned / scrollback is revealed). A `buffer_resize/grow_height`
+Criterion benchmark was added to cover the grow path (it had none); before/after
+showed no significant change (p = 0.08).
 
 #### 113.2 — Remap command blocks and prompt rows across reflow (Bug R)
 

--- a/Documents/PLAN_VERSION_100.md
+++ b/Documents/PLAN_VERSION_100.md
@@ -32,15 +32,23 @@ bundled-font change alters the default glyph set.
 
 ## Task Summary
 
-| #   | Feature             | Scope | Status   | Depends On       |
-| --- | ------------------- | ----- | -------- | ---------------- |
-| 111 | Bundled Font / Icon | Large | Complete | v0.8.0, v0.9.0   |
-| 112 | UI Beautification   | Large | Active   | v0.8.0, Task 111 |
+| #   | Feature                     | Scope  | Status   | Depends On       |
+| --- | --------------------------- | ------ | -------- | ---------------- |
+| 111 | Bundled Font / Icon         | Large  | Complete | v0.8.0, v0.9.0   |
+| 112 | UI Beautification           | Large  | Active   | v0.8.0, Task 111 |
+| 113 | Resize / Reflow Scroll Bugs | Medium | Pending  | None             |
 
 Task numbers assigned at activation (111, 112). Source: `Documents/PLANNING.MD`
 "Pre-1.0 Remediations" (UI aesthetic, built-in fonts). Task 112 depends on Task
 111 because the bundled-icon asset pipeline (112) reuses the bundled-asset
 precedent established by the font swap (111), and both touch glyph rendering.
+
+Task 113 was added after a maintainer-reported intermittent scroll-corruption
+bug was root-caused during a v0.10.0 investigation session. It is independent of
+the beautification work (it lives in `freminal-buffer` and
+`freminal-terminal-emulator`, not the chrome) but is folded into this version
+because it is a correctness bug found while this version was active and should
+ship before 1.0. It has no dependency on Tasks 111/112.
 
 ---
 
@@ -953,3 +961,244 @@ Settings persistence without surfacing it.
 
 Stop: report all four wiring steps + the guard-test diff + Nix lint results;
 await review.
+
+---
+
+## Task 113 — Resize / Reflow Scroll Corruption
+
+> **STATUS: PENDING.** Decomposed into three subtasks (113.1–113.3). 113.1 is
+> the root-cause fix and the priority; 113.2 and 113.3 are independent
+> amplifiers found alongside it. Each subtask leaves `cargo test --all` green.
+
+### Background — the reported bug
+
+A maintainer reported an intermittent, hard-to-reproduce buffer-scroll
+corruption with these symptoms:
+
+1. There is scrollback present.
+2. The active prompt has scrolled to the top of the window even though it
+   should not be there.
+3. Sometimes the prompt is visible, sometimes it is itself in the scrollback
+   and nothing is visible. Typing a command still runs it, but the output is
+   missing (it lands in the scrollback).
+4. **No amount of scrolling surfaces the missing content.**
+5. Typing `clear` recovers the terminal.
+
+One reporter could reproduce it semi-reliably on macOS while changing font
+settings; the maintainer hits it on Hyprland (a tiling WM) **without** touching
+fonts, and it predates the command-block feature (Task 72). The font-change
+correlation is therefore a red herring: changing font size triggers a terminal
+resize (cell size changes → row/col count changes), and a tiling WM streams many
+resize events during interactive window manipulation. The common factor is
+**repeated resizes**, not fonts.
+
+### Root cause — Bug G (the real bug; predates command blocks)
+
+`Buffer::resize_height` grow branch
+(`freminal-buffer/src/buffer/resize_and_alt.rs`, ~line 490):
+
+```rust
+if new_height > old_height {
+    let grow = new_height - old_height;
+    for _ in 0..grow {
+        self.rows.push(Row::new(self.width)); // append blank rows at the BOTTOM
+        self.row_cache.push(None);
+    }
+    ...
+}
+```
+
+When the window grows, this appends `new_height - old_height` blank rows **at
+the bottom** of the buffer, leaving the live cursor's absolute `pos.y`
+unchanged. The shrink branch (same file, ~line 530) deliberately **retains**
+rows as scrollback and does not move the cursor. So the appended blanks are
+never reclaimed.
+
+Across a sequence of grow/shrink cycles — exactly what an interactive tiling-WM
+resize, or repeated font-size changes, produces — the buffer accumulates an
+unbounded tail of blank rows **below** the live cursor. The visible window
+(anchored to the bottom of the buffer via `visible_window_start`) then shows
+only that blank tail, while the live prompt/output is stranded near the **top**
+of the buffer, in scrollback. Because `scroll_offset` and `max_scroll_offset`
+are computed correctly from `rows.len()`, scrolling cannot recover it — the
+corruption is in the row layout, not the offset. `clear` recovers because it
+erases scrollback and re-homes the cursor.
+
+This was confirmed with a failing test that drives a height-only resize cycle
+(`[24, 30, 18, 40, 12, 50, 20, 24]`) and observes the live cursor escape the
+visible window with ~70 blank rows below it. (The test is checked in,
+commented out — see "Smoke tests" below.)
+
+### Amplifier — Bug R (reflow does not remap command blocks / prompt rows)
+
+`Buffer::reflow_to_width` (`resize_and_alt.rs`, ~line 263) rebuilds every row
+from scratch on a **width** change (which a font-size change, or a tiling-WM
+column-count change, triggers). It correctly remaps the cursor by flat-offset,
+but it does **not** update `self.command_blocks` or `self.prompt_rows`, whose
+row fields (`prompt_start_row`, `command_start_row`, `output_start_row`,
+`end_row`, and each `prompt_rows` entry) are **buffer-absolute** indices. After
+a reflow that changes the row count, those indices point at the wrong rows.
+
+The trim path (`enforce_scrollback_limit` → `adjust_prompt_rows`,
+`lifecycle.rs:132`) already does the equivalent remap when rows are dropped from
+the front; reflow simply lacks it. Stale block rows corrupt the command-block
+gutter and folding (`compute_fold_ranges` / `compute_extra_rows` /
+`FoldLayout`), which can push content off-screen incorrectly when a fold is in
+view — compounding Bug G's visual damage. Command blocks are **on by default**
+(`CommandBlocksConfig::default().enabled == true`), so this fires in normal use
+on any width-changing resize.
+
+Confirmed with a failing test: a block ending at row 4 at width 20 still reports
+`end_row == Some(4)` after reflowing to width 10, even though its last content
+row moved to row 9.
+
+### Amplifier — Bug E (new data clears scroll offset but not fold extra-rows)
+
+`TerminalEmulator::handle_incoming_data`
+(`freminal-terminal-emulator/src/interface.rs`, ~line 385) snaps to the live
+bottom on new output by resetting `self.gui_scroll_offset = 0`, but leaves
+`self.gui_extra_rows` stale. A dedicated `reset_scroll_offset()` (same file,
+~line 507) clears **both** — `handle_incoming_data` should call it instead of
+inlining only the offset reset. While a command-block fold is in view, the stale
+`gui_extra_rows` keeps the flattened window extended above the live bottom
+against a buffer that no longer has a fold there.
+
+On its own (no fold active) the GUI's `render_skip` absorbs the stale extra
+rows, so it self-heals; combined with a fold and Bug R's wrong block rows it
+contributes to the mis-anchored window. It is still a genuine correctness bug.
+
+Confirmed with a failing test: after `set_gui_scroll_window(10, 5)` then new
+output, `scroll_offset` correctly resets to 0 but `window_extra_rows` stays 5.
+
+### Smoke tests (already checked in, commented out)
+
+Three failing reproductions are committed alongside this task as **commented-out
+tests**, so the implementing agent has a built-in benchmark. Uncomment, run,
+watch them fail, implement the fix, watch them pass, then **keep them
+uncommented** as permanent regression coverage.
+
+- Bug G + Bug R: `freminal-buffer/src/buffer/mod.rs`, module `task_113_smoke`
+  (`task_113_repeated_resize_does_not_strand_live_content`,
+  `task_113_reflow_remaps_command_block_rows`).
+  Run: `cargo test -p freminal-buffer --lib task_113_smoke`.
+- Bug E: `freminal-terminal-emulator/tests/snapshot_build.rs`, function
+  `task_113_new_data_resets_extra_rows`.
+  Run: `cargo test -p freminal-terminal-emulator --test snapshot_build task_113_new_data_resets_extra_rows`.
+
+These tests are the acceptance criteria: a subtask is not done until its smoke
+test is uncommented and passing.
+
+Sequencing: 113.1 → 113.2 → 113.3 (independent; may be done in any order, but
+113.1 is the priority because it is the user-visible root cause). Each subtask
+leaves `cargo test --all` green.
+
+### Task 113 subtasks
+
+#### 113.1 — Fix the grow path so it never strands live content (Bug G)
+
+Scope: `freminal-buffer/src/buffer/resize_and_alt.rs` (`resize_height` grow
+branch, ~line 490). May add a private helper. Test changes in
+`freminal-buffer/src/buffer/mod.rs`.
+
+What: On a **primary-buffer** height grow, the live content must stay pinned to
+the bottom of the visible window. Instead of appending `grow` blank rows at the
+bottom, the grow must **re-expose existing scrollback rows above the live
+bottom** to fill the taller window, and append blank rows **only** when there is
+not enough scrollback to fill it. Concretely, the post-grow invariant is:
+
+- If `rows.len()` already provides at least `new_height` rows below the start of
+  the live region, the window grows by revealing scrollback upward (no rows
+  appended); the live cursor's absolute `pos.y` stays valid and the live bottom
+  stays at the bottom of the window.
+- Only when there are fewer than `new_height` total rows are blank rows appended
+  — and the number appended is bounded so a grow followed by a shrink/grow cycle
+  cannot accumulate an unbounded blank tail below the cursor.
+
+The **alternate buffer** keeps its current top-anchored behavior (it has no
+scrollback and the strict `rows.len() == height` invariant; do NOT change the
+alternate branch). Re-validate `debug_assert_invariants()` after the change.
+
+Think carefully about the interaction with the full-screen LF fast path
+(`lines.rs:169`), which assumes the live cursor sits at `rows.len() - 1`. The
+fix must not leave the cursor above the last row with blank rows below it, or LF
+will walk the cursor down through those blanks instead of scrolling.
+
+Deliverable: the grow path no longer appends an unreclaimable blank tail;
+repeated resize cycles keep the live cursor in the visible window with no blank
+tail below it.
+
+Verification: uncomment and pass the `task_113_smoke` module's
+`task_113_repeated_resize_does_not_strand_live_content` test (keep it
+uncommented); `cargo test --all`; `cargo clippy --all-targets --all-features --
+-D warnings`. Per `freminal-bench-table` / `performance-benchmarks`, resize is a
+buffer operation — capture the relevant buffer/resize benchmark before/after and
+confirm < 15% regression.
+
+Prohibitions: do NOT change the alternate-buffer branch; do NOT change the
+shrink branch's row-retention behavior (it is correct); do NOT delete the
+committed smoke tests — uncomment them; do NOT "fix" the symptom in the GUI
+(`visible_window_start` / `render_skip`) — the bug is the buffer appending
+unreclaimable rows.
+
+Stop: report the new grow logic, the smoke-test result, and the benchmark
+before/after; await review.
+
+#### 113.2 — Remap command blocks and prompt rows across reflow (Bug R)
+
+Scope: `freminal-buffer/src/buffer/resize_and_alt.rs` (`reflow_to_width`, ~line
+263). May add a private helper mirroring `adjust_prompt_rows`. Test changes in
+`freminal-buffer/src/buffer/mod.rs`.
+
+What: `reflow_to_width` already tracks, during logical-line grouping, where each
+old row maps in the new layout (it uses this to remap the cursor by flat
+offset). Extend that tracking to also remap the buffer-absolute row fields of
+`self.command_blocks` (`prompt_start_row`, `command_start_row`,
+`output_start_row`, `end_row`) and each entry of `self.prompt_rows` to their new
+post-reflow row indices. The natural approach: record, per old logical line, the
+index of its first new row, and translate each stored row index through that
+map. Drop or clamp any block/prompt row that no longer maps onto a real row
+(matching the spirit of `adjust_prompt_rows`, which drops fully-scrolled-out
+blocks). Keep `command_blocks` ordering and the deque cap intact.
+
+Deliverable: after a width reflow, every command block's row fields and every
+prompt-row marker point at the row that actually holds their content.
+
+Verification: uncomment and pass `task_113_reflow_remaps_command_block_rows`
+(keep it uncommented); `cargo test --all`; `cargo clippy --all-targets
+--all-features -- -D warnings`. Add at least one more test covering a
+multi-block, multi-prompt reflow (wide → narrow AND narrow → wide) so the remap
+is exercised in both directions.
+
+Prohibitions: do NOT change the cursor remap (it is correct); do NOT leak parser
+/ escape-sequence knowledge into the buffer (this is pure row-index arithmetic
+on data the buffer already owns); do NOT delete the committed smoke test.
+
+Stop: report the remap approach + test results; await review.
+
+#### 113.3 — Clear fold extra-rows on new output (Bug E)
+
+Scope: `freminal-terminal-emulator/src/interface.rs` (`handle_incoming_data`,
+~line 385). Test changes in
+`freminal-terminal-emulator/tests/snapshot_build.rs`.
+
+What: In `handle_incoming_data`, replace the inline `if self.gui_scroll_offset >
+0 { self.gui_scroll_offset = 0; }` reset with a call to the existing
+`reset_scroll_offset()` (which clears both `gui_scroll_offset` and
+`gui_extra_rows`). Preserve the "only reset when actually scrolled back" intent
+if it matters for snapshot-cache invalidation — i.e. call `reset_scroll_offset()`
+when either `gui_scroll_offset > 0` or `gui_extra_rows > 0`, so new output always
+snaps fully to the live bottom without needlessly invalidating caches when
+already at the bottom with no fold extension.
+
+Deliverable: new PTY output clears both the scroll offset and the fold
+extra-rows request.
+
+Verification: uncomment and pass `task_113_new_data_resets_extra_rows` (keep it
+uncommented); `cargo test --all`; `cargo clippy --all-targets --all-features --
+-D warnings`.
+
+Prohibitions: do NOT change the alternate-screen scroll handling; do NOT alter
+`reset_scroll_offset`'s semantics — call it; do NOT delete the committed smoke
+test.
+
+Stop: report the one-line change + test result; await review.

--- a/Documents/PLAN_VERSION_100.md
+++ b/Documents/PLAN_VERSION_100.md
@@ -966,7 +966,7 @@ await review.
 
 ## Task 113 — Resize / Reflow Scroll Corruption
 
-> **STATUS: IN PROGRESS.** Decomposed into three subtasks (113.1–113.3). 113.1 is
+> **STATUS: COMPLETE.** Decomposed into three subtasks (113.1–113.3). 113.1 is
 > the root-cause fix and the priority; 113.2 and 113.3 are independent
 > amplifiers found alongside it. Each subtask leaves `cargo test --all` green.
 >
@@ -983,7 +983,12 @@ await review.
 >   `[output_start_row, end_row]` range the GUI consumes). Bug R smoke test
 >   plus a multi-block/both-directions test pass and are kept uncommented.
 >   `reflow_width` / `softwrap_heavy` benches within noise (< 15%).
-> - **113.3 — pending.**
+> - **113.3 — COMPLETE.** `handle_incoming_data` now calls `reset_scroll_offset()`
+>   (clearing both `gui_scroll_offset` and `gui_extra_rows`) instead of inlining
+>   only the offset reset, and runs that reset only when either is non-zero so
+>   output at the live bottom does not needlessly invalidate the snapshot cache.
+>   Bug E smoke test plus two unit tests pass and are kept uncommented.
+>   `bench_handle_incoming_data` no regression (p = 0.31, "No change").
 
 ### Background — the reported bug
 
@@ -1260,3 +1265,18 @@ Prohibitions: do NOT change the alternate-screen scroll handling; do NOT alter
 test.
 
 Stop: report the one-line change + test result; await review.
+
+**Implementation note (113.3, as landed).** `handle_incoming_data` now calls the
+existing `reset_scroll_offset()` (which clears both `gui_scroll_offset` and
+`gui_extra_rows`) in place of the old inline reset that zeroed only
+`gui_scroll_offset`. The reset runs only when the GUI is scrolled back or a fold
+has extended the window — that is, when either `gui_scroll_offset` or
+`gui_extra_rows` is non-zero — so that ordinary output at the live bottom (the
+common case, both already zero) does not call the reset and therefore does not
+needlessly touch state or invalidate the snapshot cache. `reset_scroll_offset`'s
+semantics were not changed. Tests: the Bug E smoke test
+(`task_113_new_data_resets_extra_rows`, integration) plus two interface unit
+tests — `handle_incoming_data_clears_extra_rows` (offset already zero but a fold
+is in view) and `handle_incoming_data_resets_both_offset_and_extra_rows` (both
+set) — all kept uncommented. `bench_handle_incoming_data` showed no regression
+(p = 0.31, "No change in performance detected").

--- a/Documents/PLAN_VERSION_100.md
+++ b/Documents/PLAN_VERSION_100.md
@@ -976,7 +976,13 @@ await review.
 >   window and revealing real scrollback above. Bug G smoke test passes and is
 >   kept uncommented. Added a `buffer_resize/grow_height` benchmark (no
 >   regression: p = 0.08, "No change").
-> - **113.2 — pending.** Bug R smoke test remains commented out until activated.
+> - **113.2 — COMPLETE.** `reflow_to_width` now remaps `command_blocks` and
+>   `prompt_rows` to their post-reflow row indices via a new
+>   `remap_block_rows_after_reflow` helper (start fields anchor to the old
+>   row's first cell, `end_row` to its last cell, matching the inclusive
+>   `[output_start_row, end_row]` range the GUI consumes). Bug R smoke test
+>   plus a multi-block/both-directions test pass and are kept uncommented.
+>   `reflow_width` / `softwrap_heavy` benches within noise (< 15%).
 > - **113.3 — pending.**
 
 ### Background — the reported bug
@@ -1204,6 +1210,28 @@ Prohibitions: do NOT change the cursor remap (it is correct); do NOT leak parser
 on data the buffer already owns); do NOT delete the committed smoke test.
 
 Stop: report the remap approach + test results; await review.
+
+**Implementation note (113.2, as landed).** During logical-line grouping,
+`reflow_to_width` now records `old_row_meta[r] = (logical_line_idx,
+flat_offset_of_row_start, row_len)` for every old row, and `line_new_starts`
+records where each logical line's re-wrapped rows begin in the new buffer.
+After installing the new rows and remapping the cursor, a new private helper
+`remap_block_rows_after_reflow` translates each stored row index through that
+map: an old row's content offset is located in the new layout the same way the
+cursor remap works. Start fields (`prompt_start_row`, `command_start_row`,
+`output_start_row`, and each `prompt_rows` entry) anchor to the old row's
+**first** cell; `end_row` anchors to its **last** cell, because the GUI treats
+`[output_start_row, end_row]` as an inclusive span and a row that re-wraps into
+several narrower rows must keep `end_row` on the final piece (verified against
+the consumers in `gui/terminal/input.rs`). Blocks whose `prompt_start_row` no
+longer maps are dropped (mirroring `adjust_prompt_rows`); optional later fields
+that no longer map are cleared rather than left dangling. Block ordering and the
+deque are untouched. Tests: the Bug R smoke test plus a new
+`task_113_reflow_remaps_multiple_blocks_both_directions` (two blocks, narrow→wide
+**and** wide→narrow, asserting in-range, ordered, non-overlapping block spans).
+Benchmarks `buffer_resize/reflow_width` and `softwrap_heavy` showed no regression
+beyond the bench's inherent run-to-run noise (same-code reruns swing ±3%; the
+added work is O(blocks + prompts) against an O(total cells) reflow).
 
 #### 113.3 — Clear fold extra-rows on new output (Bug E)
 

--- a/freminal-buffer/benches/buffer_row_bench.rs
+++ b/freminal-buffer/benches/buffer_row_bench.rs
@@ -150,6 +150,23 @@ fn bench_resize(c: &mut Criterion) {
         );
     });
 
+    // Height grow — the Task 113.1 path. Exercises the primary-buffer grow
+    // branch, which now reclaims trailing blank screen-padding below the live
+    // cursor instead of appending an unreclaimable blank tail.
+    group.bench_with_input(BenchmarkId::new("grow_height", 200), &data, |b, data| {
+        b.iter_batched(
+            || {
+                let mut buf = Buffer::new(100, 80);
+                buf.insert_text(data);
+                buf
+            },
+            |mut buf| {
+                std::hint::black_box(buf.set_size(100, 200, 0));
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
     group.finish();
 }
 

--- a/freminal-buffer/src/buffer/mod.rs
+++ b/freminal-buffer/src/buffer/mod.rs
@@ -7690,48 +7690,133 @@ mod task_113_smoke {
     // change but does NOT remap command_blocks / prompt_rows, whose row
     // fields are buffer-absolute. After a width reflow the block metadata
     // points at the wrong rows, corrupting gutters/folds.
-    //
-    // NOTE: this reproduction is driven and fixed by Task 113.2; it stays
-    // commented out until then so 113.1 leaves the suite green. Uncomment it
-    // in 113.2, watch it fail, implement the reflow remap, watch it pass, then
-    // keep it as permanent regression coverage.
-    //
-    // #[test]
-    // fn task_113_reflow_remaps_command_block_rows() {
-    //     let mut buf = Buffer::new(20, 5);
-    //
-    //     // Prompt + command on row 0, output starting on row 1.
-    //     let _id = buf.start_command_block(None, "fid1".to_owned());
-    //     buf.mark_prompt_row();
-    //     buf.insert_text(&t("prompt$ cmd"));
-    //     buf.mark_command_start_row("fid1"); // command_start_row = 0
-    //     buf.handle_lf(); // cursor -> row 1
-    //     buf.mark_output_start_row("fid1"); // output_start_row = 1
-    //
-    //     // A long output line that re-wraps differently at a new width.
-    //     buf.insert_text(&t(
-    //         "0123456789012345678901234567890123456789012345678901234567890",
-    //     ));
-    //     let _ = buf.finish_command_block(Some(0), "fid1"); // end_row = cursor row
-    //
-    //     let last_content_row_before = buf.rows.len() - 1;
-    //     assert_eq!(
-    //         buf.command_blocks()[0].end_row,
-    //         Some(last_content_row_before),
-    //         "precondition: end_row points at the last content row"
-    //     );
-    //
-    //     // Reflow to a narrower width — the long output re-wraps into MORE
-    //     // rows, so the last output row's absolute index increases.
-    //     buf.set_size(10, 5, 0);
-    //
-    //     let last_content_row_after = buf.rows.len() - 1;
-    //     assert_eq!(
-    //         buf.command_blocks()[0].end_row,
-    //         Some(last_content_row_after),
-    //         "reflow must remap command_block end_row to the new layout \
-    //          (block points at {:?}, last content row is {last_content_row_after})",
-    //         buf.command_blocks()[0].end_row,
-    //     );
-    // }
+    #[test]
+    fn task_113_reflow_remaps_command_block_rows() {
+        let mut buf = Buffer::new(20, 5);
+
+        // Prompt + command on row 0, output starting on row 1.
+        let _id = buf.start_command_block(None, "fid1".to_owned());
+        buf.mark_prompt_row();
+        buf.insert_text(&t("prompt$ cmd"));
+        buf.mark_command_start_row("fid1"); // command_start_row = 0
+        buf.handle_lf(); // cursor -> row 1
+        buf.mark_output_start_row("fid1"); // output_start_row = 1
+
+        // A long output line that re-wraps differently at a new width.
+        buf.insert_text(&t(
+            "0123456789012345678901234567890123456789012345678901234567890",
+        ));
+        let _ = buf.finish_command_block(Some(0), "fid1"); // end_row = cursor row
+
+        let last_content_row_before = buf.rows.len() - 1;
+        assert_eq!(
+            buf.command_blocks()[0].end_row,
+            Some(last_content_row_before),
+            "precondition: end_row points at the last content row"
+        );
+
+        // Reflow to a narrower width — the long output re-wraps into MORE
+        // rows, so the last output row's absolute index increases.
+        buf.set_size(10, 5, 0);
+
+        let last_content_row_after = buf.rows.len() - 1;
+        assert_eq!(
+            buf.command_blocks()[0].end_row,
+            Some(last_content_row_after),
+            "reflow must remap command_block end_row to the new layout \
+             (block points at {:?}, last content row is {last_content_row_after})",
+            buf.command_blocks()[0].end_row,
+        );
+    }
+
+    // Build one command block whose prompt is on its own row and whose output
+    // is `output_len` chars wide, starting from a fresh cursor row. Returns the
+    // recorded (prompt_start_row, output_start_row, end_row) for assertions.
+    fn push_block(buf: &mut Buffer, fid: &str, prompt: &str, output_len: usize) {
+        let _ = buf.start_command_block(None, fid.to_owned());
+        buf.mark_prompt_row();
+        buf.insert_text(&t(prompt));
+        buf.mark_command_start_row(fid);
+        buf.handle_lf();
+        buf.handle_cr();
+        buf.mark_output_start_row(fid);
+        let output: String = "0123456789".chars().cycle().take(output_len).collect();
+        buf.insert_text(&t(&output));
+        let _ = buf.finish_command_block(Some(0), fid);
+        buf.handle_lf();
+        buf.handle_cr();
+    }
+
+    // Assert that every command block's row fields point at rows that actually
+    // hold the block's content: the prompt row carries the prompt text, the
+    // output region [output_start_row, end_row] is a valid ascending span
+    // inside the buffer, and all indices are in range.
+    fn assert_block_rows_sane(buf: &Buffer) {
+        let len = buf.rows.len();
+        for b in buf.command_blocks() {
+            assert!(b.prompt_start_row < len, "prompt_start_row in range");
+            if let Some(c) = b.command_start_row {
+                assert!(c < len, "command_start_row in range");
+            }
+            if let (Some(o), Some(e)) = (b.output_start_row, b.end_row) {
+                assert!(o < len && e < len, "output region in range");
+                assert!(o <= e, "output_start_row {o} must be <= end_row {e}");
+                assert!(
+                    b.prompt_start_row <= o,
+                    "prompt_start_row {} must be <= output_start_row {o}",
+                    b.prompt_start_row
+                );
+            }
+        }
+    }
+
+    // Multi-block, multi-prompt reflow in BOTH directions (Task 113.2). Two
+    // command blocks with multi-row outputs are reflowed narrow→wide and then
+    // wide→narrow; after each reflow every block's row fields must still point
+    // at the rows holding their content, and the two prompt-row markers must
+    // remain ordered and in range.
+    #[test]
+    fn task_113_reflow_remaps_multiple_blocks_both_directions() {
+        let mut buf = Buffer::new(20, 6);
+
+        push_block(&mut buf, "fid1", "p1$ cmd-one", 55);
+        push_block(&mut buf, "fid2", "p2$ cmd-two", 47);
+
+        assert_eq!(buf.command_blocks().len(), 2);
+        assert_eq!(buf.prompt_rows().len(), 2);
+        assert_block_rows_sane(&buf);
+
+        // narrow → wide: re-wraps each output into FEWER rows.
+        buf.set_size(40, 6, 0);
+        assert_eq!(buf.command_blocks().len(), 2, "blocks preserved on widen");
+        assert_eq!(buf.prompt_rows().len(), 2, "prompts preserved on widen");
+        assert_block_rows_sane(&buf);
+        // Prompt markers stay ordered.
+        assert!(
+            buf.prompt_rows()[0] < buf.prompt_rows()[1],
+            "prompt rows must remain ordered after widen: {:?}",
+            buf.prompt_rows()
+        );
+
+        // wide → narrow: re-wraps each output into MORE rows.
+        buf.set_size(8, 6, 0);
+        assert_eq!(buf.command_blocks().len(), 2, "blocks preserved on narrow");
+        assert_eq!(buf.prompt_rows().len(), 2, "prompts preserved on narrow");
+        assert_block_rows_sane(&buf);
+        assert!(
+            buf.prompt_rows()[0] < buf.prompt_rows()[1],
+            "prompt rows must remain ordered after narrow: {:?}",
+            buf.prompt_rows()
+        );
+
+        // The two blocks must not overlap: block 0 ends before block 1 starts.
+        let b1_prompt = buf.command_blocks()[1].prompt_start_row;
+        match buf.command_blocks()[0].end_row {
+            Some(b0_end) => assert!(
+                b0_end < b1_prompt,
+                "block 0 end_row {b0_end} must precede block 1 prompt_start_row {b1_prompt}"
+            ),
+            None => panic!("block 0 should be finished with an end_row"),
+        }
+    }
 }

--- a/freminal-buffer/src/buffer/mod.rs
+++ b/freminal-buffer/src/buffer/mod.rs
@@ -2383,15 +2383,73 @@ mod tests_gui_resize {
     }
 
     // ------------------------------------------------------------------
-    // 5. Growing height adds rows at the bottom
+    // 5. Growing height keeps the live cursor pinned to the bottom
     // ------------------------------------------------------------------
+    //
+    // Task 113 (Bug G): growing the primary buffer must NOT append an
+    // unreclaimable blank tail below the live cursor.  When the buffer's rows
+    // are all live content (HardBreak) with the cursor on the last row and
+    // there is no scrollback to reveal, the grow appends nothing — the buffer
+    // stays as short as its content and the GUI pads the taller window below
+    // the live bottom (mirroring `Buffer::new`, which starts with a single row
+    // rather than `height` blank rows).  The live cursor stays inside the
+    // visible window in either case.
     #[test]
-    fn resize_grow_adds_rows() {
+    fn resize_grow_keeps_cursor_pinned_to_bottom() {
         let mut buf = buffer_with_rows_and_config(10, 80, 10, 1000, false);
+        // Cursor is on the last content row (set by the helper).
+        assert_eq!(buf.cursor.pos.y, 9);
 
         buf.set_size(80, 15, 0);
 
-        assert_eq!(buf.rows.len(), 15, "growing height must append blank rows");
+        // No blank tail was appended below the live cursor.
+        assert_eq!(
+            buf.rows.len(),
+            10,
+            "growing must not append an unreclaimable blank tail below the live \
+             cursor when the buffer is all content with no scrollback"
+        );
+        // The live cursor is still inside the visible window.
+        let vis_start = buf.visible_window_start(0);
+        let vis_end = vis_start + buf.height;
+        assert!(
+            buf.cursor.pos.y >= vis_start && buf.cursor.pos.y < vis_end,
+            "live cursor (row {}) must stay inside the visible window \
+             [{vis_start}, {vis_end}) after a grow",
+            buf.cursor.pos.y
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // 5b. Growing height reveals existing scrollback instead of appending
+    // ------------------------------------------------------------------
+    //
+    // Task 113 (Bug G): when there IS scrollback above the live bottom, a grow
+    // reveals it upward (the bottom-anchored window grows toward row 0) and
+    // appends nothing.  Here the buffer has 20 content rows with the cursor on
+    // the last one and a 10-row screen, so rows 0..9 are scrollback.  Growing
+    // to height 15 must reveal 5 more scrollback rows, not append blanks.
+    #[test]
+    fn resize_grow_reveals_scrollback() {
+        let mut buf = buffer_with_rows_and_config(20, 80, 10, 1000, false);
+        assert_eq!(buf.cursor.pos.y, 19);
+
+        buf.set_size(80, 15, 0);
+
+        // Row count unchanged — the taller window revealed scrollback above.
+        assert_eq!(
+            buf.rows.len(),
+            20,
+            "growing into existing scrollback must not append blank rows"
+        );
+        // The live cursor (still on the last row) is at the bottom of the
+        // visible window.
+        let vis_start = buf.visible_window_start(0);
+        assert_eq!(vis_start, 20 - 15, "window reveals scrollback upward");
+        assert_eq!(
+            buf.cursor.pos.y, 19,
+            "live cursor stays pinned to the live bottom"
+        );
     }
 
     // ------------------------------------------------------------------
@@ -6265,25 +6323,36 @@ mod resize_and_insert_tests {
     #[test]
     fn preserve_scrollback_anchor_clamps_offset() {
         let mut buf = Buffer::new(10, 5);
-        // Buffer::new starts with 1 row. Add more to get scrollback.
-        for _ in 0..14 {
-            buf.rows.push(Row::new(10));
-            buf.row_cache.push(None);
-        }
-        // Total rows = 15 (1 initial + 14 added).
-        assert_eq!(buf.rows.len(), 15);
+        // Build 18 rows of genuine CONTENT (HardBreak) so they are real
+        // scrollback, not blank screen-padding.  The cursor sits on the LAST
+        // row (the live bottom) so every row above it is scrollback and the
+        // Task 113 grow path has no trailing blank padding to reclaim.
+        buf.rows = (0..18)
+            .map(|_| Row::new_with_origin(10, RowOrigin::HardBreak, RowJoin::NewLogicalLine))
+            .collect();
+        buf.row_cache = vec![None; buf.rows.len()];
+        buf.cursor.pos.y = buf.rows.len() - 1;
+        assert_eq!(buf.rows.len(), 18);
 
         buf.preserve_scrollback_anchor = true;
-        // Grow height from 5 to 8. rows.len()=15+3=18, new_height=8.
-        // max_offset = 18-8=10. scroll_offset 20 should clamp to 10.
+        // Grow height from 5 to 8. rows.len() stays 18 (scrollback revealed,
+        // nothing appended), new_height=8 → max_offset = 18-8 = 10. A
+        // scroll_offset of 20 must clamp to 10.
         let offset = buf.resize_height(8, 20);
+        assert_eq!(
+            buf.rows.len(),
+            18,
+            "grow reveals scrollback, appends nothing"
+        );
         assert_eq!(offset, 10);
     }
 
     #[test]
     fn preserve_scrollback_anchor_few_rows_returns_zero() {
         let mut buf = Buffer::new(10, 3);
-        // 3 rows, growing to height 5 — rows.len() becomes 5 which is <= new_height.
+        // A short buffer (fewer rows than the new height) with the cursor on
+        // its single content row.  Growing reveals no scrollback and appends
+        // nothing, so rows.len() stays below new_height and max_offset is 0.
         buf.preserve_scrollback_anchor = true;
         let offset = buf.resize_height(5, 10);
         assert_eq!(offset, 0);
@@ -7549,123 +7618,120 @@ mod coverage_gap_tests {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// TASK 113 — SMOKE TESTS (commented out; uncomment to drive the fix).
+// TASK 113 — SMOKE TESTS (permanent regression coverage).
 //
-// These two tests are the failing reproductions for Task 113's buffer-side
-// bugs (Bug G — the root cause — and Bug R — the reflow amplifier). They are
-// written against the CURRENT (buggy) code and FAIL on `main`. Uncomment the
-// module, run it, watch it fail, implement the Task 113 fix, then watch it
-// pass. Once green, KEEP these tests (uncommented) as permanent regression
-// coverage — do not delete them.
+// These tests are the failing reproductions for Task 113's buffer-side bugs
+// (Bug G — the root cause — and Bug R — the reflow amplifier). They were
+// written against the buggy code, drove the fix, and are now kept as permanent
+// regression coverage — do not delete them.
 //
 //   cargo test -p freminal-buffer --lib task_113_smoke
 //
 // See Documents/PLAN_VERSION_100.md "Task 113" for the full diagnosis.
 // ─────────────────────────────────────────────────────────────────────────────
-//
-// #[cfg(test)]
-// mod task_113_smoke {
-//     use super::*;
-//     use freminal_common::buffer_states::tchar::TChar;
-//
-//     fn t(s: &str) -> Vec<TChar> {
-//         s.bytes().map(TChar::Ascii).collect()
-//     }
-//
-//     // ── Bug G (ROOT CAUSE): grow appends blank rows at the bottom and never
-//     // reclaims them. Repeated grow/shrink cycles (an interactive tiling-WM
-//     // resize, or repeated font-size changes) accumulate an unbounded tail of
-//     // blank rows BELOW the live cursor. The visible window then shows only
-//     // that blank tail while the live prompt/output is stranded at the top of
-//     // the buffer in unreachable scrollback. `clear` recovers it.
-//     //
-//     // This test FAILS on main: after the resize cycle the live cursor lands
-//     // OUTSIDE the visible window, with a large blank tail below it.
-//     #[test]
-//     fn task_113_repeated_resize_does_not_strand_live_content() {
-//         let mut b = Buffer::new(40, 24);
-//         // A few lines of content, cursor at the live bottom.
-//         for i in 0..5 {
-//             b.insert_text(&t(&format!("line{i}")));
-//             b.handle_lf();
-//             b.handle_cr();
-//         }
-//
-//         // Interactive resize: height changes only, no output between them
-//         // (like dragging a tiling window border while sitting at a prompt).
-//         for &h in &[24usize, 30, 18, 40, 12, 50, 20, 24] {
-//             b.set_size(40, h, 0);
-//         }
-//
-//         // Settle and emit one line of output.
-//         b.set_size(40, 24, 0);
-//         b.handle_lf();
-//         b.handle_cr();
-//         b.insert_text(&t("PROMPT$"));
-//
-//         // The live cursor MUST be inside the visible window.
-//         let vis_start = b.visible_window_start(0);
-//         let vis_end = vis_start + b.height;
-//         assert!(
-//             b.cursor.pos.y >= vis_start && b.cursor.pos.y < vis_end,
-//             "live cursor (row {}) escaped visible window [{vis_start}, {vis_end}) \
-//              after repeated resize — content stranded in unreachable scrollback",
-//             b.cursor.pos.y
-//         );
-//
-//         // And the live content must be near the bottom, not stranded above a
-//         // large blank tail.
-//         let blanks_below = b.rows.len().saturating_sub(b.cursor.pos.y + 1);
-//         assert!(
-//             blanks_below <= 1,
-//             "blank tail of {blanks_below} rows below the live cursor — the grow \
-//              path is appending blanks that are never reclaimed",
-//         );
-//     }
-//
-//     // ── Bug R (amplifier): reflow_to_width rebuilds every row on a width
-//     // change but does NOT remap command_blocks / prompt_rows, whose row
-//     // fields are buffer-absolute. After a width reflow the block metadata
-//     // points at the wrong rows, corrupting gutters/folds.
-//     //
-//     // This test FAILS on main: end_row stays at its pre-reflow value while
-//     // the actual last content row has moved.
-//     #[test]
-//     fn task_113_reflow_remaps_command_block_rows() {
-//         let mut buf = Buffer::new(20, 5);
-//
-//         // Prompt + command on row 0, output starting on row 1.
-//         let _id = buf.start_command_block(None, "fid1".to_owned());
-//         buf.mark_prompt_row();
-//         buf.insert_text(&t("prompt$ cmd"));
-//         buf.mark_command_start_row("fid1"); // command_start_row = 0
-//         buf.handle_lf(); // cursor -> row 1
-//         buf.mark_output_start_row("fid1"); // output_start_row = 1
-//
-//         // A long output line that re-wraps differently at a new width.
-//         buf.insert_text(&t(
-//             "0123456789012345678901234567890123456789012345678901234567890",
-//         ));
-//         let _ = buf.finish_command_block(Some(0), "fid1"); // end_row = cursor row
-//
-//         let last_content_row_before = buf.rows.len() - 1;
-//         assert_eq!(
-//             buf.command_blocks()[0].end_row,
-//             Some(last_content_row_before),
-//             "precondition: end_row points at the last content row"
-//         );
-//
-//         // Reflow to a narrower width — the long output re-wraps into MORE
-//         // rows, so the last output row's absolute index increases.
-//         buf.set_size(10, 5, 0);
-//
-//         let last_content_row_after = buf.rows.len() - 1;
-//         assert_eq!(
-//             buf.command_blocks()[0].end_row,
-//             Some(last_content_row_after),
-//             "reflow must remap command_block end_row to the new layout \
-//              (block points at {:?}, last content row is {last_content_row_after})",
-//             buf.command_blocks()[0].end_row,
-//         );
-//     }
-// }
+#[cfg(test)]
+mod task_113_smoke {
+    use super::*;
+    use freminal_common::buffer_states::tchar::TChar;
+
+    fn t(s: &str) -> Vec<TChar> {
+        s.bytes().map(TChar::Ascii).collect()
+    }
+
+    // ── Bug G (ROOT CAUSE): grow appends blank rows at the bottom and never
+    // reclaims them. Repeated grow/shrink cycles (an interactive tiling-WM
+    // resize, or repeated font-size changes) accumulate an unbounded tail of
+    // blank rows BELOW the live cursor. The visible window then shows only
+    // that blank tail while the live prompt/output is stranded at the top of
+    // the buffer in unreachable scrollback. `clear` recovers it.
+    #[test]
+    fn task_113_repeated_resize_does_not_strand_live_content() {
+        let mut b = Buffer::new(40, 24);
+        // A few lines of content, cursor at the live bottom.
+        for i in 0..5 {
+            b.insert_text(&t(&format!("line{i}")));
+            b.handle_lf();
+            b.handle_cr();
+        }
+
+        // Interactive resize: height changes only, no output between them
+        // (like dragging a tiling window border while sitting at a prompt).
+        for &h in &[24usize, 30, 18, 40, 12, 50, 20, 24] {
+            b.set_size(40, h, 0);
+        }
+
+        // Settle and emit one line of output.
+        b.set_size(40, 24, 0);
+        b.handle_lf();
+        b.handle_cr();
+        b.insert_text(&t("PROMPT$"));
+
+        // The live cursor MUST be inside the visible window.
+        let vis_start = b.visible_window_start(0);
+        let vis_end = vis_start + b.height;
+        assert!(
+            b.cursor.pos.y >= vis_start && b.cursor.pos.y < vis_end,
+            "live cursor (row {}) escaped visible window [{vis_start}, {vis_end}) \
+             after repeated resize — content stranded in unreachable scrollback",
+            b.cursor.pos.y
+        );
+
+        // And the live content must be near the bottom, not stranded above a
+        // large blank tail.
+        let blanks_below = b.rows.len().saturating_sub(b.cursor.pos.y + 1);
+        assert!(
+            blanks_below <= 1,
+            "blank tail of {blanks_below} rows below the live cursor — the grow \
+             path is appending blanks that are never reclaimed",
+        );
+    }
+
+    // ── Bug R (amplifier): reflow_to_width rebuilds every row on a width
+    // change but does NOT remap command_blocks / prompt_rows, whose row
+    // fields are buffer-absolute. After a width reflow the block metadata
+    // points at the wrong rows, corrupting gutters/folds.
+    //
+    // NOTE: this reproduction is driven and fixed by Task 113.2; it stays
+    // commented out until then so 113.1 leaves the suite green. Uncomment it
+    // in 113.2, watch it fail, implement the reflow remap, watch it pass, then
+    // keep it as permanent regression coverage.
+    //
+    // #[test]
+    // fn task_113_reflow_remaps_command_block_rows() {
+    //     let mut buf = Buffer::new(20, 5);
+    //
+    //     // Prompt + command on row 0, output starting on row 1.
+    //     let _id = buf.start_command_block(None, "fid1".to_owned());
+    //     buf.mark_prompt_row();
+    //     buf.insert_text(&t("prompt$ cmd"));
+    //     buf.mark_command_start_row("fid1"); // command_start_row = 0
+    //     buf.handle_lf(); // cursor -> row 1
+    //     buf.mark_output_start_row("fid1"); // output_start_row = 1
+    //
+    //     // A long output line that re-wraps differently at a new width.
+    //     buf.insert_text(&t(
+    //         "0123456789012345678901234567890123456789012345678901234567890",
+    //     ));
+    //     let _ = buf.finish_command_block(Some(0), "fid1"); // end_row = cursor row
+    //
+    //     let last_content_row_before = buf.rows.len() - 1;
+    //     assert_eq!(
+    //         buf.command_blocks()[0].end_row,
+    //         Some(last_content_row_before),
+    //         "precondition: end_row points at the last content row"
+    //     );
+    //
+    //     // Reflow to a narrower width — the long output re-wraps into MORE
+    //     // rows, so the last output row's absolute index increases.
+    //     buf.set_size(10, 5, 0);
+    //
+    //     let last_content_row_after = buf.rows.len() - 1;
+    //     assert_eq!(
+    //         buf.command_blocks()[0].end_row,
+    //         Some(last_content_row_after),
+    //         "reflow must remap command_block end_row to the new layout \
+    //          (block points at {:?}, last content row is {last_content_row_after})",
+    //         buf.command_blocks()[0].end_row,
+    //     );
+    // }
+}

--- a/freminal-buffer/src/buffer/mod.rs
+++ b/freminal-buffer/src/buffer/mod.rs
@@ -7547,3 +7547,125 @@ mod coverage_gap_tests {
         assert_eq!(buf.rows.len(), rows_before);
     }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TASK 113 — SMOKE TESTS (commented out; uncomment to drive the fix).
+//
+// These two tests are the failing reproductions for Task 113's buffer-side
+// bugs (Bug G — the root cause — and Bug R — the reflow amplifier). They are
+// written against the CURRENT (buggy) code and FAIL on `main`. Uncomment the
+// module, run it, watch it fail, implement the Task 113 fix, then watch it
+// pass. Once green, KEEP these tests (uncommented) as permanent regression
+// coverage — do not delete them.
+//
+//   cargo test -p freminal-buffer --lib task_113_smoke
+//
+// See Documents/PLAN_VERSION_100.md "Task 113" for the full diagnosis.
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// #[cfg(test)]
+// mod task_113_smoke {
+//     use super::*;
+//     use freminal_common::buffer_states::tchar::TChar;
+//
+//     fn t(s: &str) -> Vec<TChar> {
+//         s.bytes().map(TChar::Ascii).collect()
+//     }
+//
+//     // ── Bug G (ROOT CAUSE): grow appends blank rows at the bottom and never
+//     // reclaims them. Repeated grow/shrink cycles (an interactive tiling-WM
+//     // resize, or repeated font-size changes) accumulate an unbounded tail of
+//     // blank rows BELOW the live cursor. The visible window then shows only
+//     // that blank tail while the live prompt/output is stranded at the top of
+//     // the buffer in unreachable scrollback. `clear` recovers it.
+//     //
+//     // This test FAILS on main: after the resize cycle the live cursor lands
+//     // OUTSIDE the visible window, with a large blank tail below it.
+//     #[test]
+//     fn task_113_repeated_resize_does_not_strand_live_content() {
+//         let mut b = Buffer::new(40, 24);
+//         // A few lines of content, cursor at the live bottom.
+//         for i in 0..5 {
+//             b.insert_text(&t(&format!("line{i}")));
+//             b.handle_lf();
+//             b.handle_cr();
+//         }
+//
+//         // Interactive resize: height changes only, no output between them
+//         // (like dragging a tiling window border while sitting at a prompt).
+//         for &h in &[24usize, 30, 18, 40, 12, 50, 20, 24] {
+//             b.set_size(40, h, 0);
+//         }
+//
+//         // Settle and emit one line of output.
+//         b.set_size(40, 24, 0);
+//         b.handle_lf();
+//         b.handle_cr();
+//         b.insert_text(&t("PROMPT$"));
+//
+//         // The live cursor MUST be inside the visible window.
+//         let vis_start = b.visible_window_start(0);
+//         let vis_end = vis_start + b.height;
+//         assert!(
+//             b.cursor.pos.y >= vis_start && b.cursor.pos.y < vis_end,
+//             "live cursor (row {}) escaped visible window [{vis_start}, {vis_end}) \
+//              after repeated resize — content stranded in unreachable scrollback",
+//             b.cursor.pos.y
+//         );
+//
+//         // And the live content must be near the bottom, not stranded above a
+//         // large blank tail.
+//         let blanks_below = b.rows.len().saturating_sub(b.cursor.pos.y + 1);
+//         assert!(
+//             blanks_below <= 1,
+//             "blank tail of {blanks_below} rows below the live cursor — the grow \
+//              path is appending blanks that are never reclaimed",
+//         );
+//     }
+//
+//     // ── Bug R (amplifier): reflow_to_width rebuilds every row on a width
+//     // change but does NOT remap command_blocks / prompt_rows, whose row
+//     // fields are buffer-absolute. After a width reflow the block metadata
+//     // points at the wrong rows, corrupting gutters/folds.
+//     //
+//     // This test FAILS on main: end_row stays at its pre-reflow value while
+//     // the actual last content row has moved.
+//     #[test]
+//     fn task_113_reflow_remaps_command_block_rows() {
+//         let mut buf = Buffer::new(20, 5);
+//
+//         // Prompt + command on row 0, output starting on row 1.
+//         let _id = buf.start_command_block(None, "fid1".to_owned());
+//         buf.mark_prompt_row();
+//         buf.insert_text(&t("prompt$ cmd"));
+//         buf.mark_command_start_row("fid1"); // command_start_row = 0
+//         buf.handle_lf(); // cursor -> row 1
+//         buf.mark_output_start_row("fid1"); // output_start_row = 1
+//
+//         // A long output line that re-wraps differently at a new width.
+//         buf.insert_text(&t(
+//             "0123456789012345678901234567890123456789012345678901234567890",
+//         ));
+//         let _ = buf.finish_command_block(Some(0), "fid1"); // end_row = cursor row
+//
+//         let last_content_row_before = buf.rows.len() - 1;
+//         assert_eq!(
+//             buf.command_blocks()[0].end_row,
+//             Some(last_content_row_before),
+//             "precondition: end_row points at the last content row"
+//         );
+//
+//         // Reflow to a narrower width — the long output re-wraps into MORE
+//         // rows, so the last output row's absolute index increases.
+//         buf.set_size(10, 5, 0);
+//
+//         let last_content_row_after = buf.rows.len() - 1;
+//         assert_eq!(
+//             buf.command_blocks()[0].end_row,
+//             Some(last_content_row_after),
+//             "reflow must remap command_block end_row to the new layout \
+//              (block points at {:?}, last content row is {last_content_row_after})",
+//             buf.command_blocks()[0].end_row,
+//         );
+//     }
+// }

--- a/freminal-buffer/src/buffer/resize_and_alt.rs
+++ b/freminal-buffer/src/buffer/resize_and_alt.rs
@@ -271,15 +271,27 @@ impl Buffer {
 
         // Take ownership of the old rows
         let old_rows = std::mem::take(&mut self.rows);
+        let old_rows_len = old_rows.len();
 
         // 1) Group rows into logical lines based on RowJoin.
         //    While grouping, identify which logical line contains the cursor
         //    and compute the cursor's flat cell offset within that line.
+        //
+        //    We also record, for EVERY old row, the logical line it belongs to
+        //    and the flat cell offset of its first cell within that line
+        //    (`old_row_meta`).  After re-wrapping we use this to translate the
+        //    buffer-absolute row indices stored on `command_blocks` and
+        //    `prompt_rows` to their post-reflow positions — those indices are
+        //    absolute and would otherwise dangle once reflow changes the row
+        //    count (Task 113, Bug R).
         let mut logical_lines: Vec<Vec<Row>> = Vec::new();
         let mut current_line: Vec<Row> = Vec::new();
 
         let mut cursor_logical_line: Option<usize> = None;
         let mut cursor_flat_offset: usize = 0;
+
+        // Per old row: (logical_line_idx, flat_offset_of_row_start, row_len).
+        let mut old_row_meta: Vec<(usize, usize, usize)> = Vec::with_capacity(old_rows_len);
 
         for (old_row_idx, row) in old_rows.into_iter().enumerate() {
             if row.join == RowJoin::NewLogicalLine && !current_line.is_empty() {
@@ -287,14 +299,22 @@ impl Buffer {
                 current_line = Vec::new();
             }
 
+            // Flat offset of this row's first cell within its logical line =
+            // the sum of cells already accumulated in `current_line`.
+            let row_start_flat_offset = current_line
+                .iter()
+                .map(|r| r.characters().len())
+                .sum::<usize>();
+            old_row_meta.push((
+                logical_lines.len(),
+                row_start_flat_offset,
+                row.characters().len(),
+            ));
+
             if old_row_idx == old_cursor_y {
                 cursor_logical_line = Some(logical_lines.len());
                 // Flat offset = cells from preceding rows in this logical line + cursor X.
-                cursor_flat_offset = current_line
-                    .iter()
-                    .map(|r| r.characters().len())
-                    .sum::<usize>()
-                    + old_cursor_x;
+                cursor_flat_offset = row_start_flat_offset + old_cursor_x;
             }
 
             current_line.push(row);
@@ -308,6 +328,11 @@ impl Buffer {
         let mut new_cursor_y: Option<usize> = None;
         let mut new_cursor_x: Option<usize> = None;
 
+        // Per logical line: the index in `new_rows` at which that line's
+        // re-wrapped rows begin.  Used together with `old_row_meta` to remap
+        // command-block / prompt row indices after reflow.
+        let mut line_new_starts: Vec<usize> = Vec::with_capacity(old_row_meta.len());
+
         for (line_idx, line) in logical_lines.into_iter().enumerate() {
             // Determine origin for the first row of this logical line.
             let first_origin = line.first().map_or(RowOrigin::HardBreak, |r| r.origin);
@@ -319,8 +344,10 @@ impl Buffer {
                 flat_cells.extend(row.characters().iter().cloned());
             }
 
-            // Record where this logical line's new rows start (for cursor mapping).
+            // Record where this logical line's new rows start (for cursor and
+            // block/prompt row mapping).
             let line_start_idx = new_rows.len();
+            line_new_starts.push(line_start_idx);
 
             if flat_cells.is_empty() {
                 // Empty logical line → keep a single empty row
@@ -477,6 +504,100 @@ impl Buffer {
         } else if self.cursor.pos.x >= self.width {
             self.cursor.pos.x = self.width.saturating_sub(1);
         }
+
+        // 5) Remap command-block and prompt-row indices (Task 113, Bug R).
+        //    These fields are buffer-absolute row indices; reflow changed the
+        //    row count, so they would otherwise point at the wrong rows,
+        //    corrupting the command-block gutter and fold layout.
+        self.remap_block_rows_after_reflow(&old_row_meta, &line_new_starts);
+    }
+
+    /// Translate the buffer-absolute row indices stored on `command_blocks` and
+    /// `prompt_rows` to their post-reflow positions.
+    ///
+    /// `old_row_meta[r]` is `(logical_line_idx, flat_offset_of_row_start)` for
+    /// each old row `r`; `line_new_starts[line_idx]` is the index in the new
+    /// `self.rows` where that logical line's re-wrapped rows begin.  An old row
+    /// is mapped to the new row of its logical line whose cumulative cell span
+    /// contains the old row's first-cell flat offset — the same flat-offset
+    /// strategy the cursor remap uses.
+    ///
+    /// Block/prompt rows that no longer map onto a real row (their old index is
+    /// past the end of the pre-reflow buffer) are dropped, mirroring
+    /// `adjust_prompt_rows`, which drops fully-scrolled-out blocks.  Block
+    /// ordering and the `command_blocks` deque cap are preserved (this only
+    /// rewrites row fields and may drop whole entries; it never reorders).
+    fn remap_block_rows_after_reflow(
+        &mut self,
+        old_row_meta: &[(usize, usize, usize)],
+        line_new_starts: &[usize],
+    ) {
+        let new_len = self.rows.len();
+
+        // Translate a flat offset within a logical line to the new absolute row
+        // index whose cell span contains it.
+        let offset_to_new_row = |line_idx: usize, flat_offset: usize| -> Option<usize> {
+            let line_start = *line_new_starts.get(line_idx)?;
+            // The line's new rows span [line_start, line_end).
+            let line_end = line_new_starts
+                .get(line_idx + 1)
+                .copied()
+                .unwrap_or(new_len);
+
+            let mut acc = 0usize;
+            for new_idx in line_start..line_end {
+                let cells = self.rows[new_idx].characters().len();
+                // A zero-width row (empty logical line) still anchors offset 0.
+                if flat_offset < acc + cells.max(1) {
+                    return Some(new_idx);
+                }
+                acc += cells;
+            }
+            // Offset past the end of the line's content: clamp to the line's
+            // last new row (the cursor remap uses the same fallback).
+            Some(line_end.saturating_sub(1).max(line_start))
+        };
+
+        // A "start" field (prompt/command/output start) anchors to the FIRST
+        // cell of its old row, so it maps to the new row where that old row's
+        // content begins.
+        let map_start_row = |old_row: usize| -> Option<usize> {
+            let (line_idx, row_start, _len) = *old_row_meta.get(old_row)?;
+            offset_to_new_row(line_idx, row_start)
+        };
+
+        // An "end" field (`end_row`) marks the LAST row of a region (the GUI
+        // treats `[output_start_row, end_row]` as an inclusive range), so it
+        // anchors to the LAST cell of its old row — otherwise a row that
+        // re-wraps into several narrower rows would shrink the region to its
+        // first piece.
+        let map_end_row = |old_row: usize| -> Option<usize> {
+            let (line_idx, row_start, len) = *old_row_meta.get(old_row)?;
+            let last_cell = row_start + len.saturating_sub(1);
+            offset_to_new_row(line_idx, last_cell)
+        };
+
+        self.prompt_rows.retain_mut(|r| {
+            map_start_row(*r).is_some_and(|new_r| {
+                *r = new_r;
+                true
+            })
+        });
+
+        self.command_blocks.retain_mut(|b| {
+            // The prompt-start row anchors the block; if it cannot be mapped,
+            // the block has no valid home and is dropped.
+            let Some(new_prompt) = map_start_row(b.prompt_start_row) else {
+                return false;
+            };
+            b.prompt_start_row = new_prompt;
+            // Optional later fields are remapped where present; if a field no
+            // longer maps it is cleared rather than left dangling.
+            b.command_start_row = b.command_start_row.and_then(&map_start_row);
+            b.output_start_row = b.output_start_row.and_then(&map_start_row);
+            b.end_row = b.end_row.and_then(&map_end_row);
+            true
+        });
     }
 
     /// Adjust the buffer rows for a new height and return the adjusted `scroll_offset`.

--- a/freminal-buffer/src/buffer/resize_and_alt.rs
+++ b/freminal-buffer/src/buffer/resize_and_alt.rs
@@ -488,11 +488,51 @@ impl Buffer {
         let old_height = self.height;
 
         if new_height > old_height {
-            // Grow: add blank rows at the bottom.
-            let grow = new_height - old_height;
-            for _ in 0..grow {
-                self.rows.push(Row::new(self.width));
-                self.row_cache.push(None);
+            if self.kind == BufferType::Alternate {
+                // Alternate buffer has no scrollback and a strict
+                // `rows.len() == height` invariant.  Grow by appending exactly
+                // enough blank rows at the bottom to reach the new height; the
+                // live region is top-anchored, so this is correct.
+                let grow = new_height.saturating_sub(self.rows.len());
+                for _ in 0..grow {
+                    self.rows.push(Row::new(self.width));
+                    self.row_cache.push(None);
+                }
+            } else {
+                // Primary buffer: the visible window is anchored to the BOTTOM
+                // of the buffer (`visible_window_start` = rows.len() - height),
+                // and the live cursor sits in the bottom `height` rows.  A
+                // taller window must be filled by RE-EXPOSING existing
+                // scrollback ABOVE the live bottom — NOT by appending blank rows
+                // BELOW it.
+                //
+                // The old code appended `new_height - old_height` blank rows at
+                // the bottom unconditionally.  Because the shrink branch retains
+                // rows (they become scrollback) and the window is bottom-anchored,
+                // a sequence of grow/shrink cycles — exactly what an interactive
+                // tiling-WM resize or repeated font-size changes produce —
+                // accumulated an unreclaimable tail of blank rows below the live
+                // cursor.  After a later shrink the bottom-anchored window then
+                // showed only that blank tail while the live prompt/output was
+                // stranded above it, in unreachable scrollback; no amount of
+                // scrolling recovered it and only `clear` fixed it (Task 113,
+                // Bug G).
+                //
+                // The fix: reclaim any trailing blank screen-padding rows below
+                // the live cursor, then append nothing.  Rows below the cursor
+                // in the primary buffer are always unwritten screen padding —
+                // the cursor is the furthest-written point at the live bottom,
+                // and all real content/scrollback lies at or above it.  Such
+                // padding rows are pristine `ScrollFill` placeholders (created
+                // by `Row::new`); reclaiming them down to the cursor row pins the
+                // live cursor to the bottom of the (now taller) window while the
+                // window reveals real scrollback above.  When there is no
+                // scrollback the window simply shows the available content with
+                // blank screen space below — and the screen fills back up
+                // through the normal `handle_lf` row-push path.  Because we
+                // never append below the cursor, a grow/shrink cycle can never
+                // accumulate a blank tail.
+                self.reclaim_trailing_blank_padding();
             }
             // Mark all pre-existing rows dirty so the row-level cache is
             // invalidated.  The visible window is now taller and the old
@@ -554,6 +594,38 @@ impl Buffer {
         } else {
             // xterm-style: reset to live bottom
             0
+        }
+    }
+
+    /// Reclaim trailing blank screen-padding rows that lie strictly below the
+    /// live cursor (primary buffer only).
+    ///
+    /// In the primary buffer the cursor is the furthest-written point at the
+    /// live bottom: every real content and scrollback row lies at or above it,
+    /// and any row below it is unwritten screen padding.  A pristine padding
+    /// row is a `RowOrigin::ScrollFill` row with no cells (exactly what
+    /// `Row::new` produces).  Such rows are removed down to — but never
+    /// including — the cursor's row, so the live cursor is pinned to the bottom
+    /// of the buffer.
+    ///
+    /// This is used by the height-grow path so the taller window reveals real
+    /// scrollback above the live bottom instead of accumulating an
+    /// unreclaimable blank tail below it (Task 113, Bug G).  It deliberately
+    /// stops at the first non-pristine row from the bottom, so it never touches
+    /// BCE-filled rows, content, or scrollback.
+    fn reclaim_trailing_blank_padding(&mut self) {
+        while self.rows.len() > self.cursor.pos.y + 1 {
+            // Safe: loop guard guarantees rows.len() >= 2 here.
+            let Some(last) = self.rows.last() else { break };
+            if last.origin == RowOrigin::ScrollFill && last.characters().is_empty() {
+                // A pristine ScrollFill row has no cells, so it holds no image
+                // cells; image_cell_count needs no adjustment.  Keep row_cache
+                // length in lockstep with rows.
+                self.rows.pop();
+                self.row_cache.pop();
+            } else {
+                break;
+            }
         }
     }
 

--- a/freminal-terminal-emulator/src/interface.rs
+++ b/freminal-terminal-emulator/src/interface.rs
@@ -380,15 +380,24 @@ impl TerminalEmulator {
     /// Process a chunk of raw PTY bytes.
     ///
     /// This wraps `TerminalState::handle_incoming_data` for the consumer thread.
-    /// When the user is scrolled back (`gui_scroll_offset > 0`), new output
-    /// auto-scrolls to the bottom by resetting the offset to 0.
+    /// When the user is scrolled back (`gui_scroll_offset > 0`) or a
+    /// command-block fold has extended the flatten window above the live bottom
+    /// (`gui_extra_rows > 0`), new output auto-scrolls fully to the live bottom.
     pub fn handle_incoming_data(&mut self, incoming: &[u8]) {
         self.internal.handle_incoming_data(incoming);
-        // Auto-scroll to bottom on new output, matching standard terminal
-        // behavior.  The next snapshot will carry scroll_offset = 0 so the
-        // GUI's ViewState is synced automatically.
-        if self.gui_scroll_offset > 0 {
-            self.gui_scroll_offset = 0;
+        // Auto-scroll to the live bottom on new output, matching standard
+        // terminal behavior.  This must clear BOTH the scroll offset AND the
+        // fold extra-rows request: leaving `gui_extra_rows` stale keeps the
+        // flattened window extended above the live bottom against a buffer that
+        // no longer has a fold there (Task 113, Bug E).  `reset_scroll_offset`
+        // clears both; the next snapshot then carries scroll_offset = 0 and
+        // window_extra_rows = 0 so the GUI's ViewState is synced automatically.
+        //
+        // Only reset when actually scrolled back or extended, so that ordinary
+        // output at the live bottom (the common case) does not needlessly
+        // invalidate the snapshot cache.
+        if self.gui_scroll_offset > 0 || self.gui_extra_rows > 0 {
+            self.reset_scroll_offset();
         }
     }
 
@@ -1012,6 +1021,32 @@ mod tests {
         emu.gui_scroll_offset = 0;
         emu.handle_incoming_data(b"data");
         assert_eq!(emu.gui_scroll_offset, 0);
+    }
+
+    #[test]
+    fn handle_incoming_data_clears_extra_rows() {
+        // Task 113, Bug E: new output must clear the fold extra-rows request,
+        // not just the scroll offset.  Here the offset is already 0 but a fold
+        // has extended the window (gui_extra_rows > 0); new data must still
+        // snap fully to the live bottom.
+        let (mut emu, _rx) = TerminalEmulator::new_headless(None);
+        emu.set_gui_scroll_window(0, 4);
+        emu.handle_incoming_data(b"new data");
+        assert_eq!(emu.gui_scroll_offset, 0, "offset stays at live bottom");
+        assert_eq!(
+            emu.gui_extra_rows, 0,
+            "fold extra-rows request must be cleared on new output"
+        );
+    }
+
+    #[test]
+    fn handle_incoming_data_resets_both_offset_and_extra_rows() {
+        // Both scrolled back AND a fold in view → new output clears both.
+        let (mut emu, _rx) = TerminalEmulator::new_headless(None);
+        emu.set_gui_scroll_window(7, 3);
+        emu.handle_incoming_data(b"new data");
+        assert_eq!(emu.gui_scroll_offset, 0);
+        assert_eq!(emu.gui_extra_rows, 0);
     }
 
     // ── set_win_size ───────────────────────────────────────────────────────────

--- a/freminal-terminal-emulator/tests/snapshot_build.rs
+++ b/freminal-terminal-emulator/tests/snapshot_build.rs
@@ -706,3 +706,49 @@ fn extra_rows_change_invalidates_cache() {
     let snap = emu.build_snapshot();
     assert_eq!(snap.row_offsets.len(), snap.term_height + 3);
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TASK 113 — SMOKE TEST (commented out; uncomment to drive the fix).
+//
+// Bug E (amplifier): `handle_incoming_data` snaps the scroll offset to the live
+// bottom on new output (resets `gui_scroll_offset` to 0) but leaves
+// `gui_extra_rows` stale. A dedicated `reset_scroll_offset()` exists that clears
+// BOTH — `handle_incoming_data` should call it instead of only zeroing the
+// offset. While a fold is in view this leaves the flatten window extended above
+// the live bottom against a buffer that no longer has a fold there.
+//
+// This test is written against the CURRENT (buggy) code and FAILS on `main`.
+// Uncomment it, run it, watch it fail, implement the Task 113 fix, then watch it
+// pass. Once green, KEEP it (uncommented) as permanent regression coverage.
+//
+//   cargo test -p freminal-terminal-emulator --test snapshot_build task_113_new_data_resets_extra_rows
+//
+// See Documents/PLAN_VERSION_100.md "Task 113" for the full diagnosis.
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// #[test]
+// fn task_113_new_data_resets_extra_rows() {
+//     let (mut emu, _rx) = make_emulator();
+//     fill_scrollback(&mut emu, 150);
+//
+//     // Simulate the GUI scrolled back with a fold in view: a non-zero
+//     // extra-row request riding alongside a non-zero scroll offset.
+//     emu.set_gui_scroll_window(10, 5);
+//     let scrolled = emu.build_snapshot();
+//     assert_eq!(scrolled.scroll_offset, 10);
+//     assert_eq!(scrolled.window_extra_rows, 5);
+//
+//     // New PTY output arrives → snap to the live bottom.
+//     emu.handle_incoming_data(b"new output\r\n");
+//     let after = emu.build_snapshot();
+//     assert_eq!(after.scroll_offset, 0, "offset must snap to live bottom");
+//
+//     // The fold-extra-row request must be cleared too, otherwise the flattened
+//     // window stays extended above the live bottom against a buffer that no
+//     // longer has a fold in view.
+//     assert_eq!(
+//         after.window_extra_rows, 0,
+//         "handle_incoming_data must clear gui_extra_rows on new output \
+//          (call reset_scroll_offset, not just zero the offset)"
+//     );
+// }

--- a/freminal-terminal-emulator/tests/snapshot_build.rs
+++ b/freminal-terminal-emulator/tests/snapshot_build.rs
@@ -708,47 +708,42 @@ fn extra_rows_change_invalidates_cache() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// TASK 113 — SMOKE TEST (commented out; uncomment to drive the fix).
+// TASK 113 — SMOKE TEST (permanent regression coverage).
 //
 // Bug E (amplifier): `handle_incoming_data` snaps the scroll offset to the live
-// bottom on new output (resets `gui_scroll_offset` to 0) but leaves
-// `gui_extra_rows` stale. A dedicated `reset_scroll_offset()` exists that clears
-// BOTH — `handle_incoming_data` should call it instead of only zeroing the
-// offset. While a fold is in view this leaves the flatten window extended above
-// the live bottom against a buffer that no longer has a fold there.
-//
-// This test is written against the CURRENT (buggy) code and FAILS on `main`.
-// Uncomment it, run it, watch it fail, implement the Task 113 fix, then watch it
-// pass. Once green, KEEP it (uncommented) as permanent regression coverage.
+// bottom on new output (resets `gui_scroll_offset` to 0) but used to leave
+// `gui_extra_rows` stale. A dedicated `reset_scroll_offset()` clears BOTH;
+// `handle_incoming_data` now calls it instead of only zeroing the offset. While
+// a fold is in view, a stale `gui_extra_rows` left the flatten window extended
+// above the live bottom against a buffer that no longer had a fold there.
 //
 //   cargo test -p freminal-terminal-emulator --test snapshot_build task_113_new_data_resets_extra_rows
 //
 // See Documents/PLAN_VERSION_100.md "Task 113" for the full diagnosis.
 // ─────────────────────────────────────────────────────────────────────────────
-//
-// #[test]
-// fn task_113_new_data_resets_extra_rows() {
-//     let (mut emu, _rx) = make_emulator();
-//     fill_scrollback(&mut emu, 150);
-//
-//     // Simulate the GUI scrolled back with a fold in view: a non-zero
-//     // extra-row request riding alongside a non-zero scroll offset.
-//     emu.set_gui_scroll_window(10, 5);
-//     let scrolled = emu.build_snapshot();
-//     assert_eq!(scrolled.scroll_offset, 10);
-//     assert_eq!(scrolled.window_extra_rows, 5);
-//
-//     // New PTY output arrives → snap to the live bottom.
-//     emu.handle_incoming_data(b"new output\r\n");
-//     let after = emu.build_snapshot();
-//     assert_eq!(after.scroll_offset, 0, "offset must snap to live bottom");
-//
-//     // The fold-extra-row request must be cleared too, otherwise the flattened
-//     // window stays extended above the live bottom against a buffer that no
-//     // longer has a fold in view.
-//     assert_eq!(
-//         after.window_extra_rows, 0,
-//         "handle_incoming_data must clear gui_extra_rows on new output \
-//          (call reset_scroll_offset, not just zero the offset)"
-//     );
-// }
+#[test]
+fn task_113_new_data_resets_extra_rows() {
+    let (mut emu, _rx) = make_emulator();
+    fill_scrollback(&mut emu, 150);
+
+    // Simulate the GUI scrolled back with a fold in view: a non-zero
+    // extra-row request riding alongside a non-zero scroll offset.
+    emu.set_gui_scroll_window(10, 5);
+    let scrolled = emu.build_snapshot();
+    assert_eq!(scrolled.scroll_offset, 10);
+    assert_eq!(scrolled.window_extra_rows, 5);
+
+    // New PTY output arrives → snap to the live bottom.
+    emu.handle_incoming_data(b"new output\r\n");
+    let after = emu.build_snapshot();
+    assert_eq!(after.scroll_offset, 0, "offset must snap to live bottom");
+
+    // The fold-extra-row request must be cleared too, otherwise the flattened
+    // window stays extended above the live bottom against a buffer that no
+    // longer has a fold in view.
+    assert_eq!(
+        after.window_extra_rows, 0,
+        "handle_incoming_data must clear gui_extra_rows on new output \
+         (call reset_scroll_offset, not just zero the offset)"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes an intermittent, hard-to-reproduce buffer-scroll corruption (Task 113)
where the active prompt scrolls to the top, output lands in unreachable
scrollback, and only `clear` recovers. Three distinct bugs, root-caused during a
v0.10.0 investigation session. Independent of the beautification work; lives in
`freminal-buffer` and `freminal-terminal-emulator`.

### Bug G (root cause) — grow path stranded live content

`Buffer::resize_height` grow branch appended blank rows at the bottom
unconditionally; the shrink branch retains rows as scrollback and the window is
bottom-anchored. Repeated grow/shrink cycles (interactive tiling-WM resize, or
repeated font-size changes) accumulated an unreclaimable blank tail below the
live cursor, stranding the prompt at the top in unreachable scrollback. Predates
command blocks. Fix: the primary grow path now reclaims trailing pristine
`ScrollFill` padding instead of appending, pinning the live cursor to the bottom
and revealing real scrollback above. Alternate-buffer and shrink branches
untouched.

### Bug R (amplifier) — reflow did not remap command blocks / prompt rows

`reflow_to_width` rebuilds every row on a width change and remapped the cursor
but not the buffer-absolute row fields on `command_blocks` / `prompt_rows`,
corrupting the gutter and fold layout. Fix: new `remap_block_rows_after_reflow`
translates each field through the same flat-offset map the cursor remap uses
(start fields anchor to the old row's first cell, `end_row` to its last cell,
matching the inclusive `[output_start_row, end_row]` range the GUI consumes).

### Bug E (amplifier) — new output cleared offset but not fold extra-rows

`handle_incoming_data` reset `gui_scroll_offset` but left `gui_extra_rows`
stale, keeping the flattened window extended above the live bottom while a fold
was in view. Fix: call the existing `reset_scroll_offset()` (clears both),
guarded so output at the live bottom does not needlessly invalidate the snapshot
cache.

## Tests

Three failing reproductions were committed as smoke tests, then made to pass and
kept as permanent regression coverage:

- `task_113_repeated_resize_does_not_strand_live_content` (Bug G)
- `task_113_reflow_remaps_command_block_rows` + `..._multiple_blocks_both_directions` (Bug R)
- `task_113_new_data_resets_extra_rows` (Bug E)

Two pre-existing grow tests were rewritten to assert the new contract
(cursor pinned to bottom / scrollback revealed instead of blanks appended).

## Verification

- `cargo test --all`: 103 ok groups, 0 failures
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo machete`: clean
- Benchmarks (`buffer_resize/grow_height`, `reflow_width`, `softwrap_heavy`,
  `bench_handle_incoming_data`): no regression (all within noise / < 15%)

See `Documents/PLAN_VERSION_100.md` "Task 113" for the full diagnosis.