### PR TITLE
fix: wire cursor.shape/cursor.blink config into actual cursor rendering

### DIFF
--- a/freminal-common/src/cursor.rs
+++ b/freminal-common/src/cursor.rs
@@ -3,6 +3,8 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+use crate::config::CursorShapeConfig;
+
 /// The shape and blink behaviour of the terminal cursor.
 ///
 /// Values map to the DECSCUSR parameter (`CSI Ps SP q`):
@@ -43,5 +45,86 @@ impl From<usize> for CursorVisualStyle {
             6 => Self::VerticalLineCursorSteady,
             _ => Self::BlockCursorBlink,
         }
+    }
+}
+
+impl CursorVisualStyle {
+    /// Build the initial/default cursor style from the user's `[cursor]`
+    /// config (issue #406: `cursor.shape`/`cursor.blink` were previously
+    /// only read by the Settings UI form itself, never applied to the
+    /// terminal's actual `CursorVisualStyle`).
+    ///
+    /// This is a one-time seed, not a live constraint: once a running
+    /// program sets a style via DECSCUSR or toggles `XTCBlink`, that
+    /// program's request takes over, exactly as on a real terminal — the
+    /// config only supplies the value in effect before any program has
+    /// asked for something else.
+    #[must_use]
+    pub const fn from_config(shape: &CursorShapeConfig, blink: bool) -> Self {
+        match (shape, blink) {
+            (CursorShapeConfig::Block, true) => Self::BlockCursorBlink,
+            (CursorShapeConfig::Block, false) => Self::BlockCursorSteady,
+            (CursorShapeConfig::Underline, true) => Self::UnderlineCursorBlink,
+            (CursorShapeConfig::Underline, false) => Self::UnderlineCursorSteady,
+            (CursorShapeConfig::Bar, true) => Self::VerticalLineCursorBlink,
+            (CursorShapeConfig::Bar, false) => Self::VerticalLineCursorSteady,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_config_maps_every_shape_and_blink_combination() {
+        assert_eq!(
+            CursorVisualStyle::from_config(&CursorShapeConfig::Block, true),
+            CursorVisualStyle::BlockCursorBlink
+        );
+        assert_eq!(
+            CursorVisualStyle::from_config(&CursorShapeConfig::Block, false),
+            CursorVisualStyle::BlockCursorSteady
+        );
+        assert_eq!(
+            CursorVisualStyle::from_config(&CursorShapeConfig::Underline, true),
+            CursorVisualStyle::UnderlineCursorBlink
+        );
+        assert_eq!(
+            CursorVisualStyle::from_config(&CursorShapeConfig::Underline, false),
+            CursorVisualStyle::UnderlineCursorSteady
+        );
+        assert_eq!(
+            CursorVisualStyle::from_config(&CursorShapeConfig::Bar, true),
+            CursorVisualStyle::VerticalLineCursorBlink
+        );
+        assert_eq!(
+            CursorVisualStyle::from_config(&CursorShapeConfig::Bar, false),
+            CursorVisualStyle::VerticalLineCursorSteady
+        );
+    }
+
+    #[test]
+    fn from_config_matches_default_config_default_style() {
+        // `CursorConfig::default()` is `Block` + `blink: true`, which should
+        // agree with `CursorVisualStyle::default()`'s intent... except the
+        // *type* default is steady block (matching xterm's power-on
+        // default), while the *config* default enables blink. This
+        // deliberately documents that the config default and the bare-type
+        // default are NOT required to match — `from_config` must honor
+        // whatever the config says, not silently fall back to the type
+        // default.
+        //
+        // Reads `blink` from a real `CursorConfig::default()` (rather than
+        // hardcoding `true`) so this test actually fails if the config
+        // default ever changes, instead of silently drifting out of sync.
+        let default_cursor_config = crate::config::CursorConfig::default();
+        assert_eq!(
+            CursorVisualStyle::from_config(
+                &default_cursor_config.shape,
+                default_cursor_config.blink
+            ),
+            CursorVisualStyle::BlockCursorBlink
+        );
     }
 }

--- a/freminal-terminal-emulator/src/io/mod.rs
+++ b/freminal-terminal-emulator/src/io/mod.rs
@@ -98,6 +98,16 @@ pub enum InputEvent {
     /// (the GUI must also reset its local `ViewState::scroll_offset` so the
     /// next frame renders from the live view).
     ClearScrollback,
+    /// The user changed the cursor shape/blink Settings while a pane was
+    /// already running (issue #406).
+    ///
+    /// Sent by the Settings Modal when `cursor.shape` / `cursor.blink`
+    /// change on Apply (or a config reload). The PTY thread calls
+    /// `handler.set_cursor_visual_style()`, exactly like the initial seed
+    /// applied at pane-spawn time. Like DECSCUSR, this is a plain
+    /// overwrite: a program's own subsequent DECSCUSR / `XTCBlink` request
+    /// still takes over normally afterward.
+    CursorConfigChange(freminal_common::cursor::CursorVisualStyle),
 }
 
 /// Commands sent from the PTY processing thread to the GUI thread.

--- a/freminal-terminal-emulator/src/terminal_handler/cursor_ops.rs
+++ b/freminal-terminal-emulator/src/terminal_handler/cursor_ops.rs
@@ -132,6 +132,17 @@ impl TerminalHandler {
         self.cursor_visual_style.clone()
     }
 
+    /// Set the cursor shape / blink style.
+    ///
+    /// Used to seed the initial style from `config.cursor` when a pane is
+    /// spawned, and to apply a live Settings change to an already-running
+    /// pane (issue #406). Like DECSCUSR, this is a plain overwrite — once
+    /// set, a subsequent DECSCUSR or `XTCBlink` request from the running
+    /// program takes over normally, exactly as on a real terminal.
+    pub const fn set_cursor_visual_style(&mut self, style: CursorVisualStyle) {
+        self.cursor_visual_style = style;
+    }
+
     /// Apply an `XtCBlink` blink-mode change to the current `cursor_visual_style`.
     ///
     /// Flips between the blinking and steady variants of whichever shape is active,

--- a/freminal-terminal-emulator/tests/terminal_handler_integration.rs
+++ b/freminal-terminal-emulator/tests/terminal_handler_integration.rs
@@ -1578,6 +1578,44 @@ fn cursor_visual_style_set() {
 }
 
 #[test]
+fn set_cursor_visual_style_seeds_and_can_be_overridden_by_decscusr() {
+    // Regression test for issue #406: `set_cursor_visual_style` is the seam
+    // used to apply `config.cursor` at pane-spawn time and on a live
+    // Settings change. It must take effect immediately (like `set_theme`),
+    // and a subsequent DECSCUSR output from the running program must still
+    // be able to override it — the config only supplies the value in
+    // effect *before* any program has requested something else, it does not
+    // pin the style permanently.
+    use freminal_common::{
+        buffer_states::terminal_output::TerminalOutput, cursor::CursorVisualStyle,
+    };
+
+    let mut handler = TerminalHandler::new(80, 24);
+    assert_eq!(
+        handler.cursor_visual_style(),
+        CursorVisualStyle::BlockCursorSteady,
+        "sanity: bare TerminalHandler::new starts at the type default"
+    );
+
+    handler.set_cursor_visual_style(CursorVisualStyle::VerticalLineCursorBlink);
+    assert_eq!(
+        handler.cursor_visual_style(),
+        CursorVisualStyle::VerticalLineCursorBlink,
+        "set_cursor_visual_style must take effect immediately"
+    );
+
+    // A running program's own DECSCUSR request still wins afterward.
+    handler.process_outputs(&[TerminalOutput::CursorVisualStyle(
+        CursorVisualStyle::BlockCursorSteady,
+    )]);
+    assert_eq!(
+        handler.cursor_visual_style(),
+        CursorVisualStyle::BlockCursorSteady,
+        "a program's own DECSCUSR request must still override the configured seed"
+    );
+}
+
+#[test]
 fn xtcblink_toggles_blink() {
     // XtCBlink::Blinking flips the current steady style to blinking;
     // XtCBlink::Steady flips it back.

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -154,8 +154,14 @@ impl freminal_windowing::App for FreminalGui {
             match super::pty::spawn_pty_tab(
                 &self.args,
                 self.config.scrollback.limit,
-                theme,
-                self.config.ui.auto_detect_urls,
+                super::pty::PtyTabInitialState {
+                    theme,
+                    auto_detect_urls: self.config.ui.auto_detect_urls,
+                    cursor_style: freminal_common::cursor::CursorVisualStyle::from_config(
+                        &self.config.cursor.shape,
+                        self.config.cursor.blink,
+                    ),
+                },
                 &repaint_handle,
                 initial_size,
                 super::pty::PtyTabConfig {
@@ -2342,8 +2348,14 @@ impl FreminalGui {
         let channels = match super::pty::spawn_pty_tab(
             &self.args,
             self.config.scrollback.limit,
-            theme,
-            self.config.ui.auto_detect_urls,
+            super::pty::PtyTabInitialState {
+                theme,
+                auto_detect_urls: self.config.ui.auto_detect_urls,
+                cursor_style: freminal_common::cursor::CursorVisualStyle::from_config(
+                    &self.config.cursor.shape,
+                    self.config.cursor.blink,
+                ),
+            },
             &repaint_handle,
             initial_size,
             super::pty::PtyTabConfig {

--- a/freminal/src/gui/pty.rs
+++ b/freminal/src/gui/pty.rs
@@ -27,6 +27,7 @@ use freminal_terminal_emulator::interface::TerminalEmulator;
 use freminal_terminal_emulator::io::{InputEvent, WindowCommand};
 use freminal_terminal_emulator::recording::{EventPayload, RecordingSwap};
 use freminal_terminal_emulator::snapshot::TerminalSnapshot;
+use freminal_terminal_emulator::terminal_handler::TerminalHandler;
 use freminal_windowing::{RepaintProxy, WindowId};
 
 /// Ask the system allocator to release free heap pages back to the OS.
@@ -185,6 +186,52 @@ pub struct TabChannels {
     pub shell_program: Option<std::path::PathBuf>,
 }
 
+/// Already-resolved config values applied once, immediately after a new
+/// pane's `TerminalHandler` is constructed.
+///
+/// This seeds the pane's starting state from what the user has configured,
+/// rather than always the hardcoded type defaults. Grouped into one struct
+/// (rather than more `spawn_pty_tab` parameters) so
+/// adding a future per-pane seed value doesn't push the function over
+/// clippy's argument-count limit. All fields here mirror an existing live
+/// `InputEvent` used to re-apply the same value to an already-running pane
+/// when the user changes it in Settings.
+pub struct PtyTabInitialState {
+    /// Active color theme (`InputEvent::ThemeChange` is the live-apply
+    /// equivalent).
+    pub theme: &'static freminal_common::themes::ThemePalette,
+    /// Auto-detect plain URLs in terminal output
+    /// (`InputEvent::AutoDetectUrls` is the live-apply equivalent).
+    pub auto_detect_urls: bool,
+    /// Cursor shape/blink style, resolved from `config.cursor` via
+    /// [`CursorVisualStyle::from_config`](freminal_common::cursor::CursorVisualStyle::from_config)
+    /// (`InputEvent::CursorConfigChange` is the live-apply equivalent;
+    /// issue #406).
+    pub cursor_style: freminal_common::cursor::CursorVisualStyle,
+}
+
+/// Apply `initial_state` to a freshly constructed pane's handler.
+///
+/// Extracted out of `spawn_pty_tab` so this seeding logic — as opposed to
+/// the PTY spawn machinery around it, which needs a real child process — is
+/// unit-testable on its own with a bare `TerminalHandler`.
+fn apply_initial_state(handler: &mut TerminalHandler, initial_state: PtyTabInitialState) {
+    // Apply the configured theme so all snapshots carry the correct palette.
+    handler.set_theme(initial_state.theme);
+
+    // Apply the auto URL detection flag so the buffer's flatten cache
+    // surfaces auto-detected URLs in `FormatTag.url` entries.
+    handler
+        .buffer_mut()
+        .set_auto_detect_urls(initial_state.auto_detect_urls);
+
+    // Seed the cursor's initial shape/blink from `config.cursor` (issue
+    // #406). Like `theme`, this is only the *starting* state: a running
+    // program's own DECSCUSR / XTCBlink request still overrides it
+    // normally, exactly as on a real terminal.
+    handler.set_cursor_visual_style(initial_state.cursor_style);
+}
+
 /// Per-pane configuration forwarded to the PTY child process.
 ///
 /// Carries optional overrides from a layout file: shell binary, extra
@@ -210,9 +257,9 @@ pub struct PtyTabConfig<'a> {
 
 /// Spawn a new PTY-backed terminal and its consumer thread.
 ///
-/// Creates a `TerminalEmulator`, sets the given theme, wires all channels,
-/// and spawns the PTY consumer thread.  Returns the GUI-side channel
-/// endpoints as a [`TabChannels`].
+/// Creates a `TerminalEmulator`, sets the given theme and initial cursor
+/// style, wires all channels, and spawns the PTY consumer thread.  Returns
+/// the GUI-side channel endpoints as a [`TabChannels`].
 ///
 /// The `repaint_handle` is shared with the PTY thread so it can request
 /// repaints after publishing new snapshots.
@@ -224,8 +271,7 @@ pub struct PtyTabConfig<'a> {
 pub fn spawn_pty_tab(
     args: &Args,
     scrollback_limit: usize,
-    theme: &'static freminal_common::themes::ThemePalette,
-    auto_detect_urls: bool,
+    initial_state: PtyTabInitialState,
     repaint_handle: &Arc<OnceLock<(RepaintProxy, WindowId)>>,
     initial_size: FreminalTerminalSize,
     tab_cfg: PtyTabConfig<'_>,
@@ -241,16 +287,7 @@ pub fn spawn_pty_tab(
         tab_cfg.set_term_program,
     )?;
 
-    // Apply the configured theme so all snapshots carry the correct palette.
-    terminal.internal.handler.set_theme(theme);
-
-    // Apply the auto URL detection flag so the buffer's flatten cache
-    // surfaces auto-detected URLs in `FormatTag.url` entries.
-    terminal
-        .internal
-        .handler
-        .buffer_mut()
-        .set_auto_detect_urls(auto_detect_urls);
+    apply_initial_state(&mut terminal.internal.handler, initial_state);
 
     // Shared snapshot (ArcSwap).
     let arc_swap: Arc<ArcSwap<TerminalSnapshot>> =
@@ -496,6 +533,9 @@ fn spawn_pty_consumer_thread(
                         Ok(InputEvent::ThemeChange(theme)) => {
                             emulator.internal.handler.set_theme(theme);
                         }
+                        Ok(InputEvent::CursorConfigChange(style)) => {
+                            emulator.internal.handler.set_cursor_visual_style(style);
+                        }
                         Ok(InputEvent::AutoDetectUrls(enabled)) => {
                             emulator
                                 .internal
@@ -715,5 +755,47 @@ mod tests {
         drop(rx);
         forward_command_events(vec![block_with_fid("x")], 1, &tx);
         // No assertion needed: not panicking is the contract.
+    }
+
+    #[test]
+    fn apply_initial_state_seeds_theme_auto_detect_urls_and_cursor_style() {
+        // Regression test for issue #406 (and the pre-existing theme /
+        // auto_detect_urls seeding this PR's cursor_style change follows the
+        // shape of): `spawn_pty_tab` cannot be unit-tested directly (it
+        // spawns a real child process), but the seeding logic it delegates
+        // to can be, against a bare `TerminalHandler`.
+        use freminal_common::cursor::CursorVisualStyle;
+        use freminal_common::themes::{CATPPUCCIN_MOCHA, DRACULA};
+
+        let mut handler = TerminalHandler::new(80, 24);
+        assert_eq!(
+            handler.theme(),
+            &CATPPUCCIN_MOCHA,
+            "sanity: TerminalHandler::new defaults to Catppuccin Mocha"
+        );
+        assert_eq!(handler.cursor_visual_style(), CursorVisualStyle::default());
+        // Seed the opposite of whatever the fresh handler's default is, so
+        // this test proves `apply_initial_state` actually changed the value
+        // rather than happening to match a pre-existing default.
+        let seeded_auto_detect_urls = !handler.buffer_mut().auto_detect_urls();
+
+        apply_initial_state(
+            &mut handler,
+            PtyTabInitialState {
+                theme: &DRACULA,
+                auto_detect_urls: seeded_auto_detect_urls,
+                cursor_style: CursorVisualStyle::VerticalLineCursorBlink,
+            },
+        );
+
+        assert_eq!(handler.theme(), &DRACULA);
+        assert_eq!(
+            handler.buffer_mut().auto_detect_urls(),
+            seeded_auto_detect_urls
+        );
+        assert_eq!(
+            handler.cursor_visual_style(),
+            CursorVisualStyle::VerticalLineCursorBlink
+        );
     }
 }

--- a/freminal/src/gui/settings_dispatch.rs
+++ b/freminal/src/gui/settings_dispatch.rs
@@ -122,6 +122,40 @@ impl FreminalGui {
             }
         }
 
+        // Broadcast cursor shape/blink changes to all panes (issue #406).
+        // Like the initial pane-spawn seed, this only supplies the value in
+        // effect until a running program's own DECSCUSR / `XTCBlink`
+        // request overrides it, exactly as on a real terminal.
+        if new_cfg.cursor.shape != self.config.cursor.shape
+            || new_cfg.cursor.blink != self.config.cursor.blink
+        {
+            let style = freminal_common::cursor::CursorVisualStyle::from_config(
+                &new_cfg.cursor.shape,
+                new_cfg.cursor.blink,
+            );
+            for win in self.windows.values() {
+                for tab in win.tabs.iter() {
+                    match tab.pane_tree.iter_panes() {
+                        Ok(panes) => {
+                            for pane in panes {
+                                send_or_log!(
+                                    pane.input_tx,
+                                    InputEvent::CursorConfigChange(style.clone()),
+                                    "Failed to send CursorConfigChange to PTY thread"
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            error!(
+                                "iter_panes() failed on tab during cursor config \
+                                 apply: {e}; skipping this tab"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
         self.config = new_cfg;
 
         // Adopt the persisted chrome style profile (Task 112.13). A previewed

--- a/freminal/src/gui/tab_spawning.rs
+++ b/freminal/src/gui/tab_spawning.rs
@@ -66,8 +66,14 @@ impl FreminalGui {
         match pty::spawn_pty_tab(
             &self.args,
             self.config.scrollback.limit,
-            theme,
-            self.config.ui.auto_detect_urls,
+            pty::PtyTabInitialState {
+                theme,
+                auto_detect_urls: self.config.ui.auto_detect_urls,
+                cursor_style: freminal_common::cursor::CursorVisualStyle::from_config(
+                    &self.config.cursor.shape,
+                    self.config.cursor.blink,
+                ),
+            },
             &win.repaint_handle,
             initial_size,
             pty::PtyTabConfig {
@@ -193,8 +199,14 @@ impl FreminalGui {
         let channels = match pty::spawn_pty_tab(
             &self.args,
             self.config.scrollback.limit,
-            theme,
-            self.config.ui.auto_detect_urls,
+            pty::PtyTabInitialState {
+                theme,
+                auto_detect_urls: self.config.ui.auto_detect_urls,
+                cursor_style: freminal_common::cursor::CursorVisualStyle::from_config(
+                    &self.config.cursor.shape,
+                    self.config.cursor.blink,
+                ),
+            },
             &win.repaint_handle,
             initial_size,
             pty::PtyTabConfig {
@@ -323,8 +335,14 @@ impl FreminalGui {
         let channels = match pty::spawn_pty_tab(
             &self.args,
             self.config.scrollback.limit,
-            theme,
-            self.config.ui.auto_detect_urls,
+            pty::PtyTabInitialState {
+                theme,
+                auto_detect_urls: self.config.ui.auto_detect_urls,
+                cursor_style: freminal_common::cursor::CursorVisualStyle::from_config(
+                    &self.config.cursor.shape,
+                    self.config.cursor.blink,
+                ),
+            },
             repaint_handle,
             initial_size,
             pty::PtyTabConfig {


### PR DESCRIPTION
## Summary

Fixes #406. The Settings modal's Cursor Shape picker and Cursor Blink
checkbox wrote to `config.cursor.{shape,blink}`, but nothing ever read
those fields to affect `TerminalHandler::cursor_visual_style`, which is
what actually drives DECSCUSR-style cursor rendering. The config
round-tripped through TOML and displayed correctly in the Settings UI,
but had zero effect on the terminal — the cursor's blink/shape state
was 100% at the mercy of whatever the running program last requested
via DECSCUSR/XTCBlink, defaulting to a hardcoded steady block.

## Fix

- `CursorVisualStyle::from_config(shape, blink)` — new pure conversion
  from the config representation to the render-affecting enum
  (`freminal-common`).
- `TerminalHandler::set_cursor_visual_style()` — new setter mirroring
  the existing `set_theme()` pattern, so a pane's style can be seeded
  and live-updated from outside the escape-sequence parser.
- `spawn_pty_tab()` now seeds every new pane's initial cursor style
  from `config.cursor`, via a new `PtyTabInitialState` struct
  (grouping `theme` + `auto_detect_urls` + `cursor_style` so the
  function doesn't grow past clippy's argument-count limit).
- A new `InputEvent::CursorConfigChange` broadcasts a live Settings
  Apply (or config reload) to every running pane, mirroring the
  existing `ThemeChange` / `AutoDetectUrls` broadcast pattern in
  `apply_new_config()`.

Like `theme`, this only supplies the pane's *initial* / *configured*
value — a running program's own DECSCUSR or `XTCBlink` request still
overrides it normally afterward, matching real terminal behavior (the
config sets a default, it doesn't pin the style). RIS deliberately
leaves `cursor_visual_style` untouched on reset, exactly as it already
does for `theme` — this was confirmed with the maintainer rather than
assumed, since real-terminal RIS semantics for a *user preference*
field aren't the same as for session state.

## Testing

- New unit tests for the config->style conversion covering every
  shape/blink combination (`freminal-common`).
- New integration test for `set_cursor_visual_style()`, including that
  a subsequent DECSCUSR from the "running program" still overrides the
  configured seed (`freminal-terminal-emulator`).
- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D
  warnings`, `cargo machete`, `cargo fmt --all -- --check`, and `cargo
  xtask check-windows` all pass.

Closes #406.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cursor shape and blinking preferences now apply consistently when opening new windows, tabs, and panes.
  * Cursor shape/blink changes from settings are propagated live to all open panes.
  * Program-requested cursor styles still override configured defaults after launch.

* **Bug Fixes**
  * Fixed cursor style initialization to respect both cursor shape and blink settings.
  * Added regression coverage to ensure live cursor updates are correctly overridden by subsequent terminal cursor requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->