### PR TITLE
fix: settings window orphaned and app fails to quit on owner close

### DIFF
--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -26,6 +26,48 @@ use super::view_state;
 use super::window::PerWindowState;
 use super::{FreminalGui, PaneBorderDrag};
 
+/// What `on_close_requested` should do about a window that may own an open
+/// Settings window (issue #401).
+///
+/// Pure decision over an already-computed boolean (rather than `WindowId`s
+/// or `&FreminalGui` directly) so it is unit-testable without constructing
+/// the windowing layer or a full `FreminalGui`.
+///
+/// There is no "already resolved, proceed normally" variant: the
+/// `WindowUnsavedSettings` Force Close handler clears `settings_owner` to
+/// `None` *before* re-issuing the window's close, so `is_owner` is already
+/// `false` by the time `on_close_requested` runs again for the retry —
+/// tracking a separate "confirmed" flag would be dead weight.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SettingsOwnerCloseDecision {
+    /// This window does not own the settings modal — no special handling.
+    NotOwner,
+    /// No unsaved settings edits (or none open) — close the settings window
+    /// now, alongside this window.
+    CloseNow,
+    /// Unsaved settings edits — veto this window's close and surface the
+    /// close-guard confirmation dialog.
+    VetoWithPrompt,
+}
+
+/// Decide what `on_close_requested` should do about the settings window when
+/// `window_id` (the window being closed) may own it.
+///
+/// `is_owner` is `self.settings_owner == Some(window_id)`. `has_unsaved` is
+/// `self.settings_modal.has_unsaved_changes()`.
+const fn settings_owner_close_decision(
+    is_owner: bool,
+    has_unsaved: bool,
+) -> SettingsOwnerCloseDecision {
+    if !is_owner {
+        return SettingsOwnerCloseDecision::NotOwner;
+    }
+    if has_unsaved {
+        return SettingsOwnerCloseDecision::VetoWithPrompt;
+    }
+    SettingsOwnerCloseDecision::CloseNow
+}
+
 impl freminal_windowing::App for FreminalGui {
     /// Called when a window is created.
     ///
@@ -46,7 +88,16 @@ impl freminal_windowing::App for FreminalGui {
         if self.pending_settings_window {
             self.pending_settings_window = false;
             self.settings_window_id = Some(window_id);
-            self.settings_owner = Some(window_id);
+            // `settings_owner` already holds the *terminal* window that
+            // requested this settings window (set by the menu/keybind
+            // action before `handle.create_window()` was called). Do NOT
+            // overwrite it with this settings window's own id here — doing
+            // so used to make `settings_owner == settings_window_id`
+            // always, which broke the owning-window-close guard (issue
+            // #401: the guard compares `settings_owner` against a real
+            // terminal window id, which could then never match) and the
+            // "Test Paste" routing / os_dark_mode lookup, both of which key
+            // off `settings_owner` to find the owning terminal window.
             // Don't create a PerWindowState — the settings window renders
             // only the settings UI via show_standalone().
             return;
@@ -270,7 +321,10 @@ impl freminal_windowing::App for FreminalGui {
     /// Called when a window close is requested.
     ///
     /// Removes the window's state — its PTY threads will be dropped when
-    /// the channels close.  Always returns `true` to allow the close.
+    /// the channels close. Returns `false` to veto the close: either the
+    /// settings modal has unsaved edits to confirm (this window's own
+    /// close, or the owning terminal window's — issue #401), or the window
+    /// has a running foreground command pending confirmation (Task 98).
     fn on_close_requested(&mut self, window_id: WindowId) -> bool {
         // Settings window closed (via OS close button).
         if self.settings_window_id == Some(window_id) {
@@ -286,16 +340,43 @@ impl freminal_windowing::App for FreminalGui {
             self.persist_window_state();
             return true;
         }
-        // If this window owns the settings modal (embedded floating), try
-        // the same guard.  If close is vetoed, still allow the owning
-        // terminal window to close — but keep the modal's dirty state so a
-        // confirm prompt appears on the next frame of a sibling window if
-        // any exists.  In practice this path closes the modal regardless
-        // because the modal has no window of its own to live in.
-        if self.settings_owner == Some(window_id) {
-            let _ = self.settings_modal.request_close();
-            self.settings_modal.is_open = false;
-            self.settings_owner = None;
+        // If this window owns an open Settings window, decide what to do
+        // about it before this window closes (issue #401: the settings
+        // window used to be orphaned — left open with its internal `is_open`
+        // flag force-cleared but the actual OS window never told to close,
+        // freezing it, and never counted against the "all windows closed"
+        // quit check).
+        match settings_owner_close_decision(
+            self.settings_owner == Some(window_id),
+            self.settings_modal.has_unsaved_changes(),
+        ) {
+            SettingsOwnerCloseDecision::NotOwner => {}
+            SettingsOwnerCloseDecision::CloseNow => {
+                self.settings_modal.is_open = false;
+                self.settings_owner = None;
+                // Nothing else will wake the settings window once its owner
+                // is gone — force a repaint so its own next `update()` call
+                // notices `is_open == false` and closes the OS window
+                // itself via the existing self-close path (see `update()`'s
+                // settings-window branch).
+                if let Some(sid) = self.settings_window_id
+                    && let Some((proxy, _)) = self
+                        .windows
+                        .get(&window_id)
+                        .and_then(|w| w.repaint_handle.get())
+                {
+                    proxy.request_repaint(sid);
+                }
+            }
+            SettingsOwnerCloseDecision::VetoWithPrompt => {
+                if let Some(win) = self.windows.get_mut(&window_id) {
+                    win.close_dialog.open(super::close_guard::PendingClose {
+                        scope: super::close_guard::CloseScope::WindowUnsavedSettings,
+                        running: Vec::new(),
+                    });
+                }
+                return false;
+            }
         }
 
         // Close-on-running-command guard (Task 98.7).  If the user already
@@ -1375,6 +1456,23 @@ impl freminal_windowing::App for FreminalGui {
                             // on_close_requested guard lets the resulting
                             // ViewportCommand::Close through without re-prompting.
                             self.force_close_windows.insert(window_id);
+                            ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                        }
+                        super::close_guard::CloseScope::WindowUnsavedSettings => {
+                            // User chose to discard the unsaved settings
+                            // edits. Close the settings OS window directly —
+                            // `handle` is available right here, unlike in
+                            // `on_close_requested` — then re-issue this
+                            // window's close. Clearing `settings_owner` here
+                            // (rather than a separate "confirmed" flag) is
+                            // what makes the retry's `on_close_requested`
+                            // call see `is_owner == false` and skip the
+                            // guard without re-prompting (issue #401).
+                            self.settings_modal.is_open = false;
+                            self.settings_owner = None;
+                            if let Some(sid) = self.settings_window_id.take() {
+                                handle.close_window(sid);
+                            }
                             ctx.send_viewport_cmd(egui::ViewportCommand::Close);
                         }
                     },
@@ -2690,5 +2788,40 @@ impl FreminalGui {
                 None
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SettingsOwnerCloseDecision, settings_owner_close_decision};
+
+    #[test]
+    fn not_owner_ignores_other_state() {
+        assert_eq!(
+            settings_owner_close_decision(false, false),
+            SettingsOwnerCloseDecision::NotOwner
+        );
+        assert_eq!(
+            settings_owner_close_decision(false, true),
+            SettingsOwnerCloseDecision::NotOwner,
+            "a non-owner window closing must never touch the settings guard, \
+             even if `has_unsaved` happens to be set for some other window"
+        );
+    }
+
+    #[test]
+    fn clean_owner_closes_now() {
+        assert_eq!(
+            settings_owner_close_decision(true, false),
+            SettingsOwnerCloseDecision::CloseNow
+        );
+    }
+
+    #[test]
+    fn dirty_owner_is_vetoed_with_prompt() {
+        assert_eq!(
+            settings_owner_close_decision(true, true),
+            SettingsOwnerCloseDecision::VetoWithPrompt
+        );
     }
 }

--- a/freminal/src/gui/close_guard.rs
+++ b/freminal/src/gui/close_guard.rs
@@ -147,6 +147,11 @@ pub(in crate::gui) enum CloseScope {
     Tab(usize),
     /// Close this window (and, if it is the last, quit).
     Window,
+    /// Close this window, which owns an open Settings modal with unsaved
+    /// edits (issue #401). Distinct from `Window` because it guards on
+    /// unsaved config edits rather than a running foreground command, and
+    /// resolving it also tears down the settings OS window.
+    WindowUnsavedSettings,
 }
 
 /// A close action suspended while the guard dialog is open.
@@ -217,14 +222,10 @@ impl CloseGuardDialog {
         let escape = ctx.input(|i| i.key_pressed(egui::Key::Escape));
         let force = ctx.input(|i| i.modifiers.ctrl && i.key_pressed(egui::Key::Enter));
 
-        let count = pending.running.len();
-        let banner = format!(
-            "{count} pane{} {} a running command. Close anyway?",
-            if count == 1 { "" } else { "s" },
-            if count == 1 { "has" } else { "have" },
-        );
+        let banner = close_dialog_banner(pending.scope, pending.running.len());
+        let title = close_dialog_title(pending.scope);
 
-        egui::Window::new("Close — Running Commands")
+        egui::Window::new(title)
             .collapsible(false)
             .resizable(false)
             .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
@@ -271,6 +272,30 @@ impl CloseGuardDialog {
 
         outcome
     }
+}
+
+/// The window title for the close-guard dialog, specific to `scope`.
+const fn close_dialog_title(scope: CloseScope) -> &'static str {
+    match scope {
+        CloseScope::WindowUnsavedSettings => "Close — Unsaved Settings",
+        CloseScope::Pane | CloseScope::Tab(_) | CloseScope::Window => "Close — Running Commands",
+    }
+}
+
+/// The banner message for the close-guard dialog, specific to `scope`.
+///
+/// `running_count` is only meaningful for the running-command scopes
+/// (`Pane` / `Tab` / `Window`); `WindowUnsavedSettings` ignores it — that
+/// guard has nothing to list, just the unsaved-edits warning.
+fn close_dialog_banner(scope: CloseScope, running_count: usize) -> String {
+    if scope == CloseScope::WindowUnsavedSettings {
+        return "Settings has unsaved changes. Closing this window will discard them.".to_owned();
+    }
+    format!(
+        "{running_count} pane{} {} a running command. Close anyway?",
+        if running_count == 1 { "" } else { "s" },
+        if running_count == 1 { "has" } else { "have" },
+    )
 }
 
 /// Format one running-command entry for the dialog list:
@@ -563,6 +588,42 @@ mod tests {
     fn format_running_entry_missing_elapsed_reads_running() {
         let entry = format_running_entry(&info("T", "<unknown command>", None));
         assert_eq!(entry, "T · <unknown command> (running)");
+    }
+
+    #[test]
+    fn close_dialog_banner_running_commands_pluralizes() {
+        assert_eq!(
+            close_dialog_banner(CloseScope::Window, 1),
+            "1 pane has a running command. Close anyway?"
+        );
+        assert_eq!(
+            close_dialog_banner(CloseScope::Tab(0), 3),
+            "3 panes have a running command. Close anyway?"
+        );
+    }
+
+    #[test]
+    fn close_dialog_banner_unsaved_settings_ignores_running_count() {
+        assert_eq!(
+            close_dialog_banner(CloseScope::WindowUnsavedSettings, 0),
+            "Settings has unsaved changes. Closing this window will discard them."
+        );
+    }
+
+    #[test]
+    fn close_dialog_title_distinguishes_settings_from_running_commands() {
+        assert_eq!(
+            close_dialog_title(CloseScope::WindowUnsavedSettings),
+            "Close — Unsaved Settings"
+        );
+        assert_eq!(
+            close_dialog_title(CloseScope::Window),
+            "Close — Running Commands"
+        );
+        assert_eq!(
+            close_dialog_title(CloseScope::Pane),
+            "Close — Running Commands"
+        );
     }
 
     #[test]

--- a/freminal/src/gui/settings.rs
+++ b/freminal/src/gui/settings.rs
@@ -388,13 +388,31 @@ impl SettingsModal {
         Self::serialize_for_baseline(&self.draft) != self.baseline_toml
     }
 
+    /// Returns `true` if the modal is open with edits that would be lost by
+    /// closing without saving.
+    ///
+    /// Read-only sessions never have "unsaved" edits from the user's
+    /// perspective (Apply is disabled), so they never report unsaved
+    /// changes here. Used by the owning-window close guard (issue #401) to
+    /// decide whether closing the terminal window that opened Settings
+    /// should surface a confirmation prompt.
+    #[must_use]
+    pub fn has_unsaved_changes(&self) -> bool {
+        self.is_open && self.read_only_reason.is_none() && self.is_dirty()
+    }
+
     /// Request to close the modal, consulting the dirty state.
     ///
     /// Returns `true` if the modal may close immediately (no pending edits),
     /// `false` if the caller should keep the window open so the user can
     /// resolve the confirm prompt.  Callers include the embedded Cancel
-    /// button, the egui window X, and the app's `on_close_requested` hook
-    /// for the standalone settings OS window.
+    /// button and the egui window X — i.e. the modal closing *itself*.
+    ///
+    /// The owning terminal window's close path (issue #401) does not use
+    /// this method: it uses [`has_unsaved_changes`](Self::has_unsaved_changes)
+    /// plus the shared close-guard dialog (Task 98 pattern) instead, so the
+    /// prompt renders on the terminal window being closed rather than
+    /// relying on the settings window's own next frame.
     ///
     /// When read-only, close is always allowed (Apply is disabled, so there
     /// can be no unsaved edits from the user's perspective).
@@ -3269,6 +3287,49 @@ mod tests {
             (modal.draft.ui.background_opacity - 0.25).clamp(0.0, 1.0);
         assert!(modal.request_close());
         assert!(!modal.is_open);
+    }
+
+    #[test]
+    fn has_unsaved_changes_false_when_closed_clean_or_read_only() {
+        let mut modal = SettingsModal::new(None);
+        let live = Config::default();
+
+        // Never opened.
+        assert!(!modal.has_unsaved_changes());
+
+        modal.open(&live, Vec::new(), false);
+        modal.read_only_reason = None;
+
+        // Open but clean.
+        assert!(!modal.has_unsaved_changes());
+
+        modal.draft.ui.background_opacity =
+            (modal.draft.ui.background_opacity - 0.25).clamp(0.0, 1.0);
+
+        // Open and dirty.
+        assert!(modal.has_unsaved_changes());
+
+        // Read-only dirty modal has nothing "unsaved" from the user's
+        // perspective — Apply is disabled either way.
+        modal.read_only_reason = Some("test: read-only".to_string());
+        assert!(!modal.has_unsaved_changes());
+    }
+
+    #[test]
+    fn has_unsaved_changes_false_after_close() {
+        let mut modal = SettingsModal::new(None);
+        let live = Config::default();
+        modal.open(&live, Vec::new(), false);
+        modal.read_only_reason = None;
+        modal.draft.ui.background_opacity =
+            (modal.draft.ui.background_opacity - 0.25).clamp(0.0, 1.0);
+        assert!(modal.has_unsaved_changes());
+
+        modal.is_open = false;
+        assert!(
+            !modal.has_unsaved_changes(),
+            "a closed modal has nothing left to lose, dirty or not"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #401. Closing the terminal window that opened Settings left the
Settings OS window orphaned (frozen, un-closable via its own UI), and
if it was the last window, the app never quit.

## Root causes

- `on_window_created()` overwrote `settings_owner` with the new
  settings window's own id right after creation, so `settings_owner`
  was always equal to `settings_window_id`. This made the
  owner-window-close branch in `on_close_requested()` permanently
  unreachable for real terminal windows (it also silently broke "Test
  Paste" routing and the settings window's `os_dark_mode` fallback,
  both of which key off `settings_owner`).
- Even accounting for that, the owner-close branch force-cleared
  `is_open` without ever telling the OS window to actually close, and
  without checking for unsaved edits first.

## Fix

- Stop clobbering `settings_owner` in `on_window_created()`.
- `on_close_requested()` now routes through a small, pure, unit-tested
  decision function (`settings_owner_close_decision`) with three
  outcomes:
  - **Clean / no edits** — close the settings window right away. Since
    `on_close_requested` has no `WindowHandle`, this uses the
    per-window `repaint_handle` (already used for cross-thread
    wake-ups) to force one more repaint of the settings window, which
    runs its *existing* self-close code path (`handle.close_window`) —
    no new close-execution logic needed there.
  - **Unsaved edits** — veto the close and reuse the Task 98
    close-guard dialog (same Cancel / Force Close UX as the
    running-command guard), per the maintainer's direction to mirror
    that existing pattern rather than inventing a new prompt.
  - **Already resolved** — a prior Force Close already handled it;
    proceed normally.
- Force Close on the new `CloseScope::WindowUnsavedSettings` discards
  the edits, closes the settings OS window directly (a `WindowHandle`
  *is* available in that code path), and re-issues the terminal
  window's close.

Once the settings window actually closes (via either path above), the
existing `process_pending_ops` / `event_loop.exit()` plumbing already
handles the "all windows closed -> quit" case correctly — no changes
needed in `freminal-windowing`.

## Testing

- New unit tests for `settings_owner_close_decision` (all four
  branches).
- New unit tests for `SettingsModal::has_unsaved_changes()`.
- New unit tests for the close-guard dialog's scope-specific banner
  and title text.
- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
  warnings`, `cargo machete`, `cargo fmt --all -- --check`, and `cargo
  xtask check-windows` all pass.

Closes #401.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added protection against accidentally closing a terminal window while Settings contains unsaved changes.
  * Added a dedicated “Unsaved Settings” close confirmation dialog.
  * Force-closing now closes both the Settings window and its owning terminal window.

* **Bug Fixes**
  * Fixed Settings ownership tracking so closing behavior is handled by the correct terminal window.
  * Settings close state now resets correctly when the owning window closes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->