### PR TITLE
perf: event-driven echo-off detection + idle-CPU floor (partial #405)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "portable-pty"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "bitflags 2.13.1",

--- a/freminal-terminal-emulator/benches/buffer_benches.rs
+++ b/freminal-terminal-emulator/benches/buffer_benches.rs
@@ -324,6 +324,17 @@ fn bench_data_and_format_for_gui(c: &mut Criterion) {
 //     whose rows are all clean (no mutation since the last snapshot).  This
 //     reflects the typical cost when the PTY is idle and the GUI polls for
 //     a fresh snapshot — the cached vectors are simply cloned.
+//
+//   build_snapshot_80x24_partial_dirty
+//     Measures the *partial-dirty path*: exactly ONE visible row is dirtied
+//     per sample (a single-character edit), then `build_snapshot` is called.
+//     This is the "1-of-N rows changed" scenario from issue #405 Part C. The
+//     buffer flatten/merge step is NOT incremental: `any_visible_dirty` gates
+//     a full O(all-visible-rows) merge-and-copy even when a single row changed,
+//     so this bench is expected to land much closer to the fully-dirty cost
+//     than to the clean cost. It exists to QUANTIFY that gap and justify (or
+//     not) the deferred per-row-incremental flatten work — measure before
+//     optimising.
 // ---------------------------------------------------------------
 fn bench_build_snapshot(c: &mut Criterion) {
     let mut group = c.benchmark_group("bench_build_snapshot");
@@ -367,6 +378,34 @@ fn bench_build_snapshot(c: &mut Criterion) {
             });
         });
     }
+
+    // ── Partial-dirty path (exactly 1 of 24 visible rows changed) ────────────
+    // Warm the cache once, then per sample dirty a single row (rewrite one
+    // character on row 12) and build a snapshot. iter_batched sets up the
+    // one-row edit per sample so each measured call sees exactly one dirty row.
+    group.bench_function("build_snapshot_80x24_partial_dirty", |b| {
+        b.iter_batched(
+            || {
+                let mut emulator = TerminalEmulator::dummy_for_bench();
+                emulator.internal.set_win_size(80, 24, 8, 16);
+                let payload = cup_writes_payload(80, 24);
+                let parsed = emulator.internal.parser.push(&payload);
+                emulator.internal.handler.process_outputs(&parsed);
+                // Warm the cache: mark all rows clean.
+                let _ = emulator.build_snapshot();
+                // Dirty exactly one visible row: move to row 12, col 1, write
+                // a single character.
+                let edit = b"\x1b[12;1HZ";
+                let parsed = emulator.internal.parser.push(edit);
+                emulator.internal.handler.process_outputs(&parsed);
+                emulator
+            },
+            |mut emulator| {
+                std::hint::black_box(emulator.build_snapshot());
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
 
     group.finish();
 }

--- a/freminal-terminal-emulator/src/interface.rs
+++ b/freminal-terminal-emulator/src/interface.rs
@@ -148,10 +148,26 @@ pub struct TerminalEmulator {
     /// `TerminalSnapshot`, so the clean path (no dirty rows) hands them
     /// directly into the snapshot with a refcount bump — no Vec allocation.
     previous_visible_snap: VisibleSnap,
+    /// The flatten cache for the buffer that is **not** currently active.
+    ///
+    /// On a primary↔alternate switch we cannot reuse the active
+    /// `previous_visible_snap` (it holds the other buffer's content), but we
+    /// also must not report a spurious `content_changed = true` when returning
+    /// to a buffer whose restored content is byte-identical to what we last
+    /// rendered on it. So instead of dropping the cache on a switch, we **swap**
+    /// it with the stashed cache for the buffer we are switching *to* (issue
+    /// #405, alt/primary one-frame tax). The very next flatten then compares
+    /// against the correct same-buffer baseline, and `leave_alternate` restoring
+    /// byte-identical primary rows no longer forces a full-flatten redraw.
+    ///
+    /// `previous_visible_snap` always holds the cache for the buffer identified
+    /// by `previous_was_alternate`; this field holds the other one.
+    stashed_visible_snap_other_buffer: VisibleSnap,
     /// Whether the previous snapshot was taken while in the alternate screen
-    /// buffer.  Used to detect primary↔alternate transitions and invalidate
-    /// `previous_visible_snap` so stale content is never reused across a
-    /// buffer switch.
+    /// buffer.  Used to detect primary↔alternate transitions and swap
+    /// `previous_visible_snap` with `stashed_visible_snap_other_buffer` so the
+    /// wrong buffer's content is never reused across a switch, while the
+    /// correct same-buffer baseline is preserved for change detection.
     previous_was_alternate: bool,
     /// Scroll offset requested by the GUI (rows from the bottom, 0 = live).
     ///
@@ -210,6 +226,7 @@ impl TerminalEmulator {
             pty_io: None,
             write_tx,
             previous_visible_snap: None,
+            stashed_visible_snap_other_buffer: None,
             previous_was_alternate: false,
             gui_scroll_offset: 0,
             gui_extra_rows: 0,
@@ -239,6 +256,7 @@ impl TerminalEmulator {
             pty_io: None,
             write_tx,
             previous_visible_snap: None,
+            stashed_visible_snap_other_buffer: None,
             previous_was_alternate: false,
             gui_scroll_offset: 0,
             gui_extra_rows: 0,
@@ -319,6 +337,7 @@ impl TerminalEmulator {
             pty_io: Some(io),
             write_tx,
             previous_visible_snap: None,
+            stashed_visible_snap_other_buffer: None,
             previous_was_alternate: false,
             gui_scroll_offset: 0,
             gui_extra_rows: 0,
@@ -547,8 +566,8 @@ impl TerminalEmulator {
     ///
     /// Returns a clone of the shared `Arc<AtomicBool>` — the caller reads it
     /// with a cheap `Relaxed` atomic load each frame.  The underlying flag is
-    /// refreshed by the writer thread every 100 ms via `tcgetattr()` on the
-    /// master fd (Unix only).
+    /// refreshed by the reader thread once per PTY read burst (event-driven; no
+    /// standing timer) via `tcgetattr()` on a reader-side fd clone (Unix only).
     ///
     /// Returns `None` in headless / benchmark / playback mode where there is
     /// no real PTY.
@@ -629,12 +648,23 @@ impl TerminalEmulator {
             self.gui_extra_rows.min(available_above)
         };
 
-        // ── Invalidate the snap cache on primary ↔ alternate screen switch ───
+        // ── Swap the snap cache on primary ↔ alternate screen switch ─────────
         //
-        // When the buffer type changes, the previous visible_snap belongs to
-        // the other buffer and must never be reused for the new one.
+        // The active `previous_visible_snap` holds the OTHER buffer's content
+        // after a switch, so it must not be reused directly. But dropping it
+        // outright makes the next flatten report `content_changed = true` even
+        // when the buffer we switched *to* was restored byte-identical to what
+        // we last rendered on it (the common `leave_alternate` case). Instead we
+        // swap the active cache with the stashed cache for the buffer we are
+        // switching to: `previous_visible_snap` becomes that buffer's last-seen
+        // baseline (or `None` if we've never rendered it), and the buffer we
+        // just left is stashed for when we return. This preserves same-buffer
+        // change detection across the switch (issue #405, alt/primary tax).
         if is_alternate_screen != self.previous_was_alternate {
-            self.previous_visible_snap = None;
+            std::mem::swap(
+                &mut self.previous_visible_snap,
+                &mut self.stashed_visible_snap_other_buffer,
+            );
             self.previous_was_alternate = is_alternate_screen;
         }
 
@@ -668,6 +698,10 @@ impl TerminalEmulator {
         let current_size = (term_width, term_height);
         if current_size != self.previous_term_size {
             self.previous_visible_snap = None;
+            // A resize applies to BOTH buffers, so the stashed other-buffer
+            // cache is also the wrong dimensions and must not be restored on a
+            // later buffer switch. Clear it too.
+            self.stashed_visible_snap_other_buffer = None;
             self.previous_term_size = current_size;
         }
 
@@ -1331,12 +1365,75 @@ mod tests {
         emu.handle_incoming_data(b"primary content");
         let _ = emu.build_snapshot();
 
-        // Switch to alternate screen — should invalidate cache
+        // Switch to alternate screen — the active cache holds primary content,
+        // which must not be reused; the blank alt screen differs, so this is a
+        // genuine change.
         emu.handle_incoming_data(b"\x1b[?1049h");
         let snap = emu.build_snapshot();
         assert!(
             snap.content_changed,
             "switching to alternate screen should mark content_changed"
+        );
+    }
+
+    #[test]
+    fn build_snapshot_return_to_primary_unchanged_content_is_not_changed() {
+        // Issue #405 alt/primary one-frame tax: returning to the primary screen
+        // with byte-identical restored content must NOT report content_changed.
+        // The per-buffer cache swap preserves the primary baseline across the
+        // alt-screen excursion.
+        let (mut emu, _rx) = TerminalEmulator::new_headless(None);
+        emu.handle_incoming_data(b"primary content");
+        let primary_snap = emu.build_snapshot();
+        assert!(
+            primary_snap.content_changed,
+            "first primary snapshot is a change"
+        );
+        // A second primary snapshot with no changes is stable.
+        let stable = emu.build_snapshot();
+        assert!(!stable.content_changed, "idle primary is unchanged");
+
+        // Enter the alternate screen and render it (writes some alt content).
+        emu.handle_incoming_data(b"\x1b[?1049h");
+        emu.handle_incoming_data(b"alt screen stuff");
+        let alt_snap = emu.build_snapshot();
+        assert!(alt_snap.is_alternate_screen);
+
+        // Leave the alternate screen — `leave_alternate` restores the primary
+        // rows exactly as they were. The restored content is byte-identical to
+        // what we last rendered on primary, so the returning snapshot must
+        // report content_changed == false (the fix; previously always true).
+        emu.handle_incoming_data(b"\x1b[?1049l");
+        let returned = emu.build_snapshot();
+        assert!(
+            !returned.is_alternate_screen,
+            "should be back on the primary screen"
+        );
+        assert!(
+            !returned.content_changed,
+            "returning to a byte-identical primary screen must not report \
+             content_changed (issue #405 one-frame tax fix)"
+        );
+    }
+
+    #[test]
+    fn build_snapshot_return_to_primary_with_changed_content_is_changed() {
+        // Guard the other direction: if the primary content genuinely differs
+        // when we return (e.g. output arrived on primary via the alt buffer's
+        // exit sequence), content_changed must still be reported true. Here we
+        // change the primary AFTER leaving alt to force a real diff.
+        let (mut emu, _rx) = TerminalEmulator::new_headless(None);
+        emu.handle_incoming_data(b"primary content");
+        let _ = emu.build_snapshot();
+        emu.handle_incoming_data(b"\x1b[?1049h");
+        let _ = emu.build_snapshot();
+        emu.handle_incoming_data(b"\x1b[?1049l");
+        // New output on the restored primary screen.
+        emu.handle_incoming_data(b" plus more");
+        let returned = emu.build_snapshot();
+        assert!(
+            returned.content_changed,
+            "genuinely changed primary content must report content_changed"
         );
     }
 

--- a/freminal-terminal-emulator/src/interface.rs
+++ b/freminal-terminal-emulator/src/interface.rs
@@ -675,6 +675,13 @@ impl TerminalEmulator {
         let scroll_changed = scroll_offset != self.previous_scroll_offset;
         if scroll_changed {
             self.previous_visible_snap = None;
+            // The stashed other-buffer cache also covers a specific viewport.
+            // A primary snapshot stashed while scrolled back must not be
+            // restored after a scroll change (e.g. entering the alternate
+            // screen forces offset 0): its content is for a different visible
+            // window. Clear it so the buffer switch re-flattens instead of
+            // reusing viewport-stale rows.
+            self.stashed_visible_snap_other_buffer = None;
             self.previous_scroll_offset = scroll_offset;
         }
 
@@ -685,6 +692,10 @@ impl TerminalEmulator {
         // reused.
         if extra_rows != self.previous_extra_rows {
             self.previous_visible_snap = None;
+            // Same reasoning as the scroll-change case: the stashed cache
+            // covers a specific flatten window and must not be restored across
+            // an extra-row change.
+            self.stashed_visible_snap_other_buffer = None;
             self.previous_extra_rows = extra_rows;
         }
 
@@ -997,6 +1008,18 @@ mod tests {
     fn make_headless() -> TerminalEmulator {
         let (emu, _rx) = TerminalEmulator::new_headless(None);
         emu
+    }
+
+    /// Return the first visible row's chars (up to the first `NewLine`).
+    /// Used to compare which window of content a snapshot flattened.
+    fn first_visible_row(
+        chars: &[freminal_common::buffer_states::tchar::TChar],
+    ) -> Vec<freminal_common::buffer_states::tchar::TChar> {
+        chars
+            .iter()
+            .take_while(|c| !matches!(c, freminal_common::buffer_states::tchar::TChar::NewLine))
+            .copied()
+            .collect()
     }
 
     // ── extract_selection_text ─────────────────────────────────────────────────
@@ -1413,6 +1436,67 @@ mod tests {
             !returned.content_changed,
             "returning to a byte-identical primary screen must not report \
              content_changed (issue #405 one-frame tax fix)"
+        );
+    }
+
+    #[test]
+    fn build_snapshot_scrolled_primary_to_alt_to_primary_does_not_reuse_scrolled_content() {
+        // Issue #405 / CodeRabbit follow-up: a primary snapshot taken while
+        // scrolled back must NOT be restored (via the per-buffer cache swap)
+        // after returning from the alternate screen, because entering alt
+        // forces scroll_offset = 0 — the stashed content is for a different
+        // visible window. Regression guard for the "stale scrolled-back
+        // viewport reused at offset 0" bug.
+        let (mut emu, _rx) = TerminalEmulator::new_headless(None);
+        // Produce enough distinct lines to create scrollback. Each line's
+        // content is unique so we can distinguish the scrolled window from the
+        // live bottom.
+        for i in 0..200u32 {
+            emu.handle_incoming_data(format!("line{i}\r\n").as_bytes());
+        }
+        // Snapshot at the live bottom first (warms the primary cache clean).
+        let _ = emu.build_snapshot();
+
+        // Scroll back into history and snapshot — this caches a primary
+        // VisibleSnap for scroll_offset > 0.
+        emu.set_gui_scroll_offset(50);
+        let scrolled = emu.build_snapshot();
+        assert_eq!(scrolled.scroll_offset, 50, "should be scrolled back");
+        let scrolled_first_row = first_visible_row(&scrolled.visible_chars);
+
+        // Enter the alternate screen. This forces scroll_offset = 0, swaps the
+        // scrolled-back primary cache into the stash, and the scroll-change
+        // path must clear that stash.
+        emu.handle_incoming_data(b"\x1b[?1049h");
+        let _ = emu.build_snapshot();
+
+        // Leave the alternate screen. GUI offset is still 0, so we are at the
+        // live bottom. The returned snapshot must reflect the live-bottom
+        // primary content, NOT the stale scrolled-back window.
+        emu.handle_incoming_data(b"\x1b[?1049l");
+        let returned = emu.build_snapshot();
+        assert_eq!(
+            returned.scroll_offset, 0,
+            "should be at the live bottom after returning"
+        );
+        let returned_first_row = first_visible_row(&returned.visible_chars);
+        assert_ne!(
+            returned_first_row, scrolled_first_row,
+            "returning to the live bottom must not reuse the scrolled-back \
+             primary viewport (stale-viewport cache bug)"
+        );
+
+        // And it must match a fresh flatten at offset 0 (the source of truth).
+        let expected = emu
+            .internal
+            .handler
+            .buffer_mut()
+            .visible_as_tchars_and_tags_extended(0, 0)
+            .0;
+        let expected_first_row = first_visible_row(&expected);
+        assert_eq!(
+            returned_first_row, expected_first_row,
+            "returned content must match a fresh live-bottom flatten"
         );
     }
 

--- a/freminal-terminal-emulator/src/io/pty.rs
+++ b/freminal-terminal-emulator/src/io/pty.rs
@@ -52,11 +52,12 @@ pub struct FreminalPtyInputOutput {
     /// Shared atomic flag reflecting whether the PTY slave currently has
     /// `ECHO` disabled (i.e. a password prompt is active).
     ///
-    /// Updated by the writer thread every 100 ms (via `recv_timeout`) using
-    /// `MasterPty::get_termios()`.  Compiled only on Unix; on Windows the
-    /// `#[cfg(unix)]` termios block is omitted entirely, so the atomic stays
-    /// at its default `false`.  Read by the GUI via a cheap `Relaxed` load
-    /// without any locking overhead.
+    /// Updated by the reader thread once per PTY read burst (event-driven, no
+    /// standing timer) using `PtyReader::get_termios()` on a termios-capable
+    /// reader clone.  Compiled only on Unix; on Windows the `#[cfg(unix)]`
+    /// termios block is omitted entirely, so the atomic stays at its default
+    /// `false`.  Read by the GUI via a cheap `Relaxed` load without any locking
+    /// overhead.
     pub echo_off: std::sync::Arc<std::sync::atomic::AtomicBool>,
     /// OS process ID of the PTY child shell.
     ///
@@ -168,10 +169,10 @@ pub struct RunTerminalResult {
     /// Shared atomic flag reflecting whether the PTY slave currently has
     /// `ECHO` disabled.
     ///
-    /// The writer thread polls `pair.master.get_termios()` every 250 ms
-    /// (or immediately after each write/resize).  The PTY consumer thread
-    /// reads it atomically when building snapshots.
-    /// `Arc` lets both threads share ownership without a lock.
+    /// The reader thread checks `PtyReader::get_termios()` once per PTY read
+    /// burst (event-driven; no standing timer). The GUI reads it atomically
+    /// via a cheap `Relaxed` load. `Arc` lets both threads share ownership
+    /// without a lock.
     pub echo_off: std::sync::Arc<std::sync::atomic::AtomicBool>,
     /// OS process ID of the PTY child (shell or direct command).
     ///
@@ -613,10 +614,30 @@ pub fn run_terminal(
     // This is important because it is easy to encounter a situation
     // where read/write buffers fill and block either your process
     // or the spawned process.
+    //
+    // We obtain a termios-capable reader clone (`try_clone_reader_termios`)
+    // so the reader thread can check the slave's echo/canonical flags right
+    // after each read burst — see the `echo_off` handling below. This clone
+    // is an independent fd referring to the same pty, so `get_termios()` on
+    // it reports the same flags the master would.
     let mut reader = pair
         .master
-        .try_clone_reader()
+        .try_clone_reader_termios()
         .map_err(|e| PtyInitError::Spawn(e.to_string()))?;
+
+    // Shared atomic flag updated by the reader thread after each read burst.
+    // The PTY consumer thread reads this via `FreminalPtyInputOutput::is_echo_off()`
+    // when building snapshots. Using `Arc<AtomicBool>` avoids any lock on the hot
+    // snapshot path while keeping ownership safely shared between threads.
+    //
+    // The check is event-driven: it runs only after `read()` returns real
+    // output, so an idle pane (whose `read()` is parked) costs zero CPU. A
+    // password prompt always produces output ("Password:"), which unblocks the
+    // read and triggers the check — including for background panes, so the
+    // tab-bar lock indicator stays correct without any standing poll.
+    let echo_off = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    #[cfg(unix)]
+    let echo_off_reader = std::sync::Arc::clone(&echo_off);
 
     // Shared shutdown flag. The PTY consumer thread (which owns the
     // `PtyRead` receiver) sets this to `true` immediately before it exits
@@ -668,28 +689,40 @@ pub fn run_terminal(
                     }
                     return;
                 }
+
+                // Event-driven echo-off (password-prompt) detection.
+                //
+                // Runs once per read burst, on the reader thread that already
+                // owns the termios-capable reader clone. Password prompts
+                // (sudo, ssh, getpass) disable `ECHO` but keep `ICANON`
+                // (canonical/line-buffered mode). Shell line editors (zsh ZLE,
+                // bash readline) also disable `ECHO` but additionally disable
+                // `ICANON` (raw/char-at-a-time), so checking `!ECHO && ICANON`
+                // filters out normal interactive editing and only triggers for
+                // genuine password prompts.
+                //
+                // On Windows (ConPTY) there is no termios API, so the atomic
+                // stays at its default `false`.
+                #[cfg(unix)]
+                {
+                    use nix::sys::termios::LocalFlags;
+                    let is_off = reader.get_termios().is_some_and(|t| {
+                        !t.local_flags.contains(LocalFlags::ECHO)
+                            && t.local_flags.contains(LocalFlags::ICANON)
+                    });
+                    let old = echo_off_reader.swap(is_off, std::sync::atomic::Ordering::Relaxed);
+                    if old != is_off {
+                        debug!("echo_off changed: {old} -> {is_off}");
+                    }
+                }
             }
         })
         .map_err(|e| PtyInitError::Spawn(format!("spawn pty-read thread: {e}")))?;
-
-    // Shared atomic flag updated by the writer thread after each PTY event.
-    // The PTY consumer thread reads this via `FreminalPtyInputOutput::is_echo_off()`
-    // when building snapshots.  Using `Arc<AtomicBool>` avoids any lock on the hot
-    // snapshot path while keeping ownership safely shared between threads.
-    let echo_off = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-    #[cfg(unix)]
-    let echo_off_writer = std::sync::Arc::clone(&echo_off);
 
     {
         std::thread::Builder::new()
             .name(format!("freminal-pty-write-{pane_id}"))
             .spawn(move || {
-                // Poll interval for checking slave termios echo state.
-                // Used with `recv_timeout` so we detect password prompts
-                // even when no keystrokes are arriving.
-                const ECHO_POLL_INTERVAL: std::time::Duration =
-                    std::time::Duration::from_millis(100);
-
                 if cfg!(target_os = "macos") {
                     // macOS quirk: the child and reader must be started and
                     // allowed a brief grace period to run before we allow
@@ -711,65 +744,19 @@ pub fn run_terminal(
                     }
                 };
 
-                // Use `recv_timeout` so we also poll the slave termios
-                // periodically even when no keystrokes arrive.  This lets the
-                // lock icon appear as soon as a password prompt disables ECHO,
-                // without waiting for user input.
-                //
-                // Termios is polled only on timeout (no pending writes), not
-                // after every keystroke — this avoids ioctl overhead during
-                // rapid typing.
+                // Blocking `recv()`: the writer thread parks with zero CPU when
+                // no keystrokes or resize events are pending. Echo-off detection
+                // no longer lives here (it moved to the reader thread, driven by
+                // PTY output), so there is no standing timer — this is what lets
+                // an idle pane reach a true 0% CPU floor. Resize (`PtyWrite::Resize`)
+                // stays on this thread because it owns `pair.master`, keeping
+                // resize latency unaffected.
+                while let Ok(stuff_to_write) = write_rx.recv() {
+                    process_pty_write(&mut writer, &*pair.master, &stuff_to_write);
 
-                loop {
-                    match write_rx.recv_timeout(ECHO_POLL_INTERVAL) {
-                        Ok(stuff_to_write) => {
-                            process_pty_write(&mut writer, &*pair.master, &stuff_to_write);
-
-                            // Drain any queued writes before polling termios.
-                            while let Ok(more) = write_rx.try_recv() {
-                                process_pty_write(&mut writer, &*pair.master, &more);
-                            }
-                        }
-                        Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
-                            // No input — fall through to poll termios below.
-                        }
-                        Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
-                    }
-
-                    // Poll the slave termios after draining all pending writes
-                    // or on timeout.  The writer thread is the natural place for
-                    // this because it already owns `pair.master`.  When `ECHO` is
-                    // absent and `ICANON` is present, the foreground process
-                    // (e.g. `sudo`) has set up a canonical-mode password prompt.
-                    // Shell line editors (zsh ZLE, bash readline) also disable
-                    // `ECHO` but additionally disable `ICANON`, so checking both
-                    // flags avoids false positives during normal interactive
-                    // editing.
-                    //
-                    // This block is compiled only on Unix; on Windows (ConPTY)
-                    // there is no termios API, so the atomic stays at its
-                    // default `false`.
-                    #[cfg(unix)]
-                    {
-                        use nix::sys::termios::LocalFlags;
-                        // Password prompts (sudo, ssh, getpass) disable ECHO but
-                        // keep ICANON (canonical/line-buffered mode).  Shell line
-                        // editors (zsh ZLE, bash readline) also disable ECHO but
-                        // additionally disable ICANON (raw/char-at-a-time mode)
-                        // because they handle input character by character.
-                        //
-                        // Checking `!ECHO && ICANON` filters out the shell's
-                        // normal interactive editing and only triggers for genuine
-                        // password prompts.
-                        let is_off = pair.master.get_termios().is_some_and(|t| {
-                            !t.local_flags.contains(LocalFlags::ECHO)
-                                && t.local_flags.contains(LocalFlags::ICANON)
-                        });
-                        let old =
-                            echo_off_writer.swap(is_off, std::sync::atomic::Ordering::Relaxed);
-                        if old != is_off {
-                            debug!("echo_off changed: {old} -> {is_off}");
-                        }
+                    // Drain any queued writes in one batch.
+                    while let Ok(more) = write_rx.try_recv() {
+                        process_pty_write(&mut writer, &*pair.master, &more);
                     }
                 }
             })
@@ -830,9 +817,9 @@ impl FreminalPtyInputOutput {
     /// process (e.g. `sudo`, `ssh`) called `tcsetattr()` to turn off echoing so
     /// the typed password does not appear on screen.
     ///
-    /// On Unix the writer thread polls `MasterPty::get_termios()` every 250 ms
-    /// (and after each write/resize) and updates the shared atomic; this method
-    /// simply reads that atomic.
+    /// On Unix the reader thread checks `PtyReader::get_termios()` once per PTY
+    /// read burst (event-driven; no standing timer) and updates the shared
+    /// atomic; this method simply reads that atomic.
     ///
     /// Always returns `false` on Windows where `ConPTY` does not support termios.
     #[must_use]
@@ -1099,6 +1086,188 @@ mod shell_integration_injection_tests {
         assert!(
             cmd.get_env("XDG_DATA_DIRS").is_some(),
             "fish integration must set $XDG_DATA_DIRS"
+        );
+    }
+}
+
+/// Real-PTY integration tests for the event-driven echo-off detection.
+///
+/// These spawn an actual shell via [`run_terminal`], so they are Unix-only
+/// (Windows `ConPTY` has no termios). They assert the reader-thread,
+/// output-triggered termios check (which replaced the old 100 ms writer-thread
+/// poll) flips `echo_off` when a child disables `ECHO` while keeping `ICANON`,
+/// and that resize still reaches the child after the re-architecture.
+#[cfg(all(test, unix))]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod echo_off_event_driven_tests {
+    use super::{PtySpawnConfig, PtyWrite, run_terminal};
+    use crate::io::PtyRead;
+    use freminal_common::pty_write::FreminalTerminalSize;
+    use std::sync::atomic::Ordering;
+    use std::time::{Duration, Instant};
+
+    const fn small_size() -> FreminalTerminalSize {
+        FreminalTerminalSize {
+            width: 80,
+            height: 24,
+            pixel_width: 0,
+            pixel_height: 0,
+        }
+    }
+
+    // Drain PtyRead bytes until either `deadline` passes or `pred(echo_off)`
+    // holds. Returns the final observed value. Draining the read channel keeps
+    // the reader thread from blocking on a full channel, so its per-burst
+    // termios check keeps running.
+    fn wait_for_echo_off(
+        send_rx: &crossbeam_channel::Receiver<PtyRead>,
+        echo_off: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+        want: bool,
+        deadline: Instant,
+    ) -> bool {
+        loop {
+            // Drain any pending output (each burst drives a termios check on
+            // the reader thread).
+            while send_rx.try_recv().is_ok() {}
+            let current = echo_off.load(Ordering::Relaxed);
+            if current == want {
+                return current;
+            }
+            if Instant::now() >= deadline {
+                return current;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[test]
+    fn echo_off_flips_true_when_child_disables_echo_keeps_icanon() {
+        let (_write_tx, write_rx) = crossbeam_channel::unbounded::<PtyWrite>();
+        let (send_tx, send_rx) = crossbeam_channel::unbounded::<PtyRead>();
+
+        // `stty -echo icanon` sets the password-prompt shape (!ECHO && ICANON),
+        // then `printf x` produces a read burst that triggers the reader
+        // thread's termios check, then `sleep` holds the pty open.
+        let spawn_cfg = PtySpawnConfig {
+            command: Some((
+                String::from("/bin/sh"),
+                vec![
+                    String::from("-c"),
+                    String::from("stty -echo icanon 2>/dev/null; printf x; sleep 30"),
+                ],
+            )),
+            shell: None,
+            cwd: None,
+            extra_env: None,
+            set_term_program: false,
+        };
+
+        let result = run_terminal(write_rx, send_tx, spawn_cfg, None, &small_size(), 0)
+            .expect("run_terminal");
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let observed = wait_for_echo_off(&send_rx, &result.echo_off, true, deadline);
+        assert!(
+            observed,
+            "echo_off should flip to true after the child disables ECHO and \
+             produces output (event-driven reader-thread check)"
+        );
+    }
+
+    #[test]
+    fn echo_off_stays_false_in_normal_cooked_mode() {
+        let (_write_tx, write_rx) = crossbeam_channel::unbounded::<PtyWrite>();
+        let (send_tx, send_rx) = crossbeam_channel::unbounded::<PtyRead>();
+
+        // Normal cooked mode (ECHO + ICANON both set) must NOT be flagged as a
+        // password prompt. Emit output to drive several reader-thread checks.
+        let spawn_cfg = PtySpawnConfig {
+            command: Some((
+                String::from("/bin/sh"),
+                vec![
+                    String::from("-c"),
+                    String::from("printf 'hello\\n'; sleep 30"),
+                ],
+            )),
+            shell: None,
+            cwd: None,
+            extra_env: None,
+            set_term_program: false,
+        };
+
+        let result = run_terminal(write_rx, send_tx, spawn_cfg, None, &small_size(), 0)
+            .expect("run_terminal");
+
+        // Give the reader thread ample time / bursts to (not) set the flag.
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let observed = wait_for_echo_off(&send_rx, &result.echo_off, true, deadline);
+        assert!(
+            !observed,
+            "echo_off must stay false in normal cooked mode (ECHO + ICANON set)"
+        );
+    }
+
+    #[test]
+    fn resize_then_write_still_reaches_child_after_rearchitecture() {
+        let (write_tx, write_rx) = crossbeam_channel::unbounded::<PtyWrite>();
+        let (send_tx, send_rx) = crossbeam_channel::unbounded::<PtyRead>();
+
+        // `cat` echoes back whatever is written to it. The writer thread now
+        // owns `master` and handles BOTH `Resize` (via `master.resize()`) and
+        // `Write` in one drain loop. This test interleaves a resize before a
+        // write and asserts the write still round-trips — proving the resize
+        // did not break or stall the writer loop after the re-architecture
+        // (resize deliberately stayed on the writer thread, not the reader).
+        let spawn_cfg = PtySpawnConfig {
+            command: Some((
+                String::from("/bin/sh"),
+                vec![String::from("-c"), String::from("exec cat")],
+            )),
+            shell: None,
+            cwd: None,
+            extra_env: None,
+            set_term_program: false,
+        };
+
+        // Keep the result bound (`_result`) so its channels/handles live for
+        // the whole test; the writer/reader threads must stay alive.
+        let _result = run_terminal(write_rx, send_tx, spawn_cfg, None, &small_size(), 0)
+            .expect("run_terminal");
+
+        // Interleave a resize (must be accepted by the writer's drain loop)
+        // followed by a write that `cat` will echo back.
+        write_tx
+            .send(PtyWrite::Resize(FreminalTerminalSize {
+                width: 100,
+                height: 40,
+                pixel_width: 0,
+                pixel_height: 0,
+            }))
+            .expect("send resize");
+        write_tx
+            .send(PtyWrite::Write(b"freminal-roundtrip\n".to_vec()))
+            .expect("send write");
+
+        let mut collected: Vec<u8> = Vec::new();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut saw_echo = false;
+        while Instant::now() < deadline && !saw_echo {
+            while let Ok(read) = send_rx.try_recv() {
+                collected.extend_from_slice(&read.buf);
+            }
+            if collected
+                .windows(b"freminal-roundtrip".len())
+                .any(|w| w == b"freminal-roundtrip")
+            {
+                saw_echo = true;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            saw_echo,
+            "a write following a resize must still round-trip through the \
+             writer thread; collected output was {:?}",
+            String::from_utf8_lossy(&collected)
         );
     }
 }

--- a/freminal/benches/render_loop_bench.rs
+++ b/freminal/benches/render_loop_bench.rs
@@ -397,6 +397,77 @@ fn bench_shaping_ligatures(c: &mut Criterion) {
         });
     });
 
+    // Partial-dirty path (issue #405 Part B): prime the cache, then change a
+    // single visible row's content each sample and re-shape. `ShapingCache` is
+    // per-row content-hashed, so only the one changed row re-shapes (rustybuzz)
+    // while every other row is an `Arc::clone` hit. This isolates the shaping
+    // stage's genuinely-incremental behaviour — in contrast to the downstream
+    // vertex builders (`build_bg_instances`/`build_fg_instances`), which are
+    // NOT per-row incremental and rebuild all instances regardless (see
+    // `instanced_bg`/`instanced_fg`). Comparing this against
+    // `shape_visible_cache_hit` (0 changed) and the cold shape (all changed)
+    // quantifies the per-row shaping win that the deferred vertex-incremental
+    // work would need to preserve end-to-end.
+    {
+        let width = 200usize;
+        let height = 50usize;
+        let (base_chars, base_tags) = ligature_heavy_visible_chars(width, height);
+        group.bench_function("shape_visible_partial_dirty_200x50", |b| {
+            b.iter_batched(
+                || {
+                    let mut fm = FontManager::new(&Config::default(), 1.0).unwrap();
+                    let mut cache = ShapingCache::new();
+                    #[allow(clippy::cast_precision_loss)]
+                    let cell_w = fm.cell_width() as f32;
+                    // Prime the cache with the base content.
+                    let _ = cache.shape_visible(
+                        &base_chars,
+                        &base_tags,
+                        width,
+                        &mut fm,
+                        cell_w,
+                        false,
+                        &[],
+                    );
+                    // Produce a variant with exactly one row changed. Rows are
+                    // NewLine-delimited; flip one character on the ~middle row.
+                    let mut edited = base_chars.clone();
+                    let newline_positions: Vec<usize> = edited
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, c)| {
+                            matches!(c, freminal_common::buffer_states::tchar::TChar::NewLine)
+                        })
+                        .map(|(i, _)| i)
+                        .collect();
+                    // First char of the middle row (after the preceding newline).
+                    let mid = newline_positions.len() / 2;
+                    let target = if mid == 0 {
+                        0
+                    } else {
+                        newline_positions[mid - 1] + 1
+                    };
+                    if let Some(slot) = edited.get_mut(target) {
+                        *slot = freminal_common::buffer_states::tchar::TChar::Ascii(b'Q');
+                    }
+                    (fm, cache, cell_w, edited)
+                },
+                |(mut fm, mut cache, cell_w, edited)| {
+                    std::hint::black_box(cache.shape_visible(
+                        &edited,
+                        &base_tags,
+                        width,
+                        &mut fm,
+                        cell_w,
+                        false,
+                        &[],
+                    ));
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
     group.finish();
 }
 

--- a/portable-pty/Cargo.toml
+++ b/portable-pty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "portable-pty"
-version = "0.9.2"
+version = "0.9.3"
 # Originally authored by Wez Furlong as part of wezterm; the `authors` key is
 # deprecated by Cargo, so attribution is retained here as a comment.
 edition.workspace = true

--- a/portable-pty/src/lib.rs
+++ b/portable-pty/src/lib.rs
@@ -82,6 +82,24 @@ impl Default for PtySize {
     }
 }
 
+/// A readable pty handle that can additionally report the slave's termios.
+///
+/// This mirrors [`std::io::Read`] (output from the slave is readable via this
+/// stream) but adds [`PtyReader::get_termios`], so a reader-owning thread can
+/// inspect the slave's line-discipline flags (e.g. `ECHO`/`ICANON` for
+/// password-prompt detection) right after a read burst, without needing shared
+/// access to the [`MasterPty`] itself. On non-unix platforms `get_termios`
+/// returns `None`.
+pub trait PtyReader: std::io::Read + Send {
+    /// Return the termios associated with the underlying stream, if the
+    /// platform supports it. Mirrors [`MasterPty::get_termios`], but callable
+    /// from the owner of this reader handle.
+    #[cfg(unix)]
+    fn get_termios(&self) -> Option<nix::sys::termios::Termios> {
+        None
+    }
+}
+
 /// Represents the master/control end of the pty
 pub trait MasterPty: Downcast + Send {
     /// Inform the kernel and thus the child process that the window resized.
@@ -93,6 +111,19 @@ pub trait MasterPty: Downcast + Send {
     /// Obtain a readable handle; output from the slave(s) is readable
     /// via this stream.
     fn try_clone_reader(&self) -> Result<Box<dyn std::io::Read + Send>, Error>;
+    /// Obtain a readable handle that can also report the slave's termios.
+    ///
+    /// Like [`MasterPty::try_clone_reader`], but the returned handle
+    /// implements [`PtyReader`], so the reader-owning thread can query
+    /// termios (e.g. for password-prompt echo detection) directly, rather
+    /// than requiring the [`MasterPty`] to be shared across threads. The
+    /// default implementation returns an error; platforms that support it
+    /// (unix) override it.
+    fn try_clone_reader_termios(&self) -> Result<Box<dyn PtyReader>, Error> {
+        Err(anyhow::anyhow!(
+            "try_clone_reader_termios is not supported on this platform"
+        ))
+    }
     /// Obtain a writable handle; writing to it will send data to the
     /// slave end.
     /// Dropping the writer will send EOF to the slave end.

--- a/portable-pty/src/serial.rs
+++ b/portable-pty/src/serial.rs
@@ -227,6 +227,13 @@ impl MasterPty for Master {
         Ok(Box::new(Reader { fd }))
     }
 
+    fn try_clone_reader_termios(&self) -> anyhow::Result<Box<dyn crate::PtyReader>> {
+        // Serial ports are not ptys; `PtyReader::get_termios` uses its default
+        // `None` on unix (there is no meaningful password-prompt termios here).
+        let fd = FileDescriptor::dup(&*self.port)?;
+        Ok(Box::new(Reader { fd }))
+    }
+
     fn take_writer(&self) -> anyhow::Result<Box<dyn std::io::Write + Send>> {
         if *self.took_writer.borrow() {
             anyhow::bail!("cannot take writer more than once");
@@ -256,6 +263,8 @@ impl MasterPty for Master {
 struct Reader {
     fd: FileDescriptor,
 }
+
+impl crate::PtyReader for Reader {}
 
 impl Read for Reader {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, std::io::Error> {

--- a/portable-pty/src/unix.rs
+++ b/portable-pty/src/unix.rs
@@ -105,6 +105,15 @@ impl Read for PtyFd {
     }
 }
 
+impl crate::PtyReader for PtyFd {
+    fn get_termios(&self) -> Option<nix::sys::termios::Termios> {
+        // The reader fd is a clone of the master fd (see
+        // `try_clone_reader`/`try_clone_reader_termios`), so it refers to the
+        // same pty and reports the same termios as the master would.
+        nix::sys::termios::tcgetattr(self.0.as_fd()).ok()
+    }
+}
+
 fn tty_name(fd: RawFd) -> Option<PathBuf> {
     let mut buf = vec![0 as std::ffi::c_char; 128];
 
@@ -353,6 +362,11 @@ impl MasterPty for UnixMasterPty {
         Ok(Box::new(fd))
     }
 
+    fn try_clone_reader_termios(&self) -> Result<Box<dyn crate::PtyReader>, Error> {
+        let fd = PtyFd(self.fd.try_clone()?);
+        Ok(Box::new(fd))
+    }
+
     fn take_writer(&self) -> Result<Box<dyn Write + Send>, Error> {
         if *self.took_writer.borrow() {
             anyhow::bail!("cannot take writer more than once");
@@ -413,5 +427,73 @@ impl Write for UnixMasterWriter {
     }
     fn flush(&mut self) -> Result<(), io::Error> {
         self.fd.flush()
+    }
+}
+
+#[cfg(test)]
+mod termios_reader_tests {
+    use crate::{PtySize, PtySystem};
+    use nix::sys::termios::{LocalFlags, SetArg, tcgetattr, tcsetattr};
+    use std::os::fd::AsFd;
+
+    fn open_pair() -> crate::PtyPair {
+        super::UnixPtySystem::default()
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("openpty")
+    }
+
+    // The termios-capable reader clone must observe the SAME termios flags as
+    // the underlying pty: its fd is a clone of the master fd, referring to the
+    // same terminal. This is the invariant the event-driven echo-off detection
+    // relies on (the reader thread reads termios off its reader clone, not the
+    // master).
+    #[test]
+    fn reader_termios_reflects_slave_echo_canonical_state() {
+        let pair = open_pair();
+        let reader = pair
+            .master
+            .try_clone_reader_termios()
+            .expect("try_clone_reader_termios");
+
+        // Baseline: a freshly opened pty has ECHO and ICANON set (cooked mode).
+        let base = reader.get_termios().expect("get_termios baseline");
+        assert!(
+            base.local_flags.contains(LocalFlags::ECHO),
+            "fresh pty should have ECHO set"
+        );
+        assert!(
+            base.local_flags.contains(LocalFlags::ICANON),
+            "fresh pty should have ICANON set"
+        );
+
+        // Simulate a password prompt: disable ECHO, keep ICANON, applied via
+        // the master fd (a stand-in for what `sudo`/`getpass` does on the slave
+        // side — both ends share one termios).
+        let raw_fd = pair.master.as_raw_fd().expect("as_raw_fd");
+        let borrowed = unsafe {
+            // SAFETY: raw_fd is a valid, open master fd owned by `pair` for the
+            // duration of this test.
+            std::os::fd::BorrowedFd::borrow_raw(raw_fd)
+        };
+        let mut t = tcgetattr(borrowed.as_fd()).expect("tcgetattr");
+        t.local_flags.remove(LocalFlags::ECHO);
+        t.local_flags.insert(LocalFlags::ICANON);
+        tcsetattr(borrowed.as_fd(), SetArg::TCSANOW, &t).expect("tcsetattr");
+
+        // The reader clone must now report the password-prompt state.
+        let updated = reader.get_termios().expect("get_termios updated");
+        assert!(
+            !updated.local_flags.contains(LocalFlags::ECHO),
+            "reader clone should observe ECHO cleared"
+        );
+        assert!(
+            updated.local_flags.contains(LocalFlags::ICANON),
+            "reader clone should observe ICANON still set"
+        );
     }
 }

--- a/portable-pty/src/win/conpty.rs
+++ b/portable-pty/src/win/conpty.rs
@@ -6,6 +6,22 @@ use filedescriptor::{FileDescriptor, Pipe};
 use std::sync::{Arc, Mutex};
 use winapi::um::wincon::COORD;
 
+/// A readable ConPTY handle that also satisfies [`crate::PtyReader`].
+///
+/// Windows ConPTY exposes no termios, so `PtyReader` on this platform is just
+/// `Read + Send` with no extra methods — this wrapper merely forwards reads.
+struct WinPtyReader {
+    inner: FileDescriptor,
+}
+
+impl std::io::Read for WinPtyReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+impl crate::PtyReader for WinPtyReader {}
+
 #[derive(Default)]
 pub struct ConPtySystem {}
 
@@ -101,6 +117,15 @@ impl MasterPty for ConPtyMasterPty {
 
     fn try_clone_reader(&self) -> anyhow::Result<Box<dyn std::io::Read + Send>> {
         Ok(Box::new(lock_inner(&self.inner)?.readable.try_clone()?))
+    }
+
+    fn try_clone_reader_termios(&self) -> anyhow::Result<Box<dyn crate::PtyReader>> {
+        // Windows ConPTY has no termios; the reader is a plain readable handle.
+        // Wrap it so it satisfies `PtyReader` (which, on non-unix, is just
+        // `Read + Send` with no extra methods).
+        Ok(Box::new(WinPtyReader {
+            inner: lock_inner(&self.inner)?.readable.try_clone()?,
+        }))
     }
 
     fn take_writer(&self) -> anyhow::Result<Box<dyn std::io::Write + Send>> {


### PR DESCRIPTION
## Summary

Partial work on #405. This PR lands the **confirmed idle-CPU win** plus the
benchmarks needed to justify the remaining (deferred) work. **#405 stays open** —
see "Not in this PR" below.

Root-caused the idle floor: the per-pane 100ms termios poll that never disarmed
was the dominant idle-CPU cost (confirmed empirically — disabling it drops idle
to 0.0%). Cursor blink was **not** the driver.

## What's in this PR

### 1. Event-driven echo-off detection (the idle-CPU fix)

Re-architected the PTY threads so the **reader** thread owns the termios check and
runs it **event-driven, once per PTY read burst** — no standing timer. A blocking
`read()` parks at zero CPU when idle, so an idle pane costs nothing. A password
prompt always produces output (the prompt text), which unblocks the read and
triggers the check *in the same wake* — so it's also **lower-latency** than the
old poll (which could lag up to 100ms). Background panes still get the lock
indicator because their prompt still produces output. This mirrors wezterm's
approach (termios read during invalidate-driven paints, no timer).

- Resize stays on the writer thread (keeps `master` ownership) → resize latency
  unchanged. Writer now uses a plain blocking `recv()` (no timeout, no wakeup).
- `portable-pty` gains a `PtyReader` trait (`Read` + optional `get_termios`) and
  `MasterPty::try_clone_reader_termios()`, so the reader-owning thread queries
  termios off its own reader-fd clone without sharing the `!Sync` master.
  Implemented for unix (real termios), conpty + serial (no termios). Bumped
  `portable-pty` 0.9.2 → 0.9.3.
- Result: **0.0% idle**, and scales — N panes = N parked threads = still 0.0%,
  vs. the old N × 10 ioctls/sec.

### 2. Alt/primary one-frame tax fix

`build_snapshot` unconditionally nulled `previous_visible_snap` on any
primary↔alternate switch, forcing a full re-flatten and a spurious
`content_changed = true` on return even when `leave_alternate` restored
byte-identical content. Now keeps a second per-buffer cache slot and **swaps**
instead of dropping, preserving same-buffer change detection across the switch.

### 3. Partial-dirty benchmarks (measure before optimizing)

Every existing dirty-state bench was 0% or 100% dirty. Added `1-of-N rows changed`
variants for `build_snapshot` and the shaping cache. Measured locally:

| bench | clean / hit | 1-of-N | all dirty |
|---|---|---|---|
| `build_snapshot` 80×24 | ~119 ns | **~22 µs** | ~33 µs |
| `shape_visible` 200×50 | ~5.9 µs | **~573 µs** | ~2.1–4.3 ms |

A single-row edit already pays ~67% of a full-screen snapshot rebuild — the
data that justifies the deferred per-row incremental work.

## Not in this PR (#405 stays open)

- **Part C — per-row incremental buffer flatten/merge + per-row incremental
  vertex-instance build.** Real, now *quantified* by the benches above; deferred
  to its own branch/PR.
- **GPU named-ANSI palette-uniform offload.** Investigation found the broad
  "move everything to GPU" assertion is largely already done (bg quad placement +
  global opacity already GPU-side) or not worthwhile (truecolor cells have no
  smaller representation; glyph placement is irreducibly CPU-shaping/atlas-bound).
  Deferred pending benchmark justification.
- **End-to-end alt-screen-transition benchmark** and the `freminal-bench-table`
  catalog refresh.

Full findings and corrections (cursor-blink already disarms; the "Settings
cursor-blink no-op" was already fixed in #406) are documented on #405.

## Verification

- `cargo test --all` — green
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo machete` — clean
- `cargo fmt --all -- --check` — clean
- `cargo xtask check-windows` — clean (conpty path + reader re-architecture
  compile for windows-gnu)

New tests: real-PTY echo-off flip on `!ECHO && ICANON`, stays false in cooked
mode, resize round-trips after the re-architecture, portable-pty reader-clone
termios parity, and alt→primary return change-detection (both directions).

Refs #405 (partial — does not close).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot caching across primary/alternate screen switches to avoid false “content changed” when restored content is identical.
  * Prevented stale viewport reuse after returning from alternate views while scrolled.

* **New Features**
  * More responsive password/echo-off detection by reacting to PTY output reads instead of periodic polling.

* **Tests**
  * Added/extended checks for echo-off behavior on Unix, snapshot behavior across screen switches (including scroll/resize), and partial-row rendering changes.

* **Maintenance**
  * Extended the PTY interface with termios-aware readable clones where supported, and updated portable-pty to version 0.9.3.
  * Added shaping/rendering benchmarks for single-row “partial dirty” scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->