### PR TITLE
fix: harden last_session.toml against corruption and startup failure

### DIFF
--- a/freminal-common/src/layout.rs
+++ b/freminal-common/src/layout.rs
@@ -1042,6 +1042,40 @@ project_dir = "~/default"
         assert_eq!(tab.panes.len(), 3);
     }
 
+    /// A blank `last_session.toml` (e.g. a zero-byte file left by a write that
+    /// was killed mid-flush) deserializes to a structurally-valid but empty
+    /// `Layout` — every field is `#[serde(default)]`, so parsing *succeeds*.
+    /// `resolve()` then yields zero windows.  This is the exact condition the
+    /// GUI's session-restore path must detect and treat as "no usable session"
+    /// (fall back to a default shell) rather than as a parse error or a usable
+    /// layout.  This test pins that invariant so the empty-windows guard in the
+    /// GUI cannot silently stop being load-bearing.
+    #[test]
+    fn empty_toml_parses_to_zero_window_layout() {
+        for content in [
+            "",
+            "\n",
+            "# just a comment\n",
+            "[layout]\nname = \"Last Session\"\n",
+        ] {
+            let layout = Layout::from_str_content(Path::new("last_session.toml"), content)
+                .expect("blank/empty TOML should parse as a valid empty layout");
+            assert!(
+                layout.windows.is_empty(),
+                "expected no windows for content {content:?}"
+            );
+            assert!(
+                layout.tabs.is_empty(),
+                "expected no top-level tabs for content {content:?}"
+            );
+            let resolved = layout.resolve().expect("empty layout should resolve");
+            assert!(
+                resolved.windows.is_empty(),
+                "empty layout must resolve to zero windows for content {content:?}"
+            );
+        }
+    }
+
     #[test]
     fn validate_split_layout_ok() {
         let layout =

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -53,6 +53,12 @@ impl freminal_windowing::App for FreminalGui {
         let os_dark_mode = ctx.global_style().visuals.dark_mode;
 
         if let Some(initial) = self.initial_state.take() {
+            // Start the periodic session auto-save timer, bound to the first
+            // window's repaint handle so it can wake the (otherwise sleeping)
+            // event loop when a save is due.  Spawned exactly once, here at
+            // first-window creation.
+            self.spawn_session_autosave_timer(Arc::clone(&initial.repaint_handle));
+
             // First window — spawn the initial PTY tab now, or if a
             // startup layout/session-restore applies, delegate to the
             // layout machinery (which will build the tabs itself and
@@ -315,21 +321,24 @@ impl freminal_windowing::App for FreminalGui {
         //
         // Saving is independent of `restore_last_session` — the flag only
         // controls whether the saved session is *applied* on next launch.
-        // Always writing keeps `_last_session.toml` fresh so users can
-        // toggle the flag on at any time and get their real last session
-        // back, rather than whatever stale state happened to be on disk
-        // when they last had the flag enabled.
+        // Saving keeps `last_session.toml` fresh so users can toggle the flag
+        // on at any time and get their real last session back, rather than
+        // whatever stale state happened to be on disk when they last had the
+        // flag enabled.
         //
-        // We still skip saving when the user launched with an ad-hoc
-        // command (`freminal -- vim foo`): those panes are running a
-        // one-shot program and are not meaningfully restorable.
+        // `maybe_auto_save_session` skips the write when nothing changed since
+        // the periodic timer last persisted, and skips entirely for ad-hoc
+        // command launches (`freminal -- vim foo`).  In the common case the
+        // periodic save already wrote the current state, so this shutdown call
+        // is a no-op — by design, so we no longer depend on a write surviving
+        // an abrupt teardown.
         let remaining_terminal_windows = self
             .windows
             .keys()
             .filter(|&&wid| Some(wid) != self.settings_window_id)
             .count();
-        if remaining_terminal_windows == 1 && self.args.command.is_empty() {
-            self.auto_save_session();
+        if remaining_terminal_windows == 1 {
+            self.maybe_auto_save_session();
         }
 
         // Capture geometry of every still-open terminal window (including
@@ -481,6 +490,12 @@ impl freminal_windowing::App for FreminalGui {
             }
             return;
         }
+
+        // ── Periodic session auto-save ───────────────────────────────────────
+        // The background timer latches `session_save_due`; drain it here so a
+        // due save runs on the terminal-window update path (the settings
+        // window returned above).  Cheap no-op when not due.
+        self.poll_session_autosave();
 
         // ── Focus or create settings window (deferred from menu/keybind) ─────
         if self.pending_focus_settings {
@@ -2433,6 +2448,22 @@ impl FreminalGui {
             let var_map = self.args.layout_var_map();
             return match freminal_common::layout::Layout::from_file(&path) {
                 Ok(layout) => match layout.apply_variables(&positional, &var_map).resolve() {
+                    Ok(resolved) if resolved.windows.is_empty() => {
+                        // A structurally-valid but empty layout (no windows /
+                        // no panes) cannot produce a usable window.  Treat it
+                        // as "no layout applies" so the caller falls back to a
+                        // default shell rather than rendering a blank/fatal
+                        // window.
+                        error!("Layout '{}' contains no windows", path.display());
+                        self.push_error_toast(
+                            "Layout is empty",
+                            Some(format!(
+                                "{} defines no windows or panes; starting a default shell.",
+                                path.display()
+                            )),
+                        );
+                        None
+                    }
                     Ok(resolved) => Some(resolved),
                     Err(e) => {
                         error!("Failed to resolve layout '{}': {e}", path.display());
@@ -2463,6 +2494,29 @@ impl FreminalGui {
             l.apply_variables(&[], &std::collections::HashMap::new())
                 .resolve()
         }) {
+            // A blank or zero-window `last_session.toml` deserializes to a
+            // structurally-valid but empty `Layout` (every field is
+            // `#[serde(default)]`), so parsing *succeeds* and we land here with
+            // no windows.  This is exactly the corruption case observed when a
+            // previous run was killed mid-write (e.g. an aggressive reboot
+            // truncated the file): without this guard the empty layout produced
+            // a blank window and a fatal-error panel at startup.  Treat it like
+            // a parse failure — warn the user via a non-blocking toast and fall
+            // back to a default shell so the terminal still starts.
+            Ok(resolved) if resolved.windows.is_empty() => {
+                error!(
+                    "restore_last_session: {} contains no windows (blank/corrupt session)",
+                    path.display()
+                );
+                self.push_error_toast(
+                    "Could not restore last session",
+                    Some(
+                        "The saved session was empty or corrupt; starting a default shell."
+                            .to_owned(),
+                    ),
+                );
+                None
+            }
             Ok(resolved) => Some(resolved),
             Err(e) => {
                 error!(

--- a/freminal/src/gui/layout_ops.rs
+++ b/freminal/src/gui/layout_ops.rs
@@ -273,41 +273,54 @@ impl FreminalGui {
 
     /// Read the current working directory of the shell in the given pane.
     ///
-    /// Delegates to [`crate::gui::platform::read_cwd`], which supports Linux
-    /// (`/proc/<pid>/cwd`), macOS (`proc_pidinfo(PROC_PIDVNODEPATHINFO)` via
-    /// `sysinfo`), and Windows (`NtQueryInformationProcess` via `sysinfo`).
-    /// Returns `None` when the child PID is unknown, the process has exited,
-    /// the platform is unsupported, or the path is not valid UTF-8.
+    /// Source priority:
+    /// 1. The OSC 7 cwd carried in the pane's latest snapshot
+    ///    (`snap.cwd`).  When the shell runs freminal's shell integration it
+    ///    emits `OSC 7` at every prompt, so this is present, free (a single
+    ///    atomic snapshot load, no syscall), and tracks the user's perceived
+    ///    cwd across `cd` and subshells.
+    /// 2. Fallback: [`crate::gui::platform::read_cwd`], which inspects the OS
+    ///    process — Linux (`/proc/<pid>/cwd`), macOS / Windows (via `sysinfo`).
+    ///    This covers users who do *not* run shell integration (where
+    ///    `snap.cwd` is always `None`).  Returns `None` when the child PID is
+    ///    unknown, the process has exited, the platform is unsupported, or the
+    ///    path is not valid UTF-8.
+    ///
+    /// Returns `None` when neither source can supply a cwd — in which case the
+    /// pane simply has no `directory` recorded (and contributes nothing to a
+    /// session-change check, so an OSC-7-less freshly-spawned shell does not
+    /// churn the saved session).
     pub(super) fn read_cwd_for_pane_with_extra(
         &self,
         pane_id: panes::PaneId,
         extra_win: Option<&PerWindowState>,
     ) -> Option<String> {
-        // Search extra_win first (current window removed from self.windows during update()).
-        let child_pid = extra_win
-            .and_then(|win| {
-                win.tabs.iter().find_map(|tab| {
-                    tab.pane_tree.iter_panes().ok().and_then(|ps| {
-                        ps.into_iter()
-                            .find(|p| p.id == pane_id)
-                            .and_then(|p| p.child_pid)
-                    })
-                })
+        // Locate the pane once; from it we can read both the snapshot cwd and
+        // the child PID without iterating the window set twice.  A named `fn`
+        // (not a closure) is used so the borrow checker ties the returned
+        // `&Pane` to the input `&PerWindowState` lifetime.
+        fn find_in(win: &PerWindowState, pane_id: panes::PaneId) -> Option<&panes::Pane> {
+            win.tabs.iter().find_map(|tab| {
+                tab.pane_tree
+                    .iter_panes()
+                    .ok()
+                    .and_then(|ps| ps.into_iter().find(|p| p.id == pane_id))
             })
-            .or_else(|| {
-                // Find the pane across all other windows and tabs.
-                self.windows.values().find_map(|win| {
-                    win.tabs.iter().find_map(|tab| {
-                        tab.pane_tree.iter_panes().ok().and_then(|ps| {
-                            ps.into_iter()
-                                .find(|p| p.id == pane_id)
-                                .and_then(|p| p.child_pid)
-                        })
-                    })
-                })
-            })?;
+        }
 
-        crate::gui::platform::read_cwd(child_pid)
+        // Search extra_win first (current window removed from self.windows
+        // during update()), then all other windows and tabs.
+        let pane = extra_win
+            .and_then(|win| find_in(win, pane_id))
+            .or_else(|| self.windows.values().find_map(|win| find_in(win, pane_id)))?;
+
+        // Priority 1: OSC 7 cwd from the latest snapshot (no syscall).
+        if let Some(cwd) = pane.arc_swap.load().cwd.clone() {
+            return Some(cwd);
+        }
+
+        // Priority 2: OS process inspection (one syscall; only when OSC 7 absent).
+        crate::gui::platform::read_cwd(pane.child_pid?)
     }
 
     /// Serialise the current window/tab/pane topology as a [`freminal_common::layout::Layout`]
@@ -316,8 +329,8 @@ impl FreminalGui {
     /// `extra_win` should be `Some(win)` when called during `update()`, because
     /// the current window has been removed from `self.windows` for the duration
     /// of the frame.  Pass `None` when called outside `update()` (e.g. from
-    /// `auto_save_session` in `on_close_requested`) where all windows are still
-    /// in `self.windows`.
+    /// `maybe_auto_save_session` in `on_close_requested`) where all windows are
+    /// still in `self.windows`.
     ///
     /// `name` is the human-readable name for the layout; if empty the path
     /// file stem is used as a fallback.
@@ -331,6 +344,77 @@ impl FreminalGui {
         name: &str,
         extra_win: Option<&PerWindowState>,
     ) -> anyhow::Result<()> {
+        // Preserve the historical behavior: an empty `name` derives the layout
+        // name from the file stem.  `build_layout` itself is path-agnostic.
+        let resolved_name = if name.is_empty() {
+            path.file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or_default()
+        } else {
+            name
+        };
+        let layout = self.build_layout(resolved_name, extra_win);
+        let toml_str = layout.to_toml_string()?;
+        Self::atomic_write(path, &toml_str)?;
+        Ok(())
+    }
+
+    /// Atomically write `contents` to `path`.
+    ///
+    /// Writes to a sibling temporary file first, flushes it, then renames it
+    /// over the destination.  A rename within a filesystem is atomic, so a
+    /// concurrent reader (or a crash mid-write) always observes either the
+    /// complete old file or the complete new file — never a truncated one.
+    ///
+    /// This is the fix for the "blank `last_session.toml` after an aggressive
+    /// shutdown" failure mode: the previous `std::fs::write` truncated the
+    /// destination on open, so a process killed between truncate and write
+    /// left a zero-byte file on disk.  With temp+rename, the worst a killed
+    /// write leaves behind is a stray `.tmp` sibling (harmless; overwritten
+    /// on the next save), and the real file is left intact.
+    pub(super) fn atomic_write(path: &std::path::Path, contents: &str) -> std::io::Result<()> {
+        use std::io::Write as _;
+
+        // Place the temp file next to the destination so the rename stays
+        // within the same filesystem (cross-filesystem renames are not
+        // atomic and fail with EXDEV).  Suffix with the PID to avoid two
+        // freminal processes clobbering each other's temp file.
+        let mut tmp = path.as_os_str().to_owned();
+        tmp.push(format!(".tmp.{}", std::process::id()));
+        let tmp = std::path::PathBuf::from(tmp);
+
+        // Scope the file handle so it is closed (and flushed) before rename.
+        {
+            let mut f = std::fs::File::create(&tmp)?;
+            f.write_all(contents.as_bytes())?;
+            f.flush()?;
+        }
+
+        match std::fs::rename(&tmp, path) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                // Best-effort cleanup of the temp file on rename failure so we
+                // don't leak it.  The original error is what the caller sees.
+                let _ = std::fs::remove_file(&tmp);
+                Err(e)
+            }
+        }
+    }
+
+    /// Build an in-memory [`Layout`](freminal_common::layout::Layout) snapshot
+    /// of the current session from all open windows.
+    ///
+    /// Pure: performs no I/O of its own beyond the per-pane CWD lookup (which
+    /// prefers the OSC 7 cwd carried in each pane's snapshot and only falls
+    /// back to a `/proc` syscall when that is absent — see
+    /// [`Self::read_cwd_for_pane_with_extra`]).  Separated from
+    /// [`Self::save_layout`] so the auto-save path can serialize-and-fingerprint
+    /// the result to decide whether a write is even necessary.
+    pub(super) fn build_layout(
+        &self,
+        name: &str,
+        extra_win: Option<&PerWindowState>,
+    ) -> freminal_common::layout::Layout {
         use freminal_common::layout::{Layout, LayoutMeta, LayoutTab, LayoutWindow};
 
         let mut windows: Vec<LayoutWindow> = Vec::new();
@@ -381,12 +465,12 @@ impl FreminalGui {
         }
 
         let layout_name = if name.is_empty() {
-            path.file_stem().and_then(|s| s.to_str()).map(str::to_owned)
+            None
         } else {
             Some(name.to_owned())
         };
 
-        let layout = Layout {
+        Layout {
             layout: LayoutMeta {
                 name: layout_name,
                 description: None,
@@ -394,11 +478,7 @@ impl FreminalGui {
             },
             windows,
             tabs: Vec::new(),
-        };
-
-        let toml_str = layout.to_toml_string()?;
-        std::fs::write(path, toml_str)?;
-        Ok(())
+        }
     }
 
     /// Apply a resolved layout to the current frontmost window and spawn any
@@ -657,5 +737,74 @@ impl FreminalGui {
         }
 
         Some(commands)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::FreminalGui;
+
+    /// `atomic_write` creates the destination with the given contents.
+    #[test]
+    fn atomic_write_creates_file() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().join("session.toml");
+
+        FreminalGui::atomic_write(&path, "hello = 1").expect("write");
+
+        let read_back = std::fs::read_to_string(&path).expect("read");
+        assert_eq!(read_back, "hello = 1");
+    }
+
+    /// A second write fully replaces the first — no truncation, no leftover
+    /// bytes from a longer previous value.
+    #[test]
+    fn atomic_write_overwrites_completely() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().join("session.toml");
+
+        FreminalGui::atomic_write(&path, "a-long-initial-value = true").expect("first write");
+        FreminalGui::atomic_write(&path, "short = 1").expect("second write");
+
+        let read_back = std::fs::read_to_string(&path).expect("read");
+        assert_eq!(read_back, "short = 1");
+    }
+
+    /// After a successful write the temporary sibling file is renamed away,
+    /// so no `.tmp.<pid>` artifact is left in the directory.
+    #[test]
+    fn atomic_write_leaves_no_temp_file() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().join("session.toml");
+
+        FreminalGui::atomic_write(&path, "x = 1").expect("write");
+
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("read_dir")
+            .filter_map(Result::ok)
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            entries,
+            vec!["session.toml".to_owned()],
+            "stray files: {entries:?}"
+        );
+    }
+
+    /// The destination directory must exist; writing into a missing directory
+    /// surfaces an error rather than silently succeeding (callers create the
+    /// layout dir first).
+    #[test]
+    fn atomic_write_errors_when_parent_missing() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().join("no-such-subdir").join("session.toml");
+
+        let result = FreminalGui::atomic_write(&path, "x = 1");
+        assert!(
+            result.is_err(),
+            "expected error writing into missing parent"
+        );
     }
 }

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -328,6 +328,24 @@ struct FreminalGui {
     /// `(title, detail)` — `title` is a short headline, `detail` carries
     /// the underlying spawn error for the user to act on.
     fatal_error: Option<(String, String)>,
+
+    /// Hash of the TOML last written to `last_session.toml` by the auto-save
+    /// path, used to skip redundant writes.
+    ///
+    /// The session is auto-saved both periodically (a background timer) and on
+    /// shutdown.  Most ticks produce a layout identical to the one already on
+    /// disk; rather than rewrite an unchanged file every minute (and risk a
+    /// pointless write racing a shutdown), we fingerprint the serialized TOML
+    /// and only write when it differs from this value.  `None` until the first
+    /// successful auto-save.  Only the *automatic* path consults this — an
+    /// explicit "Save Layout As..." always writes.
+    last_session_fingerprint: Option<u64>,
+
+    /// Set by the background auto-save timer thread (every
+    /// [`SESSION_AUTOSAVE_INTERVAL`]) to request that `update()` re-evaluate
+    /// whether the session needs saving.  The thread also wakes the event loop
+    /// via the repaint proxy so this is observed promptly even at idle.
+    session_save_due: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl FreminalGui {
@@ -463,6 +481,8 @@ impl FreminalGui {
             toasts: std::cell::RefCell::new(toast::ToastStack::default()),
             force_close_windows: std::collections::HashSet::new(),
             fatal_error: None,
+            last_session_fingerprint: None,
+            session_save_due: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         if !layout_errors.is_empty() {

--- a/freminal/src/gui/session.rs
+++ b/freminal/src/gui/session.rs
@@ -3,10 +3,19 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+use std::hash::{Hash as _, Hasher as _};
+
 use tracing::error;
 
 use super::FreminalGui;
 use super::window;
+
+/// How often the background timer asks the GUI to re-evaluate the session for
+/// auto-save.  The check is cheap when nothing changed (build + hash + compare,
+/// no write), so a tight-ish minute keeps the on-disk session fresh without
+/// being chatty.  Not user-configurable by design — see the module docs on
+/// `last_session_fingerprint`.
+pub(super) const SESSION_AUTOSAVE_INTERVAL: std::time::Duration = std::time::Duration::from_mins(1);
 
 impl FreminalGui {
     /// Return the path used for auto-save/restore of the last session.
@@ -77,30 +86,137 @@ impl FreminalGui {
         self.window_state.main_windows = main_windows;
     }
 
-    /// Save the current session to `last_session.toml` in the layout library.
+    /// Auto-save the current session to `last_session.toml`, but only if it
+    /// differs from what was last written.
     ///
-    /// Called automatically when the last terminal window closes.  Runs
-    /// regardless of `restore_last_session` so the on-disk session stays
-    /// fresh; the flag only controls whether the saved session is
-    /// reapplied on next launch.  Failures are logged but not fatal.
-    pub(super) fn auto_save_session(&self) {
+    /// Runs regardless of `restore_last_session` so the on-disk session stays
+    /// fresh; the flag only controls whether the saved session is reapplied on
+    /// next launch.  Invoked from two places:
+    /// * the periodic background timer (every [`SESSION_AUTOSAVE_INTERVAL`]),
+    ///   and
+    /// * window close / shutdown.
+    ///
+    /// Because both paths converge here, most shutdown saves are no-ops: the
+    /// timer has usually already persisted the current state, so the on-disk
+    /// fingerprint matches and we skip the write entirely.  That deliberately
+    /// makes the shutdown write non-load-bearing — the resilience win is that
+    /// we no longer depend on a synchronous write surviving a hostile teardown.
+    ///
+    /// Skips saving when the user launched with an ad-hoc command
+    /// (`freminal -- vim foo`): those panes run a one-shot program and are not
+    /// meaningfully restorable.  Failures are logged but never fatal.
+    pub(super) fn maybe_auto_save_session(&mut self) {
+        if !self.args.command.is_empty() {
+            return;
+        }
+
         let Some(path) = Self::last_session_path() else {
-            error!("auto_save_session: cannot determine layout library path");
+            error!("maybe_auto_save_session: cannot determine layout library path");
             return;
         };
+
+        // Build the session layout and serialize it in memory so we can
+        // fingerprint the exact bytes we would write.  No disk read-back: the
+        // fingerprint compares against the last value *we* wrote this run.
+        let layout = self.build_layout("Last Session", None);
+        let toml_str = match layout.to_toml_string() {
+            Ok(s) => s,
+            Err(e) => {
+                error!("maybe_auto_save_session: serialize failed: {e}");
+                return;
+            }
+        };
+
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        toml_str.hash(&mut hasher);
+        let fingerprint = hasher.finish();
+
+        if self.last_session_fingerprint == Some(fingerprint) {
+            // Nothing changed since the last write — skip the I/O entirely.
+            tracing::trace!("session unchanged since last save; skipping write");
+            return;
+        }
+
         if let Some(parent) = path.parent()
             && let Err(e) = std::fs::create_dir_all(parent)
         {
-            error!("auto_save_session: cannot create layout library dir: {e}");
+            error!("maybe_auto_save_session: cannot create layout library dir: {e}");
             return;
         }
-        match self.save_layout(&path, "Last Session", None) {
+
+        match Self::atomic_write(&path, &toml_str) {
             Ok(()) => {
+                self.last_session_fingerprint = Some(fingerprint);
                 tracing::info!("Session auto-saved to {}", path.display());
             }
             Err(e) => {
-                error!("auto_save_session: failed: {e}");
+                error!(
+                    "maybe_auto_save_session: failed to write {}: {e}",
+                    path.display()
+                );
             }
+        }
+    }
+
+    /// Spawn the background thread that periodically asks `update()` to
+    /// re-evaluate the session for auto-save.
+    ///
+    /// The GUI event loop sleeps on `ControlFlow::Wait` at idle, so a timer
+    /// living on the GUI thread (a per-frame elapsed check) would never fire
+    /// without traffic.  Instead we mirror the PTY consumer pattern: a
+    /// dedicated thread sleeps for [`SESSION_AUTOSAVE_INTERVAL`], flips the
+    /// shared `session_save_due` flag, and pokes the window's
+    /// [`RepaintProxy`](freminal_windowing::RepaintProxy) to wake the loop.
+    /// `update()` observes the flag and calls
+    /// [`Self::maybe_auto_save_session`].
+    ///
+    /// The thread holds only an `Arc<OnceLock<(RepaintProxy, WindowId)>>` and
+    /// an `Arc<AtomicBool>` — no GUI state — so it cannot violate the
+    /// single-threaded GUI invariant.  It runs for the life of the process
+    /// (the proxy clone keeps the loop reachable); on process exit it is torn
+    /// down with everything else.
+    pub(super) fn spawn_session_autosave_timer(
+        &self,
+        repaint_handle: std::sync::Arc<
+            std::sync::OnceLock<(
+                freminal_windowing::RepaintProxy,
+                freminal_windowing::WindowId,
+            )>,
+        >,
+    ) {
+        use std::sync::atomic::Ordering;
+
+        let due = std::sync::Arc::clone(&self.session_save_due);
+        std::thread::Builder::new()
+            .name("session-autosave".to_owned())
+            .spawn(move || {
+                loop {
+                    std::thread::sleep(SESSION_AUTOSAVE_INTERVAL);
+                    due.store(true, Ordering::Relaxed);
+                    // Wake the event loop so `update()` runs and sees the flag.
+                    // If the handle is not yet initialised (first window still
+                    // coming up), skip this tick's wake — the next one will
+                    // catch it, and the flag is already latched.
+                    if let Some((proxy, wid)) = repaint_handle.get() {
+                        proxy.request_repaint(*wid);
+                    }
+                }
+            })
+            .map_or_else(
+                |e| error!("failed to spawn session-autosave timer: {e}"),
+                |_handle| (),
+            );
+    }
+
+    /// If the background timer has requested it, re-evaluate and auto-save the
+    /// session.  Called once near the top of each `update()`; cheap when the
+    /// flag is clear.
+    pub(super) fn poll_session_autosave(&mut self) {
+        if self
+            .session_save_due
+            .swap(false, std::sync::atomic::Ordering::Relaxed)
+        {
+            self.maybe_auto_save_session();
         }
     }
 


### PR DESCRIPTION
## Problem

A blank or corrupt `last_session.toml` could stop freminal from
starting. The auto-save used a non-atomic `std::fs::write`, which
truncates the destination on open; a process killed mid-write (e.g. an
aggressive reboot during shutdown) left a **zero-byte file**. That empty
file then parsed as a structurally-valid but empty `Layout`, resolved to
zero windows, and tripped the fatal-error "Failed to start session"
panel at startup instead of falling back to a shell.

## Fix (three layers)

1. **Atomic writes (root cause).** `save_layout` now writes to a sibling
   `.tmp.<pid>` file, flushes, and renames over the destination. A
   rename within a filesystem is atomic, so a reader (or a crash
   mid-write) always sees either the complete old file or the complete
   new one — never a truncated one.

2. **Empty-session fallback.** Startup resolution treats a resolved
   layout with zero windows as "no usable session" for both the
   session-restore path and the `--layout` / `startup.layout` path: it
   pushes a non-blocking warning toast and falls back to a default
   shell, rather than rendering a blank/fatal window.

3. **Periodic, write-if-changed auto-save.** A background timer thread
   wakes the (idle, `ControlFlow::Wait`) event loop every minute via the
   existing `RepaintProxy` and latches a flag; `update()` drains it and
   calls `maybe_auto_save_session`, which fingerprints the serialized
   TOML and writes only when it differs from the last write. The
   shutdown save runs through the same path, so it is usually a no-op and
   is no longer load-bearing: the on-disk session is kept fresh during
   the run instead of depending on a write surviving an abrupt teardown.

Also switches the per-pane CWD source for saving from a `/proc` syscall
to the **OSC 7 cwd already in each pane's snapshot**, falling back to
`/proc` only when OSC 7 is absent (shell integration disabled).

## Tests

- `empty_toml_parses_to_zero_window_layout` (freminal-common): blank /
  comment-only / `[layout]`-only TOML parses and resolves to zero
  windows — pins the invariant the empty-windows guard relies on.
- `atomic_write_*` (freminal): creates, fully overwrites, leaves no temp
  file, and errors on a missing parent.

## Manual verification

Reproduced with the original corrupted session file: launched a default
shell (with the warning toast); first periodic save fired at ~1 min; an
unchanged minute produced no write; a `cd` produced a fresh write.

## Verification suite

- `cargo test --all` — all pass
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo machete` — no unused deps
- `cargo fmt --all -- --check` — clean