### PR TITLE
fix: no BCE on line-feed/scroll-created rows (extra blank line on resize)

### DIFF
--- a/freminal-buffer/src/buffer/lines.rs
+++ b/freminal-buffer/src/buffer/lines.rs
@@ -180,14 +180,23 @@ impl Buffer {
                     self.cursor.pos.y += 1;
 
                     if self.cursor.pos.y >= self.rows.len() {
-                        // Row doesn't exist yet — always create it fresh.
-                        // BCE: fill with current SGR background.
-                        let mut new_row = Row::new_with_origin(
+                        // Row doesn't exist yet — create it fresh with a
+                        // default (sparse) background.  A line feed only moves
+                        // the active position; it is NOT an explicit erase, so
+                        // BCE (back_color_erase) does not apply here.  Filling
+                        // with `current_tag` would materialise full-width blank
+                        // cells carrying whatever SGR happens to be active
+                        // (e.g. a lingering bold from `ESC[1m`), which then
+                        // survive reflow as spurious trailing cells and produce
+                        // an extra blank continuation row on a narrower resize.
+                        // This mirrors `push_row`, `scroll_slice_up`/`_down`,
+                        // and the scrolled-in-row case below, all of which
+                        // deliberately use default here.
+                        let new_row = Row::new_with_origin(
                             self.width,
                             RowOrigin::HardBreak,
                             RowJoin::NewLogicalLine,
                         );
-                        new_row.fill_with_tag(&self.current_tag);
                         self.rows.push(new_row);
                         self.row_cache.push(None);
                     } else {
@@ -238,12 +247,13 @@ impl Buffer {
                     if self.cursor.pos.y + 1 < self.rows.len() {
                         self.cursor.pos.y += 1;
                     } else {
-                        let mut new_row = Row::new_with_origin(
+                        // New row from a line feed uses default background, not
+                        // BCE — see the full-screen fast-path comment above.
+                        let new_row = Row::new_with_origin(
                             self.width,
                             RowOrigin::HardBreak,
                             RowJoin::NewLogicalLine,
                         );
-                        new_row.fill_with_tag(&self.current_tag);
                         self.rows.push(new_row);
                         self.row_cache.push(None);
                         self.cursor.pos.y = self.rows.len() - 1;

--- a/freminal-buffer/src/buffer/scroll.rs
+++ b/freminal-buffer/src/buffer/scroll.rs
@@ -648,9 +648,11 @@ impl Buffer {
         // the same reclaim applies).
         self.gc_unreferenced_blocks();
 
-        // add a new empty row at the bottom (BCE: fill with current SGR background)
-        let mut new_row = Row::new(self.width);
-        new_row.fill_with_tag(&self.current_tag);
+        // add a new empty row at the bottom, using default background (no BCE).
+        // Scrolling only moves content; it is not an explicit erase, so the
+        // scrolled-in row must not inherit the active SGR background — same
+        // rationale as `push_row` and `scroll_slice_up`/`_down`.
+        let new_row = Row::new(self.width);
         self.rows.push(new_row);
         self.row_cache.push(None);
         self.row_block_map.push(None);

--- a/freminal-buffer/src/row.rs
+++ b/freminal-buffer/src/row.rs
@@ -455,22 +455,6 @@ impl Row {
         self.storage = RowStorage::Live(Vec::new());
     }
 
-    /// Fill this row with blank cells carrying the given format tag (BCE).
-    ///
-    /// Always clears existing cell data first.  If the tag is visually default
-    /// the row is left sparse (empty `cells` vec).  Otherwise, explicit blank
-    /// cells are written so the renderer picks up the correct background color.
-    pub fn fill_with_tag(&mut self, tag: &FormatTag) {
-        self.clear();
-
-        if tag.is_visually_default() {
-            return;
-        }
-        let width = self.width;
-        self.cells_vec_mut()
-            .resize(width, Cell::blank_with_tag(tag.clone()));
-    }
-
     /// Mark this row as clean (its flat representation is up-to-date in the cache).
     /// Called by the snapshot machinery after producing a cached flat representation.
     pub const fn mark_clean(&mut self) {
@@ -1286,11 +1270,19 @@ impl Row {
         }
         self.dirty = true;
 
-        // Extend cells to reach the target column if needed.
+        // Extend cells to reach the target column if needed.  The gap columns
+        // strictly before `col` were never explicitly written, so they carry
+        // the default blank tag rather than the incoming SGR `tag`; only the
+        // image cell itself (written at `col` below) uses `tag`.
         if col >= self.cells_vec_mut().len() {
-            let pad = col - self.cells_vec_mut().len() + 1;
+            let pad = col - self.cells_vec_mut().len();
+            self.cells_vec_mut().extend(std::iter::repeat_n(
+                Cell::blank_with_tag(FormatTag::default()),
+                pad,
+            ));
+            // Placeholder for the image cell slot itself; overwritten below.
             self.cells_vec_mut()
-                .extend(std::iter::repeat_n(Cell::blank_with_tag(tag.clone()), pad));
+                .push(Cell::blank_with_tag(FormatTag::default()));
         }
 
         // Clean up any wide character at this position.
@@ -1911,6 +1903,36 @@ mod tests {
             "col 0 should be an image cell"
         );
         assert_eq!(row.count_image_cells(), 1);
+    }
+
+    #[test]
+    fn set_image_cell_gap_padding_uses_default_tag() {
+        // Placing an image cell past the row's current length must pad the
+        // skipped gap columns with the DEFAULT tag (those columns were never
+        // explicitly written), not the incoming SGR tag.  Only the image cell
+        // itself carries the caller's tag.
+        let image_id = crate::image_store::next_image_id();
+        let mut bce_tag = FormatTag::default();
+        bce_tag
+            .colors
+            .set_background_color(freminal_common::colors::TerminalColor::Red);
+
+        let mut row = Row::new(80);
+        // Row currently empty; place the image at column 5.
+        row.set_image_cell(5, make_image_placement(image_id), bce_tag.clone());
+
+        for col in 0..5 {
+            let cell = row.resolve_cell(col);
+            assert_eq!(
+                cell.tag(),
+                &FormatTag::default(),
+                "col {col}: gap before an image placement must use the default tag, not the SGR bg"
+            );
+        }
+        assert!(
+            row.char_at(5).unwrap().has_image(),
+            "col 5 should be the image cell"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/freminal-buffer/tests/buffer_tests.rs
+++ b/freminal-buffer/tests/buffer_tests.rs
@@ -212,6 +212,61 @@ fn bce_scroll_does_not_fill_new_row_with_current_bg() {
     }
 }
 
+/// A line feed that creates a brand-new row at the bottom must NOT apply BCE:
+/// LF only moves the active position, it is not an explicit erase.  The new
+/// row must carry the default background regardless of the active SGR — even a
+/// visually-inert attribute like bold.  Regression test for the "extra blank
+/// line on narrower resize" bug: a lingering `ESC[1m` (bold) used to make the
+/// new row materialise full-width bold-blank cells, which then survived reflow
+/// as a spurious trailing continuation row.
+#[test]
+fn bce_line_feed_new_row_ignores_active_bold() {
+    // Bold, no color — visually inert on a blank cell.
+    let bold_tag = FormatTag {
+        font_weight: freminal_common::buffer_states::fonts::FontWeight::Bold,
+        ..FormatTag::default()
+    };
+
+    let mut buf = Buffer::new(10, 3);
+    buf.insert_text(&[ascii('A'), ascii('B')]);
+    buf.set_format(bold_tag);
+    // Advance past the last row so handle_lf must create a fresh row.
+    buf.handle_lf();
+    buf.handle_lf();
+
+    let rows = buf.rows();
+    let new_row = rows.last().expect("buffer has rows");
+    assert!(
+        new_row.characters().is_empty(),
+        "line-feed-created row under active bold must stay sparse (default bg), \
+         got {} stored cells",
+        new_row.characters().len()
+    );
+}
+
+/// Same as above but for a real background color: this is legitimate content
+/// state, yet a LINE FEED still must not BCE-paint the new row (BCE applies
+/// only to explicit erases — ED/EL — not to cursor movement / scrolling).
+#[test]
+fn bce_line_feed_new_row_ignores_active_bg_color() {
+    let mut buf = Buffer::new(10, 3);
+    buf.insert_text(&[ascii('A'), ascii('B')]);
+    buf.set_format(red_bg_tag());
+    buf.handle_lf();
+    buf.handle_lf();
+
+    let rows = buf.rows();
+    let new_row = rows.last().expect("buffer has rows");
+    for col in 0..10 {
+        let cell = new_row.resolve_cell(col);
+        assert_eq!(
+            cell.tag(),
+            &FormatTag::default(),
+            "col {col}: line-feed-created row must have default background (no BCE)"
+        );
+    }
+}
+
 #[test]
 fn bce_erase_chars_fills_with_current_bg() {
     let mut buf = Buffer::new(10, 5);

--- a/freminal-buffer/tests/row_tests.rs
+++ b/freminal-buffer/tests/row_tests.rs
@@ -450,47 +450,6 @@ fn clear_with_tag_nondefault_fills_row() {
 }
 
 #[test]
-fn fill_with_tag_default_leaves_empty_row_sparse() {
-    let mut row = Row::new(10);
-
-    row.fill_with_tag(&FormatTag::default());
-
-    assert!(
-        row.characters().is_empty(),
-        "fill_with_tag(default) should leave row sparse"
-    );
-}
-
-#[test]
-fn fill_with_tag_default_clears_populated_row() {
-    let mut row = Row::new(10);
-    row.insert_text(0, &[ascii('X'), ascii('Y'), ascii('Z')], &tag());
-    assert!(!row.characters().is_empty(), "precondition: row has cells");
-
-    row.fill_with_tag(&FormatTag::default());
-
-    assert!(
-        row.characters().is_empty(),
-        "fill_with_tag(default) on a populated row should clear it to sparse"
-    );
-}
-
-#[test]
-fn fill_with_tag_nondefault_fills_row() {
-    let mut row = Row::new(8);
-    let bce_tag = blue_bg_tag();
-
-    row.fill_with_tag(&bce_tag);
-
-    let chars = row.characters();
-    assert_eq!(chars.len(), 8, "fill should write to all columns");
-    for (col, cell) in chars.iter().enumerate() {
-        assert_eq!(cell.tchar(), &TChar::Space, "col {col}: expected blank");
-        assert_eq!(cell.tag(), &bce_tag, "col {col}: expected blue-bg tag");
-    }
-}
-
-#[test]
 fn erase_cells_at_with_bce_tag() {
     let mut row = Row::new(10);
     let bce_tag = blue_bg_tag();

--- a/freminal-terminal-emulator/tests/reflow_bold_lf_padding.rs
+++ b/freminal-terminal-emulator/tests/reflow_bold_lf_padding.rs
@@ -1,0 +1,87 @@
+//! Regression test for the "extra blank line on narrower resize" bug.
+//!
+//! Reproduced from a real fastfetch-over-SSH recording (`nik-freminal.frec`):
+//! a program that leaves `ESC[1m` (bold) active, disables autowrap (`ESC[?7l`),
+//! and lays out a side panel using cursor-forward (`CUF`, `ESC[<n>C`) after
+//! bare line feeds. Before the fix, each line-feed-created row was BCE-filled
+//! with the active (bold) SGR out to the full terminal width. Those full-width
+//! bold-blank rows then survived `reflow_to_width`: on a narrower resize the
+//! trailing blank padding overflowed into a spurious `SoftWrap` continuation
+//! row, inserting an empty line between every content row. This matched the
+//! user's report of extra spacing between lines that appears at one width and
+//! disappears at another.
+//!
+//! A line feed only moves the active position; it is not an explicit erase, so
+//! BCE must not apply. After the fix the line-feed-created rows are sparse and
+//! reflow produces no extra blank rows.
+
+use freminal_buffer::row::{Row, RowJoin};
+use freminal_terminal_emulator::interface::TerminalEmulator;
+
+fn row_text(row: &Row) -> String {
+    row.characters()
+        .iter()
+        .map(freminal_buffer::cell::Cell::into_utf8)
+        .collect::<String>()
+        .trim_end()
+        .to_string()
+}
+
+/// Count rows that are a blank soft-wrap continuation — the bug's signature.
+fn blank_continuation_rows(emu: &TerminalEmulator) -> usize {
+    emu.internal
+        .handler
+        .buffer()
+        .rows()
+        .iter()
+        .filter(|r| r.join == RowJoin::ContinueLogicalLine && row_text(r).is_empty())
+        .count()
+}
+
+#[test]
+fn bold_lf_side_panel_reflow_adds_no_blank_lines() {
+    let (mut emu, _rx) = TerminalEmulator::new_headless(Some(4000));
+    emu.set_win_size(80, 24, 8, 16).unwrap();
+
+    // Turn on bold and never reset it (as the real fastfetch does), disable
+    // autowrap, then draw several "art" lines each followed by a bare LF, and
+    // overlay panel text to the right using CUF. All content is well under the
+    // terminal width, so nothing should ever legitimately wrap.
+    emu.handle_incoming_data(b"\x1b[1m\x1b[?7l");
+    for i in 0..8u8 {
+        // A short art fragment on the left...
+        emu.handle_incoming_data(b"\x1b[34m###");
+        // ...then jump right and write a panel label...
+        emu.handle_incoming_data(b"\x1b[40C");
+        emu.handle_incoming_data(format!("label {i}").as_bytes());
+        // ...and a bare line feed to the next row (carriage return + LF).
+        emu.handle_incoming_data(b"\r\n");
+    }
+    emu.handle_incoming_data(b"\x1b[?7h\x1b[0m");
+
+    let rows_after_feed = emu.internal.handler.buffer().rows().len();
+    assert_eq!(
+        blank_continuation_rows(&emu),
+        0,
+        "no blank continuation rows should exist before any resize"
+    );
+
+    // Shrink the width. Nothing on screen exceeds the new width, so reflow must
+    // not create any new rows and must not insert blank continuation lines.
+    emu.set_win_size(72, 24, 8, 16).unwrap();
+    assert_eq!(
+        blank_continuation_rows(&emu),
+        0,
+        "narrowing must not insert blank continuation rows (the reported bug)"
+    );
+    assert_eq!(
+        emu.internal.handler.buffer().rows().len(),
+        rows_after_feed,
+        "narrowing content that fits must not change the row count"
+    );
+
+    // Grow back — still no spurious blanks, still the same row count.
+    emu.set_win_size(80, 24, 8, 16).unwrap();
+    assert_eq!(blank_continuation_rows(&emu), 0);
+    assert_eq!(emu.internal.handler.buffer().rows().len(), rows_after_feed);
+}

--- a/sequence_decoder.py
+++ b/sequence_decoder.py
@@ -43,11 +43,14 @@ raw_pty_out = None
 for arg in sys.argv[1:]:
     if arg.startswith("--recording-path"):
         filename = arg.split("=", 1)[1]
-    elif arg.startswith("--raw-pty"):
+    elif arg == "--raw-pty" or arg.startswith("--raw-pty="):
         # Write concatenated PtyOutput bytes (optionally for one pane via
         # --pane) to the given file path, in event order. Used to replay a
         # recording's raw terminal output into a test harness.
-        raw_pty_out = arg.split("=", 1)[1]
+        raw_pty_out = arg.split("=", 1)[1] if "=" in arg else ""
+        if not raw_pty_out:
+            print("Error: --raw-pty requires a value (e.g. --raw-pty=out.bin)")
+            sys.exit(1)
     elif arg == "--convert-escape":
         convert_escape = True
     elif arg == "--split-commands":
@@ -332,12 +335,18 @@ event_num = 0
 
 if raw_pty_out is not None:
     collected = bytearray()
+    truncated = False
+    decode_failures = []  # byte offsets of events whose payload failed to decode
     while pos + 13 <= end:
         _ts = struct.unpack_from("<Q", data, pos)[0]
         etype = data[pos + 8]
         plen = struct.unpack_from("<I", data, pos + 9)[0]
+        event_offset = pos
         pos += 13
         if pos + plen > end:
+            # The final record's payload runs past the event region: the
+            # recording is truncated and we cannot trust the tail.
+            truncated = True
             break
         payload_raw = data[pos:pos + plen]
         pos += plen
@@ -345,23 +354,42 @@ if raw_pty_out is not None:
             continue
         try:
             pd = msgpack.unpackb(payload_raw, raw=False)
-            if isinstance(pd, dict) and len(pd) == 1:
-                inner = next(iter(pd.values()))
-                if isinstance(inner, dict):
-                    pd = inner
-        except Exception:
+        except (msgpack.exceptions.UnpackException, ValueError):
+            decode_failures.append(event_offset)
             continue
-        if filter_pane is not None and pd.get("pane_id") not in (None, filter_pane):
+        if isinstance(pd, dict) and len(pd) == 1:
+            inner = next(iter(pd.values()))
+            if isinstance(inner, dict):
+                pd = inner
+        if not isinstance(pd, dict):
+            decode_failures.append(event_offset)
+            continue
+        # Strict pane filter: a PtyOutput event with no pane_id (or a
+        # non-matching one) is excluded when --pane is given, rather than
+        # matching every pane.
+        if filter_pane is not None and pd.get("pane_id") != filter_pane:
             continue
         raw = pd.get("data", b"")
         if isinstance(raw, list):
             raw = bytes(raw)
         if isinstance(raw, bytes):
             collected.extend(raw)
+
     with open(raw_pty_out, "wb") as out:
         out.write(collected)
     print(f"Wrote {len(collected)} bytes of PtyOutput to {raw_pty_out}")
-    sys.exit(0)
+
+    # A partial export (truncated stream or undecodable payloads) must fail
+    # loudly so callers never silently replay incomplete data.
+    if truncated:
+        print("Error: recording is truncated; export is incomplete.", file=sys.stderr)
+    if decode_failures:
+        print(
+            f"Error: {len(decode_failures)} event payload(s) failed to decode "
+            f"(byte offsets: {decode_failures}); export is incomplete.",
+            file=sys.stderr,
+        )
+    sys.exit(1 if (truncated or decode_failures) else 0)
 
 # Print header info
 if not events_only:

--- a/sequence_decoder.py
+++ b/sequence_decoder.py
@@ -38,10 +38,16 @@ show_timing = False
 summary_only = False
 filter_pane = None
 events_only = False
+raw_pty_out = None
 
 for arg in sys.argv[1:]:
     if arg.startswith("--recording-path"):
         filename = arg.split("=", 1)[1]
+    elif arg.startswith("--raw-pty"):
+        # Write concatenated PtyOutput bytes (optionally for one pane via
+        # --pane) to the given file path, in event order. Used to replay a
+        # recording's raw terminal output into a test harness.
+        raw_pty_out = arg.split("=", 1)[1]
     elif arg == "--convert-escape":
         convert_escape = True
     elif arg == "--split-commands":
@@ -318,6 +324,44 @@ if seek_index_offset > 0 and seek_index_offset < len(data):
     end = min(end, seek_index_offset)
 
 event_num = 0
+
+# ---------------------------------------------------------------------------
+# Raw PTY-output export mode (v2): concatenate PtyOutput payload bytes in
+# event order (optionally filtered to one pane) and write them to a file.
+# ---------------------------------------------------------------------------
+
+if raw_pty_out is not None:
+    collected = bytearray()
+    while pos + 13 <= end:
+        _ts = struct.unpack_from("<Q", data, pos)[0]
+        etype = data[pos + 8]
+        plen = struct.unpack_from("<I", data, pos + 9)[0]
+        pos += 13
+        if pos + plen > end:
+            break
+        payload_raw = data[pos:pos + plen]
+        pos += plen
+        if EVENT_TYPES.get(etype) != "PtyOutput":
+            continue
+        try:
+            pd = msgpack.unpackb(payload_raw, raw=False)
+            if isinstance(pd, dict) and len(pd) == 1:
+                inner = next(iter(pd.values()))
+                if isinstance(inner, dict):
+                    pd = inner
+        except Exception:
+            continue
+        if filter_pane is not None and pd.get("pane_id") not in (None, filter_pane):
+            continue
+        raw = pd.get("data", b"")
+        if isinstance(raw, list):
+            raw = bytes(raw)
+        if isinstance(raw, bytes):
+            collected.extend(raw)
+    with open(raw_pty_out, "wb") as out:
+        out.write(collected)
+    print(f"Wrote {len(collected)} bytes of PtyOutput to {raw_pty_out}")
+    sys.exit(0)
 
 # Print header info
 if not events_only:


### PR DESCRIPTION
## Summary

Fixes the "extra blank line on resize" bug: resizing the window narrower
(width only) inserted an extra blank line between content rows, which
disappeared again when widened. Most visible on dense block-art content
(e.g. a fastfetch logo rendered over SSH).

Related to #404, but this is the distinct **underlying** defect: not
glyph corruption, but extra vertical spacing introduced during reflow.

## Root cause

A bare line feed that creates a new row at the bottom of the buffer was
BCE-filling that row to the **full terminal width** with the active SGR
tag (`handle_lf` → `Row::fill_with_tag(&self.current_tag)`). When a
program leaves a visually-inert attribute such as **bold** (`ESC[1m`)
active across the line feed — as fastfetch-over-SSH does while laying out
its logo+panel with autowrap off (`ESC[?7l`) and cursor-forward
(`ESC[<n>C`) — every new row was materialised full-width with bold-blank
cells.

On a narrower resize, `reflow_to_width` faithfully re-wrapped that
trailing blank padding into a spurious `SoftWrap`/`ContinueLogicalLine`
row, inserting an empty line between every content row.

Per ECMA-48, a line feed only moves the active position; it is **not** an
explicit erase, so BCE (back_color_erase) must not apply. This rule was
already honoured by `push_row`, `scroll_slice_up`/`_down`, and auto-wrap
(documented on `push_row`), but the two `handle_lf` new-row branches and
`scroll_up` were never brought in line.

### Why it reproduced over SSH but not locally

The SSH fastfetch draws its layout with autowrap off + `CUF` after bold
line feeds; the local fastfetch uses no `CUF` and doesn't leave bold
active across the new-row LFs, so it never hit the full-width bold-blank
path. Confirmed empirically by replaying both recordings through a test
harness (the SSH recording reproduced 87→109 rows on shrink; the local
one stayed constant).

## Changes

- `handle_lf` (full-screen fast path + outside-DECSTBM path): create
  sparse, default-background rows instead of `fill_with_tag(current_tag)`.
- `scroll_up`: same fix (was a dormant instance of the identical bug).
- `Row::set_image_cell`: gap-pad skipped columns with the default tag
  (they were never explicitly written), not the incoming SGR tag.
- Remove the now-unused `Row::fill_with_tag` and its tests.

## Tests

- `bce_line_feed_new_row_ignores_active_bold` / `_bg_color` — a new row
  from LF stays sparse/default regardless of active SGR (verified to
  **fail on pre-fix code**, pass after).
- `set_image_cell_gap_padding_uses_default_tag`.
- `reflow_bold_lf_padding` integration test — reproduces the exact
  bold + `?7l` + LF + `CUF` + reflow mechanism and asserts no blank
  continuation rows appear on a narrower resize.
- Also adds a reusable `--raw-pty` export mode to `sequence_decoder.py`.

## Verification

`cargo test --all`, `cargo clippy --all-targets --all-features -- -D
warnings`, `cargo machete`, and `cargo xtask check-windows` — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended BCE/background painting on line feed and scrolling-created rows; new rows remain blank/un-styled unless explicitly cleared.
  * Corrected image cell gap padding and improved erasing/deleting behavior near wide characters and blank spans.
  * Fixed a regression that could add extra blank continuation lines when resizing terminal width.

* **New Features**
  * Added an FREC v2-only command-line option to export raw PTY output bytes, with optional pane filtering.

* **Chores**
  * Removed a public row “fill with tag” API in the buffer component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->