### PR TITLE
v0.11.2 — Fixes, Diagnostics & Dep Bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,18 +510,18 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -632,9 +632,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "freminal"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-buffer"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "conv2",
  "criterion",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-common"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-terminal-emulator"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-windowing"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "conv2",
  "egui",
@@ -2864,9 +2864,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "open"
-version = "5.3.6"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a"
+checksum = "a0b3d059e795d52b8a72fef45658620edd4d9c359b338564aa14391ffa511ed5"
 dependencies = [
  "is-wsl",
  "libc",
@@ -3273,9 +3273,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -3385,9 +3385,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3397,9 +3397,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3950,9 +3950,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.5"
+version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
 dependencies = [
  "libc",
  "memchr",
@@ -4078,9 +4078,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -4178,9 +4178,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4434,9 +4434,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -5234,9 +5234,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -5525,9 +5525,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["freminal", "freminal-buffer", "freminal-common", "freminal-terminal-
 default-members = ["freminal", "freminal-buffer", "freminal-common", "freminal-terminal-emulator"]
 
 [workspace.package]
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 rust-version = "1.95.0"
 description = "A terminal emulator written in Rust"
@@ -49,11 +49,11 @@ libc = "0.2.186"
 log = "0.4.32"
 nix = "0.31.3"
 notify-rust = "4.18.0"
-open = "5.3.5"
+open = "5.4.0"
 predicates = "3.1.4"
 proptest = "1.11.0"
 raw-window-handle = "0.6.2"
-regex = "1.12.3"
+regex = "1.13.0"
 rmp-serde = "1.3.0"
 rustc-hash = "2.1.3"
 rustybuzz = "0.20.1"
@@ -66,7 +66,7 @@ shell-words = "1.1.1"
 smol = "2.0.2"
 swash = "0.2.8"
 sys-locale = "0.3.2"
-sysinfo = { version = "0.39.3", default-features = false, features = ["system"] }
+sysinfo = { version = "0.39.6", default-features = false, features = ["system"] }
 tar = "0.4.46"
 tempfile = "3.27.0"
 test-log = { version = "0.2.21", features = ["trace"] }

--- a/Documents/MASTER_PLAN.md
+++ b/Documents/MASTER_PLAN.md
@@ -23,8 +23,9 @@ and plan document maintenance rules.
 | v0.10.0 | Beautification & Fonts          | `PLAN_VERSION_100.md`                                                 | 111–112          | Complete |
 | v0.11.0 | Kitty: Notifications & Graphics | `PLAN_VERSION_110.md`                                                 | 99–101, 114      | Complete |
 | v0.11.1 | Correctness Fixes               | `PLAN_VERSION_111.md`                                                 | 115–117          | Complete |
-| v0.12.0 | Kitty: Transfer & Cursors       | `PLAN_VERSION_120.md`                                                 | 102–103          | Planned  |
+| v0.12.0 | Kitty: Transfer & Cursors       | `PLAN_VERSION_120.md`                                                 | 102–103, 118     | Planned  |
 | v0.13.0 | Kitty: Text Sizing              | `PLAN_VERSION_130.md`                                                 | 104              | Planned  |
+| v0.13.1 | Scrollback Compression          | `PLAN_VERSION_131.md`                                                 | 119              | Stub     |
 | v0.14.0 | Power-User Toolkit              | `PLAN_VERSION_140.md`                                                 | 78–83, 96–97     | Stub     |
 | v0.15.0 | Remote                          | `PLAN_VERSION_150.md`                                                 | 86               | Stub     |
 | v0.16.0 | Reach & Credibility             | `PLAN_VERSION_160.md`                                                 | 88, 89, 91, 93   | Stub     |
@@ -187,6 +188,8 @@ into v0.14.0–v0.16.0 and v0.20.0) and remaining Category C housekeeping (Tasks
 | 115 | DECSCNM Per-Pane Per-Cell Reverse Video   | `PLAN_VERSION_111.md` (Task 115)              | Complete  | Task 58                |
 | 116 | Text Selection Release/Stuck Fix          | `PLAN_VERSION_111.md` (Task 116)              | Complete  | None                   |
 | 117 | DECDWL/DECDHL/DECSLRM Buffer Completeness | `PLAN_VERSION_111.md` (Task 117)              | Complete  | None                   |
+| 118 | Compact Cell Representation               | `PLAN_VERSION_120.md` (Task 118)              | Planned   | None                   |
+| 119 | Scrollback Compression (LZ4)              | `PLAN_VERSION_131.md` (Task 119)              | Stub      | Task 118               |
 
 ---
 
@@ -670,6 +673,7 @@ Update this section as tasks complete:
 - `Documents/PLAN_VERSION_111.md` — v0.11.1 "Correctness Fixes" (Tasks 115–117, decomposed)
 - `Documents/PLAN_VERSION_120.md` — v0.12.0 "Kitty: Transfer & Cursors" (Tasks 102–103, decomposed)
 - `Documents/PLAN_VERSION_130.md` — v0.13.0 "Kitty: Text Sizing" (Task 104, decomposed)
+- `Documents/PLAN_VERSION_131.md` — v0.13.1 "Scrollback Compression" (stub, Task 119)
 - `Documents/PLAN_VERSION_140.md` — v0.14.0 "Power-User Toolkit" (stubs, Tasks 78–83, 96–97)
 - `Documents/PLAN_VERSION_150.md` — v0.15.0 "Remote" (stub, Task 86)
 - `Documents/PLAN_VERSION_160.md` — v0.16.0 "Reach & Credibility" (stubs, Tasks 88, 89, 91, 93)

--- a/Documents/PLAN_VERSION_120.md
+++ b/Documents/PLAN_VERSION_120.md
@@ -7,8 +7,17 @@ bidirectional session machine with a mandatory user-consent prompt — and multi
 (CSI), a renderer-light addition. The heavy, consent-gated transfer work is balanced by
 the small, safe cursor win, so the version stays focused even if transfer expands.
 
+This version also carries **Task 118 — Compact Cell Representation**, a buffer-layer memory
+optimisation unrelated to the kitty work but deliberately slotted here because it is a
+cheap, low-risk, high-value change to the buffer's shape, and doing buffer-shape work
+*before* more features accrete on top of the buffer is prudent. It is the first phase of a
+two-phase scrollback-memory effort; phase two (LZ4 idle compression, Task 119) is a
+separate later version (v0.13.1, `PLAN_VERSION_131.md`) that builds on the compact
+representation this task introduces.
+
 Depends on v0.11.0 (Task 99 establishes the reverse-PTY-write notification path that file
-transfer reuses) and the existing lock-free architecture.
+transfer reuses) and the existing lock-free architecture. Task 118 has no dependency on the
+kitty tasks and can proceed in parallel with them.
 
 **Decomposed** per the `freminal-version-activation` skill (next-up, stable specs).
 Re-confirm the seams at activation before executing.
@@ -21,6 +30,7 @@ Re-confirm the seams at activation before executing.
 | --- | ------------------------------ | --------- | ------- | ---------- |
 | 102 | Kitty File Transfer (OSC 5113) | Very high | Planned | Task 99    |
 | 103 | Multiple Cursors (CSI)         | Medium    | Planned | None       |
+| 118 | Compact Cell Representation    | Medium    | Planned | None       |
 
 ---
 
@@ -345,3 +355,243 @@ Stop: report + await review.
   `PLAN_VERSION_DND.md`) because its spec is still under active development upstream
   (kitty 0.47, issue #9984). Building it against a moving target violates the
   build-against-a-frozen-spec rule.
+
+---
+
+## Task 118 — Compact Cell Representation
+
+### 118 Summary
+
+Reduce the resident-memory cost of scrollback so a much larger default scrollback becomes
+affordable, by shrinking the in-memory footprint of stored rows. This is **phase one** of a
+two-phase scrollback-memory effort. Phase one is pure representation/serialization — **no
+compression codec, no decompression-on-scroll, no reflow complexity, no new dependency** —
+and captures the large majority of the achievable win. Phase two (Task 119, v0.13.1) adds
+LZ4 idle compression as an incremental multiplier on top.
+
+The measured motivation (feasibility spike, 100k-line corpora with realistic
+"stable-structure + unique-content" data):
+
+| Corpus                    | In-memory today | Flat compact repr | Reduction |
+| ------------------------- | --------------- | ----------------- | --------- |
+| Shell session (typical)   | ~4160 B/line    | ~345 B/line       | **~12×**  |
+| Source / logs             | ~3739 B/line    | ~310 B/line       | **~12×**  |
+| High-entropy colored (WC) | ~5800 B/line    | ~732 B/line       | **~8×**   |
+
+The in-memory `Cell` is **72 bytes** (18-byte `TChar` + 40-byte `FormatTag` +
+2 bools + 8-byte `Option<Box<ImagePlacement>>`, padded to 72). The 40-byte `FormatTag`
+is duplicated in full on **every** cell even though runs of adjacent cells almost always
+share identical formatting, and the 8-byte image pointer is `None` for essentially every
+text cell. A compact representation that (a) shares formatting across runs instead of
+per-cell and (b) drops the always-null image slot from the common-case storage recovers
+~8–12× with zero runtime decompression cost.
+
+### 118 Design decisions (durable)
+
+- **Phase one is representation only; no codec.** The ~8–12× win comes entirely from
+  removing per-cell `FormatTag` duplication and the always-`None` image pointer from stored
+  scrollback rows. This is guaranteed regardless of content and adds **zero** read-path
+  latency (it is a compact layout, not a compressed blob). Compression (Task 119) is layered
+  on later and is explicitly out of scope here.
+- **Format-run sharing, not per-cell tags.** Store a row's formatting as a small run list
+  (`(FormatTag, run_length)` or a per-row interned tag table + per-cell index), reflecting
+  that adjacent cells overwhelmingly share a `FormatTag`. This mirrors the existing
+  `FormatTag { start, end, … }` range model already used at the flatten boundary
+  (`freminal-common/src/buffer_states/format_tag.rs`) and in `RowCacheEntry.tags`
+  (`freminal-buffer/src/buffer/flatten.rs`), so the run model is not a new concept in the
+  codebase.
+- **Scope the compaction to scrollback rows, not the active region.** The visible/active
+  region (`Buffer.rows` tail of length `height`) is mutated constantly and must stay in the
+  fast random-access `Vec<Cell>` form. Only rows that have scrolled into history
+  (`rows[0 .. rows.len()-height]`) are candidates for the compact form. The boundary is
+  crossed when a row scrolls out of the visible window.
+- **The `row_cache` duplicate is part of the prize.** `Buffer.row_cache:
+  Vec<Option<RowCacheEntry>>` (`buffer/mod.rs:84`) holds a *second*, fully-flattened copy of
+  every row (`chars`, `tags`, `bytes`, `byte_to_char`, `auto_urls`). For scrollback rows this
+  is pure duplication of data that is rarely read. Evicting / not-populating the cache entry
+  for compacted scrollback rows is a first-class part of this task's memory win, separate
+  from the cell compaction itself.
+- **Correctness is preserved exactly.** The compact form must round-trip losslessly to the
+  current `Row`/`Cell` (same `TChar`, same `FormatTag`, same wide-head/continuation flags,
+  same image placement when present). Inline-image scrollback rows (rare) may opt out of
+  compaction and stay in the `Vec<Cell>` form rather than complicate the compact encoding.
+- **No public snapshot/API change if avoidable.** `build_snapshot()` and the flatten path
+  consume rows via the existing accessors; the compact form should be internal to
+  `freminal-buffer` and decompacted on read at the flatten boundary, so the terminal-emulator
+  and GUI layers are unaffected. This respects the crate dependency boundaries in
+  `freminal-architecture`.
+- **Raising the default scrollback is a deliberate outcome, decided with data.** Once the
+  per-line cost drops ~8–12×, the default `ScrollbackConfig.limit` (currently 4000, range
+  1..=100_000, `freminal-common/src/config.rs`) can be raised substantially at net-lower
+  memory. The exact new default is chosen in 118.5 against the measured post-compaction
+  per-line cost, not guessed here.
+
+### 118 Current-state map (from recon)
+
+- **`Cell`** — `freminal-buffer/src/cell.rs:15` (`value: TChar`, `format: FormatTag`,
+  `is_wide_head`, `is_wide_continuation`, `image: Option<Box<ImagePlacement>>`). Fields are
+  private with accessors; construction via `Cell::new` / `blank_with_tag` /
+  `wide_continuation`.
+- **`Row`** — `freminal-buffer/src/row.rs:68` (`cells: Vec<Cell>`, `width`, `origin`, `join`,
+  `dirty`, `line_width`). Rows are already **sparse** (trailing default-blank cells trimmed,
+  e.g. `row.rs:570`).
+- **`Buffer.rows: Vec<Row>`** — `buffer/mod.rs:78`; scrollback = indices
+  `0..rows.len()-height`, visible = last `height`. **`Buffer.row_cache:
+  Vec<Option<RowCacheEntry>>`** — `buffer/mod.rs:84`, index-parallel to `rows`.
+- **`FormatTag`** — `freminal-common/src/buffer_states/format_tag.rs:22`; 40 bytes; the only
+  heap field is `url: Option<Arc<Url>>` (cloning bumps a refcount, never deep-copies).
+  `is_visually_default()` (`format_tag.rs:60`) is the cheap default check.
+- **Flatten boundary** — `Buffer::flatten_row` / `rows_as_tchars_and_tags_cached`
+  (`buffer/flatten.rs`) is where rows become `RowCacheEntry`; a compact scrollback row must
+  decompact correctly through this path.
+- **Benchmarks** — `freminal-buffer/benches/buffer_row_bench.rs`
+  (`bench_scrollback_flatten`, `bench_scrollback_render`, `buffer_resize`, `softwrap_heavy`)
+  and `freminal-terminal-emulator/benches/buffer_benches.rs`
+  (`bench_build_snapshot_with_scrollback`) cover the hot paths this task touches.
+
+### 118 Subtasks
+
+#### 118.1 — READ-ONLY audit + compact-representation design
+
+Scope: read-only across `freminal-buffer/src/cell.rs`, `row.rs`, `buffer/mod.rs`,
+`buffer/flatten.rs`, `freminal-common/src/buffer_states/format_tag.rs`, and the buffer
+benches.
+
+What: produce the concrete design for the compact scrollback-row representation. Decide:
+the exact compact type (e.g. `CompactRow { chars: Vec<TChar>, tag_runs: Vec<(FormatTag,
+u32)>, flags: …, line_width, origin, join }` or an interned-tag-table variant); the
+compaction trigger (row scrolls out of the visible window) and decompaction trigger (row
+re-enters visible window / is read for flatten); how inline-image rows are handled (opt out
+vs encode); how `row_cache` eviction for compacted rows is wired; and the exact accessor/
+flatten seam where decompaction happens so no higher layer sees the compact form. Confirm
+the sparse-row invariant interaction. Name every file each later subtask touches.
+
+Deliverable: design report with the chosen type definitions and the file-scoping for
+118.2–118.6. No code.
+
+Verification: none (read-only).
+
+Prohibitions: do NOT edit files; do NOT introduce a compression codec (that is Task 119);
+do NOT begin implementation; do NOT proceed without maintainer review of the design.
+
+Stop: report design; await explicit sign-off before 118.2.
+
+#### 118.2 — Compact row type + lossless round-trip (pure, in `freminal-buffer`)
+
+Scope: new module `freminal-buffer/src/compact_row.rs` (or as named in 118.1);
+`freminal-buffer/src/lib.rs` (module decl); unit tests in the new module.
+
+What: implement the compact row type chosen in 118.1 and the two conversions
+`Row -> CompactRow` and `CompactRow -> Row`, exactly lossless for `TChar`, `FormatTag`
+(including `Arc<Url>` sharing), wide-head/continuation flags, `line_width`, `origin`,
+`join`, and inline-image placement (or the documented opt-out). Pure data transform; no
+Buffer integration yet.
+
+Deliverable: the type + conversions + exhaustive round-trip tests (plain rows, colored
+runs, mixed tags, wide chars, URL tags, blank/sparse rows, and — per the 118.1 decision —
+image rows or the opt-out path). A `size_of`/heap-size assertion demonstrating the
+per-row reduction on a representative row.
+
+Verification: `cargo test --all`; `cargo clippy --all-targets --all-features -- -D warnings`.
+
+Prohibitions: do NOT touch `Buffer`; do NOT change `Cell`/`Row` public API; do NOT add a
+codec; do NOT proceed.
+
+Stop: report + await review.
+
+#### 118.3 — Buffer integration: compact scrollback rows on scroll-out
+
+Scope: `freminal-buffer/src/buffer/mod.rs` (row storage + the scroll-out path), the
+scroll/enforce-scrollback sites (`enforce_scrollback_limit`, the scroll path around
+`buffer/mod.rs:333`), and `buffer/flatten.rs` (decompact-on-read seam).
+
+What: store scrollback rows in the compact form, decompacting at the flatten/read boundary
+so no higher layer observes the change. Compact a row when it scrolls out of the visible
+window; keep the visible `height` rows in the existing `Vec<Cell>` form. Preserve every
+existing `Buffer` behaviour (visible_rows, resize, alt-screen switch, prompt_rows/
+command_blocks index shifting on drain).
+
+Deliverable: integration + tests proving identical observable output (flatten, visible_rows,
+snapshot content) before/after compaction across scroll, and that scrollback eviction still
+shifts dependent indices correctly.
+
+Verification: `cargo test --all`; clippy. Existing buffer tests must pass unchanged.
+
+Prohibitions: do NOT alter visible-region storage; do NOT change snapshot/public API; do
+NOT add a codec; do NOT proceed.
+
+Stop: report + await review.
+
+#### 118.4 — `row_cache` eviction for compacted scrollback rows
+
+Scope: `freminal-buffer/src/buffer/mod.rs` (`row_cache` population/invalidation),
+`buffer/flatten.rs` (cache lookup).
+
+What: stop populating / actively evict `RowCacheEntry` for rows that are in the compact
+scrollback form, so the second flattened copy is not held for cold history. Re-populate on
+demand when such a row is read (decompacted) for flatten. Ensure the cache-index parallelism
+with `rows` is maintained through drains and resizes.
+
+Deliverable: cache-eviction logic + tests asserting compacted scrollback rows hold no cache
+entry, that reading one repopulates correctly, and that URL auto-detection still works on
+re-read.
+
+Verification: `cargo test --all`; clippy.
+
+Prohibitions: do NOT evict cache for visible rows; do NOT proceed.
+
+Stop: report + await review.
+
+#### 118.5 — Raise default scrollback + benchmark before/after
+
+Scope: `freminal-common/src/config.rs` (`ScrollbackConfig::default`), `config_example.toml`,
+the buffer benches (`freminal-buffer/benches/buffer_row_bench.rs`,
+`freminal-terminal-emulator/benches/buffer_benches.rs`).
+
+What: capture before/after memory + throughput per `performance-benchmarks` +
+`freminal-bench-table` for `bench_scrollback_flatten`, `bench_scrollback_render`,
+`bench_build_snapshot_with_scrollback`, `buffer_resize`, and `softwrap_heavy`. Confirm no
+>15% regression on the read/flatten hot paths (some slowdown on the cold decompact-on-read
+path is acceptable and expected; the visible-region path must not regress). Using the
+measured post-compaction per-line cost, raise `ScrollbackConfig`'s default `limit` to a value
+that is net-lower-or-equal memory versus today's 4000-line default (proposed target decided
+here with data, not guessed), and update `config_example.toml` and the field doc/comment.
+
+Deliverable: benchmark record (before/after) + the new default + config doc update.
+
+Verification: `cargo test --all`; clippy; `cargo bench --no-run --all`; markdownlint clean
+for any doc edits.
+
+Prohibitions: do NOT raise the default without the benchmark justifying it; do NOT regress
+the visible-region path >15%; do NOT proceed.
+
+Stop: report + await review.
+
+#### 118.6 — Windows cross-check + final verification
+
+Scope: no new logic; verification only (plus any trivial fix the cross-check surfaces).
+
+What: run `cargo xtask check-windows` (per `freminal-windows-crosscheck`) since this touches
+buffer storage/threading-adjacent code, and the full verification suite. Fix any
+Windows-only issue surfaced.
+
+Deliverable: green verification across the suite + Windows cross-check.
+
+Verification: `cargo test --all`; `cargo clippy --all-targets --all-features -- -D warnings`;
+`cargo machete`; `cargo fmt --all -- --check`; `cargo xtask check-windows`.
+
+Prohibitions: do NOT add features here; do NOT proceed past a failing check.
+
+Stop: report results.
+
+### 118 Open questions (resolve at activation)
+
+- Compact encoding shape: format-run list vs per-row interned tag table + indices. (Lean:
+  run list, since `FormatTag` runs are already the mental model and runs are typically very
+  few per row. Decide in 118.1 with a quick size comparison on representative rows.)
+- Inline-image scrollback rows: encode into the compact form, or opt out and keep as
+  `Vec<Cell>`? (Lean: opt out — image rows are rare and the `Box<ImagePlacement>` complicates
+  the flat encoding for negligible gain. Decide in 118.1.)
+- New default scrollback value: decided in 118.5 from the measured per-line cost. Candidate
+  framing: pick the largest round number whose post-compaction memory ≤ today's 4000-line
+  uncompacted memory (likely in the tens of thousands).

--- a/Documents/PLAN_VERSION_131.md
+++ b/Documents/PLAN_VERSION_131.md
@@ -1,0 +1,140 @@
+# PLAN_VERSION_131.md — v0.13.1 "Scrollback Compression"
+
+> **STATUS: ENRICHED STUB.** Durable design decisions are captured below;
+> per-subtask decomposition happens at activation in a dedicated session,
+> against the code as it then exists (see the `freminal-version-activation`
+> skill). Do not invent subtasks early.
+
+## Goal
+
+Add LZ4 compression of idle scrollback as a memory multiplier on top of the compact cell
+representation shipped in Task 118 (v0.12.0). This is **phase two** of the two-phase
+scrollback-memory effort. Phase one (compact representation) delivers the large, guaranteed,
+zero-runtime-cost win (~8–12× smaller stored rows); phase two adds an incremental multiplier
+by compressing scrollback that has been idle, and decompressing it on demand when the user
+scrolls into it — the strategy popularised by Ghostty.
+
+**Depends on Task 118** (compact representation). Compression operates on the flat, compact,
+pointer-free byte form that Task 118 introduces; without it there is nothing sensible to
+compress (raw `Cell` structs contain `Arc`/`Box` pointers that must not be byte-compressed).
+
+Point release after v0.13.0 (last kitty version), inserted like v0.11.1 was, so no existing
+version renumbers.
+
+---
+
+## Task Summary
+
+| #   | Feature                      | Scope | Status | Depends On |
+| --- | ---------------------------- | ----- | ------ | ---------- |
+| 119 | Scrollback Compression (LZ4) | Large | Stub   | Task 118   |
+
+---
+
+## Task 119 — Scrollback Compression (LZ4)
+
+Compress blocks of idle scrollback (in the Task-118 compact form) with LZ4, decompress on
+demand when scrolled into view, keep decompressed while visible, and recompress when the
+region scrolls back out. The aim, stated as the user-facing outcome: **make a very large
+scrollback affordable so the default can be raised further, especially for users running
+many tabs/panes at once** — the aggregate memory across many buffers is what actually hurts,
+not one buffer.
+
+### Measured motivation (feasibility spike)
+
+Spike ran against 100k-line corpora with realistic "stable-structure + unique-content"
+data (repeating prompt/log/ls skeletons + genuinely unique per-line payload), plus a
+pessimistic high-entropy bracket. All ratios are **on top of** the Task-118 flat compact
+form:
+
+| Corpus                    | Flat (Task 118) | flat + LZ4      | flat + zstd-3   |
+| ------------------------- | --------------- | --------------- | --------------- |
+| Shell session (typical)   | ~345 B/line     | ~106 B/line     | ~32 B/line      |
+| Source / logs             | ~310 B/line     | ~120 B/line     | ~37 B/line      |
+| High-entropy colored (WC) | ~732 B/line     | ~625 B/line     | ~429 B/line     |
+
+Total multiplier vs. **today's** 72-byte-cell in-memory representation: flat alone ~8–12×;
+flat + LZ4 ~9× (worst case) to ~31–39× (typical); flat + zstd-3 ~14× (worst) to ~100–131×
+(typical). Throughput: LZ4 decompress ~2,600 MB/s, zstd-3 decompress ~1,300 MB/s — both far
+above any plausible scroll/reflow rate.
+
+### The decompression-on-the-fly tradeoff (durable analysis)
+
+The bulk throughput number (~2,600 MB/s) is **not** the number that governs on-the-fly cost.
+The real costs are:
+
+1. **Per-call fixed overhead** — favours LZ4 (low) over zstd (higher, especially with a
+   dictionary). This is why per-*line* compression is wrong: a ~40-byte line gives a terrible
+   ratio and pays fixed overhead every access.
+2. **Block granularity = decompress amplification** — to read one line you decompress its
+   whole block. A 256-line block ≈ ~88 KB flat ≈ ~34 µs at LZ4 speed — well under one 16.6 ms
+   frame. Compress in **blocks** (≈128–256 lines), never per line.
+3. **Allocation churn** — naive per-access output allocation causes the jank, not the codec.
+   Mitigate with a reusable scratch buffer + an LRU cache of recently-decompressed blocks
+   (decompress once, keep live while visible, recompress/evict on scroll-out). Steady-state
+   scrolling within a cached region does zero decompression.
+4. **Reflow is the genuinely expensive case, not scroll.** Full reflow of 100k lines
+   decompresses everything (~13 ms at LZ4 speed) on top of the re-wrap CPU cost that already
+   exists. Mitigation: band-decompress the viewport region first, reflow + publish a snapshot,
+   then finish the rest asynchronously.
+
+### Design decisions (durable)
+
+- **LZ4 is the default codec, not zstd.** The "fast over ratio" preference plus the on-the-fly
+  decompression profile (frequent, small, hot-path block reads) point at LZ4's low per-call
+  overhead and ~2,600 MB/s decompress. zstd-low may be offered as an opt-in "maximum savings"
+  tier (its ratio is markedly better), but the live/hot path is LZ4. A future refinement could
+  use LZ4 for recently-idle blocks and zstd for deep-cold blocks; that is not day one.
+- **Compress in blocks of idle scrollback, never per line.** Per-line compression gives a
+  terrible ratio and pays fixed overhead per access. Block size ≈128–256 lines, tuned at
+  activation.
+- **Never compress the active/visible region.** Only scrollback that has been idle past a
+  threshold (Ghostty uses ~250 ms) is compressed. The visible `height` rows and the
+  Task-118 compact-but-uncompressed scrollback near the viewport stay directly readable.
+- **LRU cache of decompressed blocks.** Decompress on scroll-into-view, keep decompressed
+  while visible, recompress/evict on scroll-out. A reusable scratch buffer avoids per-access
+  allocation churn.
+- **Reflow uses band-decompression.** On resize, decompress only the blocks around the
+  viewport, reflow that band, publish a snapshot, then finish the remaining reflow async, so
+  the user never waits on a full-scrollback decompress. This is the trickiest part of the
+  task and the main reason it is a separate version from Task 118.
+- **Lives in `freminal-buffer`, below the snapshot line.** Compression is internal to the
+  buffer; `build_snapshot()`, the terminal-emulator, and the GUI are unaffected (they read
+  decompacted/decompressed rows through the existing flatten accessors). Respects the crate
+  dependency boundaries in `freminal-architecture`.
+- **New dependency (`lz4_flex`) added via `flake.nix` + `Cargo.toml`** per
+  `flake-dev-shell-discipline` — pure-Rust LZ4, no C toolchain, Windows-clean. `freminal-buffer`
+  currently has zero serialization/compression dependencies; this is the first. (zstd, if the
+  opt-in tier is built, pulls a C dependency and must be weighed against the Windows
+  cross-check.)
+- **Phase one already delivers most of the prize.** ~8–12× comes from Task 118 alone with no
+  codec and no decompression cost. This task is the *incremental* multiplier (another ~3× LZ4
+  / ~10× zstd typical) that carries essentially all the complexity (blocks, cache, reflow
+  band-decompression). It is worth doing — the many-tabs-many-panes aggregate-memory case is
+  real — but it is explicitly the smaller, riskier half of the effort.
+
+### Open questions (decide at activation)
+
+- Block size (128 vs 256 lines) and idle threshold (250 ms?) — tune against measured
+  scroll/reflow behaviour at activation.
+- LRU cache sizing (how many decompressed blocks kept live) and eviction policy.
+- zstd opt-in "max savings" tier: ship in this version or defer? (Weigh the C-dependency /
+  Windows cross-check cost against the ratio gain.)
+- Async-reflow-tail mechanism: which thread performs the deferred full reflow, and how the
+  partially-reflowed snapshot is represented without violating the lock-free snapshot model
+  (`freminal-architecture`).
+- Interaction with the recording/FREC path and with the `row_cache` (Task 118 already evicts
+  cache for compact scrollback rows; compressed blocks should likewise hold no cache entry).
+
+---
+
+## Design Decisions (provisional)
+
+- **Two-phase, compact-first.** Compact representation (Task 118) ships in v0.12.0 and carries
+  the guaranteed win with zero runtime cost; compression (this task) is the incremental,
+  higher-complexity multiplier layered on top. They are deliberately separate versions.
+- **LZ4 over zstd for the hot path**, driven by the decompression-on-the-fly tradeoff, not
+  bulk throughput.
+- **Correctness over ratio.** Any compressed block must round-trip losslessly to the
+  Task-118 compact form and thence to `Row`/`Cell`. A wrong scrollback line is worse than a
+  larger one.

--- a/flake.lock
+++ b/flake.lock
@@ -53,55 +53,32 @@
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "precommit",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "precommit",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782467914,
-        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
         "type": "github"
       },
       "original": {
@@ -113,11 +90,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
         "type": "github"
       },
       "original": {
@@ -151,11 +128,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1780504325,
-        "narHash": "sha256-EU52VleXVEQrX/CxqdoeQdJNSoWd1yr+0uyCtNFddYg=",
+        "lastModified": 1783875506,
+        "narHash": "sha256-Hx7uYdd6XyBohpAyIJwzjsJrUsY9ucOpzxoGMV+AYsI=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "0fe4cc46813614423b1cd54c9de1c74a448c7f3d",
+        "rev": "7ffbe4d244ef810e871ff616988753131c9595e8",
         "type": "github"
       },
       "original": {
@@ -177,11 +154,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1780456895,
-        "narHash": "sha256-CvRZn3Ut0scqLJ1xwQFkZwKGVBUUNBPrFVXRTMZpbfU=",
+        "lastModified": 1783834461,
+        "narHash": "sha256-FCmrs1StAghJDKfqy56KM96KZtxpYzgeq6zM3QO8wjA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7cc96a6a3fd6613cafd633250a3934483479b9a1",
+        "rev": "a286e5b998e852297a403786f063fb2c9fe7f57a",
         "type": "github"
       },
       "original": {
@@ -197,11 +174,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782703273,
-        "narHash": "sha256-WJPfr9EAWVIuTMyb/ilHKUYlg/RNa0xrNiWR+p1iHUg=",
+        "lastModified": 1783921439,
+        "narHash": "sha256-DsSIQSRMrLOz40LrGZ03sp2RlJ9sz3wKpd8XPTOzXnw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "5106a604b3d67cffe8eb51a8bd9f04e607f0d31d",
+        "rev": "e013376c32a8fcf07ddb6ec71739552bc118b7bd",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     # cargo-bundle is only used inside the dev shell to produce the Linux
     # deb/appimage artifacts locally.  nixpkgs is pinned at 0.9.0, which predates
     # SVG-icon and `appimage` support; we build from upstream master so the dev
-    # shell matches the 0.11.1+ the release CI installs via `cargo install`.
+    # shell matches the 0.11.2+ the release CI installs via `cargo install`.
     # `nix flake update cargo-bundle-src` picks up new upstream commits.
     cargo-bundle-src = {
       url = "github:burtonageo/cargo-bundle";
@@ -107,7 +107,7 @@
             };
           };
 
-          version = "0.11.1";
+          version = "0.11.2";
 
           # The build sandbox strips `.git`, so the crate's build.rs `git
           # describe` can only ever yield "unknown".  Feed it a real value via
@@ -171,9 +171,9 @@
                     <key>CFBundleIdentifier</key>
                     <string>io.github.fredclausen.freminal</string>
                     <key>CFBundleVersion</key>
-                    <string>0.11.1</string>
+                    <string>0.11.2</string>
                     <key>CFBundleShortVersionString</key>
-                    <string>0.11.1</string>
+                    <string>0.11.2</string>
                     <key>CFBundleExecutable</key>
                     <string>freminal</string>
                     <key>CFBundleIconFile</key>
@@ -336,7 +336,7 @@
 
               # cargo-bundle built from upstream master (see the cargo-bundle-src
               # input).  nixpkgs ships 0.9.0, which cannot bundle SVG icons or
-              # produce appimages; this matches the 0.11.1+ the release CI uses.
+              # produce appimages; this matches the 0.11.2+ the release CI uses.
               # Mirrors the nixpkgs recipe (squashfsTools wrap for appimage).
               cargoBundleLatest = pkgs.rustPlatform.buildRustPackage {
                 pname = "cargo-bundle";

--- a/freminal-buffer/src/buffer/mod.rs
+++ b/freminal-buffer/src/buffer/mod.rs
@@ -1232,7 +1232,7 @@ mod pty_behavior_tests {
         buf.handle_lf();
 
         let y = buf.cursor.pos.y;
-        assert!(y == 1);
+        assert_eq!(y, 1);
         assert!(matches!(buf.rows[1].origin, RowOrigin::HardBreak));
     }
 

--- a/freminal-common/src/buffer_states/ftcs.rs
+++ b/freminal-common/src/buffer_states/ftcs.rs
@@ -241,6 +241,30 @@ pub fn parse_ftcs_params(params: &[&str]) -> Option<FtcsMarker> {
     }
 }
 
+/// Whether `marker_char` is an FTCS marker letter freminal knows about.
+///
+/// Distinguishes the two reasons [`parse_ftcs_params`] returns `None`:
+///
+/// - A **known** marker (`A`/`B`/`C`/`D`/`P`) returning `None` means a foreign
+///   emitter sent it without the `freminal=1` tag (or without a required
+///   field). Freminal understands the sequence and deliberately ignores it to
+///   avoid duplicate command blocks — this is expected and should NOT be logged
+///   as unhandled.
+/// - An **unknown** marker (any other letter, e.g. `Z`, or a future FTCS
+///   addition like `E`) or an empty parameter list means freminal does not
+///   recognise the sequence at all. That is a genuine gap — a new/malformed
+///   OSC 133 variant — and the caller should log it so the unhandled surface
+///   can be audited (see `MASTER_PLAN` v0.16.0 crash reporting).
+///
+/// This is intentionally a separate, allocation-free classifier rather than a
+/// richer return type on [`parse_ftcs_params`], so the "should I act on this?"
+/// decision (the `Option`) and the "should I log this as unhandled?" decision
+/// stay independent and the existing callers/tests are unaffected.
+#[must_use]
+pub fn is_known_ftcs_marker(params: &[&str]) -> bool {
+    matches!(params.first(), Some(&("A" | "B" | "C" | "D" | "P")))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -639,5 +663,31 @@ mod tests {
                 fid: "x".to_owned()
             })
         );
+    }
+
+    // ── is_known_ftcs_marker ────────────────────────────────────────────
+
+    #[test]
+    fn known_ftcs_markers_are_recognised() {
+        // All five FTCS marker letters are "known", regardless of whether they
+        // carry freminal=1 (i.e. even foreign duplicates are known markers).
+        for m in ["A", "B", "C", "D", "P"] {
+            assert!(is_known_ftcs_marker(&[m]), "{m} should be known");
+            assert!(
+                is_known_ftcs_marker(&[m, "aid=12345"]),
+                "{m} with foreign params should still be known"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_or_empty_ftcs_markers_are_not_known() {
+        // Unknown letters, future additions, lowercase, and empty lists are all
+        // "not known" — these are the cases that must be logged as unhandled.
+        assert!(!is_known_ftcs_marker(&["Z"]));
+        assert!(!is_known_ftcs_marker(&["E"])); // plausible future FTCS marker
+        assert!(!is_known_ftcs_marker(&["a"])); // lowercase is not a marker
+        let empty: &[&str] = &[];
+        assert!(!is_known_ftcs_marker(empty));
     }
 }

--- a/freminal-common/src/buffer_states/tchar.rs
+++ b/freminal-common/src/buffer_states/tchar.rs
@@ -412,14 +412,14 @@ mod tests {
     fn partial_eq_vec_u8_utf8_matching() {
         let t = TChar::from('é');
         let bytes = "é".as_bytes().to_vec();
-        assert!(t == bytes);
+        assert_eq!(t, bytes);
     }
 
     #[test]
     fn partial_eq_vec_u8_utf8_non_matching() {
         let t = TChar::from('é');
         let bytes = "ü".as_bytes().to_vec();
-        assert!(t != bytes);
+        assert_ne!(t, bytes);
     }
 
     #[test]
@@ -587,12 +587,12 @@ mod tests {
 
     #[test]
     fn partial_eq_u8_space_matches_32() {
-        assert!(TChar::Space == 32u8);
+        assert_eq!(TChar::Space, 32u8);
     }
 
     #[test]
     fn partial_eq_u8_newline_matches_10() {
-        assert!(TChar::NewLine == 10u8);
+        assert_eq!(TChar::NewLine, 10u8);
     }
 
     #[test]

--- a/freminal-terminal-emulator/src/ansi.rs
+++ b/freminal-terminal-emulator/src/ansi.rs
@@ -325,7 +325,10 @@ impl FreminalAnsiParser {
                         // if the last value pushed to output is terminal Invalid, print out the sequence of characters that caused the error
 
                         if output.last() == Some(&TerminalOutput::Invalid) {
-                            debug!("Invalid ANSI sequence; recent={}", self.current_trace_str());
+                            debug!(
+                                "Invalid ANSI sequence; recent={}",
+                                self.current_trace_escaped()
+                            );
                         }
                     }
                     ParserOutcome::Continue => {
@@ -341,7 +344,7 @@ impl FreminalAnsiParser {
                         debug!(
                             "Invalid ANSI sequence: {}; recent={}",
                             message,
-                            self.current_trace_str()
+                            self.current_trace_escaped()
                         );
                         self.inner = ParserInner::Empty;
                     }
@@ -421,7 +424,7 @@ impl FreminalAnsiParser {
                             if output.last() == Some(&TerminalOutput::Invalid) {
                                 debug!(
                                     "Invalid ANSI sequence; recent={}",
-                                    self.current_trace_str()
+                                    self.current_trace_escaped()
                                 );
                             }
                         }
@@ -434,7 +437,7 @@ impl FreminalAnsiParser {
                             debug!(
                                 "Invalid ANSI sequence: {}; recent={}",
                                 message,
-                                self.current_trace_str()
+                                self.current_trace_escaped()
                             );
                             self.inner = ParserInner::Empty;
                         }
@@ -482,7 +485,7 @@ impl FreminalAnsiParser {
                             if output.last() == Some(&TerminalOutput::Invalid) {
                                 debug!(
                                     "Invalid ANSI sequence; recent={}",
-                                    self.current_trace_str()
+                                    self.current_trace_escaped()
                                 );
                             }
                         }
@@ -491,7 +494,7 @@ impl FreminalAnsiParser {
                             debug!(
                                 "Invalid ANSI sequence: {}; recent={}",
                                 message,
-                                self.current_trace_str()
+                                self.current_trace_escaped()
                             );
                             self.inner = ParserInner::Empty;
                             output.push(TerminalOutput::Invalid);
@@ -500,7 +503,7 @@ impl FreminalAnsiParser {
                             debug!(
                                 "Invalid ANSI sequence: {}; recent={}",
                                 message,
-                                self.current_trace_str()
+                                self.current_trace_escaped()
                             );
                             self.inner = ParserInner::Empty;
                             output.push(TerminalOutput::Invalid);
@@ -511,7 +514,10 @@ impl FreminalAnsiParser {
                     ParserOutcome::Finished => {
                         self.inner = ParserInner::Empty;
                         if output.last() == Some(&TerminalOutput::Invalid) {
-                            debug!("Invalid ANSI sequence; recent={}", self.current_trace_str());
+                            debug!(
+                                "Invalid ANSI sequence; recent={}",
+                                self.current_trace_escaped()
+                            );
                         }
                     }
                     ParserOutcome::Continue => (),
@@ -523,7 +529,7 @@ impl FreminalAnsiParser {
                         debug!(
                             "Invalid ANSI sequence: {}; recent={}",
                             message,
-                            self.current_trace_str()
+                            self.current_trace_escaped()
                         );
                         self.inner = ParserInner::Empty;
                     }
@@ -676,9 +682,9 @@ impl FreminalAnsiParser {
                 self.inner = ParserInner::Empty;
             }
             _ => {
-                debug!(
-                    "Unknown VT52 escape: 0x{b:02x}; recent={}",
-                    self.current_trace_str()
+                warn!(
+                    "Unknown VT52 escape: 0x{b:02x}; raw sequence: \"{}\"",
+                    self.current_trace_escaped()
                 );
                 output.push(TerminalOutput::Invalid);
                 self.inner = ParserInner::Empty;

--- a/freminal-terminal-emulator/src/ansi.rs
+++ b/freminal-terminal-emulator/src/ansi.rs
@@ -254,9 +254,9 @@ impl FreminalAnsiParser {
                 0x90 => {
                     self.inner = ParserInner::Dcs(DcsParser::new());
                 }
-                // CSI (0x9B) ≡ ESC [ — Control Sequence Introducer
+                // CSI (0x9B) ≡ ESC [ — Control Sequence Introducer (8-bit C1)
                 0x9B => {
-                    self.inner = ParserInner::Csi(AnsiCsiParser::new());
+                    self.inner = ParserInner::Csi(AnsiCsiParser::new_c1());
                 }
                 // OSC (0x9D) ≡ ESC ] — Operating System Command
                 0x9D => {

--- a/freminal-terminal-emulator/src/ansi.rs
+++ b/freminal-terminal-emulator/src/ansi.rs
@@ -1396,7 +1396,7 @@ mod tests {
     fn vt52_ansi_roundtrip() {
         // Start in ANSI mode, switch to VT52 via CSI, then back via ESC <
         let mut p = FreminalAnsiParser::new();
-        assert!(p.vt52_mode == Decanm::Ansi);
+        assert_eq!(p.vt52_mode, Decanm::Ansi);
 
         // Enter VT52 mode via the mode change (parser flag set externally,
         // as sync_mode would do after processing Mode::Decanm(Decanm::Vt52))

--- a/freminal-terminal-emulator/src/ansi_components/csi.rs
+++ b/freminal-terminal-emulator/src/ansi_components/csi.rs
@@ -71,7 +71,7 @@ use super::csi_commands::{
     su::ansi_parser_inner_csi_finished_su, tbc::ansi_parser_inner_csi_finished_tbc,
     vpa::ansi_parser_inner_csi_finished_vpa, xtversion::ansi_parser_inner_csi_finished_xtversion,
 };
-use crate::ansi_components::tracer::SequenceTracer;
+use crate::ansi_components::tracer::{SequenceTracer, escape_sequence_for_log};
 use crate::{ansi::ParserOutcome, ansi_components::tracer::SequenceTraceable};
 
 #[derive(Eq, PartialEq, Debug, Default)]
@@ -120,6 +120,21 @@ impl AnsiCsiParser {
     #[must_use]
     pub fn trace_str(&self) -> String {
         self.seq_trace.as_str()
+    }
+
+    /// Render the full raw CSI sequence — including the reconstructed `ESC [`
+    /// (CSI) introducer that the sub-parser never receives — as a
+    /// reconstruction-faithful escaped string for diagnostics.
+    ///
+    /// `body` is [`Self::sequence`], the accumulated CSI body bytes (parameters,
+    /// intermediates, and the final byte). The introducer is prepended so the
+    /// logged form is the complete sequence a terminal would send.
+    #[must_use]
+    fn format_raw_csi(body: &[u8]) -> String {
+        let mut full = Vec::with_capacity(body.len().saturating_add(2));
+        full.extend_from_slice(&[0x1b, b'[']);
+        full.extend_from_slice(body);
+        escape_sequence_for_log(&full)
     }
 
     /// Push a byte into the parser
@@ -363,7 +378,19 @@ impl AnsiCsiParser {
                 }
                 push_result
             }
-            AnsiCsiParserState::Finished(_esc) => push_result,
+            AnsiCsiParserState::Finished(_esc) => {
+                // Syntactically valid CSI whose final byte we do not implement.
+                // The grammar accepted it (params/intermediates/terminator all
+                // legal) but no dispatch arm matched, so nothing is emitted.
+                // Log the complete raw sequence — reconstructed with its `ESC [`
+                // introducer — so the offending sequence is identifiable rather
+                // than silently dropped.
+                tracing::warn!(
+                    "Unhandled CSI final byte (valid grammar, no dispatch): {}",
+                    Self::format_raw_csi(&self.sequence)
+                );
+                push_result
+            }
 
             // Below should cover the invalid state(AnsiCsiParserState::Invalid) as well as any other finished states
             _ => push_result,
@@ -663,5 +690,35 @@ mod tests {
         let result = parser.ansiparser_inner_csi(b'w', &mut output);
         assert_eq!(result, ParserOutcome::Finished);
         assert!(output.is_empty());
+    }
+
+    #[test]
+    fn format_raw_csi_reconstructs_full_sequence() {
+        // The CSI body accumulated by the parser excludes the `ESC [`
+        // introducer; format_raw_csi must prepend it so the logged form is the
+        // complete sequence a terminal would send.
+        assert_eq!(AnsiCsiParser::format_raw_csi(b"38;5;9w"), "\\x1b[38;5;9w");
+        // Empty body still shows the introducer.
+        assert_eq!(AnsiCsiParser::format_raw_csi(b""), "\\x1b[");
+    }
+
+    #[test]
+    fn unhandled_final_byte_accumulates_full_body_for_logging() {
+        // Feed an unhandled-but-valid CSI (`ESC [ 1 ; 2 W`) one byte at a time
+        // and confirm the parser's `sequence` field holds the complete body so
+        // the diagnostic log can render it.
+        let mut parser = AnsiCsiParser::new();
+        let mut output = Vec::new();
+        for &b in b"1;2" {
+            let _ = parser.ansiparser_inner_csi(b, &mut output);
+        }
+        let result = parser.ansiparser_inner_csi(b'W', &mut output);
+        assert_eq!(result, ParserOutcome::Finished);
+        assert!(output.is_empty());
+        assert_eq!(parser.sequence, b"1;2W");
+        assert_eq!(
+            AnsiCsiParser::format_raw_csi(&parser.sequence),
+            "\\x1b[1;2W"
+        );
     }
 }

--- a/freminal-terminal-emulator/src/ansi_components/csi.rs
+++ b/freminal-terminal-emulator/src/ansi_components/csi.rs
@@ -83,12 +83,39 @@ pub(crate) enum AnsiCsiParserState {
     Invalid,
     InvalidFinished,
 }
+/// Which Control Sequence Introducer began this CSI sequence.
+///
+/// The 7-bit `ESC [` form and the 8-bit `0x9B` (C1) form are equivalent
+/// grammatically, but for lossless diagnostic logging they must be
+/// reconstructed distinctly: the sub-parser never receives the introducer
+/// bytes, so it records which one was used at construction time.
+#[derive(Eq, PartialEq, Debug, Default, Clone, Copy)]
+pub enum CsiIntroducer {
+    /// 7-bit CSI: `ESC [` (`0x1B 0x5B`).
+    #[default]
+    SevenBit,
+    /// 8-bit CSI: `0x9B` (C1).
+    EightBit,
+}
+
+impl CsiIntroducer {
+    /// The raw introducer bytes as they appear on the wire.
+    const fn bytes(self) -> &'static [u8] {
+        match self {
+            Self::SevenBit => b"\x1b[",
+            Self::EightBit => b"\x9b",
+        }
+    }
+}
+
 #[derive(Eq, PartialEq, Debug, Default)]
 pub struct AnsiCsiParser {
     pub(crate) state: AnsiCsiParserState,
     pub params: Vec<u8>,
     pub intermediates: Vec<u8>,
     pub sequence: Vec<u8>,
+    /// The introducer that began this sequence, for lossless diagnostics.
+    introducer: CsiIntroducer,
     /// Internal trace of recent bytes for diagnostics.
     seq_trace: SequenceTracer,
 }
@@ -105,13 +132,26 @@ impl SequenceTraceable for AnsiCsiParser {
 }
 
 impl AnsiCsiParser {
+    /// Construct a parser for a 7-bit (`ESC [`) CSI sequence.
     #[must_use]
     pub fn new() -> Self {
+        Self::with_introducer(CsiIntroducer::SevenBit)
+    }
+
+    /// Construct a parser for an 8-bit (`0x9B`, C1) CSI sequence.
+    #[must_use]
+    pub fn new_c1() -> Self {
+        Self::with_introducer(CsiIntroducer::EightBit)
+    }
+
+    #[must_use]
+    fn with_introducer(introducer: CsiIntroducer) -> Self {
         Self {
             state: AnsiCsiParserState::Params,
             params: Vec::with_capacity(8),
             intermediates: Vec::with_capacity(4),
             sequence: Vec::with_capacity(16),
+            introducer,
             seq_trace: SequenceTracer::new(),
         }
     }
@@ -122,18 +162,20 @@ impl AnsiCsiParser {
         self.seq_trace.as_str()
     }
 
-    /// Render the full raw CSI sequence — including the reconstructed `ESC [`
-    /// (CSI) introducer that the sub-parser never receives — as a
+    /// Render the full raw CSI sequence — including the reconstructed CSI
+    /// introducer that the sub-parser never receives — as a
     /// reconstruction-faithful escaped string for diagnostics.
     ///
-    /// `body` is [`Self::sequence`], the accumulated CSI body bytes (parameters,
-    /// intermediates, and the final byte). The introducer is prepended so the
-    /// logged form is the complete sequence a terminal would send.
+    /// The body is [`Self::sequence`], the accumulated CSI body bytes
+    /// (parameters, intermediates, and the final byte). The actual introducer
+    /// (`ESC [` for 7-bit, `0x9B` for 8-bit C1) is prepended so the logged form
+    /// is the complete sequence a terminal would send.
     #[must_use]
-    fn format_raw_csi(body: &[u8]) -> String {
-        let mut full = Vec::with_capacity(body.len().saturating_add(2));
-        full.extend_from_slice(&[0x1b, b'[']);
-        full.extend_from_slice(body);
+    fn format_raw_csi(&self) -> String {
+        let introducer = self.introducer.bytes();
+        let mut full = Vec::with_capacity(self.sequence.len().saturating_add(introducer.len()));
+        full.extend_from_slice(introducer);
+        full.extend_from_slice(&self.sequence);
         escape_sequence_for_log(&full)
     }
 
@@ -382,12 +424,12 @@ impl AnsiCsiParser {
                 // Syntactically valid CSI whose final byte we do not implement.
                 // The grammar accepted it (params/intermediates/terminator all
                 // legal) but no dispatch arm matched, so nothing is emitted.
-                // Log the complete raw sequence — reconstructed with its `ESC [`
+                // Log the complete raw sequence — reconstructed with its actual
                 // introducer — so the offending sequence is identifiable rather
                 // than silently dropped.
                 tracing::warn!(
                     "Unhandled CSI final byte (valid grammar, no dispatch): {}",
-                    Self::format_raw_csi(&self.sequence)
+                    self.format_raw_csi()
                 );
                 push_result
             }
@@ -697,9 +739,24 @@ mod tests {
         // The CSI body accumulated by the parser excludes the `ESC [`
         // introducer; format_raw_csi must prepend it so the logged form is the
         // complete sequence a terminal would send.
-        assert_eq!(AnsiCsiParser::format_raw_csi(b"38;5;9w"), "\\x1b[38;5;9w");
+        let mut parser = AnsiCsiParser::new();
+        parser.sequence = b"38;5;9w".to_vec();
+        assert_eq!(parser.format_raw_csi(), "\\x1b[38;5;9w");
         // Empty body still shows the introducer.
-        assert_eq!(AnsiCsiParser::format_raw_csi(b""), "\\x1b[");
+        let empty = AnsiCsiParser::new();
+        assert_eq!(empty.format_raw_csi(), "\\x1b[");
+    }
+
+    #[test]
+    fn format_raw_csi_preserves_c1_introducer() {
+        // A sequence begun by the 8-bit C1 introducer (`0x9B`) must be logged
+        // as `\x9b...`, not the 7-bit `\x1b[...` form, to stay lossless.
+        let mut parser = AnsiCsiParser::new_c1();
+        parser.sequence = b"38;5;9w".to_vec();
+        assert_eq!(parser.format_raw_csi(), "\\x9b38;5;9w");
+        // Empty body still shows the 8-bit introducer.
+        let empty = AnsiCsiParser::new_c1();
+        assert_eq!(empty.format_raw_csi(), "\\x9b");
     }
 
     #[test]
@@ -716,9 +773,6 @@ mod tests {
         assert_eq!(result, ParserOutcome::Finished);
         assert!(output.is_empty());
         assert_eq!(parser.sequence, b"1;2W");
-        assert_eq!(
-            AnsiCsiParser::format_raw_csi(&parser.sequence),
-            "\\x1b[1;2W"
-        );
+        assert_eq!(parser.format_raw_csi(), "\\x1b[1;2W");
     }
 }

--- a/freminal-terminal-emulator/src/ansi_components/csi_commands/decslpp.rs
+++ b/freminal-terminal-emulator/src/ansi_components/csi_commands/decslpp.rs
@@ -5,6 +5,7 @@
 
 use crate::ansi::{ParserOutcome, split_params_into_semicolon_delimited_usize};
 use crate::ansi_components::csi_commands::util::param_or;
+use crate::ansi_components::tracer::escape_sequence_for_log;
 use crate::error::ParserFailures;
 use freminal_common::buffer_states::terminal_output::TerminalOutput;
 use freminal_common::buffer_states::window_manipulation::WindowManipulation;
@@ -80,6 +81,9 @@ pub fn ansi_parser_inner_csi_finished_decslpp(
     params: &[u8],
     output: &mut Vec<TerminalOutput>,
 ) -> ParserOutcome {
+    // Preserve the original raw parameter bytes for diagnostics before the
+    // binding is shadowed by the parsed form below.
+    let raw_params = params;
     let params = split_params_into_semicolon_delimited_usize(params);
 
     let Ok(params) = params else {
@@ -107,7 +111,10 @@ pub fn ansi_parser_inner_csi_finished_decslpp(
     let parsed = match WindowManipulation::try_from((ps1, ps2, ps3)) {
         Ok(parsed) => parsed,
         Err(e) => {
-            warn!("Invalid DECSLPP sequence: {e}");
+            warn!(
+                "Invalid DECSLPP sequence: {e} (CSI t); raw params: \"{}\"",
+                escape_sequence_for_log(raw_params)
+            );
             output.push(TerminalOutput::Invalid);
 
             return ParserOutcome::InvalidParserFailure(ParserFailures::UnhandledDECSLPPCommand(

--- a/freminal-terminal-emulator/src/ansi_components/csi_commands/dl.rs
+++ b/freminal-terminal-emulator/src/ansi_components/csi_commands/dl.rs
@@ -4,6 +4,7 @@
 // https://opensource.org/licenses/MIT.
 
 use crate::ansi::{ParserOutcome, parse_param_as};
+use crate::ansi_components::tracer::escape_sequence_for_log;
 use crate::error::ParserFailures;
 use freminal_common::buffer_states::terminal_output::TerminalOutput;
 
@@ -16,7 +17,10 @@ pub fn ansi_parser_inner_csi_finished_dl(
     output: &mut Vec<TerminalOutput>,
 ) -> ParserOutcome {
     let Ok(param) = parse_param_as::<usize>(params) else {
-        warn!("Invalid dl command");
+        warn!(
+            "Invalid DL command (CSI M); raw params: \"{}\"",
+            escape_sequence_for_log(params)
+        );
         output.push(TerminalOutput::Invalid);
 
         return ParserOutcome::InvalidParserFailure(ParserFailures::UnhandledDLCommand(format!(

--- a/freminal-terminal-emulator/src/ansi_components/csi_commands/dsr.rs
+++ b/freminal-terminal-emulator/src/ansi_components/csi_commands/dsr.rs
@@ -4,6 +4,7 @@
 // https://opensource.org/licenses/MIT.
 
 use crate::ansi::{ParserOutcome, parse_param_as};
+use crate::ansi_components::tracer::escape_sequence_for_log;
 use crate::error::ParserFailures;
 use freminal_common::buffer_states::terminal_output::TerminalOutput;
 
@@ -27,7 +28,10 @@ pub fn ansi_parser_inner_csi_finished_dsr(
     let actual_params = if is_private { &params[1..] } else { params };
 
     let Ok(param) = parse_param_as::<usize>(actual_params) else {
-        warn!("Invalid DSR command");
+        warn!(
+            "Invalid DSR command (CSI n); raw params: \"{}\"",
+            escape_sequence_for_log(params)
+        );
         output.push(TerminalOutput::Invalid);
 
         return ParserOutcome::InvalidParserFailure(ParserFailures::UnhandledDSRCommand(format!(
@@ -46,7 +50,10 @@ pub fn ansi_parser_inner_csi_finished_dsr(
             output.push(TerminalOutput::ColorThemeReport);
         }
         _ => {
-            warn!("Unhandled DSR Ps value: {param:?}");
+            warn!(
+                "Unhandled DSR Ps value: {param:?} (CSI n); raw params: \"{}\"",
+                escape_sequence_for_log(params)
+            );
             output.push(TerminalOutput::Invalid);
         }
     }

--- a/freminal-terminal-emulator/src/ansi_components/csi_commands/el.rs
+++ b/freminal-terminal-emulator/src/ansi_components/csi_commands/el.rs
@@ -4,6 +4,7 @@
 // https://opensource.org/licenses/MIT.
 
 use crate::ansi::{ParserOutcome, parse_param_as};
+use crate::ansi_components::tracer::escape_sequence_for_log;
 use crate::error::ParserFailures;
 use freminal_common::buffer_states::terminal_output::TerminalOutput;
 
@@ -56,7 +57,10 @@ pub fn ansi_parser_inner_csi_finished_el(
         1 => output.push(TerminalOutput::ClearLineBackwards),
         2 => output.push(TerminalOutput::ClearLine),
         v => {
-            warn!("Unsupported erase in line command ({v})");
+            warn!(
+                "Unsupported erase in line command ({v}) (CSI K); raw params: \"{}\"",
+                escape_sequence_for_log(params)
+            );
             output.push(TerminalOutput::Invalid);
         }
     }

--- a/freminal-terminal-emulator/src/ansi_components/csi_commands/ich.rs
+++ b/freminal-terminal-emulator/src/ansi_components/csi_commands/ich.rs
@@ -4,6 +4,7 @@
 // https://opensource.org/licenses/MIT.
 
 use crate::ansi::{ParserOutcome, parse_param_as};
+use crate::ansi_components::tracer::escape_sequence_for_log;
 use crate::error::ParserFailures;
 use freminal_common::buffer_states::terminal_output::TerminalOutput;
 
@@ -16,7 +17,10 @@ pub fn ansi_parser_inner_csi_finished_ich(
     output: &mut Vec<TerminalOutput>,
 ) -> ParserOutcome {
     let Ok(param) = parse_param_as::<usize>(params) else {
-        warn!("Invalid ich command");
+        warn!(
+            "Invalid ICH command (CSI @); raw params: \"{}\"",
+            escape_sequence_for_log(params)
+        );
         output.push(TerminalOutput::Invalid);
 
         return ParserOutcome::InvalidParserFailure(ParserFailures::UnhandledICHCommand(format!(

--- a/freminal-terminal-emulator/src/ansi_components/csi_commands/il.rs
+++ b/freminal-terminal-emulator/src/ansi_components/csi_commands/il.rs
@@ -4,6 +4,7 @@
 // https://opensource.org/licenses/MIT.
 
 use crate::ansi::{ParserOutcome, parse_param_as};
+use crate::ansi_components::tracer::escape_sequence_for_log;
 use crate::error::ParserFailures;
 use freminal_common::buffer_states::terminal_output::TerminalOutput;
 /// IL — Insert Line (`CSI Ps L`)
@@ -15,7 +16,10 @@ pub fn ansi_parser_inner_csi_finished_il(
     output: &mut Vec<TerminalOutput>,
 ) -> ParserOutcome {
     let Ok(param) = parse_param_as::<usize>(params) else {
-        warn!("Invalid il command");
+        warn!(
+            "Invalid IL command (CSI L); raw params: \"{}\"",
+            escape_sequence_for_log(params)
+        );
         output.push(TerminalOutput::Invalid);
 
         return ParserOutcome::InvalidParserFailure(ParserFailures::UnhandledILCommand(format!(

--- a/freminal-terminal-emulator/src/ansi_components/csi_commands/sd.rs
+++ b/freminal-terminal-emulator/src/ansi_components/csi_commands/sd.rs
@@ -4,6 +4,7 @@
 // https://opensource.org/licenses/MIT.
 
 use crate::ansi::{ParserOutcome, parse_param_as};
+use crate::ansi_components::tracer::escape_sequence_for_log;
 use crate::error::ParserFailures;
 use freminal_common::buffer_states::terminal_output::TerminalOutput;
 
@@ -16,7 +17,10 @@ pub fn ansi_parser_inner_csi_finished_sd(
     output: &mut Vec<TerminalOutput>,
 ) -> ParserOutcome {
     let Ok(param) = parse_param_as::<usize>(params) else {
-        warn!("Invalid SD command");
+        warn!(
+            "Invalid SD command (CSI T); raw params: \"{}\"",
+            escape_sequence_for_log(params)
+        );
         output.push(TerminalOutput::Invalid);
 
         return ParserOutcome::InvalidParserFailure(ParserFailures::UnhandledSDCommand(format!(

--- a/freminal-terminal-emulator/src/ansi_components/csi_commands/sgr.rs
+++ b/freminal-terminal-emulator/src/ansi_components/csi_commands/sgr.rs
@@ -8,6 +8,7 @@ use std::vec::IntoIter;
 
 use crate::ansi::{ParserOutcome, parse_param_as};
 use crate::ansi_components::csi_commands::modify_other_keys::ansi_parser_inner_csi_finished_modify_other_keys;
+use crate::ansi_components::tracer::escape_sequence_for_log;
 use freminal_common::buffer_states::fonts::UnderlineStyle;
 use freminal_common::buffer_states::terminal_output::TerminalOutput;
 use freminal_common::colors::TerminalColor;
@@ -189,7 +190,10 @@ fn process_colon_segment(segment: &[u8], output: &mut Vec<TerminalOutput>) {
         }
         _ => {
             // Unknown colon form — emit the primary as a plain SGR and warn.
-            debug!("Unknown colon-form SGR: primary={primary}");
+            warn!(
+                "Unknown colon-form SGR: primary={primary}; raw segment: \"{}\"",
+                escape_sequence_for_log(segment)
+            );
             output.push(TerminalOutput::Sgr(SelectGraphicRendition::from_usize(
                 primary,
             )));
@@ -262,7 +266,12 @@ pub fn handle_custom_color(
             match SelectGraphicRendition::from_usize_color(custom_color_control_code, r, g, b) {
                 Ok(sgr) => output.push(TerminalOutput::Sgr(sgr)),
                 Err(e) => {
-                    warn!("Invalid RGB SGR sequence: {}", e);
+                    // The raw SGR byte slice is not reachable at this depth
+                    // (only the already-parsed channel values survive), so log
+                    // the parsed reconstruction instead: SGR <cc>;2;r;g;b.
+                    warn!(
+                        "Invalid RGB SGR sequence: {e}; parsed SGR {custom_color_control_code};2;{r};{g};{b}"
+                    );
                     output.push(TerminalOutput::Invalid);
                 }
             }
@@ -292,7 +301,10 @@ pub fn handle_custom_color(
         }
 
         _ => {
-            warn!("Invalid SGR sequence: {}", param);
+            // Unhandled color-mode selector after 38/48/58 (only 2 and 5 are
+            // defined). Raw bytes are not reachable here; log the parsed
+            // reconstruction: SGR <cc>;<mode>.
+            warn!("Unhandled SGR color mode: parsed SGR {custom_color_control_code};{param}");
             output.push(TerminalOutput::Invalid);
         }
     }

--- a/freminal-terminal-emulator/src/ansi_components/csi_commands/su.rs
+++ b/freminal-terminal-emulator/src/ansi_components/csi_commands/su.rs
@@ -4,6 +4,7 @@
 // https://opensource.org/licenses/MIT.
 
 use crate::ansi::{ParserOutcome, parse_param_as};
+use crate::ansi_components::tracer::escape_sequence_for_log;
 use crate::error::ParserFailures;
 use freminal_common::buffer_states::terminal_output::TerminalOutput;
 
@@ -16,7 +17,10 @@ pub fn ansi_parser_inner_csi_finished_su(
     output: &mut Vec<TerminalOutput>,
 ) -> ParserOutcome {
     let Ok(param) = parse_param_as::<usize>(params) else {
-        warn!("Invalid SU command");
+        warn!(
+            "Invalid SU command (CSI S); raw params: \"{}\"",
+            escape_sequence_for_log(params)
+        );
         output.push(TerminalOutput::Invalid);
 
         return ParserOutcome::InvalidParserFailure(ParserFailures::UnhandledSUCommand(format!(

--- a/freminal-terminal-emulator/src/ansi_components/csi_commands/tbc.rs
+++ b/freminal-terminal-emulator/src/ansi_components/csi_commands/tbc.rs
@@ -6,6 +6,7 @@
 use freminal_common::buffer_states::terminal_output::{TabClearMode, TerminalOutput};
 
 use crate::ansi::{ParserOutcome, parse_param_as};
+use crate::ansi_components::tracer::escape_sequence_for_log;
 use crate::error::ParserFailures;
 
 /// Tab Clear (TBC) — ECMA-48 Section 8.3.155
@@ -36,7 +37,10 @@ pub fn ansi_parser_inner_csi_finished_tbc(
     if let Ok(mode) = TabClearMode::try_from(ps) {
         output.push(TerminalOutput::TabClear(mode));
     } else {
-        tracing::warn!("TBC with unsupported Ps={ps} (ignored)");
+        tracing::warn!(
+            "TBC with unsupported Ps={ps} (ignored) (CSI g); raw params: \"{}\"",
+            escape_sequence_for_log(params)
+        );
     }
 
     ParserOutcome::Finished

--- a/freminal-terminal-emulator/src/ansi_components/osc.rs
+++ b/freminal-terminal-emulator/src/ansi_components/osc.rs
@@ -781,11 +781,22 @@ mod tests {
 
     #[test]
     fn osc133_known_foreign_marker_consumed_without_output() {
-        // `133;A;aid=12345` — `A` is a known marker but lacks `freminal=1`, so
-        // it is a foreign duplicate: recognised, deliberately ignored, no
-        // output (and, by design, no unhandled-log).
-        let output = feed_osc(b"133;A;aid=12345\x07");
-        assert!(output.is_empty());
+        // Broaden coverage beyond `A` (see `osc133_ftcs_foreign_marker_...`):
+        // the `freminal=1`-gated markers B/C/D, when sent WITHOUT `freminal=1`,
+        // are foreign duplicates — recognised, deliberately ignored, no output
+        // (and, by design, no unhandled-log). `P` is excluded here: it is
+        // intentionally freminal-independent and DOES emit output.
+        for seq in [
+            b"133;B\x07".as_slice(),   // prompt end / command input start
+            b"133;C\x07".as_slice(),   // command output start
+            b"133;D;1\x07".as_slice(), // command finished, exit code 1
+        ] {
+            let output = feed_osc(seq);
+            assert!(
+                output.is_empty(),
+                "known foreign marker {seq:?} must produce no output"
+            );
+        }
     }
 
     // ── Lines 272-276: OSC 7 (RemoteHost) ───────────────────────────────────

--- a/freminal-terminal-emulator/src/ansi_components/osc.rs
+++ b/freminal-terminal-emulator/src/ansi_components/osc.rs
@@ -6,7 +6,7 @@
 use crate::ansi::{ParserOutcome, parse_param_as};
 use crate::ansi_components::tracer::{SequenceTraceable, SequenceTracer};
 use crate::error::AnsiParseError;
-use freminal_common::buffer_states::ftcs::parse_ftcs_params;
+use freminal_common::buffer_states::ftcs::{is_known_ftcs_marker, parse_ftcs_params};
 use freminal_common::buffer_states::osc::{
     AnsiOscInternalType, AnsiOscToken, AnsiOscType, OscTarget, UrlResponse,
 };
@@ -267,15 +267,26 @@ fn dispatch_osc_target(
 
             if let Some(marker) = parse_ftcs_params(&ftcs_str_refs) {
                 output.push(TerminalOutput::OscResponse(AnsiOscType::Ftcs(marker)));
+            } else if is_known_ftcs_marker(&ftcs_str_refs) {
+                // Known FTCS marker (A/B/C/D/P) that we recognise but did not
+                // act on — a foreign emitter sent it without the `freminal=1`
+                // tag (e.g. Apple Terminal's `133;A;cl=m;aid=$$`, or
+                // Starship/oh-my-zsh/VTE). Freminal uses its own
+                // `freminal=1`-tagged FTCS variant (see shell-integration/) and
+                // deliberately ignores foreign duplicates to avoid double
+                // command blocks. This is expected and benign, so it is
+                // silently dropped WITHOUT a log by design.
             } else {
-                // Foreign FTCS markers (e.g. Apple Terminal's `/etc/bashrc`
-                // emitting `133;A;cl=m;aid=$$` before our PS1 wraps) are
-                // intentionally dropped to avoid duplicate command blocks.
-                // Logged at debug to aid diagnosis without flooding the
-                // log on systems where a foreign integration is active.
-                tracing::debug!(
-                    "OSC 133: ignored foreign or unrecognised FTCS params: recent='{}'",
-                    seq_trace.as_str()
+                // Unknown or malformed OSC 133: the marker letter is not one we
+                // recognise (e.g. `Z`, or a future FTCS addition like `E`), or
+                // the parameter list was empty. Unlike a known-foreign marker,
+                // this is a genuine gap — the OSC 133 surface may have grown a
+                // variant we do not handle, or a program sent something
+                // malformed. Log it at warn with the full raw sequence so the
+                // unhandled surface can be audited.
+                tracing::warn!(
+                    "OSC 133: unrecognised or malformed FTCS marker (not a known A/B/C/D/P); raw sequence: \"{}\"",
+                    seq_trace.as_escaped()
                 );
             }
         }
@@ -334,8 +345,8 @@ fn dispatch_osc_target(
         // Known-but-unimplemented OSC targets.  These are recognised
         // sequences sent by common programs (vim/neovim, zsh, tmux) that
         // Freminal cannot meaningfully act on (X11 mouse colors, Tektronix
-        // graphics, color-scheme notifications).  Silently
-        // consumed at trace level to avoid warn! spam during normal use.
+        // graphics, color-scheme notifications).  Logged at warn with the
+        // full raw sequence so the unhandled surface can be audited.
         OscTarget::MouseForeground
         | OscTarget::MouseBackground
         | OscTarget::TekForeground
@@ -343,18 +354,17 @@ fn dispatch_osc_target(
         | OscTarget::HighlightBackground
         | OscTarget::HighlightForeground
         | OscTarget::ColorSchemeNotification => {
-            tracing::trace!(
-                "Recognised but unimplemented OSC (silently consumed): target={osc_target:?}, recent='{}'",
-                seq_trace.as_str()
+            tracing::warn!(
+                "Recognised but unimplemented OSC (silently consumed): target={osc_target:?}; raw sequence: \"{}\"",
+                seq_trace.as_escaped()
             );
         }
         OscTarget::Unknown => {
-            // Unknown OSC sequences are silently consumed (like
-            // xterm/VTE).  Downgraded from error!/Invalid to warn!
-            // so they don't spam logs during normal usage.
+            // Unknown OSC sequences are silently consumed (like xterm/VTE)
+            // but logged at warn with the full raw sequence for auditing.
             tracing::warn!(
-                "Unknown OSC Target (silently consumed): type_number={osc_internal_type:?}, recent='{}'",
-                seq_trace.as_str()
+                "Unknown OSC Target (silently consumed): type_number={osc_internal_type:?}; raw sequence: \"{}\"",
+                seq_trace.as_escaped()
             );
         }
     }
@@ -760,10 +770,21 @@ mod tests {
     }
 
     #[test]
-    fn osc133_ftcs_unknown_marker_silently_consumed() {
-        // OSC 133 ; Z BEL — unknown FTCS marker
+    fn osc133_ftcs_unknown_marker_consumed_and_logged() {
+        // OSC 133 ; Z BEL — `Z` is NOT a known FTCS marker (A/B/C/D/P), so this
+        // is treated as an unrecognised/malformed OSC 133: no buffer output,
+        // but it IS logged at warn (with the raw sequence) so a new/unknown
+        // OSC 133 variant surfaces for auditing rather than vanishing.
         let output = feed_osc(b"133;Z\x07");
-        // Unknown markers produce no output (the warn! is just logging)
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn osc133_known_foreign_marker_consumed_without_output() {
+        // `133;A;aid=12345` — `A` is a known marker but lacks `freminal=1`, so
+        // it is a foreign duplicate: recognised, deliberately ignored, no
+        // output (and, by design, no unhandled-log).
+        let output = feed_osc(b"133;A;aid=12345\x07");
         assert!(output.is_empty());
     }
 

--- a/freminal-terminal-emulator/src/ansi_components/osc_clipboard.rs
+++ b/freminal-terminal-emulator/src/ansi_components/osc_clipboard.rs
@@ -34,13 +34,16 @@ pub(super) fn handle_osc_clipboard(
                 )));
             }
             Err(e) => {
-                tracing::warn!("OSC 52: invalid base64 payload: {e}");
+                tracing::warn!(
+                    "OSC 52: invalid base64 payload: {e}; raw sequence: \"{}\"",
+                    seq_trace.as_escaped()
+                );
             }
         },
         _ => {
             tracing::warn!(
-                "OSC 52: missing or invalid payload: recent='{}'",
-                seq_trace.as_str()
+                "OSC 52: missing or invalid payload; raw sequence: \"{}\"",
+                seq_trace.as_escaped()
             );
         }
     }

--- a/freminal-terminal-emulator/src/ansi_components/osc_iterm2.rs
+++ b/freminal-terminal-emulator/src/ansi_components/osc_iterm2.rs
@@ -67,8 +67,8 @@ pub(super) fn handle_osc_iterm2(
 
     // Not a recognised sub-command — silently consume, like xterm/VTE.
     tracing::warn!(
-        "OSC 1337: unrecognised sub-command: recent='{}'",
-        seq_trace.as_str()
+        "OSC 1337: unrecognised sub-command; raw sequence: \"{}\"",
+        seq_trace.as_escaped()
     );
     output.push(TerminalOutput::OscResponse(AnsiOscType::ITerm2Unknown));
 }
@@ -113,7 +113,7 @@ fn parse_iterm2_file_args(args_str: &str) -> ITerm2InlineImageData {
                     do_not_move_cursor = value == "1";
                 }
                 _ => {
-                    tracing::debug!("OSC 1337 File args: unknown arg: {key}={value}");
+                    tracing::warn!("OSC 1337 File args: unknown arg: {key}={value}");
                 }
             }
         }

--- a/freminal-terminal-emulator/src/ansi_components/osc_shell_info.rs
+++ b/freminal-terminal-emulator/src/ansi_components/osc_shell_info.rs
@@ -64,9 +64,9 @@ pub(super) fn handle_osc_shell_info(
     // future sub-commands added to newer shell-integration scripts will
     // be ignored by older freminal binaries without producing a parse
     // error.
-    tracing::debug!(
-        "OSC 1338: unrecognised sub-command (ignored): recent='{}'",
-        seq_trace.as_str()
+    tracing::warn!(
+        "OSC 1338: unrecognised sub-command (ignored); raw sequence: \"{}\"",
+        seq_trace.as_escaped()
     );
 }
 

--- a/freminal-terminal-emulator/src/ansi_components/tracer.rs
+++ b/freminal-terminal-emulator/src/ansi_components/tracer.rs
@@ -109,13 +109,16 @@ impl SequenceTracer {
 /// reconstructed from its output:
 ///
 /// - Printable ASCII (`0x20..=0x7E`) is emitted verbatim, **except** the
-///   backslash, which is doubled (`\\`) so the escaping is unambiguous.
+///   backslash, which is doubled (`\\`), and the double quote, which is
+///   escaped (`\"`) — both so the escaping is unambiguous. Nearly every call
+///   site embeds the result inside a quoted log string (e.g.
+///   `"raw sequence: \"{}\""`), so an unescaped `"` in the payload would break
+///   the surrounding quoting.
 /// - Every other byte — C0/C1 controls, `DEL`, and all bytes `>= 0x80` — is
 ///   emitted as a `\xNN` two-digit lowercase hex escape.
 ///
-/// The result is safe to embed in a log line and can be pasted back (e.g. via
-/// `printf`) to reproduce the exact sequence a terminal would need to trigger
-/// the same code path.
+/// The result is safe to embed in a quoted log line and unambiguously
+/// identifies the exact bytes received.
 #[must_use]
 pub fn escape_sequence_for_log(bytes: &[u8]) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
@@ -124,6 +127,7 @@ pub fn escape_sequence_for_log(bytes: &[u8]) -> String {
     for &b in bytes {
         match b {
             b'\\' => out.push_str("\\\\"),
+            b'"' => out.push_str("\\\""),
             0x20..=0x7E => out.push(b as char),
             _ => {
                 out.push_str("\\x");
@@ -176,6 +180,15 @@ mod tests {
     #[test]
     fn escape_backslash_is_doubled() {
         assert_eq!(escape_sequence_for_log(b"a\\b"), "a\\\\b");
+    }
+
+    #[test]
+    fn escape_double_quote_is_escaped() {
+        // Call sites embed the output inside a quoted log string, so a raw `"`
+        // in the payload must be escaped to keep the surrounding quoting intact.
+        assert_eq!(escape_sequence_for_log(b"a\"b"), "a\\\"b");
+        // Mixed backslash + quote (e.g. a JSON-ish OSC payload).
+        assert_eq!(escape_sequence_for_log(b"\\\""), "\\\\\\\"");
     }
 
     #[test]

--- a/freminal-terminal-emulator/src/ansi_components/tracer.rs
+++ b/freminal-terminal-emulator/src/ansi_components/tracer.rs
@@ -46,6 +46,19 @@ impl SequenceTracer {
         if self.len == 0 {
             return String::new();
         }
+        String::from_utf8_lossy(&self.to_bytes()).into_owned()
+    }
+
+    /// Return the traced bytes in order, oldest-to-newest.
+    ///
+    /// Unlike [`Self::as_str`], this is lossless: it never applies UTF-8
+    /// replacement. Use it when the exact bytes matter (diagnostics that must
+    /// let a reader reconstruct the offending sequence).
+    #[must_use]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        if self.len == 0 {
+            return Vec::new();
+        }
         let end = self.idx;
         let start = (self.idx + self.buf.len() - self.len) % self.buf.len();
         let mut out = Vec::with_capacity(self.len);
@@ -55,7 +68,14 @@ impl SequenceTracer {
             out.extend_from_slice(&self.buf[start..]);
             out.extend_from_slice(&self.buf[..end]);
         }
-        String::from_utf8_lossy(&out).into_owned()
+        out
+    }
+
+    /// Render the traced bytes as an unambiguous, reconstruction-faithful
+    /// string for logging (see [`escape_sequence_for_log`]).
+    #[must_use]
+    pub fn as_escaped(&self) -> String {
+        escape_sequence_for_log(&self.to_bytes())
     }
 
     /// Trim trailing control terminators (ESC, '\', BEL) from the end of the trace.
@@ -77,6 +97,45 @@ impl SequenceTracer {
     }
 }
 
+/// Render a raw escape-sequence byte slice as an unambiguous, printable,
+/// reconstruction-faithful string for logging.
+///
+/// Escape-sequence payloads routinely contain non-printable control bytes
+/// (`ESC`, `ST`, `BEL`), 8-bit C1 introducers, and non-UTF-8 binary (base64
+/// padding, DCS/APC bodies). Rendering them with `String::from_utf8_lossy`
+/// destroys that detail — every unrepresentable byte collapses to U+FFFD, so
+/// the log no longer identifies the exact bytes that were received. This
+/// function is lossless in the sense that the original bytes can be
+/// reconstructed from its output:
+///
+/// - Printable ASCII (`0x20..=0x7E`) is emitted verbatim, **except** the
+///   backslash, which is doubled (`\\`) so the escaping is unambiguous.
+/// - Every other byte — C0/C1 controls, `DEL`, and all bytes `>= 0x80` — is
+///   emitted as a `\xNN` two-digit lowercase hex escape.
+///
+/// The result is safe to embed in a log line and can be pasted back (e.g. via
+/// `printf`) to reproduce the exact sequence a terminal would need to trigger
+/// the same code path.
+#[must_use]
+pub fn escape_sequence_for_log(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    // Worst case every byte becomes a 4-char `\xNN` escape.
+    let mut out = String::with_capacity(bytes.len().saturating_mul(4));
+    for &b in bytes {
+        match b {
+            b'\\' => out.push_str("\\\\"),
+            0x20..=0x7E => out.push(b as char),
+            _ => {
+                out.push_str("\\x");
+                // Two lowercase hex digits, no allocation.
+                out.push(HEX[(b >> 4) as usize] as char);
+                out.push(HEX[(b & 0x0f) as usize] as char);
+            }
+        }
+    }
+    out
+}
+
 /// A small helper trait that standardizes how parsers collect and present
 /// the raw bytes of the *current* sequence they are parsing.
 pub trait SequenceTraceable {
@@ -94,11 +153,79 @@ pub trait SequenceTraceable {
     fn current_trace_str(&self) -> String {
         self.seq_tracer_ref().as_str()
     }
+
+    /// The current sequence trace rendered as a reconstruction-faithful,
+    /// escaped string suitable for diagnostics (see [`escape_sequence_for_log`]).
+    fn current_trace_escaped(&self) -> String {
+        self.seq_tracer_ref().as_escaped()
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::SequenceTracer;
+    use super::{SequenceTracer, escape_sequence_for_log};
+
+    #[test]
+    fn escape_printable_ascii_is_verbatim() {
+        assert_eq!(
+            escape_sequence_for_log(b"1337;SetUserVar"),
+            "1337;SetUserVar"
+        );
+    }
+
+    #[test]
+    fn escape_backslash_is_doubled() {
+        assert_eq!(escape_sequence_for_log(b"a\\b"), "a\\\\b");
+    }
+
+    #[test]
+    fn escape_control_bytes_as_hex() {
+        // ESC, BEL, ST-final backslash handled as controls / doubled backslash.
+        assert_eq!(escape_sequence_for_log(&[0x1b, b'[', b'm']), "\\x1b[m");
+        assert_eq!(escape_sequence_for_log(&[0x07]), "\\x07");
+        assert_eq!(escape_sequence_for_log(&[0x00, 0x1f]), "\\x00\\x1f");
+    }
+
+    #[test]
+    fn escape_high_and_c1_bytes_as_hex() {
+        // 8-bit CSI introducer (0x9b) and arbitrary high bytes.
+        assert_eq!(
+            escape_sequence_for_log(&[0x9b, 0xff, 0x80]),
+            "\\x9b\\xff\\x80"
+        );
+    }
+
+    #[test]
+    fn escape_non_utf8_is_lossless() {
+        // A byte sequence that is NOT valid UTF-8 must round-trip through the
+        // escaper without information loss (no U+FFFD).
+        let raw = &[b'A', 0xC3, 0x28, b'B'];
+        let escaped = escape_sequence_for_log(raw);
+        assert_eq!(escaped, "A\\xc3(B");
+        assert!(!escaped.contains('\u{fffd}'));
+    }
+
+    #[test]
+    fn tracer_as_escaped_matches_free_fn() {
+        let mut tracer = SequenceTracer::new();
+        for &b in &[0x1b, b'[', b'3', b'8', b';', b'2', b'm'] {
+            tracer.push(b);
+        }
+        assert_eq!(tracer.as_escaped(), "\\x1b[38;2m");
+        assert_eq!(
+            tracer.as_escaped(),
+            escape_sequence_for_log(&tracer.to_bytes())
+        );
+    }
+
+    #[test]
+    fn tracer_to_bytes_is_lossless() {
+        let mut tracer = SequenceTracer::new();
+        for &b in &[0x9c, 0xff, b'x'] {
+            tracer.push(b);
+        }
+        assert_eq!(tracer.to_bytes(), vec![0x9c, 0xff, b'x']);
+    }
 
     #[test]
     fn new_tracer_is_empty() {

--- a/freminal-terminal-emulator/src/ansi_components/tracer.rs
+++ b/freminal-terminal-emulator/src/ansi_components/tracer.rs
@@ -167,7 +167,22 @@ pub trait SequenceTraceable {
 
 #[cfg(test)]
 mod tests {
-    use super::{SequenceTracer, escape_sequence_for_log};
+    use super::{SequenceTraceable, SequenceTracer, escape_sequence_for_log};
+
+    /// Minimal `SequenceTraceable` host so the trait's default methods can be
+    /// exercised directly (rather than only via real parsers).
+    struct TraceHost {
+        tracer: SequenceTracer,
+    }
+
+    impl SequenceTraceable for TraceHost {
+        fn seq_tracer(&mut self) -> &mut SequenceTracer {
+            &mut self.tracer
+        }
+        fn seq_tracer_ref(&self) -> &SequenceTracer {
+            &self.tracer
+        }
+    }
 
     #[test]
     fn escape_printable_ascii_is_verbatim() {
@@ -229,6 +244,25 @@ mod tests {
             tracer.as_escaped(),
             escape_sequence_for_log(&tracer.to_bytes())
         );
+    }
+
+    #[test]
+    fn current_trace_escaped_renders_traced_bytes() {
+        // Directly exercise the public trait method: it must render the current
+        // trace using the same lossless escaping as `escape_sequence_for_log`,
+        // including non-printable and non-UTF-8 bytes.
+        let mut host = TraceHost {
+            tracer: SequenceTracer::new(),
+        };
+        for &b in &[0x1b, b'[', b'3', b'8', b';', 0xff, b'"'] {
+            host.append_trace(b);
+        }
+        assert_eq!(host.current_trace_escaped(), "\\x1b[38;\\xff\\\"");
+        // Empty trace renders as an empty string.
+        let empty = TraceHost {
+            tracer: SequenceTracer::new(),
+        };
+        assert_eq!(empty.current_trace_escaped(), "");
     }
 
     #[test]

--- a/freminal-terminal-emulator/src/input.rs
+++ b/freminal-terminal-emulator/src/input.rs
@@ -2831,7 +2831,7 @@ mod tests {
 
     #[test]
     fn kkp_keypad_application_mode_digits() {
-        let expected_suffixes = [b'p', b'q', b'r', b's', b't', b'u', b'v', b'w', b'x', b'y'];
+        let expected_suffixes = b"pqrstuvwxy";
         for (digit, suffix) in (0u8..=9).zip(expected_suffixes.iter()) {
             let p = to_payload_kkp_app(&TerminalInput::KeyPad(digit), 1);
             let expected = [0x1b, b'[', b'O', *suffix];

--- a/freminal-terminal-emulator/src/snapshot.rs
+++ b/freminal-terminal-emulator/src/snapshot.rs
@@ -417,7 +417,10 @@ mod tests {
 
     #[test]
     fn empty_application_escape_key_is_reset() {
-        assert!(TerminalSnapshot::empty().application_escape_key == ApplicationEscapeKey::Reset);
+        assert_eq!(
+            TerminalSnapshot::empty().application_escape_key,
+            ApplicationEscapeKey::Reset
+        );
     }
 
     #[test]

--- a/freminal-terminal-emulator/src/terminal_handler/dcs.rs
+++ b/freminal-terminal-emulator/src/terminal_handler/dcs.rs
@@ -20,6 +20,7 @@ use freminal_common::{buffer_states::modes::s8c1t::S8c1t, cursor::CursorVisualSt
 use super::TerminalHandler;
 use crate::ansi_components::csi_commands::ed::EraseDisplayMode;
 use crate::ansi_components::csi_commands::el::EraseLineMode;
+use crate::ansi_components::tracer::escape_sequence_for_log;
 
 impl TerminalHandler {
     /// Handle a DCS (Device Control String) sequence.
@@ -380,7 +381,10 @@ impl TerminalHandler {
                 if let Ok(m) = EraseDisplayMode::try_from(mode) {
                     self.handle_erase_in_display(m);
                 } else {
-                    tracing::warn!("DCS tmux passthrough: unknown ED mode {mode}");
+                    tracing::warn!(
+                        "DCS tmux passthrough: unknown ED mode {mode}; raw CSI: \"\\x1b[{}\"",
+                        escape_sequence_for_log(csi_body)
+                    );
                 }
                 true
             }
@@ -394,7 +398,10 @@ impl TerminalHandler {
                 if let Ok(m) = EraseLineMode::try_from(mode) {
                     self.handle_erase_in_line(m);
                 } else {
-                    tracing::warn!("DCS tmux passthrough: unknown EL mode {mode}");
+                    tracing::warn!(
+                        "DCS tmux passthrough: unknown EL mode {mode}; raw CSI: \"\\x1b[{}\"",
+                        escape_sequence_for_log(csi_body)
+                    );
                 }
                 true
             }

--- a/freminal-terminal-emulator/src/terminal_handler/osc.rs
+++ b/freminal-terminal-emulator/src/terminal_handler/osc.rs
@@ -188,10 +188,14 @@ impl TerminalHandler {
 
     /// Handle an OSC 133 (FTCS) shell integration marker.
     ///
-    /// Only markers carrying `freminal=1` and a `fid` (parsed upstream by
-    /// [`parse_ftcs_params`]) reach this function.  Foreign markers (`WezTerm`,
-    /// Starship, `iTerm2`) are already filtered out at the parse layer and
-    /// never arrive here.
+    /// The `A`/`B`/`C`/`D` markers reach this function only when they carry
+    /// `freminal=1` and a `fid` (parsed upstream by [`parse_ftcs_params`]);
+    /// foreign `A`/`B`/`C`/`D` markers (`WezTerm`, Starship, `iTerm2`) are
+    /// filtered out at the parse layer and never arrive here.  The `P`
+    /// (`PromptProperty`) marker is the exception: it is freminal-independent
+    /// (accepted from any emitter, no `freminal=1`/`fid` required), so it
+    /// *does* reach this function — where it is handled as an informational
+    /// no-op (see the `PromptProperty` arm below).
     pub(super) fn handle_osc_ftcs(&mut self, marker: &FtcsMarker) {
         tracing::debug!("OSC 133 FTCS marker: {marker}");
         match marker {

--- a/freminal-terminal-emulator/src/terminal_handler/osc.rs
+++ b/freminal-terminal-emulator/src/terminal_handler/osc.rs
@@ -19,6 +19,8 @@ use freminal_common::buffer_states::{
     window_manipulation::{NotificationKind, WindowManipulation},
 };
 
+use crate::ansi_components::tracer::escape_sequence_for_log;
+
 use super::{TerminalHandler, notify_99, shell_integration};
 
 impl TerminalHandler {
@@ -31,8 +33,8 @@ impl TerminalHandler {
             Ok(cmd) => self.handle_kitty_graphics(cmd),
             Err(KittyParseError::NotKittyGraphics) => {
                 tracing::warn!(
-                    "APC received (not Kitty graphics, ignored): {}",
-                    String::from_utf8_lossy(apc)
+                    "APC received (not Kitty graphics, ignored); raw sequence: \"{}\"",
+                    escape_sequence_for_log(apc)
                 );
             }
             Err(e) => {

--- a/freminal-terminal-emulator/src/terminal_handler/shell_integration.rs
+++ b/freminal-terminal-emulator/src/terminal_handler/shell_integration.rs
@@ -438,9 +438,7 @@ mod tests {
 
     #[test]
     fn hex_val_non_hex_chars_return_none() {
-        for byte in [
-            b'G', b'Z', b'g', b'z', b' ', b'!', b'/', b':', b'@', b'[', b'`', b'{',
-        ] {
+        for &byte in b"GZgz !/:@[`{" {
             assert_eq!(
                 hex_val(byte),
                 None,

--- a/freminal/Cargo.toml
+++ b/freminal/Cargo.toml
@@ -69,7 +69,7 @@ deb_depends = [
 # `cargo xtask bump-version` keeps this in sync, translating the SemVer
 # pre-release separator to the RPM tilde operator (e.g. "0.9.0~beta.2"), which
 # sorts older than the final release just like the SemVer pre-release does.
-version = "0.11.1"
+version = "0.11.2"
 assets = [
   { source = "target/release/freminal", dest = "/usr/bin/freminal", mode = "755" },
   # Ship the desktop entry (carrying StartupWMClass=freminal, which matches the

--- a/freminal/src/gui/tabs.rs
+++ b/freminal/src/gui/tabs.rs
@@ -280,9 +280,14 @@ impl TabManager {
     }
 
     /// Allocate the next unique `TabId`.
+    ///
+    /// Uses saturating arithmetic so the counter can never overflow and wrap
+    /// back to a low, already-issued id. Exhausting the full `u64` id space is
+    /// physically unreachable (it would require `u64::MAX` live tabs), so the
+    /// saturation point is a safety floor, not an expected condition.
     pub const fn next_tab_id(&mut self) -> TabId {
         let id = TabId(self.next_id);
-        self.next_id += 1;
+        self.next_id = self.next_id.saturating_add(1);
         id
     }
 
@@ -755,6 +760,23 @@ mod tests {
         mgr.add_tab(dummy_tab(TabId(1), "Low id"));
 
         assert_eq!(mgr.next_tab_id(), TabId(3));
+    }
+
+    /// Regression: an id counter at `u64::MAX` must saturate rather than
+    /// overflow. Overflowing `next_id` would panic in debug and wrap to a low,
+    /// already-issued id in release. This is physically unreachable in practice
+    /// (it needs `u64::MAX` live tabs) but `TabId::offset` is public, so a
+    /// hand-crafted layout could seed the counter near the ceiling.
+    #[test]
+    fn next_tab_id_saturates_at_u64_max() {
+        let tab = dummy_tab(TabId(u64::MAX), "Ceiling");
+        let mut mgr = TabManager::new(tab);
+
+        // `new` seeds `next_id` via saturating_add, so it stays at u64::MAX
+        // rather than wrapping to 0.
+        assert_eq!(mgr.next_tab_id(), TabId(u64::MAX));
+        // Further allocations must not wrap/panic; they stay pinned at the max.
+        assert_eq!(mgr.next_tab_id(), TabId(u64::MAX));
     }
 
     #[test]

--- a/freminal/src/gui/tabs.rs
+++ b/freminal/src/gui/tabs.rs
@@ -267,10 +267,15 @@ impl TabManager {
     /// Create a new `TabManager` with a single initial tab.
     #[must_use]
     pub fn new(initial: Tab) -> Self {
+        // `next_id` must never collide with an id already in use. The initial
+        // tab is normally `TabId::first()` (0), but a layout restore can seed
+        // it with an arbitrary offset id, so derive the counter from the
+        // initial tab's id rather than assuming 0.
+        let next_id = initial.id.0.saturating_add(1);
         Self {
             tabs: vec![initial],
             active: 0,
-            next_id: 1,
+            next_id,
         }
     }
 
@@ -322,7 +327,15 @@ impl TabManager {
     }
 
     /// Add a new tab at the end and switch to it.
+    ///
+    /// The id-allocation counter is advanced past the added tab's id when
+    /// necessary. Tabs built outside `next_tab_id` (e.g. layout restore, which
+    /// assigns `TabId::offset(i)`) carry ids the counter has not yet seen;
+    /// without this, a subsequently spawned tab could be handed a duplicate id,
+    /// which then causes two tabs to match a single `renaming_tab` id and both
+    /// render the rename editor (keystrokes doubled across two tabs).
     pub fn add_tab(&mut self, tab: Tab) {
+        self.next_id = self.next_id.max(tab.id.0.saturating_add(1));
         self.tabs.push(tab);
         self.active = self.tabs.len() - 1;
     }
@@ -691,6 +704,57 @@ mod tests {
         assert_eq!(id1, TabId(1));
         assert_eq!(id2, TabId(2));
         assert_eq!(id3, TabId(3));
+    }
+
+    /// Regression: a manager seeded with an initial tab whose id is not 0
+    /// (as a layout restore does via `TabId::offset`) must not hand out that
+    /// id again. Previously `next_id` was hard-coded to 1, so a first tab with
+    /// id 5 would collide with the next spawned tab.
+    #[test]
+    fn new_manager_seeds_next_id_past_initial_tab_id() {
+        let tab = dummy_tab(TabId(5), "Restored");
+        let mut mgr = TabManager::new(tab);
+
+        assert_eq!(mgr.next_tab_id(), TabId(6));
+    }
+
+    /// Regression: adding a tab whose id was assigned outside `next_tab_id`
+    /// (layout restore assigns `TabId::offset(i)`) must advance the counter
+    /// past it, so a subsequently spawned tab cannot receive a duplicate id.
+    /// A duplicate id caused two tabs to match a single `renaming_tab` value
+    /// and both render the rename editor (keystrokes doubled across two tabs).
+    #[test]
+    fn add_tab_advances_next_id_past_preassigned_ids() {
+        // Mimic a 3-tab layout restore: ids 0, 1, 2 assigned by offset,
+        // `next_id` still at 1 before this fix.
+        let tab0 = dummy_tab(TabId(0), "Tab 0");
+        let mut mgr = TabManager::new(tab0);
+        mgr.add_tab(dummy_tab(TabId(1), "Tab 1"));
+        mgr.add_tab(dummy_tab(TabId(2), "Tab 2"));
+
+        // The next spawned tab must get a fresh, non-colliding id.
+        let spawned = mgr.next_tab_id();
+        assert_eq!(spawned, TabId(3));
+
+        assert!(
+            !mgr.iter().any(|t| t.id == spawned),
+            "spawned id {spawned:?} collides with an existing tab id"
+        );
+    }
+
+    /// Adding a tab with a lower id than the current counter must not rewind
+    /// the counter.
+    #[test]
+    fn add_tab_does_not_rewind_next_id() {
+        let tab0 = dummy_tab(TabId(0), "Tab 0");
+        let mut mgr = TabManager::new(tab0);
+        // Advance the counter well past 0.
+        let _ = mgr.next_tab_id(); // 1
+        let _ = mgr.next_tab_id(); // 2
+        // Add a tab with a small, already-consumed-range id.
+        mgr.add_tab(dummy_tab(TabId(1), "Low id"));
+
+        assert_eq!(mgr.next_tab_id(), TabId(3));
     }
 
     #[test]

--- a/freminal/src/gui/terminal/input.rs
+++ b/freminal/src/gui/terminal/input.rs
@@ -921,7 +921,7 @@ pub(super) fn dispatch_binding_action(
 pub(super) fn control_key(key: Key) -> Option<Cow<'static, [TerminalInput]>> {
     if key >= Key::A && key <= Key::Z {
         let name = key.name();
-        assert!(name.len() == 1);
+        assert_eq!(name.len(), 1);
         let name_c = name.as_bytes()[0];
         return Some(vec![TerminalInput::Ctrl(name_c)].into());
     }


### PR DESCRIPTION
Point release bundling a few small, independent changes plus a dependency bump.

## Changes

### fix: duplicate TabId collision after layout restore
`TabManager::new` hard-coded `next_id = 1` and `add_tab` never advanced the counter. A layout restore assigns tab ids `0..N` via `TabId::offset(i)` while `next_id` stayed at `1`, so the next spawned tab got a duplicate id. Two tabs sharing an id both matched a single `renaming_tab` value and both rendered the rename `TextEdit` with the same egui id and buffer — keystrokes doubled across two tabs. Fixed at the id-allocation source (`new` seeds from the initial tab's id; `add_tab` advances past any pre-assigned id). Regression tests added.

### feat: log full raw byte sequence on unhandled escape sequences
Unhandled/unrecognised-sequence logs previously showed a parsed description (or nothing) but not the offending bytes, making them useless for auditing coverage gaps.

- New `escape_sequence_for_log()` in `tracer`: lossless, reconstruction-faithful rendering (printable ASCII verbatim, backslash doubled, everything else `\xNN`) — unlike `from_utf8_lossy`, non-UTF-8 bytes are never collapsed to U+FFFD. Plus `SequenceTracer::to_bytes`/`as_escaped` and `current_trace_escaped()`.
- Threaded the raw sequence into the cold-path unhandled sites and standardised them to `warn!` (visible at the default log level): the previously-silent CSI valid-grammar/unknown-final-byte fallthrough; every CSI leaf handler; OSC unknown/unimplemented targets, iTerm2/shell-info unknown sub-commands, OSC 52 malformed payloads; DCS tmux unknown ED/EL modes; ansi.rs top-level Invalid sites (non-lossy trace); VT52 unknown escape.
- **OSC 133 (FTCS) special-cased**: freminal's own `freminal=1` variant is handled, and known foreign markers (A/B/C/D/P without `freminal=1`) are deliberately ignored **without** a log (expected duplicate suppression). Only genuinely unknown/malformed OSC 133 (unknown marker letter, future spec addition, empty params) logs at `warn`, so a new 133 variant surfaces for auditing instead of vanishing. New `is_known_ftcs_marker()` makes the distinction without changing `parse_ftcs_params` or its callers.

Groundwork for the planned v0.16.0 opt-in unhandled-sequence crash reporting. Unit tests added for the escaper, the CSI raw-sequence reconstruction, and the FTCS classifier.

### docs: scrollback memory plan (Tasks 118 & 119)
Backed by a feasibility spike measuring freminal's real 72-byte cell layout and LZ4/zstd ratios on realistic 100k-line corpora. Two-phase, compact-first:

- **Task 118 (Compact Cell Representation)** — decomposed into **v0.12.0**: shrink the in-memory cell by sharing `FormatTag` across runs + dropping the always-null image slot from stored scrollback, evict the duplicate `row_cache` for compacted rows, raise the default scrollback. ~8–12× smaller stored rows, zero runtime decompression cost, no codec, no new dependency.
- **Task 119 (Scrollback Compression, LZ4)** — enriched-stub **v0.13.1** (`PLAN_VERSION_131.md`), inserted after the last kitty version so nothing renumbers. Captures the durable decisions (LZ4 over zstd on the hot path, block-not-per-line compression, LRU decompress cache, band-decompression on reflow, buffer-internal below the snapshot line) and the decompression-on-the-fly tradeoff analysis. No subtasks until activation.

### chore: dependency + flake bumps
Cargo/flake dependency updates and freminal version bump. `glow` kept at 0.17.0 to match `egui_glow 0.35.0` (the `glow::Context` type crosses that boundary; bumping ahead of egui introduces a duplicate glow and a type mismatch in `freminal-windowing`).

## Verification
- `cargo test --all` — green
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo machete` — clean
- `cargo xtask check-windows` — clean (all crates check for x86_64-pc-windows-gnu)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added log-safe, lossless rendering for invalid/unknown terminal sequences, including more complete raw-sequence details in warnings.
  * Silently ignore known foreign OSC 133 FTCS markers while preserving warnings for truly unknown/malformed ones.
* **Bug Fixes**
  * Prevented tab ID collisions when restoring layouts or adding tabs with preassigned IDs.
* **Documentation**
  * Updated roadmap for compact scrollback representation and upcoming scrollback compression phases.
* **Chores**
  * Bumped application/package version to **0.11.2** and refreshed dependency versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->