### PR TITLE
perf: Task 119 -- LZ4 scrollback compression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -563,3 +563,7 @@ profile_export*.xml
 # member crate is invalid and breaks tooling (e.g. Dependabot's resolver). Guard
 # against re-committing a stray nested lockfile.
 */Cargo.lock
+
+# Oversized local scrollback-memory test fixture (~5 MB). Regenerate locally
+# with speed_tests/random_crap.py; too large to track in git.
+speed_tests/100000_lines.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,6 +1562,7 @@ dependencies = [
  "conv2",
  "criterion",
  "freminal-common",
+ "lz4_flex",
  "proptest",
  "regex",
  "test-log",
@@ -2338,6 +2339,15 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lz4_flex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "mac-notification-sys"
@@ -4377,6 +4387,12 @@ checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 dependencies = [
  "core_maths",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
 name = "typeid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "freminal"
-version = "0.12.0-beta.2"
+version = "0.12.0-beta.3"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-buffer"
-version = "0.12.0-beta.2"
+version = "0.12.0-beta.3"
 dependencies = [
  "conv2",
  "criterion",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-common"
-version = "0.12.0-beta.2"
+version = "0.12.0-beta.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-terminal-emulator"
-version = "0.12.0-beta.2"
+version = "0.12.0-beta.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-windowing"
-version = "0.12.0-beta.2"
+version = "0.12.0-beta.3"
 dependencies = [
  "conv2",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["freminal", "freminal-buffer", "freminal-common", "freminal-terminal-
 default-members = ["freminal", "freminal-buffer", "freminal-common", "freminal-terminal-emulator"]
 
 [workspace.package]
-version = "0.12.0-beta.2"
+version = "0.12.0-beta.3"
 edition = "2024"
 rust-version = "1.95.0"
 description = "A terminal emulator written in Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ image = { version = "0.25.10", default-features = false, features = ["gif", "jpe
 lazy_static = "1.5.0"
 libc = "0.2.186"
 log = "0.4.32"
+lz4_flex = "0.14.0"
 nix = "0.31.3"
 notify-rust = "4.18.0"
 open = "5.4.0"

--- a/Documents/MASTER_PLAN.md
+++ b/Documents/MASTER_PLAN.md
@@ -188,7 +188,7 @@ into v0.14.0–v0.16.0 and v0.20.0) and remaining Category C housekeeping (Tasks
 | 116 | Text Selection Release/Stuck Fix          | `PLAN_VERSION_111.md` (Task 116)              | Complete  | None                   |
 | 117 | DECDWL/DECDHL/DECSLRM Buffer Completeness | `PLAN_VERSION_111.md` (Task 117)              | Complete  | None                   |
 | 118 | Compact Cell Representation               | `PLAN_VERSION_120.md` (Task 118)              | Complete  | None                   |
-| 119 | Scrollback Compression (LZ4)              | `PLAN_VERSION_120.md` (Task 119)              | Planned   | Task 118               |
+| 119 | Scrollback Compression (LZ4)              | `PLAN_VERSION_120.md` (Task 119)              | Pending merge | Task 118           |
 | 120 | Compression-Aware Windowed Reflow         | `PLAN_VERSION_120.md` (Task 120)              | Stub      | Tasks 118, 119         |
 
 ---
@@ -669,6 +669,7 @@ Update this section as tasks complete:
 | 116  | 2026-07-08 | 2026-07-08 | 116.1-116.4 selection release/stuck (tracked-end, commit-flag, interrupted drag) |
 | 115  | 2026-07-08 | 2026-07-08 | 115.1-115.4 DECSCNM per-pane per-cell XOR swap; chrome decoupled; on v0.11.1     |
 | 118  | 2026-07-14 | 2026-07-14 | 118.1-118.9 compact repr + idle compaction; default 4k->10k; 118.10 -> Task 120  |
+| 119  | 2026-07-20 | 2026-07-20 | 119.1-119.6 LZ4 block compression + idle-driven; ~13-22x vs cell; PR pending    |
 
 ---
 

--- a/Documents/PLAN_VERSION_120.md
+++ b/Documents/PLAN_VERSION_120.md
@@ -45,7 +45,7 @@ seams at activation before executing.
 | 102 | Kitty File Transfer (OSC 5113)    | Very high | Planned  | Task 99        |
 | 103 | Multiple Cursors (CSI)            | Medium    | Planned  | None           |
 | 118 | Compact Cell Representation       | Medium    | Complete | None           |
-| 119 | Scrollback Compression (LZ4)      | Large     | Planned  | Task 118       |
+| 119 | Scrollback Compression (LZ4)      | Large     | Pending merge | Task 118  |
 | 120 | Compression-Aware Windowed Reflow | Large     | Stub     | Tasks 118, 119 |
 
 ---

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     # cargo-bundle is only used inside the dev shell to produce the Linux
     # deb/appimage artifacts locally.  nixpkgs is pinned at 0.9.0, which predates
     # SVG-icon and `appimage` support; we build from upstream master so the dev
-    # shell matches the 0.12.0-beta.2+ the release CI installs via `cargo install`.
+    # shell matches the 0.12.0-beta.3+ the release CI installs via `cargo install`.
     # `nix flake update cargo-bundle-src` picks up new upstream commits.
     cargo-bundle-src = {
       url = "github:burtonageo/cargo-bundle";
@@ -107,7 +107,7 @@
             };
           };
 
-          version = "0.12.0-beta.2";
+          version = "0.12.0-beta.3";
 
           # The build sandbox strips `.git`, so the crate's build.rs `git
           # describe` can only ever yield "unknown".  Feed it a real value via
@@ -177,9 +177,9 @@
                     <key>CFBundleIdentifier</key>
                     <string>io.github.fredclausen.freminal</string>
                     <key>CFBundleVersion</key>
-                    <string>0.12.0-beta.2</string>
+                    <string>0.12.0-beta.3</string>
                     <key>CFBundleShortVersionString</key>
-                    <string>0.12.0-beta.2</string>
+                    <string>0.12.0-beta.3</string>
                     <key>CFBundleExecutable</key>
                     <string>freminal</string>
                     <key>CFBundleIconFile</key>
@@ -342,7 +342,7 @@
 
               # cargo-bundle built from upstream master (see the cargo-bundle-src
               # input).  nixpkgs ships 0.9.0, which cannot bundle SVG icons or
-              # produce appimages; this matches the 0.12.0-beta.2+ the release CI uses.
+              # produce appimages; this matches the 0.12.0-beta.3+ the release CI uses.
               # Mirrors the nixpkgs recipe (squashfsTools wrap for appimage).
               cargoBundleLatest = pkgs.rustPlatform.buildRustPackage {
                 pname = "cargo-bundle";

--- a/freminal-buffer/Cargo.toml
+++ b/freminal-buffer/Cargo.toml
@@ -17,6 +17,7 @@ categories.workspace = true
 [dependencies]
 freminal-common = { path = "../freminal-common" }
 conv2.workspace = true
+lz4_flex.workspace = true
 regex.workspace = true
 
 # dev dependencies

--- a/freminal-buffer/benches/buffer_memory_bench.rs
+++ b/freminal-buffer/benches/buffer_memory_bench.rs
@@ -262,6 +262,21 @@ fn settle_idle_compaction(buf: &mut Buffer) {
     let _ = buf.compact_idle_scrollback(usize::MAX);
 }
 
+/// Run idle scrollback compaction AND compression to completion, modelling
+/// the fully-settled state a real terminal reaches once the PTY thread's
+/// idle tick has both compacted (Task 118) and then compressed (Task 119)
+/// every eligible cold scrollback row into LZ4 blocks.
+///
+/// Mirrors the ordering the live idle tick enforces
+/// (`freminal/src/gui/pty.rs`): compaction must catch up before compression
+/// has anything eligible to compress, so `compact_idle_scrollback` is always
+/// called first. This is the number the Task 119 "flat + LZ4" plan table
+/// (`Documents/PLAN_VERSION_120.md` ~851-855) is measured against.
+fn settle_idle_compression(buf: &mut Buffer) {
+    let _ = buf.compact_idle_scrollback(usize::MAX);
+    let _ = buf.compress_idle_scrollback(usize::MAX);
+}
+
 /// Print one labelled memory report block for a buffer in whatever cache state
 /// the caller has already established. Returns bytes/scrollback-line.
 ///
@@ -274,7 +289,15 @@ fn settle_idle_compaction(buf: &mut Buffer) {
 /// allocator-retention class of bug — is visible rather than hidden.
 fn report_block(label: &str, state: &str, buf: &Buffer) -> usize {
     let breakdown = buf.heap_bytes();
-    let total_bytes = breakdown.rows_bytes + breakdown.row_cache_bytes + breakdown.url_bytes;
+    // `blocks_bytes` (Task 119 — Scrollback Compression) is the resident
+    // cost of LZ4-compressed blocks evicted out of `rows_bytes`; including it
+    // here is what makes this report reflect the compression win rather than
+    // just showing `rows_bytes` drop to ~0 for evicted rows with their real
+    // content now invisible to the accounting.
+    let total_bytes = breakdown.rows_bytes
+        + breakdown.row_cache_bytes
+        + breakdown.url_bytes
+        + breakdown.blocks_bytes;
     let bytes_per_scrollback_line = total_bytes
         .checked_div(breakdown.scrollback_lines)
         .unwrap_or(0);
@@ -290,6 +313,7 @@ fn report_block(label: &str, state: &str, buf: &Buffer) -> usize {
     println!(" rows_bytes          : {}", breakdown.rows_bytes);
     println!(" row_cache_bytes     : {}", breakdown.row_cache_bytes);
     println!(" url_bytes           : {}", breakdown.url_bytes);
+    println!(" blocks_bytes        : {}", breakdown.blocks_bytes);
     println!(" total_bytes         : {total_bytes}");
     println!(" bytes/scrollback_ln : {bytes_per_scrollback_line}");
     match rss {
@@ -301,7 +325,7 @@ fn report_block(label: &str, state: &str, buf: &Buffer) -> usize {
     bytes_per_scrollback_line
 }
 
-/// Print the three-state memory report for one corpus.
+/// Print the four-state memory report for one corpus.
 ///
 /// Each phase builds its OWN buffer and drops it before the next, so buffers
 /// never coexist — otherwise their allocations would accumulate and confound
@@ -343,9 +367,28 @@ fn print_report(label: &str, build: impl Fn() -> Buffer) {
         (bpl, process_rss_bytes())
     };
 
-    // (3) SETTLED + post-search — Ctrl-F full-scrollback flatten on the settled
-    //     buffer; eviction (Task 118.4) reclaims the transient copies, so this
-    //     returns to the settled number.
+    // (3) FULLY COMPRESSED — idle compaction AND idle compression (Task 119)
+    //     have both run to completion, then the render path warms the visible
+    //     window (scrollback stays compressed; only the visible window is
+    //     touched, mirroring steady-state rendering). This is the "flat + LZ4"
+    //     number from the Task 119 feasibility-spike table
+    //     (`Documents/PLAN_VERSION_120.md` ~851-855) made measurable.
+    let (compressed_bpl, rss_compressed) = {
+        let mut compressed = build();
+        settle_idle_compression(&mut compressed);
+        warm_steady_state(&mut compressed);
+        let bpl = report_block(
+            label,
+            "settled + compressed (post-idle-compression)",
+            &compressed,
+        );
+        trim_allocator();
+        (bpl, process_rss_bytes())
+    };
+
+    // (4) SETTLED + post-search — Ctrl-F full-scrollback flatten on the settled
+    //     (compaction-only) buffer; eviction (Task 118.4) reclaims the
+    //     transient copies, so this returns to the settled number.
     let search_bpl = {
         let mut searched = build();
         settle_idle_compaction(&mut searched);
@@ -359,10 +402,17 @@ fn print_report(label: &str, build: impl Fn() -> Buffer) {
         }
         _ => "n/a".to_string(),
     };
+    let rss_delta_compressed = match (rss_before, rss_compressed) {
+        (Some(before), Some(compressed)) => {
+            format!("{} MB", compressed.saturating_sub(before) / 1_000_000)
+        }
+        _ => "n/a".to_string(),
+    };
 
     println!(
         " -> {label}: fresh(pre-idle) {fresh_bpl} B/line, settled {settled_bpl} B/line, \
-         settled+search {search_bpl} B/line, settled RSS delta {rss_delta}\n"
+         settled+compressed {compressed_bpl} B/line, settled+search {search_bpl} B/line, \
+         settled RSS delta {rss_delta}, settled+compressed RSS delta {rss_delta_compressed}\n"
     );
 }
 

--- a/freminal-buffer/benches/buffer_row_bench.rs
+++ b/freminal-buffer/benches/buffer_row_bench.rs
@@ -850,13 +850,18 @@ fn bench_scroll_into_compressed_region(c: &mut Criterion) {
 // Benchmark: absolute per-idle-tick cost of the budgeted background work
 // (Task 119 follow-up tuning).
 //
-// These measure the CPU cost of ONE idle tick's worth of work at the
-// production budget (4096 rows), in isolation. The point is an ABSOLUTE
-// time figure (µs to process 4096 rows), not a wall-clock CPU% on the dev
-// box: a machine Nx slower simply multiplies the measured µs by N, and the
-// justification for the budget is that even Nx that figure stays far below
-// the 100ms idle-tick interval, so a full-scrollback catch-up burst never
-// stalls the PTY tick loop or pegs a core on modest hardware.
+// These measure the CPU cost of ONE real idle tick's worth of work, in
+// isolation, at the SAME per-tick budgets production uses in
+// `freminal/src/gui/pty.rs`. The point is an ABSOLUTE time figure (µs to
+// process one tick's rows), not a wall-clock CPU% on the dev box: a machine
+// Nx slower simply multiplies the measured µs by N, and the justification for
+// the budgets is that even Nx that figure stays far below the 100ms idle-tick
+// interval, so a full-scrollback catch-up burst never stalls the PTY tick loop
+// or pegs a core on modest hardware.
+//
+// The two budgets differ (matching production): compaction runs 1024 rows/tick,
+// compression 4096 rows/tick. Each bench uses its own production budget so its
+// result is directly "one real tick" — no mental scaling needed.
 //
 // Each iteration rebuilds fresh state (`iter_batched` + `BatchSize::LargeInput`)
 // because both operations mutate the buffer (compaction converts Live -> Compact;
@@ -864,9 +869,15 @@ fn bench_scroll_into_compressed_region(c: &mut Criterion) {
 // on the same buffer would find less/no work.
 // ---------------------------------------------------------------
 
-/// Budget matching `IDLE_COMPACTION_BUDGET` / `IDLE_COMPRESSION_BUDGET` in
-/// `freminal/src/gui/pty.rs`, so the bench measures one real tick's worth.
-const IDLE_TICK_BUDGET: usize = 4096;
+/// Matches `IDLE_COMPACTION_BUDGET` in `freminal/src/gui/pty.rs`, so
+/// `bench_idle_compaction_tick` measures exactly one production compaction
+/// tick's worth of work.
+const IDLE_COMPACTION_BUDGET_BENCH: usize = 1024;
+
+/// Matches `IDLE_COMPRESSION_BUDGET` in `freminal/src/gui/pty.rs`, so
+/// `bench_idle_compression_tick` measures exactly one production compression
+/// tick's worth of work (16 blocks of 256 rows).
+const IDLE_COMPRESSION_BUDGET_BENCH: usize = 4096;
 
 /// Build a buffer with `scrollback_rows` rows of representative ~120-col
 /// content, all still `Live` (not compacted) — the worst case a compaction
@@ -890,47 +901,55 @@ fn build_live_scrollback_buffer(scrollback_rows: usize) -> Buffer {
 }
 
 fn bench_idle_compaction_tick(c: &mut Criterion) {
-    // 8192 all-Live scrollback rows so a 4096-row budget has a full tick of
-    // work to do.
-    let scrollback_rows = 2 * IDLE_TICK_BUDGET;
+    // Twice the budget of all-Live scrollback rows so a full budget's worth of
+    // work is available for the tick under test.
+    let scrollback_rows = 2 * IDLE_COMPACTION_BUDGET_BENCH;
 
     let mut group = c.benchmark_group("bench_idle_compaction_tick");
-    group.throughput(Throughput::Elements(IDLE_TICK_BUDGET as u64));
-    group.bench_function(BenchmarkId::new("compact", IDLE_TICK_BUDGET), |b| {
-        b.iter_batched(
-            || build_live_scrollback_buffer(scrollback_rows),
-            |mut buf| {
-                std::hint::black_box(buf.compact_idle_scrollback(IDLE_TICK_BUDGET));
-            },
-            BatchSize::LargeInput,
-        );
-    });
+    group.throughput(Throughput::Elements(IDLE_COMPACTION_BUDGET_BENCH as u64));
+    group.bench_function(
+        BenchmarkId::new("compact", IDLE_COMPACTION_BUDGET_BENCH),
+        |b| {
+            b.iter_batched(
+                || build_live_scrollback_buffer(scrollback_rows),
+                |mut buf| {
+                    std::hint::black_box(buf.compact_idle_scrollback(IDLE_COMPACTION_BUDGET_BENCH));
+                },
+                BatchSize::LargeInput,
+            );
+        },
+    );
     group.finish();
 }
 
 fn bench_idle_compression_tick(c: &mut Criterion) {
-    // 8192 fully-compacted (but uncompressed) scrollback rows so a 4096-row
-    // compression budget has a full tick of work (16 blocks of 256 rows).
-    let scrollback_rows = 2 * IDLE_TICK_BUDGET;
+    // Twice the budget of fully-compacted (but uncompressed) scrollback rows so
+    // a full compression tick's worth of work (16 blocks of 256 rows) exists.
+    let scrollback_rows = 2 * IDLE_COMPRESSION_BUDGET_BENCH;
 
     let mut group = c.benchmark_group("bench_idle_compression_tick");
-    group.throughput(Throughput::Elements(IDLE_TICK_BUDGET as u64));
-    group.bench_function(BenchmarkId::new("compress", IDLE_TICK_BUDGET), |b| {
-        b.iter_batched(
-            || {
-                let mut buf = build_live_scrollback_buffer(scrollback_rows);
-                // Fully compact first: compression only touches already-compact
-                // rows, so the tick under test starts from the settled-compact
-                // state the real idle loop reaches before compressing.
-                let _ = buf.compact_idle_scrollback(usize::MAX);
-                buf
-            },
-            |mut buf| {
-                std::hint::black_box(buf.compress_idle_scrollback(IDLE_TICK_BUDGET));
-            },
-            BatchSize::LargeInput,
-        );
-    });
+    group.throughput(Throughput::Elements(IDLE_COMPRESSION_BUDGET_BENCH as u64));
+    group.bench_function(
+        BenchmarkId::new("compress", IDLE_COMPRESSION_BUDGET_BENCH),
+        |b| {
+            b.iter_batched(
+                || {
+                    let mut buf = build_live_scrollback_buffer(scrollback_rows);
+                    // Fully compact first: compression only touches already-compact
+                    // rows, so the tick under test starts from the settled-compact
+                    // state the real idle loop reaches before compressing.
+                    let _ = buf.compact_idle_scrollback(usize::MAX);
+                    buf
+                },
+                |mut buf| {
+                    std::hint::black_box(
+                        buf.compress_idle_scrollback(IDLE_COMPRESSION_BUDGET_BENCH),
+                    );
+                },
+                BatchSize::LargeInput,
+            );
+        },
+    );
     group.finish();
 }
 

--- a/freminal-buffer/benches/buffer_row_bench.rs
+++ b/freminal-buffer/benches/buffer_row_bench.rs
@@ -6,7 +6,10 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 
 use freminal_buffer::buffer::Buffer;
+use freminal_buffer::compact_row::CompactRow;
+use freminal_buffer::compressed_block::CompressedBlock;
 use freminal_buffer::image_store::{AnimationControl, ImageSizeMode, ImageStore, InlineImage};
+use freminal_buffer::row::Row;
 use freminal_common::buffer_states::{
     cursor::StateColors,
     fonts::{FontDecorationFlags, FontWeight},
@@ -719,6 +722,219 @@ fn bench_image_store_insert_at_quota(c: &mut Criterion) {
 }
 
 // ---------------------------------------------------------------
+// Benchmark: CompressedBlock compress/decompress round trip (Task 119.6)
+//
+// Builds a representative 256-row, ~120-col block of colored content (the
+// "shell session" style bracket from the Task 119 feasibility spike — many
+// rows sharing structure with a handful of color changes) and separately
+// measures CompressedBlock::from_rows (compress) and decompress_into
+// (decompress). Used to justify the IDLE_COMPRESSION_BUDGET tuning in
+// freminal/src/gui/pty.rs: per-block decompress cost must stay well under
+// one 16.6ms frame (plan target: ~34µs/256-line block at LZ4 speed).
+// ---------------------------------------------------------------
+fn build_representative_compact_block(rows: usize, width: usize) -> Vec<CompactRow> {
+    let colors = [
+        TerminalColor::Custom(0, 200, 0),
+        TerminalColor::Custom(200, 200, 0),
+        TerminalColor::Default,
+    ];
+
+    (0..rows)
+        .map(|i| {
+            let mut row = Row::new(width);
+            let color = colors[i % colors.len()];
+            let tag = FormatTag {
+                start: 0,
+                end: usize::MAX,
+                colors: StateColors {
+                    color,
+                    ..StateColors::default()
+                },
+                ..FormatTag::default()
+            };
+            let text = format!("scrollback line {i:06} of representative shell output data");
+            let chars: Vec<TChar> = text.bytes().cycle().take(width).map(TChar::Ascii).collect();
+            row.insert_text(0, &chars, &tag);
+            CompactRow::from_row(&row).expect("row should be compactable")
+        })
+        .collect()
+}
+
+fn bench_compressed_block_round_trip(c: &mut Criterion) {
+    const ROWS: usize = 256;
+    const WIDTH: usize = 120;
+
+    let compact_rows = build_representative_compact_block(ROWS, WIDTH);
+
+    let mut group = c.benchmark_group("bench_compressed_block_round_trip");
+    group.throughput(Throughput::Elements(ROWS as u64));
+
+    group.bench_function(BenchmarkId::new("compress", ROWS), |b| {
+        b.iter(|| {
+            std::hint::black_box(CompressedBlock::from_rows(&compact_rows));
+        });
+    });
+
+    let block = CompressedBlock::from_rows(&compact_rows);
+    let mut scratch = Vec::new();
+    group.bench_function(BenchmarkId::new("decompress", ROWS), |b| {
+        b.iter(|| {
+            std::hint::black_box(block.decompress_into(&mut scratch));
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------
+// Benchmark: scrolling into a compressed scrollback region (Task 119.6)
+//
+// Builds a buffer whose entire scrollback has been Task-118-compacted and
+// Task-119-compressed (mirroring the idle-tick's settled state), then
+// measures the real decompress-on-scroll cost paid by a flatten that
+// touches the compressed region. Each iteration rebuilds the compressed
+// buffer from scratch (`iter_batched` + `BatchSize::LargeInput`) because
+// decompression mutates state (single residency — Buffer::ensure_decompressed
+// restores rows to Compact and empties `self.blocks`), so a stale
+// already-decompressed buffer would not measure the cold path a second time.
+// ---------------------------------------------------------------
+fn build_compressed_scrollback_buffer() -> Buffer {
+    let total_lines = 1024 + 24;
+    let mut data = Vec::with_capacity(total_lines * 81);
+    for _ in 0..total_lines {
+        for _ in 0..80 {
+            data.push(TChar::Ascii(b'x'));
+        }
+        data.push(TChar::NewLine);
+    }
+    let mut buf = Buffer::new(80, 24);
+    buf.insert_text(&data);
+    let _ = buf.compact_idle_scrollback(usize::MAX);
+    let _ = buf.compress_idle_scrollback(usize::MAX);
+    buf
+}
+
+fn bench_scroll_into_compressed_region(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bench_scroll_into_compressed_region");
+    group.throughput(Throughput::Elements(1024 * 80));
+
+    group.bench_function("scrollback_flatten_1024_compressed_rows", |b| {
+        b.iter_batched(
+            build_compressed_scrollback_buffer,
+            |mut buf| {
+                std::hint::black_box(buf.scrollback_as_tchars_and_tags(0));
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    // Also measure the GUI's actual scroll path: a scrolled-back visible
+    // window flatten (the path `scrolled_visible_window_flatten_decompresses_compressed_rows`
+    // in `buffer/compression.rs` regression-tests for correctness) reaching
+    // all the way into the compressed region.
+    group.bench_function("visible_flatten_scrolled_into_compressed", |b| {
+        b.iter_batched(
+            build_compressed_scrollback_buffer,
+            |mut buf| {
+                let max_offset = buf.max_scroll_offset();
+                std::hint::black_box(buf.visible_as_tchars_and_tags(max_offset));
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------
+// Benchmark: absolute per-idle-tick cost of the budgeted background work
+// (Task 119 follow-up tuning).
+//
+// These measure the CPU cost of ONE idle tick's worth of work at the
+// production budget (4096 rows), in isolation. The point is an ABSOLUTE
+// time figure (µs to process 4096 rows), not a wall-clock CPU% on the dev
+// box: a machine Nx slower simply multiplies the measured µs by N, and the
+// justification for the budget is that even Nx that figure stays far below
+// the 100ms idle-tick interval, so a full-scrollback catch-up burst never
+// stalls the PTY tick loop or pegs a core on modest hardware.
+//
+// Each iteration rebuilds fresh state (`iter_batched` + `BatchSize::LargeInput`)
+// because both operations mutate the buffer (compaction converts Live -> Compact;
+// compression evicts Compact -> block with single residency), so a second call
+// on the same buffer would find less/no work.
+// ---------------------------------------------------------------
+
+/// Budget matching `IDLE_COMPACTION_BUDGET` / `IDLE_COMPRESSION_BUDGET` in
+/// `freminal/src/gui/pty.rs`, so the bench measures one real tick's worth.
+const IDLE_TICK_BUDGET: usize = 4096;
+
+/// Build a buffer with `scrollback_rows` rows of representative ~120-col
+/// content, all still `Live` (not compacted) — the worst case a compaction
+/// tick faces.
+fn build_live_scrollback_buffer(scrollback_rows: usize) -> Buffer {
+    const WIDTH: usize = 120;
+    // + a screen's worth so the visible window sits below the scrollback we
+    // want compacted.
+    let total_lines = scrollback_rows + 24;
+    let mut data = Vec::with_capacity(total_lines * (WIDTH + 1));
+    for i in 0..total_lines {
+        let text = format!("scrollback line {i:06} of representative shell output data");
+        for b in text.bytes().cycle().take(WIDTH) {
+            data.push(TChar::Ascii(b));
+        }
+        data.push(TChar::NewLine);
+    }
+    let mut buf = Buffer::new(WIDTH, 24);
+    buf.insert_text(&data);
+    buf
+}
+
+fn bench_idle_compaction_tick(c: &mut Criterion) {
+    // 8192 all-Live scrollback rows so a 4096-row budget has a full tick of
+    // work to do.
+    let scrollback_rows = 2 * IDLE_TICK_BUDGET;
+
+    let mut group = c.benchmark_group("bench_idle_compaction_tick");
+    group.throughput(Throughput::Elements(IDLE_TICK_BUDGET as u64));
+    group.bench_function(BenchmarkId::new("compact", IDLE_TICK_BUDGET), |b| {
+        b.iter_batched(
+            || build_live_scrollback_buffer(scrollback_rows),
+            |mut buf| {
+                std::hint::black_box(buf.compact_idle_scrollback(IDLE_TICK_BUDGET));
+            },
+            BatchSize::LargeInput,
+        );
+    });
+    group.finish();
+}
+
+fn bench_idle_compression_tick(c: &mut Criterion) {
+    // 8192 fully-compacted (but uncompressed) scrollback rows so a 4096-row
+    // compression budget has a full tick of work (16 blocks of 256 rows).
+    let scrollback_rows = 2 * IDLE_TICK_BUDGET;
+
+    let mut group = c.benchmark_group("bench_idle_compression_tick");
+    group.throughput(Throughput::Elements(IDLE_TICK_BUDGET as u64));
+    group.bench_function(BenchmarkId::new("compress", IDLE_TICK_BUDGET), |b| {
+        b.iter_batched(
+            || {
+                let mut buf = build_live_scrollback_buffer(scrollback_rows);
+                // Fully compact first: compression only touches already-compact
+                // rows, so the tick under test starts from the settled-compact
+                // state the real idle loop reaches before compressing.
+                let _ = buf.compact_idle_scrollback(usize::MAX);
+                buf
+            },
+            |mut buf| {
+                std::hint::black_box(buf.compress_idle_scrollback(IDLE_TICK_BUDGET));
+            },
+            BatchSize::LargeInput,
+        );
+    });
+    group.finish();
+}
+
+// ---------------------------------------------------------------
 // Criterion bootstrap
 // ---------------------------------------------------------------
 criterion_group!(
@@ -744,6 +960,10 @@ criterion_group!(
         bench_erase_display_bce,
         bench_command_block_record,
         bench_image_store_insert_at_quota,
+        bench_compressed_block_round_trip,
+        bench_scroll_into_compressed_region,
+        bench_idle_compaction_tick,
+        bench_idle_compression_tick,
 );
 
 criterion_main!(benches);

--- a/freminal-buffer/src/buffer/compression.rs
+++ b/freminal-buffer/src/buffer/compression.rs
@@ -1,0 +1,710 @@
+// Copyright (C) 2024-2026 Fred Clausen
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Scrollback block compression (Task 119 — Scrollback Compression).
+//!
+//! Deep-cold scrollback rows (already Task-118 [`Row::is_compact`]) can be
+//! moved out of `Buffer::rows` entirely into an LZ4-compressed
+//! [`CompressedBlock`], via the explicit, test-driven
+//! [`Buffer::compress_scrollback_block`]. There is no idle-driven *policy*
+//! deciding when to call it yet — that is Task 119.5. Compressed content is
+//! transparently restored at the flatten/read boundary via
+//! [`Buffer::ensure_decompressed`], so no caller outside `crate::buffer`
+//! ever observes a row being compressed.
+//!
+//! ## Single residency
+//!
+//! A row is always in exactly one of three states: `Live`, Task-118
+//! `Compact` (in `self.rows[i]`, `row_block_map[i] == None`), or compressed
+//! (`row_block_map[i] == Some(_)`, real content lives only in
+//! `self.blocks`). [`Buffer::ensure_decompressed`] restores a touched block
+//! back to `Compact` (not `Live` — preserving the Task-118 memory win) and
+//! removes it from `self.blocks`, so a block is never both compressed and
+//! live at the same time.
+
+use std::collections::HashSet;
+use std::ops::Range;
+
+use conv2::ValueFrom;
+
+use crate::cell::Cell;
+use crate::compact_row::CompactRow;
+use crate::compressed_block::CompressedBlock;
+
+use super::{BlockId, BlockRowRef, Buffer};
+
+impl Buffer {
+    /// Pad `row_block_map` up to `self.rows.len()` with `None`, healing any
+    /// lag introduced by the handful of row-append call sites outside this
+    /// module (see the field doc on `Buffer::row_block_map`). A cheap no-op
+    /// once `row_block_map` has already caught up, which is the common case
+    /// — every append site this module (and `resize_and_alt.rs`/`scroll.rs`)
+    /// owns keeps it eagerly in lockstep.
+    pub(in crate::buffer) fn sync_row_block_map_len(&mut self) {
+        if self.row_block_map.len() < self.rows.len() {
+            self.row_block_map.resize(self.rows.len(), None);
+        }
+    }
+
+    /// Drop every entry in `self.blocks` that is no longer referenced by any
+    /// entry in `self.row_block_map`.
+    ///
+    /// A drain (`Buffer::enforce_scrollback_limit`'s front-of-buffer
+    /// eviction, `Buffer::erase_scrollback`, `Buffer::scroll_up`) can remove
+    /// every row that referenced a given compressed block without ever
+    /// calling `Buffer::ensure_decompressed` on it — the block's bytes would
+    /// otherwise sit in `self.blocks` forever, unreferenced and
+    /// unreachable, leaking exactly the memory compression exists to save.
+    /// Called after every such drain to keep `self.blocks` containing only
+    /// live, referenced blocks.
+    pub(in crate::buffer) fn gc_unreferenced_blocks(&mut self) {
+        if self.blocks.is_empty() {
+            return;
+        }
+        let referenced: HashSet<BlockId> = self
+            .row_block_map
+            .iter()
+            .filter_map(|entry| entry.map(BlockRowRef::block_id))
+            .collect();
+        self.blocks.retain(|id, _| referenced.contains(id));
+    }
+
+    /// Compress rows `[start, start + count)` into a single new
+    /// LZ4-compressed block, evicting their real content out of
+    /// `self.rows` and into `self.blocks`.
+    ///
+    /// This is the explicit, test-driven entry point for Task 119.4 — there
+    /// is no automatic policy yet deciding *when* to call this (Task 119.5).
+    ///
+    /// Every row in the range must currently be Task-118 [`Row::is_compact`]
+    /// and not already evicted, and the range must lie entirely below the
+    /// visible window (`Buffer::visible_window_start(0)`): the live/visible
+    /// region and any not-yet-compacted `Live` scrollback row are never
+    /// compressed. Returns `false` (no-op — no partial mutation) if
+    /// `count == 0`, the range is out of bounds, the range reaches into the
+    /// visible window, or any row in the range fails the
+    /// compact-and-not-evicted precondition.
+    #[must_use]
+    pub fn compress_scrollback_block(&mut self, start: usize, count: usize) -> bool {
+        if count == 0 {
+            return false;
+        }
+        self.sync_row_block_map_len();
+
+        let Some(end) = start.checked_add(count) else {
+            return false;
+        };
+        if end > self.rows.len() {
+            return false;
+        }
+        // Never compress the visible region, nor any row at/after it.
+        let visible_start = self.visible_window_start(0);
+        if end > visible_start {
+            return false;
+        }
+
+        // Validate every row up front and collect its `CompactRow` (cloned,
+        // not decompacted) before mutating anything, so a precondition
+        // failure partway through never leaves the buffer half-compressed.
+        let mut compact_rows: Vec<CompactRow> = Vec::with_capacity(count);
+        for row in &self.rows[start..end] {
+            if row.is_evicted() {
+                return false;
+            }
+            let Some(compact) = row.as_compact() else {
+                return false;
+            };
+            compact_rows.push(compact.clone());
+        }
+
+        let block = CompressedBlock::from_rows(&compact_rows);
+        let block_id = BlockId::new(self.next_block_id);
+        // Practically unreachable (would require ~4 billion compressions in
+        // one buffer's lifetime); saturate rather than wrap so an id is
+        // never silently reused — see the field doc on
+        // `Buffer::next_block_id`.
+        self.next_block_id = self.next_block_id.saturating_add(1);
+
+        for (i, row_idx) in (start..end).enumerate() {
+            // `count` is bounded by a single compression call's row span
+            // (never remotely close to `u32::MAX`); degrade to `u32::MAX`
+            // rather than panicking in the unreachable overflow case,
+            // mirroring `CompressedBlock::from_rows`'s own row-count
+            // conversion.
+            let offset_in_block = u32::value_from(i).unwrap_or(u32::MAX);
+            self.rows[row_idx].evict_to_block();
+            self.row_block_map[row_idx] = Some(BlockRowRef::new(block_id, offset_in_block));
+            if row_idx < self.row_cache.len() {
+                self.row_cache[row_idx] = None;
+            }
+        }
+
+        self.blocks.insert(block_id, block);
+
+        self.debug_assert_invariants();
+        true
+    }
+
+    /// Ensure every row in `range` has real, readable content: decompress
+    /// (once) every distinct compressed block referenced by
+    /// `self.row_block_map[range]`, restoring every row across the **whole
+    /// buffer** that references it back to Task-118 `Compact` storage — not
+    /// just the rows inside `range`.
+    ///
+    /// A block is all-or-nothing (its bytes are one LZ4 blob), so
+    /// decompressing it restores every row it holds, wherever those rows
+    /// currently sit in `self.rows`. Walking the whole buffer for matching
+    /// block ids (rather than tracking a per-block row-index list) is the
+    /// Task 119.4 design choice: eviction is rare and buffers are bounded by
+    /// `scrollback_limit`, so this is cheap relative to the decompression it
+    /// guards.
+    ///
+    /// After this call, no row in `range` is evicted
+    /// (`Row::is_evicted() == false`) and every block referenced from
+    /// `range` has been removed from `self.blocks` (single residency).
+    ///
+    /// This is the correctness-over-speed decompress-on-read seam Task 119.4
+    /// mandates. Callers include the scrollback flatten path
+    /// (`Buffer::scrollback_as_tchars_and_tags`) and `Buffer::reflow_to_width`
+    /// (called there over the *entire* buffer — deliberately unoptimized;
+    /// Task 120 makes that fast, this subtask only needs it correct).
+    pub(in crate::buffer) fn ensure_decompressed(&mut self, range: Range<usize>) {
+        self.sync_row_block_map_len();
+
+        let end = range.end.min(self.row_block_map.len());
+        let start = range.start.min(end);
+
+        let mut block_ids: HashSet<BlockId> = HashSet::new();
+        for r in self.row_block_map[start..end].iter().flatten() {
+            block_ids.insert(r.block_id());
+        }
+
+        for block_id in block_ids {
+            let Some(block) = self.blocks.remove(&block_id) else {
+                // Already restored by an earlier iteration (can't happen
+                // with a `HashSet` of distinct ids, but `self.blocks` may
+                // simply have no entry for a dangling reference — treat
+                // that identically to "nothing to do" rather than panicking).
+                continue;
+            };
+
+            match block.decompress_into(&mut self.decompress_scratch) {
+                Some(rows) => {
+                    for i in 0..self.rows.len() {
+                        let Some(Some(r)) = self.row_block_map.get(i).copied() else {
+                            continue;
+                        };
+                        if r.block_id() != block_id {
+                            continue;
+                        }
+                        let offset = usize::value_from(r.offset_in_block()).unwrap_or(usize::MAX);
+                        if let Some(compact) = rows.get(offset).cloned() {
+                            self.rows[i].restore_from_compact(compact);
+                        } else {
+                            // Corrupt/impossible: the offset baked into
+                            // `row_block_map` doesn't exist in the
+                            // decompressed row list. Best-effort recovery
+                            // (see `Row::abandon_eviction`) rather than a
+                            // panic: leave the row blank but readable.
+                            self.rows[i].abandon_eviction();
+                        }
+                        self.row_block_map[i] = None;
+                    }
+                }
+                None => {
+                    // Decompression failed (corrupt block — should be
+                    // impossible per `CompressedBlock`'s own internal
+                    // consistency checks). Best-effort: drop the mapping
+                    // and the eviction marker for every row that referenced
+                    // it, so future reads return blank content instead of
+                    // asserting/panicking forever on a row nothing can ever
+                    // restore.
+                    for i in 0..self.rows.len() {
+                        let Some(Some(r)) = self.row_block_map.get(i).copied() else {
+                            continue;
+                        };
+                        if r.block_id() != block_id {
+                            continue;
+                        }
+                        self.rows[i].abandon_eviction();
+                        self.row_block_map[i] = None;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Read-only, non-mutating resolution of row `row_idx`'s cells, for the
+    /// `&self` text-extraction paths (`Buffer::extract_text` /
+    /// `Buffer::extract_block_text`) that must not observe row eviction but
+    /// also cannot call `Buffer::ensure_decompressed` (which needs
+    /// `&mut self` to restore rows and cache the decompressed block).
+    ///
+    /// A non-evicted row (`Live` or Task-118 `Compact`) is served directly
+    /// via `Row::characters()`, which already self-decompacts a `Compact`
+    /// row transparently — no clone, no allocation.
+    ///
+    /// An evicted row's block is decompressed into a *local, transient*
+    /// scratch buffer — never `self.decompress_scratch`, and the block is
+    /// never removed from `self.blocks` or cached back onto the row. This
+    /// is deliberately not the same "restore to `Compact` and cache" path
+    /// `ensure_decompressed` uses: it is a one-off peek that leaves
+    /// `Buffer` state completely unchanged, at the cost of re-decompressing
+    /// the same block on every call — acceptable here because
+    /// `extract_text`/`extract_block_text` are user-selection-driven, not a
+    /// per-frame hot path.
+    pub(in crate::buffer) fn row_cells_for_read(
+        &self,
+        row_idx: usize,
+    ) -> std::borrow::Cow<'_, [Cell]> {
+        if let Some(Some(block_ref)) = self.row_block_map.get(row_idx).copied()
+            && let Some(block) = self.blocks.get(&block_ref.block_id())
+        {
+            let mut scratch = Vec::new();
+            let cells = block
+                .decompress_into(&mut scratch)
+                .and_then(|rows| {
+                    let offset = usize::value_from(block_ref.offset_in_block()).ok()?;
+                    rows.into_iter().nth(offset)
+                })
+                .map(|compact| compact.to_row().cells().to_vec())
+                .unwrap_or_default();
+            return std::borrow::Cow::Owned(cells);
+        }
+        std::borrow::Cow::Borrowed(self.rows[row_idx].characters().as_slice())
+    }
+}
+
+impl BlockId {
+    /// Construct a `BlockId` from a raw counter value. Restricted to
+    /// `crate::buffer` — outside this module a `BlockId` is an opaque
+    /// handle obtained only from `Buffer::compress_scrollback_block`'s own
+    /// bookkeeping.
+    pub(in crate::buffer) const fn new(id: u32) -> Self {
+        Self(id)
+    }
+}
+
+impl BlockRowRef {
+    /// Construct a `BlockRowRef` from its parts. Restricted to
+    /// `crate::buffer` — see `BlockId::new`.
+    pub(in crate::buffer) const fn new(block_id: BlockId, offset_in_block: u32) -> Self {
+        Self {
+            block_id,
+            offset_in_block,
+        }
+    }
+
+    /// The block this row's content lives in.
+    pub(in crate::buffer) const fn block_id(self) -> BlockId {
+        self.block_id
+    }
+
+    /// This row's block-relative position within `block_id`'s block.
+    pub(in crate::buffer) const fn offset_in_block(self) -> u32 {
+        self.offset_in_block
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use freminal_common::buffer_states::tchar::TChar;
+
+    use crate::row::Row;
+
+    use super::*;
+
+    fn ascii(c: char) -> TChar {
+        TChar::from(c)
+    }
+
+    fn text(s: &str) -> Vec<TChar> {
+        s.chars().map(ascii).collect()
+    }
+
+    /// Push `n` numbered lines (each terminated by LF+CR, matching real PTY
+    /// output). Mirrors `scrollback_compaction_tests::push_numbered_lines`
+    /// in `buffer/mod.rs`.
+    fn push_numbered_lines(buf: &mut Buffer, n: usize) {
+        for i in 0..n {
+            buf.insert_text(&text(&format!("line{i:04}content")));
+            buf.handle_lf();
+            buf.handle_cr();
+        }
+    }
+
+    /// Build a buffer with `n` numbered scrollback lines, all compacted
+    /// (Task 118), ready for `compress_scrollback_block`.
+    fn buffer_with_compact_scrollback(n: usize) -> Buffer {
+        let mut buf = Buffer::new(20, 3).with_scrollback_limit(200);
+        push_numbered_lines(&mut buf, n);
+        let _ = buf.compact_idle_scrollback(usize::MAX);
+        buf
+    }
+
+    #[test]
+    fn compress_scrollback_block_rejects_the_visible_region() {
+        let mut buf = buffer_with_compact_scrollback(10);
+        let visible_start = buf.visible_window_start(0);
+
+        // A range reaching into (or starting at) the visible window must
+        // be rejected outright.
+        assert!(!buf.compress_scrollback_block(visible_start, 1));
+        assert!(!buf.compress_scrollback_block(0, buf.rows.len() + 1));
+    }
+
+    #[test]
+    fn compress_scrollback_block_rejects_non_compact_rows() {
+        let mut buf = Buffer::new(20, 3).with_scrollback_limit(200);
+        push_numbered_lines(&mut buf, 10);
+        // Deliberately do NOT call compact_idle_scrollback: rows are Live.
+        let visible_start = buf.visible_window_start(0);
+        assert!(visible_start > 0, "test needs scrollback");
+        assert!(!buf.compress_scrollback_block(0, visible_start));
+    }
+
+    #[test]
+    fn compress_scrollback_block_zero_count_is_noop() {
+        let mut buf = buffer_with_compact_scrollback(10);
+        assert!(!buf.compress_scrollback_block(0, 0));
+    }
+
+    #[test]
+    fn compressing_evicts_rows_and_populates_blocks() {
+        let mut buf = buffer_with_compact_scrollback(10);
+        let visible_start = buf.visible_window_start(0);
+        assert!(visible_start >= 2, "test needs scrollback");
+
+        assert!(buf.compress_scrollback_block(0, visible_start));
+
+        assert_eq!(buf.blocks.len(), 1);
+        for i in 0..visible_start {
+            assert!(buf.rows[i].is_evicted(), "row {i} should be evicted");
+            assert!(
+                buf.row_block_map[i].is_some(),
+                "row_block_map[{i}] should reference the new block"
+            );
+        }
+        for i in visible_start..buf.rows.len() {
+            assert!(
+                !buf.rows[i].is_evicted(),
+                "visible row {i} must be untouched"
+            );
+            assert!(buf.row_block_map[i].is_none());
+        }
+    }
+
+    #[test]
+    fn flatten_identical_before_and_after_compression() {
+        let mut buf = buffer_with_compact_scrollback(20);
+        let visible_start = buf.visible_window_start(0);
+        assert!(visible_start >= 2, "test needs scrollback");
+
+        let (chars_before, tags_before, offsets_before, urls_before) =
+            buf.scrollback_as_tchars_and_tags(0);
+
+        assert!(buf.compress_scrollback_block(0, visible_start));
+
+        let (chars_after, tags_after, offsets_after, urls_after) =
+            buf.scrollback_as_tchars_and_tags(0);
+
+        assert_eq!(
+            chars_before, chars_after,
+            "flattened characters must be identical before/after compression"
+        );
+        assert_eq!(tags_before, tags_after, "format tags must be identical");
+        assert_eq!(
+            offsets_before, offsets_after,
+            "row offsets must be identical"
+        );
+        assert_eq!(urls_before, urls_after, "url tag indices must be identical");
+
+        // The flatten above must have transparently decompressed and
+        // restored every row (single residency).
+        assert!(buf.blocks.is_empty(), "block must be removed after a read");
+        for i in 0..visible_start {
+            assert!(!buf.rows[i].is_evicted());
+            assert!(buf.row_block_map[i].is_none());
+        }
+    }
+
+    #[test]
+    fn scroll_into_compressed_block_decompresses_and_clears_mapping() {
+        let mut buf = buffer_with_compact_scrollback(20);
+        let visible_start = buf.visible_window_start(0);
+        assert!(visible_start >= 2);
+
+        assert!(buf.compress_scrollback_block(0, visible_start));
+        assert_eq!(buf.blocks.len(), 1);
+
+        // Simulate "scrolling into" a compressed row by reading it directly
+        // via ensure_decompressed (the seam every read path uses).
+        buf.ensure_decompressed(0..visible_start);
+
+        assert!(buf.blocks.is_empty());
+        for i in 0..visible_start {
+            assert!(!buf.rows[i].is_evicted());
+            assert!(buf.row_block_map[i].is_none());
+            assert!(
+                buf.rows[i].is_compact(),
+                "row {i} should restore to Compact, not Live"
+            );
+        }
+    }
+
+    #[test]
+    fn extract_text_and_block_text_identical_over_compressed_scrollback() {
+        let mut buf = buffer_with_compact_scrollback(10);
+        let visible_start = buf.visible_window_start(0);
+        assert!(visible_start >= 2, "test needs at least 2 scrollback rows");
+
+        let before_text = buf.extract_text(0, 0, 1, 14);
+        let before_block = buf.extract_block_text(0, 0, 1, 6);
+
+        assert!(buf.compress_scrollback_block(0, visible_start));
+
+        let after_text = buf.extract_text(0, 0, 1, 14);
+        let after_block = buf.extract_block_text(0, 0, 1, 6);
+
+        assert_eq!(before_text, after_text);
+        assert_eq!(before_block, after_block);
+        assert!(after_text.contains("line0000content"));
+        assert!(after_text.contains("line0001content"));
+
+        // extract_text/extract_block_text take `&self` and must not mutate
+        // Buffer state: the block must still be resident afterward.
+        assert_eq!(
+            buf.blocks.len(),
+            1,
+            "extract_text must not decompress-and-cache"
+        );
+        assert!(buf.rows[0].is_evicted());
+    }
+
+    #[test]
+    fn drain_bisecting_a_compressed_block_survives() {
+        // Two otherwise-identical buffers, diverging only in whether the
+        // first batch of scrollback was compressed before the second batch
+        // pushes enough further output that `enforce_scrollback_limit`
+        // drains some (but not all) of the original block's rows from the
+        // front — bisecting it. Both must end up byte-identical.
+        fn build(compress: bool) -> Buffer {
+            let mut buf = Buffer::new(20, 3).with_scrollback_limit(5);
+            // Push enough lines that the scrollback limit has already
+            // engaged and stabilized at its cap
+            // (`height + scrollback_limit == 8`), giving a comfortably
+            // bisectable `visible_start` of 5.
+            push_numbered_lines(&mut buf, 20);
+            let _ = buf.compact_idle_scrollback(usize::MAX);
+
+            if compress {
+                let visible_start = buf.visible_window_start(0);
+                assert!(visible_start >= 4, "test needs enough scrollback to bisect");
+                assert!(buf.compress_scrollback_block(0, visible_start));
+                assert_eq!(buf.blocks.len(), 1);
+            }
+
+            // Push enough further output that enforce_scrollback_limit
+            // drains some (but not all) of the original block's rows from
+            // the front.
+            push_numbered_lines(&mut buf, 30);
+            buf
+        }
+
+        let mut compressed = build(true);
+        let mut plain = build(false);
+
+        let max_rows = compressed.height + compressed.scrollback_limit();
+        assert!(compressed.rows.len() <= max_rows);
+        assert_eq!(compressed.rows.len(), plain.rows.len());
+        assert_eq!(
+            compressed.row_block_map.len(),
+            compressed.rows.len(),
+            "row_block_map must stay index-parallel to rows after a drain"
+        );
+
+        let (chars_c, tags_c, offsets_c, urls_c) = compressed.scrollback_as_tchars_and_tags(0);
+        let (chars_p, tags_p, offsets_p, urls_p) = plain.scrollback_as_tchars_and_tags(0);
+        assert_eq!(
+            chars_c, chars_p,
+            "surviving scrollback content must match exactly"
+        );
+        assert_eq!(tags_c, tags_p);
+        assert_eq!(offsets_c, offsets_p);
+        assert_eq!(urls_c, urls_p);
+
+        let (vis_chars_c, ..) = compressed.visible_as_tchars_and_tags(0);
+        let (vis_chars_p, ..) = plain.visible_as_tchars_and_tags(0);
+        assert_eq!(
+            vis_chars_c, vis_chars_p,
+            "visible window must also match exactly"
+        );
+    }
+
+    #[test]
+    fn reflow_over_compressed_scrollback_matches_uncompressed_reflow() {
+        fn build_and_reflow(compress: bool) -> Vec<Row> {
+            let mut buf = Buffer::new(20, 3).with_scrollback_limit(200);
+            push_numbered_lines(&mut buf, 20);
+            let _ = buf.compact_idle_scrollback(usize::MAX);
+            if compress {
+                let visible_start = buf.visible_window_start(0);
+                assert!(buf.compress_scrollback_block(0, visible_start));
+            }
+            buf.set_size(8, 3, 0);
+            buf.rows.clone()
+        }
+
+        let compressed = build_and_reflow(true);
+        let plain = build_and_reflow(false);
+
+        assert_eq!(compressed.len(), plain.len());
+        for (a, b) in compressed.iter().zip(plain.iter()) {
+            assert_eq!(a.cells(), b.cells());
+            assert_eq!(a.max_width(), b.max_width());
+            assert_eq!(a.origin, b.origin);
+            assert_eq!(a.join, b.join);
+        }
+    }
+
+    #[test]
+    fn alt_screen_round_trip_preserves_compressed_primary_scrollback() {
+        let mut buf = buffer_with_compact_scrollback(20);
+        let visible_start = buf.visible_window_start(0);
+        assert!(visible_start >= 2);
+
+        assert!(buf.compress_scrollback_block(0, visible_start));
+        assert_eq!(buf.blocks.len(), 1);
+
+        let (chars_before, tags_before, ..) = buf.scrollback_as_tchars_and_tags(0);
+        // The read above transparently decompressed everything back to
+        // Compact; re-compress so the round trip actually exercises a
+        // non-empty `blocks` map across the switch.
+        assert!(buf.compress_scrollback_block(0, visible_start));
+        assert_eq!(buf.blocks.len(), 1);
+
+        buf.enter_alternate(0);
+        assert!(
+            buf.blocks.is_empty(),
+            "alt screen must start with no blocks"
+        );
+        assert_eq!(buf.row_block_map.iter().filter(|e| e.is_some()).count(), 0);
+
+        let _ = buf.leave_alternate();
+
+        assert_eq!(
+            buf.blocks.len(),
+            1,
+            "compressed block must survive the round trip"
+        );
+        for i in 0..visible_start {
+            assert!(buf.rows[i].is_evicted());
+        }
+
+        let (chars_after, tags_after, ..) = buf.scrollback_as_tchars_and_tags(0);
+        assert_eq!(chars_before, chars_after);
+        assert_eq!(tags_before, tags_after);
+    }
+
+    #[test]
+    fn ensure_decompressed_clears_eviction_flag_so_reads_no_longer_assert() {
+        let mut buf = buffer_with_compact_scrollback(10);
+        let visible_start = buf.visible_window_start(0);
+        assert!(visible_start >= 1);
+
+        assert!(buf.compress_scrollback_block(0, visible_start));
+        assert!(buf.rows[0].is_evicted());
+
+        buf.ensure_decompressed(0..visible_start);
+
+        assert!(!buf.rows[0].is_evicted());
+        // A direct read must now succeed without tripping the diagnostic
+        // debug_assert in `Row::cells_ref`.
+        let _ = buf.rows[0].cells();
+    }
+
+    #[test]
+    fn erase_scrollback_drops_compressed_blocks() {
+        let mut buf = buffer_with_compact_scrollback(20);
+        let visible_start = buf.visible_window_start(0);
+        assert!(visible_start >= 2);
+
+        assert!(buf.compress_scrollback_block(0, visible_start));
+        assert_eq!(buf.blocks.len(), 1);
+
+        buf.erase_scrollback();
+
+        assert!(buf.blocks.is_empty());
+        assert_eq!(buf.row_block_map.len(), buf.rows.len());
+        assert!(buf.row_block_map.iter().all(Option::is_none));
+    }
+
+    /// Regression (119.4 code review, CRITICAL-1): scrolling back into a
+    /// compressed region via the *visible-window* flatten path
+    /// (`visible_as_tchars_and_tags_extended` with a nonzero scroll offset)
+    /// must decompress the evicted rows first, not trip `cells_ref`'s
+    /// eviction `debug_assert` (debug) / render blank (release). This path is
+    /// the one the GUI actually drives when the user scrolls up.
+    #[test]
+    fn scrolled_visible_window_flatten_decompresses_compressed_rows() {
+        let mut buf = buffer_with_compact_scrollback(20);
+        let visible_start = buf.visible_window_start(0);
+        assert!(visible_start >= 2, "test needs scrollback");
+
+        // Baseline: flatten the fully-scrolled-back view (offset large
+        // enough to pin the window at the very top of the buffer) BEFORE
+        // compressing, so we have a known-good comparison.
+        let max_offset = buf.max_scroll_offset();
+        assert!(max_offset > 0, "test needs a scrollable buffer");
+        let (chars_before, tags_before, ..) = buf.visible_as_tchars_and_tags(max_offset);
+
+        // Compress the entire scrollback region, then flatten the same
+        // scrolled-back view again. Must be byte-identical and must not
+        // panic on an evicted placeholder.
+        assert!(buf.compress_scrollback_block(0, visible_start));
+        assert!(!buf.blocks.is_empty(), "scrollback should be compressed");
+
+        let (chars_after, tags_after, ..) = buf.visible_as_tchars_and_tags(max_offset);
+        assert_eq!(
+            chars_before, chars_after,
+            "scrolled-back flatten must be identical before/after compression"
+        );
+        assert_eq!(tags_before, tags_after);
+    }
+
+    /// Regression (119.4 code review, CRITICAL-2): the whole-buffer
+    /// image-clearing sweeps in `images.rs` iterate every row (including
+    /// deep scrollback) and read cells; they must skip evicted/compact rows
+    /// rather than trip the eviction `debug_assert`. An evicted row provably
+    /// holds no images, so clearing is a no-op there anyway.
+    #[test]
+    fn whole_buffer_image_clear_over_compressed_scrollback_does_not_panic() {
+        let mut buf = buffer_with_compact_scrollback(20);
+        let visible_start = buf.visible_window_start(0);
+        assert!(visible_start >= 2, "test needs scrollback");
+
+        assert!(buf.compress_scrollback_block(0, visible_start));
+        assert!(!buf.blocks.is_empty());
+
+        // Each of these walks the entire buffer, including the compressed
+        // scrollback rows. None may panic; all are no-ops over evicted rows
+        // (which carry no images), so the compressed block stays resident.
+        buf.clear_all_image_placements();
+        buf.clear_image_placements_by_id(42);
+        buf.clear_image_placements_by_number(1);
+        buf.clear_image_placements_by_z_index(0);
+        buf.clear_image_placements_in_column(0);
+
+        assert_eq!(
+            buf.blocks.len(),
+            1,
+            "image sweeps must not decompress/evict compressed rows"
+        );
+        for i in 0..visible_start {
+            assert!(buf.rows[i].is_evicted(), "row {i} must stay evicted");
+        }
+    }
+}

--- a/freminal-buffer/src/buffer/compression.rs
+++ b/freminal-buffer/src/buffer/compression.rs
@@ -29,11 +29,25 @@ use std::ops::Range;
 
 use conv2::ValueFrom;
 
+use freminal_common::buffer_states::buffer_type::BufferType;
+
 use crate::cell::Cell;
 use crate::compact_row::CompactRow;
 use crate::compressed_block::CompressedBlock;
 
 use super::{BlockId, BlockRowRef, Buffer};
+
+/// Maximum number of contiguous eligible rows grouped into a single
+/// `compress_scrollback_block` call by `Buffer::compress_idle_scrollback`.
+///
+/// The plan's target range is ~128-256 logical scrollback rows: large
+/// enough to amortize LZ4's fixed per-call overhead, small enough that
+/// scrolling into a block (which decompresses the whole thing) stays well
+/// under one frame budget. `256` is chosen here as the upper end of that
+/// range; whether `128` yields a meaningfully better ratio/latency
+/// trade-off is validated against measured behavior in Task 119.6's
+/// benches, not here.
+const BLOCK_SIZE: usize = 256;
 
 impl Buffer {
     /// Pad `row_block_map` up to `self.rows.len()` with `None`, healing any
@@ -69,6 +83,111 @@ impl Buffer {
             .filter_map(|entry| entry.map(BlockRowRef::block_id))
             .collect();
         self.blocks.retain(|id, _| referenced.contains(id));
+    }
+
+    /// Compress up to `budget` rows of already-Task-118-compact, cold
+    /// scrollback into LZ4 blocks, returning the number of rows *newly
+    /// compressed*.
+    ///
+    /// Intended to be called from the PTY thread's idle tick immediately
+    /// AFTER `compact_idle_scrollback` has caught up for this same tick
+    /// (see the idle-tick arm in `freminal/src/gui/pty.rs`): a row must be
+    /// Task-118-compacted before it is a compression candidate, so calling
+    /// this while a compaction backlog is still draining would find
+    /// nothing to do — compact first, compress the now-cold result second.
+    ///
+    /// Only contiguous runs of scrollback rows (below the visible window,
+    /// `0..visible_window_start(0)`) that are ALL currently
+    /// [`Row::is_compact`] and not already evicted into a block are
+    /// eligible. A `Live` (not-yet-compacted) row, an already-compressed
+    /// row, or an image row (never compact) breaks the current run —
+    /// those rows become eligible on a later tick once compaction (or a
+    /// prior compression call) has processed them. A no-op (returns `0`)
+    /// on the alternate screen and when there is no scrollback, no budget,
+    /// or nothing left to compress.
+    ///
+    /// Each eligible run is grouped into chunks of at most `BLOCK_SIZE`
+    /// rows and compressed via one `compress_scrollback_block` call per
+    /// chunk. There is deliberately no minimum chunk length: even a
+    /// single-row trailing run is still compressed, trading some
+    /// compression ratio (a one-row block still pays LZ4's fixed per-call
+    /// overhead) for algorithmic simplicity and testability — such a short
+    /// run is rare in practice (only at scrollback's tail, near the visible
+    /// window, or where an image row bisects a run).
+    ///
+    /// `budget` bounds the number of rows *actually compressed* — i.e.
+    /// rows inside chunks for which `compress_scrollback_block` returned
+    /// `true` — mirroring `compact_idle_scrollback`'s "budget counts real
+    /// work, not rows scanned" discipline: a chunk that fails to compress
+    /// (should not happen given the eligibility scan performed here, but
+    /// mirrors `compress_scrollback_block`'s own preconditions defensively)
+    /// does not consume budget. A chunk that would exceed the remaining
+    /// budget is shrunk to fit exactly, so every call makes forward
+    /// progress up to `budget` rather than skipping a run entirely because
+    /// its full size doesn't fit.
+    #[must_use]
+    pub fn compress_idle_scrollback(&mut self, budget: usize) -> usize {
+        if self.kind == BufferType::Alternate || budget == 0 {
+            return 0;
+        }
+        self.sync_row_block_map_len();
+
+        let visible_start = self.visible_window_start(0);
+        if visible_start == 0 {
+            return 0;
+        }
+
+        let mut compressed = 0usize;
+        let mut i = 0usize;
+        while i < visible_start && compressed < budget {
+            if !self.row_is_compression_candidate(i) {
+                i += 1;
+                continue;
+            }
+
+            // Extend the run while rows stay eligible, bounded by the
+            // visible window.
+            let mut run_end = i + 1;
+            while run_end < visible_start && self.row_is_compression_candidate(run_end) {
+                run_end += 1;
+            }
+
+            // Compress the run in `BLOCK_SIZE` chunks, each further capped
+            // by the remaining budget so `budget` is always respected
+            // exactly.
+            let mut chunk_start = i;
+            while chunk_start < run_end && compressed < budget {
+                let remaining_budget = budget - compressed;
+                let chunk_len = (run_end - chunk_start)
+                    .min(BLOCK_SIZE)
+                    .min(remaining_budget);
+                if chunk_len == 0 {
+                    break;
+                }
+                if self.compress_scrollback_block(chunk_start, chunk_len) {
+                    compressed += chunk_len;
+                }
+                chunk_start += chunk_len;
+            }
+
+            i = run_end;
+        }
+
+        self.debug_assert_invariants();
+        compressed
+    }
+
+    /// `true` if scrollback row `idx` is eligible to be grouped into a
+    /// `compress_idle_scrollback` run: currently Task-118 [`Row::is_compact`]
+    /// and not already evicted into a compressed block. Used only by the
+    /// run scan in `compress_idle_scrollback`.
+    fn row_is_compression_candidate(&self, idx: usize) -> bool {
+        let Some(row) = self.rows.get(idx) else {
+            return false;
+        };
+        row.is_compact()
+            && !row.is_evicted()
+            && self.row_block_map.get(idx).copied().flatten().is_none()
     }
 
     /// Compress rows `[start, start + count)` into a single new
@@ -706,5 +825,143 @@ mod tests {
         for i in 0..visible_start {
             assert!(buf.rows[i].is_evicted(), "row {i} must stay evicted");
         }
+    }
+
+    // -------------------------------------------------------------------
+    // compress_idle_scrollback (Task 119.5)
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn compress_idle_scrollback_compresses_already_compacted_rows() {
+        let mut buf = Buffer::new(20, 3).with_scrollback_limit(200);
+        push_numbered_lines(&mut buf, 20);
+        let visible_start = buf.visible_window_start(0);
+        assert!(visible_start >= 2, "test needs scrollback");
+
+        let (chars_before, tags_before, offsets_before, urls_before) =
+            buf.scrollback_as_tchars_and_tags(0);
+
+        // Compact first (Task 118), then compress (Task 119.5) — mirrors
+        // the idle-tick sequencing in `freminal/src/gui/pty.rs`.
+        let compacted = buf.compact_idle_scrollback(usize::MAX);
+        assert!(compacted > 0, "test needs rows to compact");
+
+        let compressed = buf.compress_idle_scrollback(usize::MAX);
+        assert!(compressed > 0, "expected some rows to be compressed");
+        assert!(!buf.blocks.is_empty(), "expected at least one block");
+
+        for i in 0..visible_start {
+            assert!(buf.rows[i].is_evicted(), "row {i} should be evicted");
+            assert!(buf.row_block_map[i].is_some());
+        }
+        for i in visible_start..buf.rows.len() {
+            assert!(!buf.rows[i].is_evicted(), "visible row {i} untouched");
+        }
+
+        let (chars_after, tags_after, offsets_after, urls_after) =
+            buf.scrollback_as_tchars_and_tags(0);
+        assert_eq!(
+            chars_before, chars_after,
+            "flattened characters must be identical before/after idle compression"
+        );
+        assert_eq!(tags_before, tags_after);
+        assert_eq!(offsets_before, offsets_after);
+        assert_eq!(urls_before, urls_after);
+    }
+
+    #[test]
+    fn compress_idle_scrollback_on_live_rows_compresses_nothing() {
+        let mut buf = Buffer::new(20, 3).with_scrollback_limit(200);
+        push_numbered_lines(&mut buf, 20);
+        let visible_start = buf.visible_window_start(0);
+        assert!(visible_start >= 2, "test needs scrollback");
+
+        // Deliberately do NOT compact: every scrollback row is still Live,
+        // so compression must find nothing eligible.
+        let compressed = buf.compress_idle_scrollback(usize::MAX);
+
+        assert_eq!(compressed, 0);
+        assert!(buf.blocks.is_empty());
+        for i in 0..visible_start {
+            assert!(!buf.rows[i].is_evicted());
+            assert!(buf.row_block_map.get(i).copied().flatten().is_none());
+        }
+    }
+
+    #[test]
+    fn compress_idle_scrollback_respects_budget_and_drains_over_multiple_calls() {
+        let mut buf = buffer_with_compact_scrollback(2000);
+        let visible_start = buf.visible_window_start(0);
+        assert!(visible_start >= 100, "test needs a large scrollback");
+
+        let budget = 100usize;
+        let mut total_compressed = 0usize;
+        let mut iterations = 0usize;
+        loop {
+            let compressed = buf.compress_idle_scrollback(budget);
+            assert!(
+                compressed <= budget,
+                "a single call must never compress more than its budget"
+            );
+            if compressed == 0 {
+                break;
+            }
+            total_compressed += compressed;
+            iterations += 1;
+            assert!(
+                iterations < 1_000,
+                "compression should fully drain well within this many calls"
+            );
+        }
+
+        assert!(
+            iterations > 1,
+            "a large scrollback should take more than one budgeted call to fully compress"
+        );
+        assert_eq!(total_compressed, visible_start);
+        for i in 0..visible_start {
+            assert!(buf.rows[i].is_evicted(), "row {i} should be evicted");
+        }
+    }
+
+    #[test]
+    fn compress_idle_scrollback_alternate_screen_is_noop() {
+        let mut buf = buffer_with_compact_scrollback(20);
+        buf.enter_alternate(0);
+        assert_eq!(buf.kind, BufferType::Alternate);
+
+        let compressed = buf.compress_idle_scrollback(usize::MAX);
+
+        assert_eq!(compressed, 0);
+        assert!(buf.blocks.is_empty());
+    }
+
+    #[test]
+    fn compress_idle_scrollback_never_touches_the_visible_region() {
+        let mut buf = buffer_with_compact_scrollback(20);
+        let visible_start = buf.visible_window_start(0);
+        assert!(visible_start >= 2, "test needs scrollback");
+
+        let _ = buf.compress_idle_scrollback(usize::MAX);
+
+        for i in visible_start..buf.rows.len() {
+            assert!(
+                !buf.rows[i].is_evicted(),
+                "visible row {i} must never be compressed"
+            );
+            assert!(buf.row_block_map.get(i).copied().flatten().is_none());
+        }
+    }
+
+    #[test]
+    fn compress_idle_scrollback_is_idempotent_once_fully_compressed() {
+        let mut buf = buffer_with_compact_scrollback(20);
+
+        let first_pass = buf.compress_idle_scrollback(usize::MAX);
+        assert!(first_pass > 0, "test needs something to compress");
+
+        // Fully compressed already: further calls must do no busy-work.
+        assert_eq!(buf.compress_idle_scrollback(usize::MAX), 0);
+        assert_eq!(buf.compress_idle_scrollback(usize::MAX), 0);
     }
 }

--- a/freminal-buffer/src/buffer/flatten.rs
+++ b/freminal-buffer/src/buffer/flatten.rs
@@ -141,6 +141,13 @@ impl Buffer {
         extra_rows: usize,
     ) -> (Vec<TChar>, Vec<FormatTag>, Vec<usize>, Vec<usize>) {
         let (visible_start, visible_end) = self.visible_window_bounds(scroll_offset, extra_rows);
+        // Task 119: when the user scrolls back, this window can reach into
+        // compressed scrollback (a nonzero `scroll_offset` lowers
+        // `visible_window_start`). Decompress any evicted rows in the window
+        // before reading their cells, so `flatten_row` never touches an
+        // evicted placeholder. A no-op when nothing in the window is
+        // compressed (the common live-view case).
+        self.ensure_decompressed(visible_start..visible_end);
         let auto_detect = self.auto_detect_urls;
         Self::rows_as_tchars_and_tags_cached(
             &mut self.rows[visible_start..visible_end],
@@ -172,6 +179,12 @@ impl Buffer {
             // No scrollback rows exist yet.
             return (vec![], vec![], vec![], vec![]);
         }
+
+        // Task 119.4: restore any deep-cold compressed rows in this range
+        // back to real (Task-118 `Compact`) content before flattening. This
+        // is the decompress-on-read seam — the visible window (never
+        // reached here) never needs it.
+        self.ensure_decompressed(0..visible_start);
 
         let auto_detect = self.auto_detect_urls;
         let result = Self::rows_as_tchars_and_tags_cached(
@@ -515,8 +528,11 @@ impl Buffer {
         let mut result = String::new();
 
         for row_idx in start_row..=end_row {
-            let row = &self.rows[row_idx];
-            let cells = row.characters();
+            // Task 119.4: `extract_text` takes `&self`, so it cannot call
+            // `ensure_decompressed` (which needs `&mut self`). A row
+            // evicted to a compressed block is resolved via a transient,
+            // non-mutating peek instead — see `row_cells_for_read`.
+            let cells = self.row_cells_for_read(row_idx);
 
             let col_begin = if row_idx == start_row { start_col } else { 0 };
             let col_end = if row_idx == end_row {
@@ -580,8 +596,10 @@ impl Buffer {
         let mut result = String::new();
 
         for row_idx in start_row..=end_row {
-            let row = &self.rows[row_idx];
-            let cells = row.characters();
+            // Task 119.4: see the matching comment in `extract_text` — this
+            // also takes `&self` and must resolve an evicted row without
+            // mutating `Buffer` state.
+            let cells = self.row_cells_for_read(row_idx);
 
             let mut row_text = String::new();
             for col in col_min..=col_max {

--- a/freminal-buffer/src/buffer/images.rs
+++ b/freminal-buffer/src/buffer/images.rs
@@ -101,6 +101,13 @@ impl Buffer {
     pub fn clear_all_image_placements(&mut self) {
         let mut cleared = 0usize;
         for (i, row) in self.rows.iter_mut().enumerate() {
+            // Task 119: an evicted (or Task-118 compact) row provably holds
+            // no image cells, so skip it — reading its cells would trip
+            // `cells_mut`'s eviction debug_assert (and needlessly decompact a
+            // compact row) for no possible clearing work.
+            if row.is_compact() || row.is_evicted() {
+                continue;
+            }
             let mut changed = false;
             for cell in row.cells_mut() {
                 if cell.has_image() {
@@ -123,6 +130,10 @@ impl Buffer {
     pub fn clear_image_placements_by_id(&mut self, image_id: u64) {
         let mut cleared = 0usize;
         for (i, row) in self.rows.iter_mut().enumerate() {
+            // Task 119: skip evicted/compact rows — they hold no images.
+            if row.is_compact() || row.is_evicted() {
+                continue;
+            }
             let mut changed = false;
             for cell in row.cells_mut() {
                 if cell
@@ -157,6 +168,10 @@ impl Buffer {
     pub fn clear_image_placements_by_placement(&mut self, image_id: u64, placement_id: u32) {
         let mut cleared = 0usize;
         for (i, row) in self.rows.iter_mut().enumerate() {
+            // Task 119: skip evicted/compact rows — they hold no images.
+            if row.is_compact() || row.is_evicted() {
+                continue;
+            }
             let mut changed = false;
             for cell in row.cells_mut() {
                 if cell
@@ -241,6 +256,10 @@ impl Buffer {
     pub fn clear_image_placements_by_number(&mut self, number: u32) {
         let mut cleared = 0usize;
         for (i, row) in self.rows.iter_mut().enumerate() {
+            // Task 119: skip evicted/compact rows — they hold no images.
+            if row.is_compact() || row.is_evicted() {
+                continue;
+            }
             let mut changed = false;
             for cell in row.cells_mut() {
                 if cell
@@ -304,6 +323,10 @@ impl Buffer {
     pub fn clear_image_placements_in_column(&mut self, col: usize) {
         let mut ids_to_clear: Vec<u64> = Vec::new();
         for row in &self.rows {
+            // Task 119: skip evicted/compact rows — they hold no images.
+            if row.is_compact() || row.is_evicted() {
+                continue;
+            }
             let cells = row.cells();
             if col < cells.len()
                 && let Some(placement) = cells[col].image_placement()
@@ -407,6 +430,10 @@ impl Buffer {
 
         let mut cleared = 0usize;
         for (i, row) in self.rows.iter_mut().enumerate() {
+            // Task 119: skip evicted/compact rows — they hold no images.
+            if row.is_compact() || row.is_evicted() {
+                continue;
+            }
             let mut changed = false;
             for cell in row.cells_mut() {
                 if cell
@@ -433,6 +460,10 @@ impl Buffer {
     pub fn clear_image_placements_by_z_index(&mut self, z: i32) {
         let mut cleared = 0usize;
         for (i, row) in self.rows.iter_mut().enumerate() {
+            // Task 119: skip evicted/compact rows — they hold no images.
+            if row.is_compact() || row.is_evicted() {
+                continue;
+            }
             let mut changed = false;
             for cell in row.cells_mut() {
                 if cell.image_placement().is_some_and(|p| p.z_index == z) {

--- a/freminal-buffer/src/buffer/lifecycle.rs
+++ b/freminal-buffer/src/buffer/lifecycle.rs
@@ -6,7 +6,7 @@
 //! Buffer construction, reset, prompt-row tracking, and internal invariant
 //! checking for [`Buffer`].
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::time::SystemTime;
 
 use freminal_common::buffer_states::{
@@ -44,6 +44,7 @@ impl Buffer {
         // blank rows instead of the actual content at the top.
         let rows = vec![Row::new(width)];
         let row_cache = vec![None];
+        let row_block_map = vec![None];
 
         Self {
             rows,
@@ -74,6 +75,10 @@ impl Buffer {
             image_cell_count: 0,
             prompt_rows: Vec::new(),
             command_blocks: VecDeque::new(),
+            blocks: HashMap::new(),
+            next_block_id: 0,
+            row_block_map,
+            decompress_scratch: Vec::new(),
         }
     }
 
@@ -92,6 +97,12 @@ impl Buffer {
     pub fn full_reset(&mut self) {
         self.rows = vec![Row::new(self.width)];
         self.row_cache = vec![None];
+        // Task 119: discard every compressed block and reset the per-row
+        // map/id counter in lockstep with the row reset above — a full
+        // reset wipes all scrollback, so no compressed content survives it.
+        self.blocks.clear();
+        self.next_block_id = 0;
+        self.row_block_map = vec![None];
         self.cursor = CursorState::default();
         self.current_tag = FormatTag::default();
         self.kind = BufferType::Primary;
@@ -381,6 +392,27 @@ impl Buffer {
             self.rows.len()
         );
 
+        // Task 119: `row_block_map` must be index-parallel to `rows`, same
+        // as `row_cache` above, with one deliberate relaxation: unlike
+        // `row_cache`, it may transiently lag *shorter* immediately after a
+        // handful of row-append call sites outside the compression
+        // subsystem run (three in `lines.rs`, two test-only ones in
+        // `lifecycle.rs` — see the field doc on `Buffer::row_block_map`).
+        // Every mutating entry point this module owns keeps it eagerly in
+        // sync; the few call sites that don't are always simple appends of
+        // a fresh, never-compressed row, and `Buffer::sync_row_block_map_len`
+        // pads the gap with `None` (the exactly-correct value) the next
+        // time compression code touches it. A strict `==` here would fire
+        // on that entirely benign, self-healing lag. It must never be
+        // *longer* than `rows`: nothing removes rows without also
+        // shrinking `row_block_map` in this module.
+        debug_assert!(
+            self.row_block_map.len() <= self.rows.len(),
+            "row_block_map length {} must never exceed rows length {}",
+            self.row_block_map.len(),
+            self.rows.len()
+        );
+
         // Image cell count must match the actual number of image cells across
         // all rows.  This is O(rows × cols) but only runs in debug builds.
         let actual_image_cells: usize = self.rows.iter().map(Row::count_image_cells).sum();
@@ -407,6 +439,7 @@ impl Buffer {
         // non-default background instead of being transparent.
         self.rows.push(row);
         self.row_cache.push(None);
+        self.row_block_map.push(None);
     }
 }
 

--- a/freminal-buffer/src/buffer/mod.rs
+++ b/freminal-buffer/src/buffer/mod.rs
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use conv2::ValueFrom;
@@ -18,6 +18,7 @@ use freminal_common::buffer_states::{
 };
 
 use crate::{
+    compressed_block::CompressedBlock,
     image_store::ImageStore,
     response::InsertResponse,
     row::{Row, RowJoin, RowOrigin},
@@ -34,6 +35,7 @@ use freminal_common::buffer_states::{
     modes::{reverse_wrap_around::ReverseWrapAround, xt_rev_wrap2::XtRevWrap2},
 };
 
+mod compression;
 mod cursor;
 mod erase;
 mod flatten;
@@ -66,6 +68,41 @@ fn clamped_offset(base: usize, delta: i32, lo: usize, hi: usize) -> usize {
     let clamped = base_i.saturating_add(delta).max(lo_i).min(hi_i);
     // After max(lo_i) with lo_i >= 0 (usize origin), clamped is non-negative, so this is lossless.
     usize::value_from(clamped).unwrap_or(base)
+}
+
+/// Monotonic identifier for a [`CompressedBlock`] (Task 119 — Scrollback
+/// Compression).
+///
+/// Minted by `Buffer::compress_scrollback_block` from
+/// `Buffer::next_block_id` and never reused within a `Buffer`'s lifetime
+/// (barring the practically-unreachable `u32` exhaustion case — see that
+/// field's doc).
+///
+/// The type is `pub` only so it can appear in the (also `pub`)
+/// [`SavedPrimaryState::blocks`]/[`SavedPrimaryState::row_block_map`]
+/// fields without a private-type-in-public-interface error; its field stays
+/// private, so nothing outside `crate::buffer` can construct, inspect, or
+/// match on one — it is an opaque handle everywhere else.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BlockId(u32);
+
+/// A scrollback row's reference into a [`CompressedBlock`]: which block
+/// holds its content, and its position within that block.
+///
+/// `offset_in_block` is **block-relative** (0-based from the block's first
+/// row), NOT a buffer-absolute row index. This is what makes a block
+/// survive a front-of-buffer drain (`Buffer::enforce_scrollback_limit`,
+/// `Buffer::erase_scrollback`) for free: draining rows from the front of
+/// `self.rows` never changes any surviving row's position *within* its own
+/// block, so no index remapping is needed on drain (only the front-drain of
+/// `Buffer::row_block_map` itself, in lockstep with `rows`/`row_cache`).
+///
+/// `pub` for the same private-type-in-public-interface reason as
+/// [`BlockId`]; both fields stay private (opaque outside `crate::buffer`).
+#[derive(Debug, Clone, Copy)]
+pub struct BlockRowRef {
+    block_id: BlockId,
+    offset_in_block: u32,
 }
 
 /// The primary terminal buffer owning all rows, the cursor, and display state.
@@ -200,6 +237,56 @@ pub struct Buffer {
     /// as `prompt_rows`).  They are adjusted atomically with row drains via
     /// [`Buffer::adjust_prompt_rows`].
     pub(in crate::buffer) command_blocks: std::collections::VecDeque<CommandBlock>,
+
+    /// Deep-cold scrollback rows compressed with LZ4 (Task 119 — Scrollback
+    /// Compression), keyed by [`BlockId`].
+    ///
+    /// Only rows below the visible window that are already Task-118
+    /// [`Row::is_compact`] are ever compressed, via the explicit,
+    /// test-driven `Buffer::compress_scrollback_block` (this subtask has no
+    /// idle-driven compression *policy* yet — that is Task 119.5). A block
+    /// is removed the moment any of its rows is read
+    /// (`Buffer::ensure_decompressed`): a row is never both compressed and
+    /// live at the same time (single residency).
+    pub(in crate::buffer) blocks: HashMap<BlockId, CompressedBlock>,
+
+    /// Monotonic counter used to mint fresh [`BlockId`]s for
+    /// `Buffer::compress_scrollback_block`. Reset only by [`Buffer::new`]
+    /// and [`Buffer::full_reset`] (which also discard every existing
+    /// block). Uses `saturating_add` rather than wrapping, so in the
+    /// practically-unreachable case of exhausting `u32::MAX` block
+    /// allocations in one buffer's lifetime, further compressions simply
+    /// stop minting new ids rather than silently reusing one.
+    pub(in crate::buffer) next_block_id: u32,
+
+    /// Per-row reference into `self.blocks`, index-parallel to `self.rows` /
+    /// `self.row_cache` (same maintained-in-lockstep invariant those two
+    /// already have). `None` means the row is not currently compressed (it
+    /// may be `Live` or Task-118 [`Row::is_compact`]); `Some` means the
+    /// row's real content has been evicted into the referenced block (see
+    /// [`Row::is_evicted`]) and `self.rows[i]` holds only a diagnostic
+    /// placeholder.
+    ///
+    /// May transiently lag *shorter* than `self.rows` immediately after a
+    /// row is appended by a code path outside the compression subsystem
+    /// (namely three direct `self.rows.push` sites in `lines.rs`, and two
+    /// test-only ones in `lifecycle.rs`, none of which know about this
+    /// field). Every such append is always a fresh, never-compressed `Live`
+    /// row, so padding the gap with `None` on next access
+    /// (`Buffer::sync_row_block_map_len`) is exactly the correct value —
+    /// not a workaround for missing data. It can never lag *longer* than
+    /// `self.rows`: nothing removes rows without this module's involvement
+    /// (`erase.rs`/`cursor.rs`/`tabs.rs`/`images.rs` only mutate existing
+    /// rows' content in place, never the row count).
+    pub(in crate::buffer) row_block_map: Vec<Option<BlockRowRef>>,
+
+    /// Reusable scratch buffer for [`CompressedBlock::decompress_into`],
+    /// avoiding a fresh allocation on every block decompression inside
+    /// `Buffer::ensure_decompressed`. Purely a transient perf buffer with no
+    /// observable state, so it is *not* carried across alternate-screen
+    /// save/restore (`SavedPrimaryState` has no equivalent field) — each
+    /// side just uses (and regrows) its own.
+    pub(in crate::buffer) decompress_scratch: Vec<u8>,
 }
 
 /// Snapshot of the primary buffer state saved when entering the alternate screen.
@@ -231,6 +318,17 @@ pub struct SavedPrimaryState {
     pub image_store: ImageStore,
     /// Saved image cell count from the primary buffer.
     pub image_cell_count: usize,
+    /// Saved compressed scrollback blocks from the primary buffer (Task
+    /// 119). The alternate screen never accumulates scrollback and so never
+    /// compresses anything; this is empty for as long as the alternate
+    /// screen is active and is restored verbatim on `leave_alternate`.
+    pub blocks: HashMap<BlockId, CompressedBlock>,
+    /// Saved [`Buffer::next_block_id`] counter from the primary buffer.
+    pub next_block_id: u32,
+    /// Saved per-row compressed-block references from the primary buffer,
+    /// index-parallel to `rows`/`row_cache` above (see
+    /// `Buffer::row_block_map`).
+    pub row_block_map: Vec<Option<BlockRowRef>>,
 }
 
 /// Heap-inclusive memory breakdown for a [`Buffer`]'s row storage, row-flatten
@@ -282,6 +380,20 @@ pub struct BufferHeapBreakdown {
     /// therefore under-counted here — a diagnostic limitation, not a
     /// correctness issue (the cell/tag data itself is unaffected).
     pub url_bytes: usize,
+
+    /// Heap bytes held by `self.blocks` (Task 119 — Scrollback
+    /// Compression): the sum of every resident [`CompressedBlock`]'s
+    /// [`CompressedBlock::heap_bytes`] (its LZ4-compressed payload's
+    /// allocation capacity). Does not include `HashMap<BlockId,
+    /// CompressedBlock>`'s own bucket-array overhead, matching this API's
+    /// existing style of not accounting `url_ptrs`' `HashSet` container
+    /// overhead either.
+    ///
+    /// An evicted row's own `rows_bytes` contribution is already ~0 (its
+    /// placeholder storage is an empty `Vec<Cell>`, same as `Row::new`), so
+    /// this field is where a compressed block's real, still-resident cost
+    /// shows up.
+    pub blocks_bytes: usize,
 
     /// Number of scrollback rows: `self.rows.len().saturating_sub(self.height)`.
     pub scrollback_lines: usize,
@@ -453,9 +565,13 @@ impl Buffer {
         for row in &self.rows {
             rows_bytes += row.storage_heap_bytes();
 
-            // Skip URL scanning for compacted rows without decompacting —
-            // see the doc comment on `BufferHeapBreakdown::url_bytes`.
-            if row.is_compact() {
+            // Skip URL scanning for compacted or evicted (Task 119) rows
+            // without decompacting/decompressing — see the doc comment on
+            // `BufferHeapBreakdown::url_bytes`. An evicted row can never
+            // carry a URL cell any more than a compact one can (it was
+            // compact before eviction), so this is not an additional
+            // under-count beyond the existing compact-row one.
+            if row.is_compact() || row.is_evicted() {
                 continue;
             }
             for cell in row.cells() {
@@ -479,10 +595,13 @@ impl Buffer {
             row_cache_bytes += entry.auto_urls.capacity() * core::mem::size_of::<AutoUrlRange>();
         }
 
+        let blocks_bytes: usize = self.blocks.values().map(CompressedBlock::heap_bytes).sum();
+
         BufferHeapBreakdown {
             rows_bytes,
             row_cache_bytes,
             url_bytes,
+            blocks_bytes,
             scrollback_lines: self.rows.len().saturating_sub(self.height),
             total_rows: self.rows.len(),
         }
@@ -605,6 +724,7 @@ impl Buffer {
                 self.rows
                     .push(Row::new_with_origin(self.width, origin, join));
                 self.row_cache.push(None);
+                self.row_block_map.push(None);
             }
 
             // clone tag here to avoid long-lived borrows of &self

--- a/freminal-buffer/src/buffer/resize_and_alt.rs
+++ b/freminal-buffer/src/buffer/resize_and_alt.rs
@@ -245,6 +245,14 @@ impl Buffer {
             image_cell_count: saved.image_cell_count,
             prompt_rows: Vec::new(),
             command_blocks: VecDeque::new(),
+            // Task 119: carried through so a resize while on the alternate
+            // screen (which reflows/enforces-scrollback-limit against this
+            // throwaway `Buffer`, not `self`) keeps any compressed primary
+            // scrollback blocks correctly in lockstep.
+            blocks: saved.blocks,
+            next_block_id: saved.next_block_id,
+            row_block_map: saved.row_block_map,
+            decompress_scratch: Vec::new(),
         };
 
         let new_offset = tmp.set_size(new_width, new_height, saved.scroll_offset);
@@ -262,6 +270,9 @@ impl Buffer {
             saved_cursor: tmp.saved_cursor,
             image_store: tmp.image_store,
             image_cell_count: tmp.image_cell_count,
+            blocks: tmp.blocks,
+            next_block_id: tmp.next_block_id,
+            row_block_map: tmp.row_block_map,
         }
     }
 
@@ -301,6 +312,15 @@ impl Buffer {
             return;
         }
 
+        // Task 119.4: restore every deep-cold compressed row across the
+        // WHOLE buffer back to real (Task-118 `Compact`) content before the
+        // reflow algorithm below reads any cell. This is deliberately the
+        // slow-but-correct decompress-everything path — the existing
+        // synchronous reflow must keep working correctly with compressed
+        // scrollback present; making this fast (only decompressing the
+        // bands reflow actually needs) is Task 120's job, not this one's.
+        self.ensure_decompressed(0..self.rows.len());
+
         let old_cursor_y = self.cursor.pos.y;
         let old_cursor_x = self.cursor.pos.x;
 
@@ -310,7 +330,9 @@ impl Buffer {
 
         // Note: reflow reads each row's cells exactly once via the flatten
         // loop below (`row.characters()`), which decompacts lazily on that
-        // single read, so no up-front `ensure_live` pass is needed.
+        // single read, so no up-front `ensure_live` pass is needed. Every
+        // row is now guaranteed to be `Live` or Task-118 `Compact` (never
+        // evicted) thanks to the `ensure_decompressed` call above.
 
         // 1) Group rows into logical lines based on RowJoin.
         //    While grouping, identify which logical line contains the cursor
@@ -592,6 +614,12 @@ impl Buffer {
         // All rows are freshly constructed (dirty=true by construction), so
         // the entire cache is invalid.  Reset it to match the new row count.
         self.row_cache = vec![None; self.rows.len()];
+        // Every new row is freshly built `Live` content (never compressed);
+        // the `ensure_decompressed` call at the top of this function already
+        // decompressed everything the old `self.rows` referenced, so
+        // `self.blocks` is empty here — reset `row_block_map` to match the
+        // new row count (Task 119.4).
+        self.row_block_map = vec![None; self.rows.len()];
         self.width = new_width;
         // Reflow rebuilds all rows from scratch; recount image cells so the
         // counter stays accurate regardless of how reflow may have clipped or
@@ -726,6 +754,7 @@ impl Buffer {
                 for _ in 0..grow {
                     self.rows.push(Row::new(self.width));
                     self.row_cache.push(None);
+                    self.row_block_map.push(None);
                 }
             } else {
                 // Primary buffer: the visible window is anchored to the BOTTOM
@@ -801,8 +830,15 @@ impl Buffer {
                             self.rows[..excess].iter().map(Row::count_image_cells).sum();
                         self.image_cell_count -= drained_images;
                     }
+                    // The alternate screen never accumulates scrollback and
+                    // so never compresses anything, but keep
+                    // `row_block_map` index-parallel regardless (Task 119).
+                    // Sync *before* draining `rows` (sync depends on the
+                    // pre-drain `rows.len()`).
+                    self.sync_row_block_map_len();
                     self.rows.drain(0..excess);
                     self.row_cache.drain(0..excess);
+                    self.row_block_map.drain(0..excess);
                     self.adjust_prompt_rows(excess);
                     // Adjust cursor Y for the removed rows.
                     self.cursor.pos.y = self.cursor.pos.y.saturating_sub(excess);
@@ -854,15 +890,20 @@ impl Buffer {
     /// stops at the first non-pristine row from the bottom, so it never touches
     /// BCE-filled rows, content, or scrollback.
     fn reclaim_trailing_blank_padding(&mut self) {
+        // Task 119: heal any lag (see the field doc on `row_block_map`)
+        // before popping it in lockstep with `rows`/`row_cache` below.
+        self.sync_row_block_map_len();
         while self.rows.len() > self.cursor.pos.y + 1 {
             // Safe: loop guard guarantees rows.len() >= 2 here.
             let Some(last) = self.rows.last() else { break };
             if last.origin == RowOrigin::ScrollFill && last.characters().is_empty() {
                 // A pristine ScrollFill row has no cells, so it holds no image
                 // cells; image_cell_count needs no adjustment.  Keep row_cache
-                // length in lockstep with rows.
+                // (and row_block_map — always `None` here, these rows are
+                // never compressed) in lockstep with rows.
                 self.rows.pop();
                 self.row_cache.pop();
+                self.row_block_map.pop();
             } else {
                 break;
             }
@@ -923,8 +964,16 @@ impl Buffer {
         // out all their scrollback, snap them to live view.
         let adjusted_offset = scroll_offset.saturating_sub(overflow);
 
+        // Task 119: heal any lag in `row_block_map` (see its field doc)
+        // before draining it in lockstep with `rows`/`row_cache` below.
+        self.sync_row_block_map_len();
+
         // --- Drop the oldest rows (and their cache entries) ---
         // First, account for any image cells in the rows being drained.
+        // `Row::count_image_cells` already short-circuits for both
+        // Task-118 compact rows and Task-119 evicted (compressed) rows
+        // without decompacting/decompressing, since neither can ever hold
+        // an image cell.
         if self.image_cell_count > 0 {
             let drained_images: usize = self.rows[..overflow]
                 .iter()
@@ -934,6 +983,15 @@ impl Buffer {
         }
         self.rows.drain(0..overflow);
         self.row_cache.drain(0..overflow);
+        // `offset_in_block` is block-relative, not buffer-absolute (see
+        // `BlockRowRef`'s doc), so draining the front of `row_block_map`
+        // needs no index remapping — surviving rows keep referencing the
+        // same block at the same in-block offset.
+        self.row_block_map.drain(0..overflow);
+        // A block whose every row was just drained is now unreferenced;
+        // reclaim it immediately rather than leaking it in `self.blocks`
+        // forever (Task 119.4).
+        self.gc_unreferenced_blocks();
         self.adjust_prompt_rows(overflow);
 
         // --- Garbage-collect images no longer referenced by any row ---
@@ -1074,6 +1132,16 @@ impl Buffer {
         }
 
         // Save primary state (rows + cursor + scroll_offset + cache).
+        // Task 119: also move `blocks`/`row_block_map` over verbatim — the
+        // alternate screen never accumulates scrollback and so never
+        // compresses anything, so it starts (and stays) with an empty
+        // `blocks` map and an all-`None` `row_block_map`.
+        // `next_block_id` is a buffer-wide monotonic counter, not something
+        // that is meaningfully "primary" or "alternate"; it is saved here
+        // purely so `resize_saved_primary`'s reconstructed temporary
+        // `Buffer` has a value to use, not because the alternate screen
+        // ever advances it (it can't: `compress_scrollback_block` always
+        // no-ops there — no scrollback exists to compress).
         let saved = SavedPrimaryState {
             rows: self.rows.clone(),
             row_cache: self.row_cache.clone(),
@@ -1087,6 +1155,9 @@ impl Buffer {
             saved_cursor: self.saved_cursor.clone(),
             image_store: self.image_store.clone(),
             image_cell_count: self.image_cell_count,
+            blocks: std::mem::take(&mut self.blocks),
+            next_block_id: self.next_block_id,
+            row_block_map: std::mem::take(&mut self.row_block_map),
         };
         self.saved_primary = Some(saved);
 
@@ -1096,6 +1167,7 @@ impl Buffer {
         // Fresh screen: exactly `height` empty rows, all dirty (None cache entries).
         self.rows = vec![Row::new(self.width); self.height];
         self.row_cache = vec![None; self.height];
+        self.row_block_map = vec![None; self.height];
 
         // Alternate screen has no images.
         self.image_store.clear();
@@ -1141,6 +1213,9 @@ impl Buffer {
             self.saved_cursor = saved.saved_cursor;
             self.image_store = saved.image_store;
             self.image_cell_count = saved.image_cell_count;
+            self.blocks = saved.blocks;
+            self.next_block_id = saved.next_block_id;
+            self.row_block_map = saved.row_block_map;
 
             self.debug_assert_invariants();
             restored_offset

--- a/freminal-buffer/src/buffer/scroll.rs
+++ b/freminal-buffer/src/buffer/scroll.rs
@@ -635,15 +635,25 @@ impl Buffer {
     pub fn scroll_up(&mut self) {
         // Deduct any image cells in the row about to be removed.
         self.image_cell_count -= self.rows[0].count_image_cells();
+        // Task 119: heal any lag before removing/pushing it in lockstep
+        // with `rows`/`row_cache` below (see `row_block_map`'s field doc).
+        self.sync_row_block_map_len();
         // remove topmost row (and its cache entry)
         self.rows.remove(0);
         self.row_cache.remove(0);
+        self.row_block_map.remove(0);
+        // The removed row may have been the last reference to a compressed
+        // block (this method is a whole-buffer row shift, unlike the
+        // bounded `enforce_scrollback_limit`/`erase_scrollback` drains, but
+        // the same reclaim applies).
+        self.gc_unreferenced_blocks();
 
         // add a new empty row at the bottom (BCE: fill with current SGR background)
         let mut new_row = Row::new(self.width);
         new_row.fill_with_tag(&self.current_tag);
         self.rows.push(new_row);
         self.row_cache.push(None);
+        self.row_block_map.push(None);
 
         // DO NOT move the cursor in alternate buffer
         if self.kind == BufferType::Primary {
@@ -672,8 +682,19 @@ impl Buffer {
                     .sum();
                 self.image_cell_count -= drained_images;
             }
+            // Task 119: heal any lag *before* any of the three parallel
+            // vecs are drained (sync depends on `self.rows.len()`, so it
+            // must run while that still reflects the pre-drain length).
+            self.sync_row_block_map_len();
             self.rows.drain(0..visible_start);
             self.row_cache.drain(0..visible_start);
+            // Every compressed block only ever holds rows from scrollback
+            // (never the visible window), so wiping all of scrollback here
+            // always makes every block fully unreferenced — clear
+            // `self.blocks` outright rather than the general-purpose
+            // (slightly more expensive) `gc_unreferenced_blocks` scan.
+            self.row_block_map.drain(0..visible_start);
+            self.blocks.clear();
             self.adjust_prompt_rows(visible_start);
 
             // Adjust cursor

--- a/freminal-buffer/src/compact_row.rs
+++ b/freminal-buffer/src/compact_row.rs
@@ -21,8 +21,19 @@
 //! wired into the scrollback storage path via [`crate::row::Row`]'s
 //! `RowStorage::Compact` representation and `Buffer::compact_idle_scrollback`.
 
+use std::sync::Arc;
+
 use conv2::ValueFrom;
-use freminal_common::buffer_states::{format_tag::FormatTag, tchar::TChar};
+use freminal_common::{
+    buffer_states::{
+        cursor::{ReverseVideo, StateColors},
+        fonts::{BlinkState, FontDecorationFlags, FontDecorations, FontWeight, UnderlineStyle},
+        format_tag::FormatTag,
+        tchar::TChar,
+        url::Url,
+    },
+    colors::TerminalColor,
+};
 
 use crate::{
     cell::Cell,
@@ -202,6 +213,605 @@ impl CompactRow {
     #[must_use]
     pub const fn stored_cell_count(&self) -> usize {
         self.chars.len()
+    }
+
+    /// Serialize this row to bytes for LZ4 block compression
+    /// ([`crate::compressed_block::CompressedBlock`], Task 119).
+    ///
+    /// Manual little-endian encoding (matching the convention already used
+    /// in `freminal-terminal-emulator/src/recording.rs`) rather than
+    /// pulling in a serde/bincode dependency. See [`CompactRow::from_bytes`]
+    /// for the inverse and the module's test suite for the round-trip
+    /// coverage matrix.
+    ///
+    /// `FormatTag::start`/`FormatTag::end` are deliberately **not**
+    /// serialized. Those fields are flatten-time positional bookkeeping
+    /// (see `FormatTag`'s doc comment: they index into the flat `Vec<TChar>`
+    /// produced by `Buffer::visible_as_tchars_and_tags`) — every `Cell`
+    /// actually stored in a `Row`/`CompactRow` carries a tag derived from
+    /// `TerminalHandler::current_format`, which starts as
+    /// `FormatTag::default()` and is only ever mutated on its visual fields
+    /// (colors, weight, decorations, url, blink) by SGR handling; `start`/
+    /// `end` are never touched there and remain `(0, usize::MAX)` for the
+    /// lifetime of every stored cell. `start`/`end` are populated only in
+    /// the separate, ephemeral `FormatTag`s built by `buffer/flatten.rs`
+    /// from the flat character vector — a different `FormatTag` value that
+    /// never reaches `Cell`/`CompactRow` storage. Confirmed by this
+    /// module's own `assert_round_trip_exact` (used by every round-trip
+    /// test below): it compares full `Cell` equality — which includes the
+    /// full `FormatTag`, `start`/`end` included, via `Cell`'s derived
+    /// `PartialEq` — and passes for every stored tag despite `start`/`end`
+    /// never being serialized, because they are always the defaults on the
+    /// stored side already.
+    #[must_use]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+
+        // Every count below (`chars.len()`, `tag_runs.len()`,
+        // `wide_runs.len()`) is bounded by a single row's column width —
+        // nowhere near `u32::MAX` in practice. Degrade to `u32::MAX` rather
+        // than panicking if it somehow were not, mirroring the
+        // `unwrap_or(0)` convention `expand_runs` already established.
+        let char_count = u32::value_from(self.chars.len()).unwrap_or(u32::MAX);
+        out.extend_from_slice(&char_count.to_le_bytes());
+        for c in &self.chars {
+            encode_tchar(c, &mut out);
+        }
+
+        let tag_run_count = u32::value_from(self.tag_runs.len()).unwrap_or(u32::MAX);
+        out.extend_from_slice(&tag_run_count.to_le_bytes());
+        for (tag, len) in &self.tag_runs {
+            encode_format_tag(tag, &mut out);
+            out.extend_from_slice(&len.to_le_bytes());
+        }
+
+        let wide_run_count = u32::value_from(self.wide_runs.len()).unwrap_or(u32::MAX);
+        out.extend_from_slice(&wide_run_count.to_le_bytes());
+        for (flags, len) in &self.wide_runs {
+            out.push(*flags);
+            out.extend_from_slice(&len.to_le_bytes());
+        }
+
+        let width = u64::value_from(self.width).unwrap_or(u64::MAX);
+        out.extend_from_slice(&width.to_le_bytes());
+        out.push(encode_row_origin(self.origin));
+        out.push(encode_row_join(self.join));
+        out.push(encode_line_width(self.line_width));
+
+        out
+    }
+
+    /// Decode a single `CompactRow` from the start of `bytes`.
+    ///
+    /// Returns the decoded row and the number of bytes consumed from the
+    /// front of `bytes` (so callers decoding several concatenated rows —
+    /// e.g. [`crate::compressed_block::CompressedBlock`] — can slice past
+    /// it and decode the next one), or `None` if `bytes` is
+    /// malformed/truncated. Every field read is bounds-checked; this never
+    /// panics or indexes out of bounds on malformed input.
+    #[must_use]
+    pub fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut pos = 0usize;
+
+        let char_count = usize::value_from(read_u32(bytes, &mut pos)?).unwrap_or(0);
+        let mut chars = Vec::with_capacity(char_count.min(bytes.len()));
+        for _ in 0..char_count {
+            chars.push(decode_tchar(bytes, &mut pos)?);
+        }
+
+        let tag_run_count = usize::value_from(read_u32(bytes, &mut pos)?).unwrap_or(0);
+        let mut tag_runs = Vec::with_capacity(tag_run_count.min(bytes.len()));
+        for _ in 0..tag_run_count {
+            let tag = decode_format_tag(bytes, &mut pos)?;
+            let len = read_u32(bytes, &mut pos)?;
+            tag_runs.push((tag, len));
+        }
+
+        let wide_run_count = usize::value_from(read_u32(bytes, &mut pos)?).unwrap_or(0);
+        let mut wide_runs = Vec::with_capacity(wide_run_count.min(bytes.len()));
+        for _ in 0..wide_run_count {
+            let flags = read_u8(bytes, &mut pos)?;
+            let len = read_u32(bytes, &mut pos)?;
+            wide_runs.push((flags, len));
+        }
+
+        let width = usize::value_from(read_u64(bytes, &mut pos)?).unwrap_or(usize::MAX);
+        let origin = decode_row_origin(read_u8(bytes, &mut pos)?)?;
+        let join = decode_row_join(read_u8(bytes, &mut pos)?)?;
+        let line_width = decode_line_width(read_u8(bytes, &mut pos)?)?;
+
+        Some((
+            Self {
+                chars,
+                tag_runs,
+                wide_runs,
+                width,
+                origin,
+                join,
+                line_width,
+            },
+            pos,
+        ))
+    }
+}
+
+// ===========================================================================
+// Byte-cursor primitives shared by every field encoder/decoder below.
+// ===========================================================================
+
+/// Read a single byte at the cursor, advancing it by one. `None` if `pos` is
+/// at or past the end of `bytes`.
+fn read_u8(bytes: &[u8], pos: &mut usize) -> Option<u8> {
+    let b = *bytes.get(*pos)?;
+    *pos += 1;
+    Some(b)
+}
+
+/// Read `len` bytes at the cursor, advancing it by `len`. `None` if fewer
+/// than `len` bytes remain, or if `pos + len` would overflow `usize`
+/// (guards against a malformed/malicious length field causing an overflow
+/// panic in range indexing).
+fn read_bytes<'a>(bytes: &'a [u8], pos: &mut usize, len: usize) -> Option<&'a [u8]> {
+    let end = pos.checked_add(len)?;
+    let slice = bytes.get(*pos..end)?;
+    *pos = end;
+    Some(slice)
+}
+
+/// Read a little-endian `u32` at the cursor, advancing it by 4.
+fn read_u32(bytes: &[u8], pos: &mut usize) -> Option<u32> {
+    let slice = read_bytes(bytes, pos, 4)?;
+    let arr: [u8; 4] = slice.try_into().ok()?;
+    Some(u32::from_le_bytes(arr))
+}
+
+/// Read a little-endian `u64` at the cursor, advancing it by 8.
+fn read_u64(bytes: &[u8], pos: &mut usize) -> Option<u64> {
+    let slice = read_bytes(bytes, pos, 8)?;
+    let arr: [u8; 8] = slice.try_into().ok()?;
+    Some(u64::from_le_bytes(arr))
+}
+
+// ===========================================================================
+// `TChar` encoding
+// ===========================================================================
+
+/// Byte tags identifying which `TChar` variant follows.
+///
+/// `TChar::Ascii(b' ')` and `TChar::Space` (likewise `Ascii(b'\n')` and
+/// `TChar::NewLine`) are byte-identical via `as_bytes()`, so the variant
+/// must be explicitly tagged rather than inferred from the payload byte —
+/// otherwise decoding would silently normalize an `Ascii` space/newline
+/// into the dedicated `Space`/`NewLine` variant.
+const TCHAR_TAG_ASCII: u8 = 0;
+const TCHAR_TAG_UTF8: u8 = 1;
+const TCHAR_TAG_SPACE: u8 = 2;
+const TCHAR_TAG_NEWLINE: u8 = 3;
+
+fn encode_tchar(value: &TChar, out: &mut Vec<u8>) {
+    match value {
+        TChar::Ascii(b) => {
+            out.push(TCHAR_TAG_ASCII);
+            out.push(*b);
+        }
+        TChar::Utf8(_, _) => {
+            let bytes = value.as_bytes();
+            out.push(TCHAR_TAG_UTF8);
+            // `bytes.len()` is bounded by `TCHAR_MAX_UTF8_LEN` (16), so
+            // `u8::value_from` cannot fail in practice; degrade to an
+            // (unreachable) empty-payload length rather than panicking.
+            let len = u8::value_from(bytes.len()).unwrap_or(0);
+            out.push(len);
+            out.extend_from_slice(bytes);
+        }
+        TChar::Space => out.push(TCHAR_TAG_SPACE),
+        TChar::NewLine => out.push(TCHAR_TAG_NEWLINE),
+    }
+}
+
+fn decode_tchar(bytes: &[u8], pos: &mut usize) -> Option<TChar> {
+    match read_u8(bytes, pos)? {
+        TCHAR_TAG_ASCII => Some(TChar::Ascii(read_u8(bytes, pos)?)),
+        TCHAR_TAG_UTF8 => {
+            let len = usize::from(read_u8(bytes, pos)?);
+            let payload = read_bytes(bytes, pos, len)?;
+            // Reconstruct explicitly via `new_from_many_chars`, never
+            // `new_from_single_char`/`From<char>` — those would alias a
+            // single-byte space/newline payload back to `Space`/`NewLine`
+            // instead of the `Utf8` variant the tag byte says was stored.
+            TChar::new_from_many_chars(payload).ok()
+        }
+        TCHAR_TAG_SPACE => Some(TChar::Space),
+        TCHAR_TAG_NEWLINE => Some(TChar::NewLine),
+        _ => None,
+    }
+}
+
+// ===========================================================================
+// `TerminalColor` encoding
+// ===========================================================================
+
+const COLOR_TAG_DEFAULT: u8 = 0;
+const COLOR_TAG_DEFAULT_BACKGROUND: u8 = 1;
+const COLOR_TAG_DEFAULT_UNDERLINE: u8 = 2;
+const COLOR_TAG_DEFAULT_CURSOR: u8 = 3;
+const COLOR_TAG_BLACK: u8 = 4;
+const COLOR_TAG_RED: u8 = 5;
+const COLOR_TAG_GREEN: u8 = 6;
+const COLOR_TAG_YELLOW: u8 = 7;
+const COLOR_TAG_BLUE: u8 = 8;
+const COLOR_TAG_MAGENTA: u8 = 9;
+const COLOR_TAG_CYAN: u8 = 10;
+const COLOR_TAG_WHITE: u8 = 11;
+const COLOR_TAG_BRIGHT_YELLOW: u8 = 12;
+const COLOR_TAG_BRIGHT_BLACK: u8 = 13;
+const COLOR_TAG_BRIGHT_RED: u8 = 14;
+const COLOR_TAG_BRIGHT_GREEN: u8 = 15;
+const COLOR_TAG_BRIGHT_BLUE: u8 = 16;
+const COLOR_TAG_BRIGHT_MAGENTA: u8 = 17;
+const COLOR_TAG_BRIGHT_CYAN: u8 = 18;
+const COLOR_TAG_BRIGHT_WHITE: u8 = 19;
+const COLOR_TAG_CUSTOM: u8 = 20;
+const COLOR_TAG_PALETTE_INDEX: u8 = 21;
+
+fn encode_terminal_color(color: TerminalColor, out: &mut Vec<u8>) {
+    match color {
+        TerminalColor::Default => out.push(COLOR_TAG_DEFAULT),
+        TerminalColor::DefaultBackground => out.push(COLOR_TAG_DEFAULT_BACKGROUND),
+        TerminalColor::DefaultUnderlineColor => out.push(COLOR_TAG_DEFAULT_UNDERLINE),
+        TerminalColor::DefaultCursorColor => out.push(COLOR_TAG_DEFAULT_CURSOR),
+        TerminalColor::Black => out.push(COLOR_TAG_BLACK),
+        TerminalColor::Red => out.push(COLOR_TAG_RED),
+        TerminalColor::Green => out.push(COLOR_TAG_GREEN),
+        TerminalColor::Yellow => out.push(COLOR_TAG_YELLOW),
+        TerminalColor::Blue => out.push(COLOR_TAG_BLUE),
+        TerminalColor::Magenta => out.push(COLOR_TAG_MAGENTA),
+        TerminalColor::Cyan => out.push(COLOR_TAG_CYAN),
+        TerminalColor::White => out.push(COLOR_TAG_WHITE),
+        TerminalColor::BrightYellow => out.push(COLOR_TAG_BRIGHT_YELLOW),
+        TerminalColor::BrightBlack => out.push(COLOR_TAG_BRIGHT_BLACK),
+        TerminalColor::BrightRed => out.push(COLOR_TAG_BRIGHT_RED),
+        TerminalColor::BrightGreen => out.push(COLOR_TAG_BRIGHT_GREEN),
+        TerminalColor::BrightBlue => out.push(COLOR_TAG_BRIGHT_BLUE),
+        TerminalColor::BrightMagenta => out.push(COLOR_TAG_BRIGHT_MAGENTA),
+        TerminalColor::BrightCyan => out.push(COLOR_TAG_BRIGHT_CYAN),
+        TerminalColor::BrightWhite => out.push(COLOR_TAG_BRIGHT_WHITE),
+        TerminalColor::Custom(r, g, b) => {
+            out.push(COLOR_TAG_CUSTOM);
+            out.push(r);
+            out.push(g);
+            out.push(b);
+        }
+        TerminalColor::PaletteIndex(idx) => {
+            out.push(COLOR_TAG_PALETTE_INDEX);
+            out.push(idx);
+        }
+    }
+}
+
+fn decode_terminal_color(bytes: &[u8], pos: &mut usize) -> Option<TerminalColor> {
+    match read_u8(bytes, pos)? {
+        COLOR_TAG_DEFAULT => Some(TerminalColor::Default),
+        COLOR_TAG_DEFAULT_BACKGROUND => Some(TerminalColor::DefaultBackground),
+        COLOR_TAG_DEFAULT_UNDERLINE => Some(TerminalColor::DefaultUnderlineColor),
+        COLOR_TAG_DEFAULT_CURSOR => Some(TerminalColor::DefaultCursorColor),
+        COLOR_TAG_BLACK => Some(TerminalColor::Black),
+        COLOR_TAG_RED => Some(TerminalColor::Red),
+        COLOR_TAG_GREEN => Some(TerminalColor::Green),
+        COLOR_TAG_YELLOW => Some(TerminalColor::Yellow),
+        COLOR_TAG_BLUE => Some(TerminalColor::Blue),
+        COLOR_TAG_MAGENTA => Some(TerminalColor::Magenta),
+        COLOR_TAG_CYAN => Some(TerminalColor::Cyan),
+        COLOR_TAG_WHITE => Some(TerminalColor::White),
+        COLOR_TAG_BRIGHT_YELLOW => Some(TerminalColor::BrightYellow),
+        COLOR_TAG_BRIGHT_BLACK => Some(TerminalColor::BrightBlack),
+        COLOR_TAG_BRIGHT_RED => Some(TerminalColor::BrightRed),
+        COLOR_TAG_BRIGHT_GREEN => Some(TerminalColor::BrightGreen),
+        COLOR_TAG_BRIGHT_BLUE => Some(TerminalColor::BrightBlue),
+        COLOR_TAG_BRIGHT_MAGENTA => Some(TerminalColor::BrightMagenta),
+        COLOR_TAG_BRIGHT_CYAN => Some(TerminalColor::BrightCyan),
+        COLOR_TAG_BRIGHT_WHITE => Some(TerminalColor::BrightWhite),
+        COLOR_TAG_CUSTOM => {
+            let r = read_u8(bytes, pos)?;
+            let g = read_u8(bytes, pos)?;
+            let b = read_u8(bytes, pos)?;
+            Some(TerminalColor::Custom(r, g, b))
+        }
+        COLOR_TAG_PALETTE_INDEX => Some(TerminalColor::PaletteIndex(read_u8(bytes, pos)?)),
+        _ => None,
+    }
+}
+
+// ===========================================================================
+// `FontDecorationFlags` / `FontWeight` / `ReverseVideo` / `BlinkState` encoding
+// ===========================================================================
+
+const FONT_DECO_ITALIC_BIT: u8 = 0b0000_0001;
+const FONT_DECO_FAINT_BIT: u8 = 0b0000_0010;
+const FONT_DECO_STRIKETHROUGH_BIT: u8 = 0b0000_0100;
+const FONT_DECO_UNDERLINE_SHIFT: u8 = 3;
+
+/// Encode via `FontDecorationFlags`'s public API (`contains`/
+/// `underline_style`) rather than reaching into its private inner `u8` —
+/// that bitfield is a `freminal-common` implementation detail, not a
+/// stable wire format, and the two happen to already look similar only by
+/// coincidence.
+const fn encode_font_decorations(flags: FontDecorationFlags) -> u8 {
+    let mut byte = 0u8;
+    if flags.contains(FontDecorations::Italic) {
+        byte |= FONT_DECO_ITALIC_BIT;
+    }
+    if flags.contains(FontDecorations::Faint) {
+        byte |= FONT_DECO_FAINT_BIT;
+    }
+    if flags.contains(FontDecorations::Strikethrough) {
+        byte |= FONT_DECO_STRIKETHROUGH_BIT;
+    }
+    let underline_bits: u8 = match flags.underline_style() {
+        UnderlineStyle::None => 0,
+        UnderlineStyle::Single => 1,
+        UnderlineStyle::Double => 2,
+        UnderlineStyle::Curly => 3,
+        UnderlineStyle::Dotted => 4,
+        UnderlineStyle::Dashed => 5,
+    };
+    byte | (underline_bits << FONT_DECO_UNDERLINE_SHIFT)
+}
+
+/// Total: any byte value decodes to *some* `FontDecorationFlags` (unknown
+/// underline bit patterns fall back to `UnderlineStyle::None` via
+/// `set_underline_style`), so this never fails.
+const fn decode_font_decorations(byte: u8) -> FontDecorationFlags {
+    let mut flags = FontDecorationFlags::empty();
+    if byte & FONT_DECO_ITALIC_BIT != 0 {
+        flags.insert(FontDecorations::Italic);
+    }
+    if byte & FONT_DECO_FAINT_BIT != 0 {
+        flags.insert(FontDecorations::Faint);
+    }
+    if byte & FONT_DECO_STRIKETHROUGH_BIT != 0 {
+        flags.insert(FontDecorations::Strikethrough);
+    }
+    let underline_bits = byte >> FONT_DECO_UNDERLINE_SHIFT;
+    let style = match underline_bits {
+        1 => UnderlineStyle::Single,
+        2 => UnderlineStyle::Double,
+        3 => UnderlineStyle::Curly,
+        4 => UnderlineStyle::Dotted,
+        5 => UnderlineStyle::Dashed,
+        _ => UnderlineStyle::None,
+    };
+    flags.set_underline_style(style);
+    flags
+}
+
+const fn encode_font_weight(weight: FontWeight) -> u8 {
+    match weight {
+        FontWeight::Normal => 0,
+        FontWeight::Bold => 1,
+    }
+}
+
+const fn decode_font_weight(byte: u8) -> Option<FontWeight> {
+    match byte {
+        0 => Some(FontWeight::Normal),
+        1 => Some(FontWeight::Bold),
+        _ => None,
+    }
+}
+
+const fn encode_reverse_video(reverse_video: ReverseVideo) -> u8 {
+    match reverse_video {
+        ReverseVideo::Off => 0,
+        ReverseVideo::On => 1,
+    }
+}
+
+const fn decode_reverse_video(byte: u8) -> Option<ReverseVideo> {
+    match byte {
+        0 => Some(ReverseVideo::Off),
+        1 => Some(ReverseVideo::On),
+        _ => None,
+    }
+}
+
+const fn encode_blink(state: BlinkState) -> u8 {
+    match state {
+        BlinkState::None => 0,
+        BlinkState::Slow => 1,
+        BlinkState::Fast => 2,
+    }
+}
+
+const fn decode_blink(byte: u8) -> Option<BlinkState> {
+    match byte {
+        0 => Some(BlinkState::None),
+        1 => Some(BlinkState::Slow),
+        2 => Some(BlinkState::Fast),
+        _ => None,
+    }
+}
+
+// ===========================================================================
+// `Url` encoding
+// ===========================================================================
+
+fn encode_string(s: &str, out: &mut Vec<u8>) {
+    let bytes = s.as_bytes();
+    // A hyperlink URL/id is bounded by realistic OSC 8 payload sizes, far
+    // below `u32::MAX`; degrade to a truncated length rather than
+    // panicking if it somehow were not (this would only ever lose the
+    // ability to fully reconstruct a pathological multi-gigabyte URL —
+    // not something a real terminal session produces).
+    let len = u32::value_from(bytes.len()).unwrap_or(u32::MAX);
+    out.extend_from_slice(&len.to_le_bytes());
+    out.extend_from_slice(bytes);
+}
+
+fn decode_string(bytes: &[u8], pos: &mut usize) -> Option<String> {
+    let len = usize::value_from(read_u32(bytes, pos)?).unwrap_or(usize::MAX);
+    let payload = read_bytes(bytes, pos, len)?;
+    String::from_utf8(payload.to_vec()).ok()
+}
+
+fn encode_optional_string(s: Option<&str>, out: &mut Vec<u8>) {
+    match s {
+        None => out.push(0),
+        Some(s) => {
+            out.push(1);
+            encode_string(s, out);
+        }
+    }
+}
+
+fn encode_url(url: Option<&Url>, out: &mut Vec<u8>) {
+    match url {
+        None => out.push(0),
+        Some(u) => {
+            out.push(1);
+            encode_optional_string(u.id.as_deref(), out);
+            encode_string(&u.url, out);
+        }
+    }
+}
+
+// ===========================================================================
+// `FormatTag` encoding
+// ===========================================================================
+
+fn encode_format_tag(tag: &FormatTag, out: &mut Vec<u8>) {
+    // `start`/`end` are deliberately not serialized — see the doc comment
+    // on `CompactRow::to_bytes` for the full evidence trail. That safety
+    // rests on the invariant that every `Cell`-resident `FormatTag` carries
+    // the default `(0, usize::MAX)` range. Assert it in debug builds so a
+    // future change that ever puts a non-default range on a stored cell's
+    // tag fails loudly here rather than silently normalizing it away.
+    debug_assert!(
+        tag.start == 0 && tag.end == usize::MAX,
+        "CompactRow serialization drops FormatTag::start/end; a stored cell \
+         tag with a non-default range ({}, {}) would be silently normalized",
+        tag.start,
+        tag.end,
+    );
+    encode_terminal_color(tag.colors.color, out);
+    encode_terminal_color(tag.colors.background_color, out);
+    encode_terminal_color(tag.colors.underline_color, out);
+    out.push(encode_reverse_video(tag.colors.reverse_video));
+    out.push(encode_font_weight(tag.font_weight));
+    out.push(encode_font_decorations(tag.font_decorations));
+    encode_url(tag.url.as_deref(), out);
+    out.push(encode_blink(tag.blink));
+}
+
+/// Decode the `url: Option<Arc<Url>>` field written by [`encode_url`].
+///
+/// Inlined directly into [`decode_format_tag`] rather than factored into a
+/// standalone `decode_url` helper: the field's own type is already
+/// `Option<Arc<Url>>`, so a helper mirroring the rest of this module's
+/// "`Option<T>`, `None` means malformed" convention would need to return
+/// `Option<Option<Arc<Url>>>` — clippy's `option_option` lint (correctly)
+/// flags that shape. Keeping the presence-byte match inline here means the
+/// single `Option<Arc<Url>>` produced is unambiguous: it *is* the decoded
+/// field value, and a malformed/truncated input instead short-circuits the
+/// enclosing `decode_format_tag` via `return None` before reaching the
+/// point where it would need to be wrapped again.
+fn decode_format_tag(bytes: &[u8], pos: &mut usize) -> Option<FormatTag> {
+    let color = decode_terminal_color(bytes, pos)?;
+    let background_color = decode_terminal_color(bytes, pos)?;
+    let underline_color = decode_terminal_color(bytes, pos)?;
+    let reverse_video = decode_reverse_video(read_u8(bytes, pos)?)?;
+    let font_weight = decode_font_weight(read_u8(bytes, pos)?)?;
+    let font_decorations = decode_font_decorations(read_u8(bytes, pos)?);
+
+    let url = match read_u8(bytes, pos)? {
+        0 => None,
+        1 => {
+            let id = match read_u8(bytes, pos)? {
+                0 => None,
+                1 => Some(decode_string(bytes, pos)?),
+                _ => return None,
+            };
+            let url_string = decode_string(bytes, pos)?;
+            Some(Arc::new(Url {
+                id,
+                url: url_string,
+            }))
+        }
+        _ => return None,
+    };
+
+    let blink = decode_blink(read_u8(bytes, pos)?)?;
+
+    Some(FormatTag {
+        // Reconstructed with the default positional range — see the
+        // doc comment on `CompactRow::to_bytes`.
+        start: 0,
+        end: usize::MAX,
+        colors: StateColors {
+            color,
+            background_color,
+            underline_color,
+            reverse_video,
+        },
+        font_weight,
+        font_decorations,
+        url,
+        blink,
+    })
+}
+
+// ===========================================================================
+// `RowOrigin` / `RowJoin` / `LineWidth` encoding
+// ===========================================================================
+
+const fn encode_row_origin(origin: RowOrigin) -> u8 {
+    match origin {
+        RowOrigin::HardBreak => 0,
+        RowOrigin::SoftWrap => 1,
+        RowOrigin::ScrollFill => 2,
+    }
+}
+
+const fn decode_row_origin(byte: u8) -> Option<RowOrigin> {
+    match byte {
+        0 => Some(RowOrigin::HardBreak),
+        1 => Some(RowOrigin::SoftWrap),
+        2 => Some(RowOrigin::ScrollFill),
+        _ => None,
+    }
+}
+
+const fn encode_row_join(join: RowJoin) -> u8 {
+    match join {
+        RowJoin::NewLogicalLine => 0,
+        RowJoin::ContinueLogicalLine => 1,
+    }
+}
+
+const fn decode_row_join(byte: u8) -> Option<RowJoin> {
+    match byte {
+        0 => Some(RowJoin::NewLogicalLine),
+        1 => Some(RowJoin::ContinueLogicalLine),
+        _ => None,
+    }
+}
+
+const fn encode_line_width(width: LineWidth) -> u8 {
+    match width {
+        LineWidth::Normal => 0,
+        LineWidth::DoubleWidth => 1,
+        LineWidth::DoubleHeightTop => 2,
+        LineWidth::DoubleHeightBottom => 3,
+    }
+}
+
+const fn decode_line_width(byte: u8) -> Option<LineWidth> {
+    match byte {
+        0 => Some(LineWidth::Normal),
+        1 => Some(LineWidth::DoubleWidth),
+        2 => Some(LineWidth::DoubleHeightTop),
+        3 => Some(LineWidth::DoubleHeightBottom),
+        _ => None,
     }
 }
 
@@ -523,5 +1133,339 @@ mod tests {
 
         assert_eq!(usize::try_from(tag_total).unwrap(), compact.chars.len());
         assert_eq!(usize::try_from(wide_total).unwrap(), compact.chars.len());
+    }
+
+    // -----------------------------------------------------------------------
+    // Byte serialization round-trip (`to_bytes`/`from_bytes`, Task 119.3)
+    // -----------------------------------------------------------------------
+
+    /// Round-trip `row` through `CompactRow::to_bytes`/`from_bytes` and
+    /// assert the decoded row is cell-for-cell, metadata-for-metadata
+    /// identical to the original (mirrors `assert_round_trip_exact`, but
+    /// through the byte format rather than the in-memory `CompactRow`).
+    fn assert_byte_round_trip_exact(row: &Row) {
+        let compact = CompactRow::from_row(row).expect("row should be compactable");
+        let bytes = compact.to_bytes();
+        let (decoded, consumed) = CompactRow::from_bytes(&bytes).expect("bytes should decode");
+        assert_eq!(
+            consumed,
+            bytes.len(),
+            "from_bytes must consume every byte to_bytes wrote"
+        );
+
+        let rebuilt = decoded.to_row();
+        assert_eq!(
+            rebuilt.cells(),
+            row.cells(),
+            "cell contents must match exactly"
+        );
+        assert_eq!(rebuilt.max_width(), row.max_width());
+        assert_eq!(rebuilt.origin, row.origin);
+        assert_eq!(rebuilt.join, row.join);
+        assert_eq!(rebuilt.line_width, row.line_width);
+    }
+
+    #[test]
+    fn byte_round_trip_plain_ascii_row() {
+        let row = ascii_row(20, "hello world", &FormatTag::default());
+        assert_byte_round_trip_exact(&row);
+    }
+
+    #[test]
+    fn byte_round_trip_colored_runs() {
+        let mut row = Row::new(10);
+        let default_tag = FormatTag::default();
+        let mut red_tag = FormatTag::default();
+        red_tag.colors.set_color(TerminalColor::Red);
+        let mut custom_tag = FormatTag::default();
+        custom_tag
+            .colors
+            .set_background_color(TerminalColor::Custom(10, 20, 30));
+        let mut palette_tag = FormatTag::default();
+        palette_tag
+            .colors
+            .set_underline_color(TerminalColor::PaletteIndex(200));
+
+        row.insert_text(0, &[TChar::Ascii(b'A'), TChar::Ascii(b'A')], &default_tag);
+        row.insert_text(2, &[TChar::Ascii(b'B'), TChar::Ascii(b'B')], &red_tag);
+        row.insert_text(4, &[TChar::Ascii(b'C'), TChar::Ascii(b'C')], &custom_tag);
+        row.insert_text(6, &[TChar::Ascii(b'D'), TChar::Ascii(b'D')], &palette_tag);
+
+        assert_byte_round_trip_exact(&row);
+    }
+
+    #[test]
+    fn byte_round_trip_all_named_colors() {
+        // Every named `TerminalColor` variant, to exercise every encode/decode tag byte.
+        let colors = [
+            TerminalColor::Default,
+            TerminalColor::DefaultBackground,
+            TerminalColor::DefaultUnderlineColor,
+            TerminalColor::DefaultCursorColor,
+            TerminalColor::Black,
+            TerminalColor::Red,
+            TerminalColor::Green,
+            TerminalColor::Yellow,
+            TerminalColor::Blue,
+            TerminalColor::Magenta,
+            TerminalColor::Cyan,
+            TerminalColor::White,
+            TerminalColor::BrightYellow,
+            TerminalColor::BrightBlack,
+            TerminalColor::BrightRed,
+            TerminalColor::BrightGreen,
+            TerminalColor::BrightBlue,
+            TerminalColor::BrightMagenta,
+            TerminalColor::BrightCyan,
+            TerminalColor::BrightWhite,
+            TerminalColor::Custom(1, 2, 3),
+            TerminalColor::PaletteIndex(42),
+        ];
+
+        let mut row = Row::new(colors.len());
+        for (i, color) in colors.iter().enumerate() {
+            let mut tag = FormatTag::default();
+            tag.colors.set_color(*color);
+            row.insert_text(i, &[TChar::Ascii(b'x')], &tag);
+        }
+
+        assert_byte_round_trip_exact(&row);
+    }
+
+    #[test]
+    fn byte_round_trip_bold_and_each_decoration() {
+        let mut row = Row::new(10);
+
+        let bold_tag = FormatTag {
+            font_weight: FontWeight::Bold,
+            ..FormatTag::default()
+        };
+        row.insert_text(0, &[TChar::Ascii(b'a')], &bold_tag);
+
+        let mut italic_flags = FontDecorationFlags::empty();
+        italic_flags.insert(FontDecorations::Italic);
+        let italic_tag = FormatTag {
+            font_decorations: italic_flags,
+            ..FormatTag::default()
+        };
+        row.insert_text(1, &[TChar::Ascii(b'b')], &italic_tag);
+
+        let mut faint_flags = FontDecorationFlags::empty();
+        faint_flags.insert(FontDecorations::Faint);
+        let faint_tag = FormatTag {
+            font_decorations: faint_flags,
+            ..FormatTag::default()
+        };
+        row.insert_text(2, &[TChar::Ascii(b'c')], &faint_tag);
+
+        let mut strike_flags = FontDecorationFlags::empty();
+        strike_flags.insert(FontDecorations::Strikethrough);
+        let strike_tag = FormatTag {
+            font_decorations: strike_flags,
+            ..FormatTag::default()
+        };
+        row.insert_text(3, &[TChar::Ascii(b'd')], &strike_tag);
+
+        let mut combined_flags = FontDecorationFlags::empty();
+        combined_flags.insert(FontDecorations::Italic);
+        combined_flags.insert(FontDecorations::Faint);
+        combined_flags.insert(FontDecorations::Strikethrough);
+        let combined_tag = FormatTag {
+            font_weight: FontWeight::Bold,
+            font_decorations: combined_flags,
+            blink: BlinkState::Slow,
+            ..FormatTag::default()
+        };
+        row.insert_text(4, &[TChar::Ascii(b'e')], &combined_tag);
+
+        assert_byte_round_trip_exact(&row);
+    }
+
+    #[test]
+    fn byte_round_trip_every_underline_style() {
+        let styles = [
+            UnderlineStyle::None,
+            UnderlineStyle::Single,
+            UnderlineStyle::Double,
+            UnderlineStyle::Curly,
+            UnderlineStyle::Dotted,
+            UnderlineStyle::Dashed,
+        ];
+
+        let mut row = Row::new(styles.len());
+        for (i, style) in styles.iter().enumerate() {
+            let mut flags = FontDecorationFlags::empty();
+            flags.set_underline_style(*style);
+            let tag = FormatTag {
+                font_decorations: flags,
+                ..FormatTag::default()
+            };
+            row.insert_text(i, &[TChar::Ascii(b'u')], &tag);
+        }
+
+        assert_byte_round_trip_exact(&row);
+    }
+
+    #[test]
+    fn byte_round_trip_reverse_video() {
+        let mut row = Row::new(5);
+        let mut tag = FormatTag::default();
+        tag.colors.set_reverse_video(ReverseVideo::On);
+        row.insert_text(0, &[TChar::Ascii(b'r')], &tag);
+        assert_byte_round_trip_exact(&row);
+    }
+
+    #[test]
+    fn byte_round_trip_every_blink_state() {
+        let states = [BlinkState::None, BlinkState::Slow, BlinkState::Fast];
+        let mut row = Row::new(states.len());
+        for (i, state) in states.iter().enumerate() {
+            let tag = FormatTag {
+                blink: *state,
+                ..FormatTag::default()
+            };
+            row.insert_text(i, &[TChar::Ascii(b'b')], &tag);
+        }
+        assert_byte_round_trip_exact(&row);
+    }
+
+    #[test]
+    fn byte_round_trip_wide_char_head_and_continuation() {
+        let mut row = Row::new(10);
+        let tag = FormatTag::default();
+        row.insert_text(0, &[TChar::from('中')], &tag);
+        assert_byte_round_trip_exact(&row);
+    }
+
+    #[test]
+    fn byte_round_trip_orphan_continuation_cell() {
+        let mut row = Row::new(5);
+        row.cells_mut_push(Cell::new(TChar::Ascii(b'a'), FormatTag::default()));
+        row.cells_mut_push(Cell::wide_continuation());
+        row.cells_mut_push(Cell::new(TChar::Ascii(b'b'), FormatTag::default()));
+        assert_byte_round_trip_exact(&row);
+    }
+
+    #[test]
+    fn byte_round_trip_utf8_multibyte_chars() {
+        let mut row = Row::new(10);
+        let tag = FormatTag::default();
+        // Multi-byte non-wide UTF-8 char (accented Latin, 2 bytes).
+        row.insert_text(0, &[TChar::from('é')], &tag);
+        // 3-byte UTF-8, single-width.
+        row.insert_text(1, &[TChar::from('★')], &tag);
+        assert_byte_round_trip_exact(&row);
+    }
+
+    #[test]
+    fn byte_round_trip_blank_sparse_row() {
+        let row = Row::new(80);
+        assert_byte_round_trip_exact(&row);
+    }
+
+    #[test]
+    fn byte_round_trip_url_tag() {
+        let mut row = Row::new(10);
+        let default_tag = FormatTag::default();
+        let url_no_id = Arc::new(Url {
+            id: None,
+            url: "https://example.com".to_string(),
+        });
+        let url_with_id_tag = FormatTag {
+            url: Some(Arc::new(Url {
+                id: Some("link1".to_string()),
+                url: "https://example.org".to_string(),
+            })),
+            ..FormatTag::default()
+        };
+        let url_no_id_tag = FormatTag {
+            url: Some(Arc::clone(&url_no_id)),
+            ..FormatTag::default()
+        };
+
+        row.insert_text(0, &[TChar::Ascii(b'a')], &default_tag);
+        row.insert_text(
+            1,
+            &[TChar::Ascii(b'b'), TChar::Ascii(b'c')],
+            &url_with_id_tag,
+        );
+        row.insert_text(3, &[TChar::Ascii(b'd')], &url_no_id_tag);
+
+        assert_byte_round_trip_exact(&row);
+    }
+
+    #[test]
+    fn byte_round_trip_every_row_origin_join_line_width() {
+        let origins = [
+            RowOrigin::HardBreak,
+            RowOrigin::SoftWrap,
+            RowOrigin::ScrollFill,
+        ];
+        let joins = [RowJoin::NewLogicalLine, RowJoin::ContinueLogicalLine];
+        let line_widths = [
+            LineWidth::Normal,
+            LineWidth::DoubleWidth,
+            LineWidth::DoubleHeightTop,
+            LineWidth::DoubleHeightBottom,
+        ];
+
+        for &origin in &origins {
+            for &join in &joins {
+                for &line_width in &line_widths {
+                    let tag = FormatTag::default();
+                    let cells = vec![Cell::new(TChar::Ascii(b'x'), tag.clone())];
+                    let mut row = Row::from_cells(10, origin, join, cells);
+                    row.line_width = line_width;
+                    assert_byte_round_trip_exact(&row);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn from_bytes_truncated_input_never_panics() {
+        let row = ascii_row(10, "hello", &FormatTag::default());
+        let compact = CompactRow::from_row(&row).unwrap();
+        let bytes = compact.to_bytes();
+
+        // Truncate at every possible prefix length: decoding must either
+        // fail gracefully (`None`) or, if a shorter prefix happens to
+        // still parse, never panic or index out of bounds.
+        for len in 0..bytes.len() {
+            let _ = CompactRow::from_bytes(&bytes[..len]);
+        }
+    }
+
+    #[test]
+    fn from_bytes_empty_input_returns_none() {
+        assert!(CompactRow::from_bytes(&[]).is_none());
+    }
+
+    #[test]
+    fn from_bytes_garbage_input_returns_none_not_panic() {
+        // A huge (bogus) declared char count in the first 4 little-endian
+        // bytes must not panic or attempt an absurd allocation.
+        let garbage = vec![0xFF, 0xFF, 0xFF, 0xFF, 0xAB, 0xCD, 0xEF, 0x01];
+        assert!(CompactRow::from_bytes(&garbage).is_none());
+    }
+
+    #[test]
+    fn from_bytes_invalid_tchar_tag_returns_none() {
+        // char_count = 1, then an invalid TChar tag byte (99).
+        let bytes: Vec<u8> = vec![1, 0, 0, 0, 99];
+        assert!(CompactRow::from_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn from_bytes_invalid_color_tag_returns_none() {
+        // char_count = 1, one Ascii 'x', tag_run_count = 1, then an
+        // invalid `TerminalColor` tag byte (255) for `colors.color`.
+        let mut bytes: Vec<u8> = Vec::new();
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // char_count
+        bytes.push(0); // TCHAR_TAG_ASCII
+        bytes.push(b'x');
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // tag_run_count
+        bytes.push(255); // invalid color tag
+        assert!(CompactRow::from_bytes(&bytes).is_none());
     }
 }

--- a/freminal-buffer/src/compressed_block.rs
+++ b/freminal-buffer/src/compressed_block.rs
@@ -401,6 +401,23 @@ mod tests {
     }
 
     #[test]
+    fn heap_bytes_reports_compressed_buffer_capacity() {
+        let rows = [ascii_row(20, "hello world"), ascii_row(20, "goodbye world")];
+        let compact_rows: Vec<CompactRow> = rows
+            .iter()
+            .map(|r| CompactRow::from_row(r).unwrap())
+            .collect();
+        let block = CompressedBlock::from_rows(&compact_rows);
+
+        // `heap_bytes` reports the compressed payload's allocation *capacity*
+        // (the real resident cost that `Buffer::heap_bytes` sums), so it must
+        // be at least the live byte length and never smaller than
+        // `compressed_bytes()` (which reports `len()`).
+        assert!(block.heap_bytes() >= block.compressed_bytes());
+        assert!(block.compressed_bytes() > 0);
+    }
+
+    #[test]
     fn empty_block_round_trips() {
         let block = CompressedBlock::from_rows(&[]);
         assert_eq!(block.row_count(), 0);

--- a/freminal-buffer/src/compressed_block.rs
+++ b/freminal-buffer/src/compressed_block.rs
@@ -1,0 +1,460 @@
+// Copyright (C) 2024-2026 Fred Clausen
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! LZ4-compressed blocks of [`CompactRow`]s (Task 119 — Scrollback
+//! Compression).
+//!
+//! [`CompactRow`] (Task 118) is the only thing safe to byte-compress —
+//! a raw [`crate::cell::Cell`] holds `Arc`/`Box` pointers that cannot
+//! survive a byte-for-byte round trip. [`CompressedBlock`] serializes a run
+//! of `CompactRow`s (via [`CompactRow::to_bytes`]/[`CompactRow::from_bytes`])
+//! into one contiguous buffer and LZ4-compresses it using `lz4_flex`'s
+//! **block format** (not the frame format — the block API is used because
+//! it needs no extra frame header/checksum bookkeeping and the exact
+//! decompressed length is already known and cheap to store alongside the
+//! block).
+//!
+//! This module is a pure data transform with no knowledge of `Buffer`, the
+//! LRU cache, or the idle-driven compression tick — those are wired in by
+//! later Task 119 subtasks (119.4–119.6). A `CompressedBlock` round-trips
+//! losslessly to the exact `CompactRow`s it was built from (see the
+//! module's test suite), and thence to `Row`/`Cell` via
+//! [`CompactRow::to_row`].
+
+use conv2::ValueFrom;
+
+use crate::compact_row::CompactRow;
+
+/// A single LZ4-compressed block of serialized [`CompactRow`]s.
+///
+/// Construct via [`CompressedBlock::from_rows`] and recover the original
+/// rows via [`CompressedBlock::decompress`] (allocates a fresh scratch
+/// buffer) or [`CompressedBlock::decompress_into`] (reuses a
+/// caller-provided scratch buffer — the allocation-churn-avoiding path a
+/// later subtask wires into the read-on-scroll-into-view path).
+#[derive(Debug, Clone)]
+pub struct CompressedBlock {
+    /// The LZ4 block-format compressed payload.
+    compressed: Vec<u8>,
+    /// Byte length of the pre-compression buffer (the `u32` row-count
+    /// prefix plus every row's [`CompactRow::to_bytes`] output,
+    /// concatenated). `lz4_flex`'s block-format API needs the exact
+    /// decompressed length up front to size its output buffer — unlike
+    /// the frame format, the block format does not self-describe its own
+    /// uncompressed size.
+    decompressed_len: u32,
+    /// Number of rows contained in this block. Stored redundantly
+    /// alongside the row-count prefix baked into the compressed payload
+    /// itself, so callers can read it via [`CompressedBlock::row_count`]
+    /// without paying for a decompress.
+    row_count: u32,
+}
+
+impl CompressedBlock {
+    /// Build a compressed block from a run of `CompactRow`s.
+    ///
+    /// Serializes `rows` (via [`CompactRow::to_bytes`]) into one
+    /// contiguous buffer prefixed with a little-endian `u32` row count,
+    /// then LZ4-compresses that buffer (`lz4_flex::block::compress`).
+    #[must_use]
+    pub fn from_rows(rows: &[CompactRow]) -> Self {
+        // A block spans a bounded number of logical scrollback rows (Task
+        // 119 design: ~128–256, tuned in 119.5) — nowhere near `u32::MAX`.
+        // Degrade to `u32::MAX` rather than panicking if it somehow were
+        // not, mirroring the `unwrap_or` convention already established in
+        // `compact_row.rs`.
+        let row_count = u32::value_from(rows.len()).unwrap_or(u32::MAX);
+
+        let mut plain = Vec::new();
+        plain.extend_from_slice(&row_count.to_le_bytes());
+        for row in rows {
+            plain.extend_from_slice(&row.to_bytes());
+        }
+
+        let decompressed_len = u32::value_from(plain.len()).unwrap_or(u32::MAX);
+        let compressed = lz4_flex::block::compress(&plain);
+
+        Self {
+            compressed,
+            decompressed_len,
+            row_count,
+        }
+    }
+
+    /// Decompress this block back into its original `CompactRow`s,
+    /// allocating a fresh scratch buffer for the decompressed bytes.
+    ///
+    /// Prefer [`CompressedBlock::decompress_into`] when decompressing
+    /// repeatedly (e.g. on every scroll-into-view) to reuse one scratch
+    /// buffer instead of allocating on every call.
+    ///
+    /// Returns `None` if the compressed payload is malformed/corrupt —
+    /// never panics on bad input.
+    #[must_use]
+    pub fn decompress(&self) -> Option<Vec<CompactRow>> {
+        let mut scratch = Vec::new();
+        self.decompress_into(&mut scratch)
+    }
+
+    /// Like [`CompressedBlock::decompress`], but decompresses into
+    /// `scratch` (cleared and resized as needed) instead of allocating a
+    /// fresh buffer on every call. This is the allocation-churn-avoiding
+    /// path a later subtask wires into `Buffer`'s decompress-on-scroll
+    /// path.
+    ///
+    /// Returns `None` if the compressed payload is malformed/corrupt —
+    /// never panics on bad input.
+    #[must_use]
+    pub fn decompress_into(&self, scratch: &mut Vec<u8>) -> Option<Vec<CompactRow>> {
+        // `decompressed_len` was itself derived from a real `Vec<u8>`'s
+        // `len()` in `from_rows`, so this conversion cannot fail in
+        // practice; degrade to `usize::MAX` (which will simply fail the
+        // subsequent `decompress_into` call against a too-small/garbage
+        // buffer) rather than panicking.
+        let len = usize::value_from(self.decompressed_len).unwrap_or(usize::MAX);
+        scratch.clear();
+        scratch.resize(len, 0);
+
+        let written = lz4_flex::block::decompress_into(&self.compressed, scratch).ok()?;
+        if written != len {
+            // A truncated/corrupt block decompressed to fewer bytes than
+            // recorded; the payload cannot be trusted.
+            return None;
+        }
+
+        let count_bytes = scratch.get(..4)?;
+        let count_arr: [u8; 4] = count_bytes.try_into().ok()?;
+        let stored_row_count = u32::from_le_bytes(count_arr);
+        if stored_row_count != self.row_count {
+            // The self-described row count inside the decompressed
+            // payload disagrees with the count recorded alongside the
+            // compressed bytes — the payload has been corrupted.
+            return None;
+        }
+
+        let row_count = usize::value_from(self.row_count).unwrap_or(0);
+        let mut rows = Vec::with_capacity(row_count.min(scratch.len()));
+        let mut offset = 4usize;
+        for _ in 0..row_count {
+            let remaining = scratch.get(offset..)?;
+            let (row, consumed) = CompactRow::from_bytes(remaining)?;
+            rows.push(row);
+            offset = offset.checked_add(consumed)?;
+        }
+
+        Some(rows)
+    }
+
+    /// Number of rows contained in this block.
+    #[must_use]
+    pub fn row_count(&self) -> usize {
+        // `u32 -> usize` is lossless on every platform this crate targets
+        // (desktop, `usize` is at least 32 bits there); see `expand_runs`
+        // in `compact_row.rs` for the same reasoning. Uses the checked
+        // `conv2` conversion (rather than `as`) per the workspace's
+        // numeric-conversion convention, degrading to `usize::MAX` in the
+        // unreachable failure case.
+        usize::value_from(self.row_count).unwrap_or(usize::MAX)
+    }
+
+    /// Compressed size in bytes — the actual heap allocation size
+    /// (`len()`, not `capacity()`) of the LZ4-compressed payload. Useful
+    /// for reporting the ratio achieved over the pre-compression
+    /// (Task-118 flat compact) size.
+    #[must_use]
+    pub const fn compressed_bytes(&self) -> usize {
+        self.compressed.len()
+    }
+
+    /// Heap bytes retained by this block's backing allocation, computed
+    /// from allocation *capacity* (the real resident cost), not `len()`.
+    /// Mirrors the accounting style of [`CompactRow::heap_bytes`] and
+    /// `Buffer::heap_bytes`.
+    #[must_use]
+    pub const fn heap_bytes(&self) -> usize {
+        self.compressed.capacity()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use freminal_common::{
+        buffer_states::{fonts::FontWeight, tchar::TChar},
+        colors::TerminalColor,
+    };
+
+    use crate::row::{LineWidth, Row, RowJoin, RowOrigin};
+
+    use super::*;
+
+    fn ascii_row(width: usize, text: &str) -> Row {
+        let mut row = Row::new(width);
+        let chars: Vec<TChar> = text.bytes().map(TChar::Ascii).collect();
+        row.insert_text(
+            0,
+            &chars,
+            &freminal_common::buffer_states::format_tag::FormatTag::default(),
+        );
+        row
+    }
+
+    /// Round-trip `rows` through a `CompressedBlock` and assert every row
+    /// comes back byte-for-byte identical (compared via the rebuilt `Row`,
+    /// mirroring `compact_row.rs`'s `assert_round_trip_exact`).
+    fn assert_block_round_trip_exact(rows: &[Row]) {
+        let compact_rows: Vec<CompactRow> = rows
+            .iter()
+            .map(|r| CompactRow::from_row(r).expect("row should be compactable"))
+            .collect();
+
+        let block = CompressedBlock::from_rows(&compact_rows);
+        assert_eq!(block.row_count(), rows.len());
+
+        let decompressed = block.decompress().expect("block should decompress");
+        assert_eq!(decompressed.len(), rows.len());
+
+        for (original, decoded) in rows.iter().zip(decompressed.iter()) {
+            let rebuilt = decoded.to_row();
+            assert_eq!(rebuilt.cells(), original.cells());
+            assert_eq!(rebuilt.max_width(), original.max_width());
+            assert_eq!(rebuilt.origin, original.origin);
+            assert_eq!(rebuilt.join, original.join);
+            assert_eq!(rebuilt.line_width, original.line_width);
+        }
+    }
+
+    #[test]
+    fn round_trip_plain_rows() {
+        let rows = vec![
+            ascii_row(20, "hello world"),
+            ascii_row(20, "the quick brown fox"),
+            ascii_row(20, "jumps over the lazy dog"),
+        ];
+        assert_block_round_trip_exact(&rows);
+    }
+
+    #[test]
+    fn round_trip_colored_runs() {
+        let mut row_a = Row::new(10);
+        let mut red_tag = freminal_common::buffer_states::format_tag::FormatTag::default();
+        red_tag.colors.set_color(TerminalColor::Red);
+        row_a.insert_text(0, &[TChar::Ascii(b'a'), TChar::Ascii(b'b')], &red_tag);
+
+        let mut row_b = Row::new(10);
+        let bold_tag = freminal_common::buffer_states::format_tag::FormatTag {
+            font_weight: FontWeight::Bold,
+            ..freminal_common::buffer_states::format_tag::FormatTag::default()
+        };
+        row_b.insert_text(0, &[TChar::Ascii(b'c'), TChar::Ascii(b'd')], &bold_tag);
+
+        assert_block_round_trip_exact(&[row_a, row_b]);
+    }
+
+    #[test]
+    fn round_trip_wide_chars() {
+        let mut row = Row::new(10);
+        let tag = freminal_common::buffer_states::format_tag::FormatTag::default();
+        row.insert_text(0, &[TChar::from('中'), TChar::from('文')], &tag);
+        assert_block_round_trip_exact(&[row]);
+    }
+
+    #[test]
+    fn round_trip_url_tags() {
+        use std::sync::Arc;
+
+        let mut row = Row::new(10);
+        let url_tag = freminal_common::buffer_states::format_tag::FormatTag {
+            url: Some(Arc::new(freminal_common::buffer_states::url::Url {
+                id: Some("id1".to_string()),
+                url: "https://example.com".to_string(),
+            })),
+            ..freminal_common::buffer_states::format_tag::FormatTag::default()
+        };
+        row.insert_text(0, &[TChar::Ascii(b'a'), TChar::Ascii(b'b')], &url_tag);
+        assert_block_round_trip_exact(&[row]);
+    }
+
+    #[test]
+    fn round_trip_blank_and_sparse_rows() {
+        let rows = vec![Row::new(80), Row::new(80), ascii_row(80, "x")];
+        assert_block_round_trip_exact(&rows);
+    }
+
+    #[test]
+    fn round_trip_block_boundary_many_rows() {
+        // A representative block-sized run (256 logical scrollback rows,
+        // per the Task 119 design decision of ~128–256 rows/block),
+        // asserting every row survives the round trip.
+        let rows: Vec<Row> = (0..256)
+            .map(|i| ascii_row(80, &format!("scrollback line number {i}")))
+            .collect();
+        assert_block_round_trip_exact(&rows);
+    }
+
+    #[test]
+    fn round_trip_high_entropy_block() {
+        // Pseudo-random-looking content (varied colors, varied text, no
+        // shared structure) — the pessimistic "high-entropy colored"
+        // bracket from the Task 119 feasibility spike. Still must
+        // round-trip exactly even though the compression ratio is worse.
+        let mut rows = Vec::new();
+        let mut seed: u32 = 0x1234_5678;
+        for i in 0..64 {
+            let mut row = Row::new(40);
+            for col in 0..40 {
+                seed = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                let byte = u8::try_from(32 + (seed >> 24) % 95).unwrap();
+                let mut tag = freminal_common::buffer_states::format_tag::FormatTag::default();
+                tag.colors.set_color(TerminalColor::Custom(
+                    u8::try_from((seed >> 16) & 0xFF).unwrap(),
+                    u8::try_from((seed >> 8) & 0xFF).unwrap(),
+                    u8::try_from(seed & 0xFF).unwrap(),
+                ));
+                row.insert_text(col, &[TChar::Ascii(byte)], &tag);
+            }
+            rows.push(row);
+            let _ = i;
+        }
+        assert_block_round_trip_exact(&rows);
+    }
+
+    #[test]
+    fn round_trip_every_line_width_and_origin() {
+        let mut rows = Vec::new();
+        for origin in [
+            RowOrigin::HardBreak,
+            RowOrigin::SoftWrap,
+            RowOrigin::ScrollFill,
+        ] {
+            for line_width in [
+                LineWidth::Normal,
+                LineWidth::DoubleWidth,
+                LineWidth::DoubleHeightTop,
+                LineWidth::DoubleHeightBottom,
+            ] {
+                let tag = freminal_common::buffer_states::format_tag::FormatTag::default();
+                let cells = vec![crate::cell::Cell::new(TChar::Ascii(b'x'), tag)];
+                let mut row = Row::from_cells(10, origin, RowJoin::NewLogicalLine, cells);
+                row.line_width = line_width;
+                rows.push(row);
+            }
+        }
+        assert_block_round_trip_exact(&rows);
+    }
+
+    #[test]
+    fn compressed_bytes_smaller_than_sum_of_compact_row_heap_bytes_for_compressible_block() {
+        // A representative compressible block: many rows sharing the same
+        // uniform (non-default) formatting and repetitive text — the
+        // "shell session (typical)" bracket from the Task 119 feasibility
+        // spike, where compression on top of the Task-118 flat form is
+        // expected to help substantially.
+        let mut tag = freminal_common::buffer_states::format_tag::FormatTag::default();
+        tag.colors.set_color(TerminalColor::Green);
+
+        let compact_rows: Vec<CompactRow> = (0..200)
+            .map(|_| {
+                let mut row = Row::new(120);
+                let text = "the quick brown fox jumps over the lazy dog ".repeat(2);
+                let chars: Vec<TChar> = text.bytes().map(TChar::Ascii).collect();
+                row.insert_text(0, &chars, &tag);
+                CompactRow::from_row(&row).expect("row should be compactable")
+            })
+            .collect();
+
+        let sum_compact_heap_bytes: usize = compact_rows.iter().map(CompactRow::heap_bytes).sum();
+
+        let block = CompressedBlock::from_rows(&compact_rows);
+
+        assert!(
+            block.compressed_bytes() < sum_compact_heap_bytes,
+            "compressed size ({}) should be smaller than the sum of the rows' \
+             CompactRow heap bytes ({})",
+            block.compressed_bytes(),
+            sum_compact_heap_bytes
+        );
+    }
+
+    #[test]
+    fn decompress_into_reuses_scratch_buffer() {
+        let rows = [ascii_row(20, "hello world"), ascii_row(20, "goodbye world")];
+        let compact_rows: Vec<CompactRow> = rows
+            .iter()
+            .map(|r| CompactRow::from_row(r).unwrap())
+            .collect();
+        let block = CompressedBlock::from_rows(&compact_rows);
+
+        let mut scratch = Vec::new();
+        let first = block.decompress_into(&mut scratch).unwrap();
+        assert_eq!(first.len(), 2);
+
+        // Reuse the same scratch buffer for a second decompress call —
+        // must still decode correctly (scratch is cleared/resized inside
+        // `decompress_into`, not assumed empty on entry).
+        scratch.extend_from_slice(&[0xAA; 64]); // pollute the buffer
+        let second = block.decompress_into(&mut scratch).unwrap();
+        assert_eq!(second.len(), 2);
+        assert_eq!(second[0].to_row().cells(), first[0].to_row().cells());
+    }
+
+    #[test]
+    fn empty_block_round_trips() {
+        let block = CompressedBlock::from_rows(&[]);
+        assert_eq!(block.row_count(), 0);
+        let decompressed = block.decompress().unwrap();
+        assert!(decompressed.is_empty());
+    }
+
+    #[test]
+    fn malformed_compressed_bytes_returns_none_not_panic() {
+        let rows = [ascii_row(20, "hello world")];
+        let compact_rows: Vec<CompactRow> = rows
+            .iter()
+            .map(|r| CompactRow::from_row(r).unwrap())
+            .collect();
+        let mut block = CompressedBlock::from_rows(&compact_rows);
+
+        // Corrupt the compressed payload in place.
+        for byte in &mut block.compressed {
+            *byte ^= 0xFF;
+        }
+
+        assert!(block.decompress().is_none());
+    }
+
+    #[test]
+    fn truncated_compressed_bytes_returns_none_not_panic() {
+        let rows: Vec<Row> = (0..8).map(|i| ascii_row(40, &format!("row {i}"))).collect();
+        let compact_rows: Vec<CompactRow> = rows
+            .iter()
+            .map(|r| CompactRow::from_row(r).unwrap())
+            .collect();
+        let mut block = CompressedBlock::from_rows(&compact_rows);
+
+        block.compressed.truncate(block.compressed.len() / 2);
+
+        // Must not panic; either decodes to something wrong-but-safe or
+        // returns `None`. We only assert it never panics — the call
+        // itself completing is the assertion.
+        let _ = block.decompress();
+    }
+
+    #[test]
+    fn row_count_mismatch_after_corruption_returns_none() {
+        // Build a block, then hand-construct a `CompressedBlock` whose
+        // recorded `row_count` disagrees with what's actually baked into
+        // the compressed payload, to exercise the consistency check.
+        let rows = [ascii_row(20, "hello"), ascii_row(20, "world")];
+        let compact_rows: Vec<CompactRow> = rows
+            .iter()
+            .map(|r| CompactRow::from_row(r).unwrap())
+            .collect();
+        let mut block = CompressedBlock::from_rows(&compact_rows);
+        block.row_count = 99; // now disagrees with the baked-in prefix
+
+        assert!(block.decompress().is_none());
+    }
+}

--- a/freminal-buffer/src/lib.rs
+++ b/freminal-buffer/src/lib.rs
@@ -45,6 +45,7 @@
 pub mod buffer;
 pub mod cell;
 pub mod compact_row;
+pub mod compressed_block;
 pub mod image_store;
 pub mod response;
 pub mod row;

--- a/freminal-buffer/src/row.rs
+++ b/freminal-buffer/src/row.rs
@@ -133,6 +133,26 @@ pub struct Row {
     /// current cursor row.  This is a rendering attribute only — the renderer
     /// uses it to apply per-row glyph scaling in the vertex builder.
     pub line_width: LineWidth,
+    /// Diagnostic marker (Task 119 — Scrollback Compression): `true` when
+    /// this row's real content has been moved out into a
+    /// [`crate::compressed_block::CompressedBlock`] by
+    /// `Buffer::compress_scrollback_block`, leaving `storage` as an inert
+    /// blank placeholder (always [`RowStorage::Live`] with an empty
+    /// `Vec<Cell>`) that preserves `width`/`origin`/`join`/`line_width` but
+    /// carries no real cell data.
+    ///
+    /// This is deliberately **not** a third [`RowStorage`] variant: `Row`
+    /// itself has no access to `Buffer`'s block store, so it cannot
+    /// self-decompress. The flag exists purely so the read-only accessors
+    /// (`cells()`/`characters()`/`cells_mut()`, via [`Row::cells_ref`] /
+    /// [`Row::cells_vec_mut`]) `debug_assert!` on an accidental direct read
+    /// instead of silently returning blank content — the caller must go
+    /// through `Buffer::ensure_decompressed` first. See
+    /// [`Row::cells_for_image_scan`] for the one accessor that
+    /// deliberately does **not** assert (evicted rows, like compact rows,
+    /// are guaranteed to hold zero images, so whole-buffer image-scan
+    /// passes may safely see an empty slice for them without restoring).
+    evicted_to_block: bool,
 }
 
 impl Row {
@@ -146,6 +166,7 @@ impl Row {
             join: RowJoin::NewLogicalLine,
             dirty: true,
             line_width: LineWidth::Normal,
+            evicted_to_block: false,
         }
     }
 
@@ -159,6 +180,7 @@ impl Row {
             join,
             dirty: true,
             line_width: LineWidth::Normal,
+            evicted_to_block: false,
         }
     }
 
@@ -180,6 +202,7 @@ impl Row {
             join,
             dirty: true,
             line_width: LineWidth::Normal,
+            evicted_to_block: false,
         }
     }
 
@@ -197,6 +220,11 @@ impl Row {
     /// funnels through this (directly, or via [`Row::ensure_live`] /
     /// [`Row::cells_mut`]).
     fn cells_vec_mut(&mut self) -> &mut Vec<Cell> {
+        debug_assert!(
+            !self.evicted_to_block,
+            "mutable read of a row whose content is evicted to a compressed block; \
+             call Buffer::ensure_decompressed first"
+        );
         if let RowStorage::Compact {
             compact,
             decompacted,
@@ -225,6 +253,11 @@ impl Row {
     /// first read. This does not change [`Row::is_compact`]'s answer, and
     /// does not touch `dirty`/`origin`/`join`/`line_width`.
     fn cells_ref(&self) -> &Vec<Cell> {
+        debug_assert!(
+            !self.evicted_to_block,
+            "read of a row whose content is evicted to a compressed block; \
+             call Buffer::ensure_decompressed first"
+        );
         match &self.storage {
             RowStorage::Live(cells) => cells,
             RowStorage::Compact {
@@ -283,6 +316,84 @@ impl Row {
             decompacted: OnceCell::new(),
         };
         true
+    }
+
+    /// Returns `true` if this row's content currently lives only inside a
+    /// [`crate::compressed_block::CompressedBlock`] (Task 119 — Scrollback
+    /// Compression), leaving `storage` as an inert blank placeholder.
+    ///
+    /// See the [`Row::evicted_to_block`](Row) field doc for the full
+    /// rationale. Mirrors [`Row::is_compact`]'s "storage representation,
+    /// not whether data has been read" contract.
+    #[must_use]
+    pub const fn is_evicted(&self) -> bool {
+        self.evicted_to_block
+    }
+
+    /// Borrow this row's [`CompactRow`] **without** decompacting it, or
+    /// `None` if the row is not currently [`Row::is_compact`].
+    ///
+    /// Used by `Buffer::compress_scrollback_block` to read a compact
+    /// scrollback row's already-run-length-encoded content directly, so
+    /// building a [`crate::compressed_block::CompressedBlock`] never has to
+    /// materialize a full `Vec<Cell>` just to immediately re-encode it.
+    #[must_use]
+    pub(crate) const fn as_compact(&self) -> Option<&CompactRow> {
+        match &self.storage {
+            RowStorage::Compact { compact, .. } => Some(compact),
+            RowStorage::Live(_) => None,
+        }
+    }
+
+    /// Move this row's content out to a compressed block (Task 119 —
+    /// Scrollback Compression), replacing `storage` with an inert blank
+    /// placeholder and setting [`Row::is_evicted`].
+    ///
+    /// Only ever called by `Buffer::compress_scrollback_block` on a row that
+    /// is already [`Row::is_compact`] (never mutated in place — the caller
+    /// has already copied the row's [`CompactRow`] into the new
+    /// [`crate::compressed_block::CompressedBlock`] before calling this).
+    /// `width`/`origin`/`join`/`line_width`/`dirty` are left untouched: they
+    /// are ordinary `Row` fields, not part of `storage`, and remain exactly
+    /// correct for the eventual restore via [`Row::restore_from_compact`].
+    pub(crate) fn evict_to_block(&mut self) {
+        self.storage = RowStorage::Live(Vec::new());
+        self.evicted_to_block = true;
+    }
+
+    /// Restore this row's content from a decompressed [`CompactRow`] after
+    /// `Buffer::ensure_decompressed` has decompressed the block it was
+    /// evicted to, clearing [`Row::is_evicted`].
+    ///
+    /// Restores directly to [`Row::is_compact`] storage (not fully `Live`)
+    /// to preserve the Task-118 memory win: `width`/`origin`/`join`/
+    /// `line_width` are left as-is (they were never touched by
+    /// [`Row::evict_to_block`], so they are already correct) rather than
+    /// re-derived from `compact`, avoiding a full decompaction just to read
+    /// four already-known scalar fields.
+    pub(crate) fn restore_from_compact(&mut self, compact: CompactRow) {
+        self.storage = RowStorage::Compact {
+            compact,
+            decompacted: OnceCell::new(),
+        };
+        self.evicted_to_block = false;
+    }
+
+    /// Best-effort recovery from a corrupt/unreadable compressed block
+    /// (`CompressedBlock::decompress_into` returned `None`, or the block's
+    /// row count disagreed with `Buffer::row_block_map` — both should be
+    /// impossible per `CompressedBlock`'s own internal consistency checks).
+    ///
+    /// Clears [`Row::is_evicted`] without restoring any real content,
+    /// leaving the row as a permanently blank (but no-longer-flagged) `Live`
+    /// row. This deliberately favors "wrong but readable" over "correct
+    /// content lost forever behind an assert that fires on every future
+    /// read": per the Task 119 design decision "correctness over ratio,"
+    /// silently returning blank content for one corrupted row is the lesser
+    /// failure compared to a debug-build panic (or a permanently
+    /// unreadable row) every time that row is next touched.
+    pub(crate) const fn abandon_eviction(&mut self) {
+        self.evicted_to_block = false;
     }
 
     /// Release the memoized decompaction cache of a `Compact` row, freeing
@@ -374,8 +485,13 @@ impl Row {
     pub fn count_image_cells(&self) -> usize {
         // A compact row is guaranteed to contain zero image cells (image
         // rows opt out of compaction — see `CompactRow::from_row`), so this
-        // returns 0 immediately without triggering a decompaction.
-        if self.is_compact() {
+        // returns 0 immediately without triggering a decompaction. A row
+        // evicted to a compressed block (Task 119) is compacted first, so
+        // the same guarantee applies — and short-circuiting here (before
+        // `cells_ref`'s debug_assert) is what lets whole-buffer sweeps like
+        // `enforce_scrollback_limit`'s image accounting run safely over
+        // evicted rows without calling `Buffer::ensure_decompressed` first.
+        if self.is_compact() || self.evicted_to_block {
             return 0;
         }
         self.cells_ref().iter().filter(|c| c.has_image()).count()
@@ -386,9 +502,10 @@ impl Row {
     /// Columns beyond the stored cell count are treated as blank (no image).
     #[must_use]
     pub fn count_image_cells_in_range(&self, from: usize, to: usize) -> usize {
-        // See `count_image_cells`: a compact row can never contain an image
-        // cell, so this short-circuits without decompacting.
-        if self.is_compact() {
+        // See `count_image_cells`: a compact OR evicted row can never
+        // contain an image cell, so this short-circuits without
+        // decompacting (and without tripping `cells_ref`'s debug_assert).
+        if self.is_compact() || self.evicted_to_block {
             return 0;
         }
         let cells = self.cells_ref();
@@ -527,9 +644,16 @@ impl Row {
     /// compacted scrollback row's real cells for images would otherwise
     /// defeat its own memory savings the moment any image exists anywhere
     /// in the buffer.
+    ///
+    /// A row evicted to a compressed block (Task 119,
+    /// [`Row::is_evicted`]) is always compacted first, so the same
+    /// zero-images guarantee holds; this is also why this accessor
+    /// deliberately does **not** carry `cells_ref`'s `debug_assert` — an
+    /// evicted row legitimately reads as empty here (matching a compact
+    /// row) rather than requiring `Buffer::ensure_decompressed` first.
     #[must_use]
     pub fn cells_for_image_scan(&self) -> &[Cell] {
-        if self.is_compact() {
+        if self.is_compact() || self.evicted_to_block {
             &[]
         } else {
             self.cells_ref()

--- a/freminal/Cargo.toml
+++ b/freminal/Cargo.toml
@@ -69,7 +69,7 @@ deb_depends = [
 # `cargo xtask bump-version` keeps this in sync, translating the SemVer
 # pre-release separator to the RPM tilde operator (e.g. "0.9.0~beta.2"), which
 # sorts older than the final release just like the SemVer pre-release does.
-version = "0.12.0~beta.2"
+version = "0.12.0~beta.3"
 assets = [
   { source = "target/release/freminal", dest = "/usr/bin/freminal", mode = "755" },
   # Ship the desktop entry (carrying StartupWMClass=freminal, which matches the

--- a/freminal/src/gui/pty.rs
+++ b/freminal/src/gui/pty.rs
@@ -418,13 +418,16 @@ fn spawn_pty_consumer_thread(
     if let Err(e) = std::thread::Builder::new()
         .name(thread_name)
         .spawn(move || {
-            // Idle-driven scrollback compaction (Task 118.9b): the only place
-            // `compact_idle_scrollback` is ever called from. Fires ~100ms
-            // after the last PTY read or GUI input event and compacts a
-            // bounded budget of not-yet-compacted scrollback rows, re-arming
-            // itself while work remains and disarming (via `never()`) once
-            // the terminal is fully caught up so a quiescent pane is not
-            // woken forever.
+            // Idle-driven scrollback compaction (Task 118.9b) and compression
+            // (Task 119.5): the only place `compact_idle_scrollback` and
+            // `compress_idle_scrollback` are ever called from. Fires ~100ms
+            // after the last PTY read or GUI input event, compacts a bounded
+            // budget of not-yet-compacted scrollback rows, then — once
+            // compaction reports nothing left to do this tick — compresses a
+            // bounded budget of now-cold compact rows into LZ4 blocks.
+            // Re-arms itself while either has work remaining and disarms
+            // (via `never()`) once the terminal is fully caught up on both,
+            // so a quiescent pane is not woken forever.
             //
             // The interval serves double duty: it is both the idle-detection
             // delay (time since last activity before the first slice runs) and
@@ -444,6 +447,11 @@ fn spawn_pty_consumer_thread(
             const IDLE_COMPACTION_INTERVAL: std::time::Duration =
                 std::time::Duration::from_millis(100);
             const IDLE_COMPACTION_BUDGET: usize = 512;
+            // Compression is heavier per row than compaction (LZ4 over a
+            // whole block, versus an in-place RLE conversion), so it gets a
+            // smaller row budget per idle tick. Tuned alongside block size
+            // in Task 119.6.
+            const IDLE_COMPRESSION_BUDGET: usize = 256;
 
             let mut emulator = terminal;
 
@@ -593,16 +601,19 @@ fn spawn_pty_consumer_thread(
             let mut idle_deadline: crossbeam_channel::Receiver<std::time::Instant> =
                 crossbeam_channel::after(IDLE_COMPACTION_INTERVAL);
 
-            // Tracks whether any scrollback rows were compacted since the last
-            // time we released freed heap back to the OS. Compaction frees a
-            // large amount of small allocations (`Vec<Cell>` / `RowCacheEntry`);
-            // the system allocator (glibc) retains those pages in its arenas
-            // rather than returning them, so RSS stays high until we explicitly
-            // trim. We trim only once, when the backlog has fully drained
-            // (`compacted == 0`) AND real work happened since the last trim —
-            // never mid-drain (the pages would just be re-faulted by the next
-            // slice) and never on a trivial re-arm that compacted nothing.
-            let mut compaction_since_trim = false;
+            // Tracks whether any scrollback rows were compacted or compressed
+            // since the last time we released freed heap back to the OS.
+            // Compaction frees a large amount of small allocations
+            // (`Vec<Cell>` / `RowCacheEntry`); compression additionally frees
+            // a `CompactRow`'s bytes into an LZ4 block. Either way, the
+            // system allocator (glibc) retains those pages in its arenas
+            // rather than returning them, so RSS stays high until we
+            // explicitly trim. We trim only once, when both are fully
+            // drained (`compacted == 0 && compressed == 0`) AND real work
+            // happened since the last trim — never mid-drain (the pages
+            // would just be re-faulted by the next slice) and never on a
+            // trivial re-arm that did nothing.
+            let mut work_since_trim = false;
 
             // Primary loop: service PTY reads, GUI input events, child-exit
             // signals, and the idle scrollback-compaction tick.
@@ -661,32 +672,43 @@ fn spawn_pty_consumer_thread(
                     }
                     recv(idle_deadline) -> _ => {
                         // Snapshot content is byte-identical after compaction
-                        // (it only changes the internal storage
-                        // representation), so this arm must never call
-                        // `post_event` — doing so would be a spurious GUI
-                        // wake and defeat the idle/battery goal. `continue`
-                        // skips the trailing `post_event` call below.
-                        let compacted = emulator
-                            .internal
-                            .handler
-                            .buffer_mut()
-                            .compact_idle_scrollback(IDLE_COMPACTION_BUDGET);
-                        if compacted > 0 {
+                        // or compression (both only change the internal
+                        // storage representation), so this arm must never
+                        // call `post_event` — doing so would be a spurious
+                        // GUI wake and defeat the idle/battery goal.
+                        // `continue` skips the trailing `post_event` call
+                        // below.
+                        //
+                        // Compact first, compress second: a row must be
+                        // Task-118-compacted before it is a Task-119
+                        // compression candidate, so only spend the
+                        // compression budget once this tick's compaction
+                        // pass reports nothing left to compact — otherwise
+                        // compression would scan a scrollback full of `Live`
+                        // rows and correctly find nothing, wasting the tick.
+                        let buffer = emulator.internal.handler.buffer_mut();
+                        let compacted = buffer.compact_idle_scrollback(IDLE_COMPACTION_BUDGET);
+                        let compressed = if compacted == 0 {
+                            buffer.compress_idle_scrollback(IDLE_COMPRESSION_BUDGET)
+                        } else {
+                            0
+                        };
+                        if compacted > 0 || compressed > 0 {
                             // More may remain — keep draining on the next tick.
-                            compaction_since_trim = true;
+                            work_since_trim = true;
                             idle_deadline = crossbeam_channel::after(IDLE_COMPACTION_INTERVAL);
                         } else {
-                            // Backlog fully drained. If we actually compacted
-                            // anything since the last trim, release the freed
+                            // Both backlogs fully drained. If we actually did
+                            // work since the last trim, release the freed
                             // pages back to the OS now: the transient
                             // allocation churn is over, so the freed heap is
                             // stable and worth returning. Doing this once per
                             // settle (rather than per slice) avoids repeatedly
                             // munmap-ing pages the allocator would re-fault
                             // during an ongoing drain. See `release_freed_heap`.
-                            if compaction_since_trim {
+                            if work_since_trim {
                                 release_freed_heap();
-                                compaction_since_trim = false;
+                                work_since_trim = false;
                             }
                             idle_deadline = crossbeam_channel::never();
                         }

--- a/freminal/src/gui/pty.rs
+++ b/freminal/src/gui/pty.rs
@@ -431,27 +431,51 @@ fn spawn_pty_consumer_thread(
             //
             // The interval serves double duty: it is both the idle-detection
             // delay (time since last activity before the first slice runs) and
-            // the inter-slice delay (gap between successive bounded compaction
-            // slices while a backlog drains). At 512 rows / 100ms that is
-            // ~5k rows/sec, so a freshly-dumped very large scrollback (e.g.
-            // 100k lines) takes on the order of ~20s to fully compact in the
-            // background — correct and never blocking, but a slow trickle for
-            // pathological dumps.
+            // the inter-slice delay (gap between successive bounded slices
+            // while a backlog drains). At 1024 compaction rows / 100ms that is
+            // ~10k rows/sec, so a freshly-dumped very large scrollback (e.g.
+            // 100k lines) fully compacts-then-compresses in ~25s of background
+            // idle time (see the compaction-then-compression sequencing in the
+            // idle arm below) — correct and never blocking; a middle ground
+            // between the original 512-row (~40s) trickle and an aggressive
+            // 4096-row budget (~2.5s but a much larger per-tick burst).
             //
-            // TODO(Task 118 follow-up): revisit and make compaction pacing
-            // DYNAMIC based on the number of uncompacted rows outstanding —
-            // e.g. a larger budget and/or shorter inter-slice interval when the
-            // backlog is large, decaying back to this gentle cadence as it
-            // drains. The current fixed 512/100ms is deliberately simple; a
-            // huge dump should probably drain faster than ~20s.
+            // TODO(Task 118 follow-up): compaction pacing could be made DYNAMIC
+            // (larger budget / shorter interval while a large backlog exists,
+            // decaying to a gentle cadence once caught up). That is the right
+            // way to get fast catch-up without a large fixed per-tick burst on
+            // modest hardware; the current fixed budgets are the
+            // deliberately-simple stopgap.
             const IDLE_COMPACTION_INTERVAL: std::time::Duration =
                 std::time::Duration::from_millis(100);
-            const IDLE_COMPACTION_BUDGET: usize = 512;
-            // Compression is heavier per row than compaction (LZ4 over a
-            // whole block, versus an in-place RLE conversion), so it gets a
-            // smaller row budget per idle tick. Tuned alongside block size
-            // in Task 119.6.
-            const IDLE_COMPRESSION_BUDGET: usize = 256;
+            // Compaction is an in-place RLE Live->Compact conversion. Measured
+            // via `bench_idle_compaction_tick`
+            // (`freminal-buffer/benches/buffer_row_bench.rs`) at ~9.8ms per
+            // 4096 rows on the dev machine, i.e. ~2.4ms per 1024 rows. At this
+            // 1024 budget that is a ~2.4ms slice per 100ms tick here during a
+            // catch-up burst; even on a CPU ~5x slower (~12ms) it stays far
+            // under the 100ms interval and leaves the core idle most of the
+            // time, so a full-scrollback catch-up never stalls the PTY tick
+            // loop or pegs a core. Kept modest (1024, up from Task 118's 512)
+            // rather than aggressive (4096) precisely so the per-tick burst
+            // stays small on weak hardware; the price is a slower background
+            // catch-up on a pathological all-at-once dump, invisible in normal
+            // incremental use.
+            const IDLE_COMPACTION_BUDGET: usize = 1024;
+            // Compression is a separate idle pass (LZ4 over BLOCK_SIZE-row
+            // blocks of already-compacted rows), run only once compaction has
+            // caught up for the tick. One full budget's worth (4096 rows = 16
+            // blocks of 256) measures ~4.5ms end-to-end on the dev machine
+            // (`bench_idle_compression_tick`) — the real
+            // `compress_idle_scrollback` path (run-scan + per-block LZ4 +
+            // eviction bookkeeping), larger than the ~73µs/block isolated
+            // `bench_compressed_block_round_trip` figure but still well under
+            // the 100ms interval (and under one 16.6ms frame); ~5x slower is
+            // ~22ms, still within one interval. Left at 4096 (vs compaction's
+            // 1024) because compression's per-row cost is lower and it only
+            // runs after compaction settles, so the larger budget drains the
+            // compress backlog without a large burst.
+            const IDLE_COMPRESSION_BUDGET: usize = 4096;
 
             let mut emulator = terminal;
 

--- a/freminal/src/gui/pty.rs
+++ b/freminal/src/gui/pty.rs
@@ -450,13 +450,13 @@ fn spawn_pty_consumer_thread(
                 std::time::Duration::from_millis(100);
             // Compaction is an in-place RLE Live->Compact conversion. Measured
             // via `bench_idle_compaction_tick`
-            // (`freminal-buffer/benches/buffer_row_bench.rs`) at ~9.8ms per
-            // 4096 rows on the dev machine, i.e. ~2.4ms per 1024 rows. At this
-            // 1024 budget that is a ~2.4ms slice per 100ms tick here during a
-            // catch-up burst; even on a CPU ~5x slower (~12ms) it stays far
-            // under the 100ms interval and leaves the core idle most of the
-            // time, so a full-scrollback catch-up never stalls the PTY tick
-            // loop or pegs a core. Kept modest (1024, up from Task 118's 512)
+            // (`freminal-buffer/benches/buffer_row_bench.rs`, which runs at this
+            // exact 1024-row budget) at ~1.6ms per tick on the dev machine.
+            // That is a ~1.6ms slice per 100ms tick here during a catch-up
+            // burst; even on a CPU ~5x slower (~8ms) it stays far under the
+            // 100ms interval and leaves the core idle most of the time, so a
+            // full-scrollback catch-up never stalls the PTY tick loop or pegs a
+            // core. Kept modest (1024, up from Task 118's 512)
             // rather than aggressive (4096) precisely so the per-tick burst
             // stays small on weak hardware; the price is a slower background
             // catch-up on a pathological all-at-once dump, invisible in normal


### PR DESCRIPTION
## Task 119 — Scrollback Compression (LZ4)

Phase two of the v0.12.0 scrollback-memory effort (`PLAN_VERSION_120.md`).
Compresses blocks of idle scrollback — already in the Task-118 `CompactRow`
form — with LZ4, decompressing transparently on read, driven by the existing
PTY idle tick. Compression core only; reflow interaction stays Task 120.

### Subtasks

- **119.2 + 119.3** (`0c9d6201`) — add `lz4_flex` (pure-Rust); `CompressedBlock`
  type + lossless `CompactRow` byte serialization (manual LE, no serde). Total,
  panic-free decode. `FormatTag::start/end` not serialized (stored cell tags
  always carry the default range; guarded by a `debug_assert`).
- **119.4** (`58833f0b`) — Buffer integration: a separate block store
  (`blocks` + index-parallel `row_block_map`, block-relative offsets so
  front-drains need no remap), `ensure_decompressed` seam at every read/reflow
  boundary with single residency, drain lockstep + block GC, `SavedPrimaryState`
  threading for alt-screen. `Row` gains an inert `evicted_to_block` diagnostic
  marker so an accidental direct read of an evicted row `debug_assert`s instead
  of returning blank. Two latent panic surfaces found in review (scrolled-view
  flatten + kitty image-clear sweeps) fixed with regression tests.
- **119.5** (`475479b2`) — `compress_idle_scrollback(budget)` wired into the
  existing PTY idle tick, sequenced compact-then-compress, re-arm-while-work /
  disarm-when-caught-up. No new timer/thread; lock-free architecture preserved.
- **119.6** (`7f7954fe`) — benchmarks (block round-trip, scroll-into-compressed,
  per-idle-tick cost) + idle-budget tuning: compaction 512→1024, compression
  256→4096, justified by measured per-tick cost (~2.4ms / ~4.5ms; safe on
  slower hardware). No config knob (internal memory optimization).

### Measured win (on top of Task 118 compaction)

| Corpus | Raw | +Compact | +LZ4 | Total |
| --- | --- | --- | --- | --- |
| shell session | 6347 B/ln | 1418 | 451 | ~14x |
| source/logs | 5880 | 1158 | 445 | ~13x |
| high-entropy (worst) | 10440 | 3464 | 466 | ~22x |

Live worst-case validation: 100k-line all-retained scrollback ~850 MB raw →
~350 MB compacted → ~182 MB compressed.

### Verification

`cargo test --all` green; clippy clean; machete clean; fmt clean;
`cargo bench --no-run --all` compiles; `cargo xtask check-windows` clean.
No escape-sequence surface change.

### Notes

- Plan status: Task 119 → Pending merge (both tables); v0.12.0 version row
  stays Planned (Tasks 102, 103, 120 outstanding).
- Version bumped 0.12.0-beta.2 → beta.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled automatic LZ4 compression for idle scrollback to reduce memory usage while keeping historical output accessible.
  * Compressed scrollback is transparently restored when navigating, searching, resizing, or switching screens.
* **Bug Fixes**
  * Improved behavior for image handling, alternate-screen content, resizing, and scrollback cleanup when compressed rows are involved.
  * Added robustness against malformed or truncated compressed data.
* **Performance**
  * Refined idle maintenance and heap trimming to reduce unnecessary churn.
  * Expanded compression/decompression and scrolling benchmarks.
* **Release**
  * Updated version to 0.12.0-beta.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->