### PR TITLE
fix: detect wrapped plain-text URLs in full across soft-wrap boundaries (#418)

### DIFF
--- a/freminal-buffer/benches/buffer_row_bench.rs
+++ b/freminal-buffer/benches/buffer_row_bench.rs
@@ -609,35 +609,87 @@ fn bench_flatten_url_heavy(c: &mut Criterion) {
     let prefix = b"see ";
     let suffix_template = b" for more info xyz";
 
-    let mut data: Vec<TChar> = Vec::with_capacity(height * (width + 1));
-    for _ in 0..height {
-        let mut row_len = 0usize;
-        for &b in prefix {
-            data.push(TChar::Ascii(b));
-            row_len += 1;
+    // One row's content. A real hard break is driven per row via
+    // `handle_lf`/`handle_cr` below (matching how the PTY thread actually
+    // terminates a line) rather than embedding a `TChar::NewLine` cell in the
+    // inserted text: `TChar::NewLine` is an ordinary printable cell to
+    // `insert_text`, not a line-break instruction, so embedding it does not
+    // produce a hard break and would make every row after the first a DECAWM
+    // soft-wrap continuation of one giant logical line — defeating the
+    // point of this benchmark (one complete, self-contained URL per row).
+    let mut row_data: Vec<TChar> = Vec::with_capacity(width);
+    let mut row_len = 0usize;
+    for &b in prefix {
+        row_data.push(TChar::Ascii(b));
+        row_len += 1;
+    }
+    for &b in url {
+        row_data.push(TChar::Ascii(b));
+        row_len += 1;
+    }
+    for &b in suffix_template {
+        if row_len >= width {
+            break;
         }
-        for &b in url {
-            data.push(TChar::Ascii(b));
-            row_len += 1;
-        }
-        for &b in suffix_template {
-            if row_len >= width {
-                break;
-            }
-            data.push(TChar::Ascii(b));
-            row_len += 1;
-        }
-        while row_len < width {
-            data.push(TChar::Ascii(b' '));
-            row_len += 1;
-        }
-        data.push(TChar::NewLine);
+        row_data.push(TChar::Ascii(b));
+        row_len += 1;
+    }
+    while row_len < width {
+        row_data.push(TChar::Ascii(b' '));
+        row_len += 1;
     }
 
     let mut group = c.benchmark_group("bench_flatten_url_heavy");
     group.throughput(Throughput::Elements((width * height) as u64));
 
     group.bench_function("visible_80x50_with_urls", |b| {
+        b.iter_batched(
+            || {
+                let mut buf = Buffer::new(width, height);
+                for i in 0..height {
+                    buf.insert_text(&row_data);
+                    if i + 1 < height {
+                        buf.handle_lf();
+                        buf.handle_cr();
+                    }
+                }
+                buf
+            },
+            |mut buf| {
+                std::hint::black_box(buf.visible_as_tchars_and_tags(0));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------
+// Benchmark: URL auto-detection when it wraps across rows (Task 418)
+//
+// Unlike `bench_flatten_url_heavy` (one complete URL per row, hard-broken by
+// a real newline), this benchmark fills every row edge-to-edge with URL
+// content that DECAWM soft-wraps across many rows, so the group-level
+// redetect path added for GitHub issue #418 (URLs wrapping across rows must
+// be detected in full) is actually exercised on every flatten.
+// ---------------------------------------------------------------
+fn bench_flatten_wrapped_url_heavy(c: &mut Criterion) {
+    let width = 80usize;
+    let height = 50usize;
+
+    // One continuous URL, longer than the whole screen, so it soft-wraps
+    // across every row with no hard breaks at all.
+    let mut url = String::from("https://example.com/");
+    while url.len() < width * height {
+        url.push_str("a/very/long/path/segment/");
+    }
+    let data: Vec<TChar> = url.chars().map(TChar::from).collect();
+
+    let mut group = c.benchmark_group("bench_flatten_wrapped_url_heavy");
+    group.throughput(Throughput::Elements((width * height) as u64));
+
+    group.bench_function("visible_80x50_one_wrapped_url", |b| {
         b.iter_batched(
             || {
                 let mut buf = Buffer::new(width, height);
@@ -967,6 +1019,7 @@ criterion_group!(
         bench_visible_flatten,
         bench_scrollback_flatten,
         bench_flatten_url_heavy,
+        bench_flatten_wrapped_url_heavy,
         bench_insert_with_color_changes,
         bench_cursor_ops,
         bench_move_cursor_relative,

--- a/freminal-buffer/src/buffer/flatten.rs
+++ b/freminal-buffer/src/buffer/flatten.rs
@@ -38,7 +38,7 @@ use freminal_common::buffer_states::{
     buffer_type::BufferType, format_tag::FormatTag, tchar::TChar, url::Url,
 };
 
-use crate::row::Row;
+use crate::row::{Row, RowJoin};
 use crate::url_detect;
 
 use super::tags_same_format;
@@ -58,6 +58,13 @@ pub struct AutoUrlRange {
     pub char_end: usize,
     /// The detected URL, wrapped for cheap splicing into multiple tags.
     pub url: Arc<Url>,
+    /// Mirrors [`url_detect::UrlMatch::touches_buffer_end`]: `true` when the
+    /// raw (pre-trim) match reached the end of the row's byte buffer, i.e.
+    /// this range might be a DECAWM-wrapped URL continuing onto the next
+    /// row. Used as the cheap, precise signal for whether a soft-wrapped
+    /// group of rows needs the group-level URL redetection in
+    /// [`Buffer::refresh_row_cache_and_refine_wrapped_urls`].
+    pub touches_row_end: bool,
 }
 
 /// Per-row flatten cache entry.
@@ -258,29 +265,18 @@ impl Buffer {
         cache: &mut [Option<RowCacheEntry>],
         auto_detect: bool,
     ) -> (Vec<TChar>, Vec<FormatTag>, Vec<usize>, Vec<usize>) {
-        // ── Step 1: ensure every row has an up-to-date cache entry ──────────
-        for (row, entry) in rows.iter_mut().zip(cache.iter_mut()) {
-            // Invalidate cache entries that were built with a different
-            // `auto_detect` mode than the one currently in effect. When
-            // auto_detect is true we need `bytes` populated; when false the
-            // cache entry may still have them but that is harmless — we keep
-            // the entry in that case.
-            let needs_rebuild = row.dirty
-                || entry.is_none()
-                || (auto_detect
-                    && entry
-                        .as_ref()
-                        .is_some_and(|e| e.bytes.is_empty() && !e.chars.is_empty()));
-            if needs_rebuild {
-                *entry = Some(Self::flatten_row(row, auto_detect));
-                row.mark_clean();
-            }
-        }
+        let row_count = rows.len();
+
+        // ── Step 1 (+ 1.5): ensure every row has an up-to-date cache entry,
+        // and fix up auto-detected URLs that wrap across rows. See
+        // `refresh_row_cache_and_refine_wrapped_urls`'s doc comment.
+        let refined_auto_urls =
+            Self::refresh_row_cache_and_refine_wrapped_urls(rows, cache, auto_detect);
+        let mut refined_cursor = 0usize;
 
         // ── Step 2: merge per-row results into the global flat vectors ───────
         // Per-row tags have offsets relative to the start of that row's chars.
         // We accumulate a running `global_offset` and re-base each tag.
-        let row_count = rows.len();
         let mut chars: Vec<TChar> = Vec::new();
         let mut tags: Vec<FormatTag> = Vec::new();
         let mut row_offsets: Vec<usize> = Vec::with_capacity(row_count);
@@ -298,8 +294,21 @@ impl Buffer {
                 // Rebase per-row tags into the global index space, then splice
                 // any auto-detected URL ranges on top. Splicing is done in
                 // row-local character space first (cheap) and the result is
-                // then rebased.
-                let spliced = splice_auto_urls(&row_entry.tags, &row_entry.auto_urls);
+                // then rebased. Prefer the Step 1.5 group-corrected ranges
+                // (whole-URL text, wrap-boundary-safe) when present — `refined_auto_urls`
+                // is sorted by `row_idx`, so a single forward cursor finds the
+                // match (if any) in amortised O(1).
+                while refined_auto_urls
+                    .get(refined_cursor)
+                    .is_some_and(|(idx, _)| *idx < row_idx)
+                {
+                    refined_cursor += 1;
+                }
+                let row_auto_urls = match refined_auto_urls.get(refined_cursor) {
+                    Some((idx, ranges)) if *idx == row_idx => ranges.as_slice(),
+                    _ => &row_entry.auto_urls,
+                };
+                let spliced = splice_auto_urls(&row_entry.tags, row_auto_urls);
 
                 // Append this row's characters, adjusting tag offsets.
                 for row_tag in &spliced {
@@ -371,6 +380,104 @@ impl Buffer {
 
         let url_tag_indices = Self::collect_url_tag_indices(&tags);
         (chars, tags, row_offsets, url_tag_indices)
+    }
+
+    /// Step 1 (+ 1.5) of [`Self::rows_as_tchars_and_tags_cached`]: ensure
+    /// every row has an up-to-date [`RowCacheEntry`], and fix up
+    /// auto-detected URLs that wrap across rows, in one pass over `rows`.
+    ///
+    /// [`Self::flatten_row`] detects URLs using only that row's own bytes, so
+    /// a URL that DECAWM soft-wraps across two or more physical rows is seen
+    /// as several independent, truncated matches. This pass finds contiguous
+    /// runs of rows joined by `RowJoin::ContinueLogicalLine` (soft-wrap
+    /// continuations of one logical line) and, only when the run actually
+    /// contains URL-looking content, re-runs URL detection on the rows'
+    /// concatenated bytes via [`redetect_urls_for_group`] so wrap boundaries
+    /// stop being treated as the end of the URL (both for truncation and for
+    /// the trailing sentence-punctuation heuristic in
+    /// `url_detect::trim_trailing`, which otherwise misfires when a wrap
+    /// boundary lands right before stripped punctuation).
+    ///
+    /// The grouping scan is fused into the same loop that rebuilds dirty row
+    /// caches — rather than a second full pass over `rows` — so the common
+    /// case (nothing wraps, or a wrap has no URL content) costs only a few
+    /// extra cheap comparisons per row instead of a whole extra traversal.
+    ///
+    /// Returns a **sparse** list of `(row_idx, ranges)` pairs, sorted by
+    /// ascending `row_idx`, covering only rows whose `auto_urls` were
+    /// replaced by a group-level redetection. A row not present means "no
+    /// change; use the row's own cached `auto_urls`". It stays empty (no heap
+    /// allocation) whenever no row needed correction — the overwhelmingly
+    /// common case.
+    fn refresh_row_cache_and_refine_wrapped_urls(
+        rows: &mut [Row],
+        cache: &mut [Option<RowCacheEntry>],
+        auto_detect: bool,
+    ) -> Vec<(usize, Vec<AutoUrlRange>)> {
+        let row_count = rows.len();
+        let mut refined_auto_urls: Vec<(usize, Vec<AutoUrlRange>)> = Vec::new();
+        let mut group_start = 0usize;
+        let mut group_has_url_signal = false;
+
+        for row_idx in 0..row_count {
+            // Invalidate cache entries that were built with a different
+            // `auto_detect` mode than the one currently in effect. When
+            // auto_detect is true we need `bytes` populated; when false the
+            // cache entry may still have them but that is harmless — we keep
+            // the entry in that case.
+            {
+                let row = &mut rows[row_idx];
+                let needs_rebuild = row.dirty
+                    || cache[row_idx].is_none()
+                    || (auto_detect
+                        && cache[row_idx]
+                            .as_ref()
+                            .is_some_and(|e| e.bytes.is_empty() && !e.chars.is_empty()));
+                if needs_rebuild {
+                    cache[row_idx] = Some(Self::flatten_row(row, auto_detect));
+                    row.mark_clean();
+                }
+            }
+
+            if !auto_detect {
+                continue;
+            }
+
+            // A new logical-line group starts at row 0, or wherever a row is
+            // not a soft-wrap continuation of the previous one. Runs of
+            // `RowJoin::ContinueLogicalLine` rows are one DECAWM-wrapped
+            // logical line; see `redetect_urls_for_group`'s doc comment.
+            let starts_new_group =
+                row_idx == 0 || rows[row_idx].join != RowJoin::ContinueLogicalLine;
+            if starts_new_group {
+                if row_idx - group_start > 1 && group_has_url_signal {
+                    redetect_urls_for_group(cache, group_start, row_idx, &mut refined_auto_urls);
+                }
+                group_start = row_idx;
+                group_has_url_signal = false;
+            }
+            // Only a match whose raw (pre-trim) end reached this row's raw
+            // byte end is a candidate continuation — a URL that ends
+            // naturally mid-row (the common case: followed by whitespace or
+            // more prose) can never be split by a wrap, no matter how many
+            // other rows in this soft-wrapped run happen to also contain
+            // unrelated, fully self-contained URLs. Only the last match in a
+            // row can possibly reach the row's end (matches are found in
+            // increasing order), so checking `.last()` suffices.
+            if cache[row_idx]
+                .as_ref()
+                .is_some_and(|e| e.auto_urls.last().is_some_and(|r| r.touches_row_end))
+            {
+                group_has_url_signal = true;
+            }
+        }
+        // Finalize the last group (the loop above only finalizes a group
+        // once it sees the *next* group start).
+        if auto_detect && row_count - group_start > 1 && group_has_url_signal {
+            redetect_urls_for_group(cache, group_start, row_count, &mut refined_auto_urls);
+        }
+
+        refined_auto_urls
     }
 
     /// Collect the indices of tags in `tags` that carry a URL.
@@ -629,6 +736,43 @@ impl Buffer {
     }
 }
 
+/// Convert a byte range into a character range using a `byte_to_char` map.
+///
+/// `byte_to_char[i]` is the character index for the character that starts at
+/// byte `i` of the buffer `byte_to_char` was built for (`bytes.len()` bytes
+/// long). Returns `None` when the map is malformed (should never happen, but
+/// this is production code so we cannot unwrap) or when the resulting range
+/// is empty.
+fn byte_range_to_char_range(
+    byte_start: usize,
+    byte_end: usize,
+    bytes_len: usize,
+    byte_to_char: &[u32],
+) -> Option<(usize, usize)> {
+    let &start_u32 = byte_to_char.get(byte_start)?;
+    // `byte_end` is exclusive; we want the character index *after* the last
+    // included character. If `byte_end` reaches the end of the buffer, use
+    // one past the last character index (inferred from the last byte's char
+    // index).
+    let end_char_u32 = if byte_end >= bytes_len {
+        byte_to_char
+            .last()
+            .copied()
+            .map_or(0, |c| c.saturating_add(1))
+    } else {
+        *byte_to_char.get(byte_end)?
+    };
+
+    let char_start = usize::try_from(start_u32).ok()?;
+    let char_end = usize::try_from(end_char_u32).ok()?;
+
+    if char_end <= char_start {
+        return None;
+    }
+
+    Some((char_start, char_end))
+}
+
 /// Convert the detected URL byte ranges into row-local character ranges.
 ///
 /// `bytes` is the row's UTF-8 byte buffer; `byte_to_char` maps each byte
@@ -640,37 +784,11 @@ fn build_auto_urls(bytes: &[u8], byte_to_char: &[u32]) -> Vec<AutoUrlRange> {
     let mut out = Vec::with_capacity(matches.len());
 
     for m in matches {
-        // Guard against malformed `byte_to_char` (should never happen but we
-        // cannot unwrap in production code).
-        let Some(&start_u32) = byte_to_char.get(m.byte_start) else {
+        let Some((char_start, char_end)) =
+            byte_range_to_char_range(m.byte_start, m.byte_end, bytes.len(), byte_to_char)
+        else {
             continue;
         };
-        // `byte_end` is exclusive; we want the character index *after* the
-        // last included character. If `byte_end == bytes.len()`, use
-        // `chars.len()` (the maximum character index + 1 = byte_to_char's
-        // highest value + 1, inferred from the last byte's char index).
-        let end_char_u32 = if m.byte_end >= bytes.len() {
-            // Last character spans to end of byte buffer.
-            byte_to_char
-                .last()
-                .copied()
-                .map_or(0, |c| c.saturating_add(1))
-        } else if let Some(&next) = byte_to_char.get(m.byte_end) {
-            next
-        } else {
-            continue;
-        };
-
-        let Ok(char_start) = usize::try_from(start_u32) else {
-            continue;
-        };
-        let Ok(char_end) = usize::try_from(end_char_u32) else {
-            continue;
-        };
-
-        if char_end <= char_start {
-            continue;
-        }
 
         // Build the URL string from the matched byte range. This is the only
         // per-match string allocation in the pipeline; it is amortised by the
@@ -687,10 +805,111 @@ fn build_auto_urls(bytes: &[u8], byte_to_char: &[u32]) -> Vec<AutoUrlRange> {
                 id: None,
                 url: url_str,
             }),
+            touches_row_end: m.touches_buffer_end,
         });
     }
 
     out
+}
+
+/// Re-detect auto URLs across a run of rows joined by
+/// `RowJoin::ContinueLogicalLine` (`rows[group_start..group_end)`).
+///
+/// Concatenates the already-cached per-row byte buffers into one buffer and
+/// runs [`url_detect::find_urls_bytes`] once on the result, so that a URL
+/// wrap boundary is no longer mistaken for the URL's real end — this both
+/// stops truncation and avoids `trim_trailing` misfiring on a wrap boundary
+/// that happens to land right before stripped punctuation. Each match's byte
+/// range is then mapped back across the contributing rows (via each row's own
+/// `byte_to_char` map) into per-row [`AutoUrlRange`]s that all share one
+/// `Arc<Url>` holding the full, untruncated URL text.
+///
+/// Appends an entry for every row in the group (an empty `Vec` when no match
+/// touches that row), replacing whatever the row's own single-row detection
+/// found. Caller is expected to have already checked that the group actually
+/// contains URL-looking content before calling this (this function does not
+/// check `auto_detect` or the join flags itself — it operates purely on the
+/// cache), and to call groups in ascending `group_start` order so `refined`
+/// stays sorted by `row_idx`.
+fn redetect_urls_for_group(
+    cache: &[Option<RowCacheEntry>],
+    group_start: usize,
+    group_end: usize,
+    refined: &mut Vec<(usize, Vec<AutoUrlRange>)>,
+) {
+    let mut group_bytes: Vec<u8> = Vec::new();
+    let mut row_byte_start: Vec<usize> = Vec::with_capacity(group_end - group_start);
+    for entry in &cache[group_start..group_end] {
+        row_byte_start.push(group_bytes.len());
+        if let Some(entry) = entry.as_ref() {
+            group_bytes.extend_from_slice(&entry.bytes);
+        }
+    }
+    let group_total_len = group_bytes.len();
+
+    let matches = url_detect::find_urls_bytes(&group_bytes);
+
+    // Every row in the group gets an authoritative (possibly empty) refined
+    // entry, superseding its own single-row `auto_urls` — the group
+    // redetection reproduces equivalent matches for URLs fully contained in
+    // one row too, so nothing is lost by replacing wholesale.
+    let first_new_idx = refined.len();
+    refined.extend((group_start..group_end).map(|row_idx| (row_idx, Vec::new())));
+
+    if matches.is_empty() {
+        return;
+    }
+
+    for m in matches {
+        let Ok(url_str) = std::str::from_utf8(&group_bytes[m.byte_start..m.byte_end]) else {
+            continue;
+        };
+        let shared_url = Arc::new(Url {
+            id: None,
+            url: url_str.to_string(),
+        });
+
+        for offset_idx in 0..(group_end - group_start) {
+            let row_idx = group_start + offset_idx;
+            let row_byte_lo = row_byte_start[offset_idx];
+            let row_byte_hi = row_byte_start
+                .get(offset_idx + 1)
+                .copied()
+                .unwrap_or(group_total_len);
+
+            // No overlap between the match and this row's byte span.
+            if m.byte_end <= row_byte_lo || m.byte_start >= row_byte_hi {
+                continue;
+            }
+
+            let Some(entry) = cache[row_idx].as_ref() else {
+                continue;
+            };
+            if entry.bytes.is_empty() {
+                continue;
+            }
+
+            let local_start = m.byte_start.max(row_byte_lo) - row_byte_lo;
+            let local_end = m.byte_end.min(row_byte_hi) - row_byte_lo;
+
+            let Some((char_start, char_end)) = byte_range_to_char_range(
+                local_start,
+                local_end,
+                entry.bytes.len(),
+                &entry.byte_to_char,
+            ) else {
+                continue;
+            };
+
+            let (_, row_ranges) = &mut refined[first_new_idx + offset_idx];
+            row_ranges.push(AutoUrlRange {
+                char_start,
+                char_end,
+                url: shared_url.clone(),
+                touches_row_end: local_end >= entry.bytes.len(),
+            });
+        }
+    }
 }
 
 /// Splice auto-detected URL ranges into a row's per-row tag vec.
@@ -1075,5 +1294,161 @@ mod scrollback_eviction_tests {
         // reporting the image row intact.
         let _ = buf.scrollback_as_tchars_and_tags(0);
         assert!(buf.rows[0].cells().iter().any(crate::cell::Cell::has_image));
+    }
+}
+
+/// Regression coverage for GitHub issue #418: a plain-text URL that
+/// DECAWM-wraps across two or more physical rows must be auto-detected as
+/// one full, untruncated URL — not as several independent per-row fragments.
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod wrapped_url_tests {
+    use crate::buffer::Buffer;
+    use crate::row::RowJoin;
+    use freminal_common::buffer_states::tchar::TChar;
+
+    fn text(s: &str) -> Vec<TChar> {
+        s.chars().map(TChar::from).collect()
+    }
+
+    /// Collect the distinct URL strings carried by the tags at `url_indices`.
+    fn url_strings(
+        tags: &[freminal_common::buffer_states::format_tag::FormatTag],
+        url_indices: &[usize],
+    ) -> Vec<String> {
+        url_indices
+            .iter()
+            .filter_map(|&i| tags[i].url.as_ref().map(|u| u.url.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn url_wrapping_across_two_rows_is_detected_in_full() {
+        // Width chosen so the URL itself (not just surrounding prose) spans
+        // the row boundary: "see " (4) + first part of the URL fills row 0,
+        // the remainder wraps onto row 1.
+        let mut buf = Buffer::new(20, 3);
+        assert!(buf.auto_detect_urls());
+        let url = "https://example.com/a/very/long/path";
+        buf.insert_text(&text(&format!("see {url} end")));
+
+        assert_eq!(
+            buf.rows()[1].join,
+            RowJoin::ContinueLogicalLine,
+            "test setup: row 1 must be a soft-wrap continuation of row 0"
+        );
+
+        let (_chars, tags, _row_offsets, url_indices) = buf.visible_as_tchars_and_tags(0);
+        assert!(!url_indices.is_empty(), "URL must be auto-detected");
+
+        let urls = url_strings(&tags, &url_indices);
+        assert!(
+            urls.iter().all(|u| u == url),
+            "every URL-tagged fragment must carry the full, untruncated URL; got {urls:?}"
+        );
+    }
+
+    #[test]
+    fn url_wrapping_across_three_rows_is_detected_in_full() {
+        // A long URL that wraps twice (spans three physical rows), to
+        // exercise the multi-row chaining (not just a single adjacent pair).
+        let mut buf = Buffer::new(15, 5);
+        assert!(buf.auto_detect_urls());
+        let url = "https://example.com/a/very/long/path/that/keeps/going/and/going";
+        buf.insert_text(&text(url));
+
+        assert_eq!(buf.rows()[1].join, RowJoin::ContinueLogicalLine);
+        assert_eq!(buf.rows()[2].join, RowJoin::ContinueLogicalLine);
+
+        let (_chars, tags, _row_offsets, url_indices) = buf.visible_as_tchars_and_tags(0);
+        assert!(!url_indices.is_empty(), "URL must be auto-detected");
+
+        let urls = url_strings(&tags, &url_indices);
+        assert!(
+            urls.iter().all(|u| u == url),
+            "every URL-tagged fragment must carry the full, untruncated URL; got {urls:?}"
+        );
+    }
+
+    #[test]
+    fn wrap_boundary_on_trailing_punctuation_char_is_not_stripped() {
+        // Width chosen so the wrap boundary lands exactly on the '.' in
+        // "index.html" — a single-row detector's `trim_trailing` heuristic
+        // would misidentify that '.' as sentence punctuation and strip it,
+        // even though it is a real path separator continued on the next row.
+        let mut buf = Buffer::new(26, 3);
+        assert!(buf.auto_detect_urls());
+        let url = "https://example.com/index.html";
+        buf.insert_text(&text(url));
+
+        assert_eq!(
+            buf.rows()[0].cells().len(),
+            26,
+            "row 0 must be exactly full width"
+        );
+        assert_eq!(buf.rows()[1].join, RowJoin::ContinueLogicalLine);
+
+        let (_chars, tags, _row_offsets, url_indices) = buf.visible_as_tchars_and_tags(0);
+        assert!(!url_indices.is_empty(), "URL must be auto-detected");
+
+        let urls = url_strings(&tags, &url_indices);
+        assert!(
+            urls.iter().all(|u| u == url),
+            "the '.' before the wrap must be preserved, not stripped; got {urls:?}"
+        );
+    }
+
+    #[test]
+    fn hard_break_after_full_width_url_does_not_merge_with_next_line() {
+        // Row 0 is filled exactly by a URL with no trailing content (so its
+        // per-row match already reaches the row's raw end), but row 1 is a
+        // genuine new logical line (hard break, not a soft wrap) containing
+        // an unrelated URL starting at column 0. These must NOT be merged
+        // into one URL.
+        let url_a = "https://a.example.com/xxxxx"; // 28 chars
+        let mut buf = Buffer::new(28, 3);
+        assert!(buf.auto_detect_urls());
+        buf.insert_text(&text(url_a));
+        buf.handle_lf();
+        buf.handle_cr();
+        buf.insert_text(&text("https://b.example.com"));
+
+        assert_eq!(
+            buf.rows()[1].join,
+            RowJoin::NewLogicalLine,
+            "test setup: row 1 must be a hard break, not a soft wrap"
+        );
+
+        let (_chars, tags, _row_offsets, url_indices) = buf.visible_as_tchars_and_tags(0);
+        let urls = url_strings(&tags, &url_indices);
+        assert!(urls.contains(&url_a.to_string()), "got {urls:?}");
+        assert!(
+            urls.contains(&"https://b.example.com".to_string()),
+            "got {urls:?}"
+        );
+        assert!(
+            urls.iter()
+                .all(|u| u != &format!("{url_a}https://b.example.com")),
+            "unrelated URLs on a hard-broken next line must not be merged; got {urls:?}"
+        );
+    }
+
+    #[test]
+    fn wrapped_line_without_any_url_is_unaffected() {
+        // A long wrapped line with no URL content at all must not produce
+        // any URL tags (and must not panic in the group-redetect pre-check
+        // skip path).
+        let mut buf = Buffer::new(10, 5);
+        assert!(buf.auto_detect_urls());
+        buf.insert_text(&text(
+            "the quick brown fox jumps over the lazy dog again and again",
+        ));
+        assert_eq!(buf.rows()[1].join, RowJoin::ContinueLogicalLine);
+
+        let (_chars, _tags, _row_offsets, url_indices) = buf.visible_as_tchars_and_tags(0);
+        assert!(
+            url_indices.is_empty(),
+            "a wrapped line with no URL content must not produce URL tags"
+        );
     }
 }

--- a/freminal-buffer/src/buffer/flatten.rs
+++ b/freminal-buffer/src/buffer/flatten.rs
@@ -90,6 +90,17 @@ pub struct RowCacheEntry {
     /// Auto-detected URL ranges (character indices). Empty when detection
     /// was disabled or no URLs were found.
     pub auto_urls: Vec<AutoUrlRange>,
+    /// Precomputed [`url_detect::row_tail_could_be_wrapped_scheme`] result
+    /// for this row's `bytes`. Always `false` when detection was disabled.
+    ///
+    /// Computed once here (at the same time as `auto_urls`, only when the
+    /// row is actually rebuilt) rather than on every merge call, so the
+    /// group-signal check in
+    /// [`Buffer::refresh_row_cache_and_refine_wrapped_urls`] stays an O(1)
+    /// cached lookup instead of re-scanning every row's byte tail on every
+    /// flatten — the tail-scan itself is cheap per call, but paying it again
+    /// on every already-cached (non-dirty) row on every single frame is not.
+    pub tail_could_be_wrapped_scheme: bool,
 }
 
 impl RowCacheEntry {
@@ -102,6 +113,7 @@ impl RowCacheEntry {
             bytes: Vec::new(),
             byte_to_char: Vec::new(),
             auto_urls: Vec::new(),
+            tail_could_be_wrapped_scheme: false,
         }
     }
 }
@@ -456,19 +468,25 @@ impl Buffer {
                 group_start = row_idx;
                 group_has_url_signal = false;
             }
-            // Only a match whose raw (pre-trim) end reached this row's raw
-            // byte end is a candidate continuation — a URL that ends
-            // naturally mid-row (the common case: followed by whitespace or
-            // more prose) can never be split by a wrap, no matter how many
-            // other rows in this soft-wrapped run happen to also contain
-            // unrelated, fully self-contained URLs. Only the last match in a
-            // row can possibly reach the row's end (matches are found in
-            // increasing order), so checking `.last()` suffices.
-            if cache[row_idx]
-                .as_ref()
-                .is_some_and(|e| e.auto_urls.last().is_some_and(|r| r.touches_row_end))
-            {
-                group_has_url_signal = true;
+            // Two independent signals that this row might be part of a
+            // wrapped URL:
+            //
+            // 1. A match whose raw (pre-trim) end reached this row's raw
+            //    byte end — a URL that ends naturally mid-row (the common
+            //    case: followed by whitespace or more prose) can never be
+            //    split by a wrap. Only the last match in a row can possibly
+            //    reach the row's end (matches are found in increasing
+            //    order), so checking `.last()` suffices.
+            // 2. The row's tail looks like a *partial* scheme prefix (e.g.
+            //    "see htt"), meaning the wrap split the scheme itself — in
+            //    that case `find_urls_bytes` found no match at all on this
+            //    row, so signal 1 alone would miss it entirely (not just
+            //    truncate it).
+            if let Some(entry) = cache[row_idx].as_ref() {
+                let touches_end = entry.auto_urls.last().is_some_and(|r| r.touches_row_end);
+                if touches_end || entry.tail_could_be_wrapped_scheme {
+                    group_has_url_signal = true;
+                }
             }
         }
         // Finalize the last group (the loop above only finalizes a group
@@ -575,12 +593,20 @@ impl Buffer {
             Vec::new()
         };
 
+        // Precompute the partial-scheme-tail signal once here (see
+        // `RowCacheEntry::tail_could_be_wrapped_scheme`'s doc comment) so it
+        // is a cached O(1) read at merge time instead of a fresh byte scan
+        // on every flatten call.
+        let tail_could_be_wrapped_scheme =
+            auto_detect && url_detect::row_tail_could_be_wrapped_scheme(&bytes);
+
         RowCacheEntry {
             chars,
             tags,
             bytes,
             byte_to_char,
             auto_urls,
+            tail_could_be_wrapped_scheme,
         }
     }
 
@@ -1449,6 +1475,36 @@ mod wrapped_url_tests {
         assert!(
             url_indices.is_empty(),
             "a wrapped line with no URL content must not produce URL tags"
+        );
+    }
+
+    #[test]
+    fn url_wrapping_mid_scheme_is_still_detected() {
+        // Width chosen so "see http" fills row 0 exactly, splitting the
+        // "https://" scheme prefix itself across the wrap boundary. Neither
+        // row's own per-row `find_urls_bytes` call matches anything on its
+        // own ("see http" and "s://example.com" are each missing a
+        // recognized complete scheme), so `touches_row_end` alone can never
+        // fire here — this is what `row_tail_could_be_wrapped_scheme` (the
+        // partial-scheme-prefix signal) exists for. Regression test for a
+        // CodeRabbit review finding on PR #426.
+        let mut buf = Buffer::new(8, 4);
+        assert!(buf.auto_detect_urls());
+        let url = "https://example.com";
+        buf.insert_text(&text(&format!("see {url}")));
+
+        assert_eq!(buf.rows()[1].join, RowJoin::ContinueLogicalLine);
+
+        let (_chars, tags, _row_offsets, url_indices) = buf.visible_as_tchars_and_tags(0);
+        assert!(
+            !url_indices.is_empty(),
+            "a URL whose scheme is split by a wrap must still be auto-detected"
+        );
+
+        let urls = url_strings(&tags, &url_indices);
+        assert!(
+            urls.iter().all(|u| u == url),
+            "the full URL must be reconstructed across the scheme split; got {urls:?}"
         );
     }
 }

--- a/freminal-buffer/src/url_detect.rs
+++ b/freminal-buffer/src/url_detect.rs
@@ -39,6 +39,18 @@ pub struct UrlMatch {
     pub byte_start: usize,
     /// Exclusive end byte offset into the row's byte buffer.
     pub byte_end: usize,
+    /// `true` when the **raw regex match**, before trailing-punctuation
+    /// trimming, reached the very end of `bytes`.
+    ///
+    /// This is the precise signal that a match *might* be a DECAWM-wrapped
+    /// URL continuing onto the next physical row: wrapping only ever occurs
+    /// at the row's exact last column, so a URL that got cut off by wrapping
+    /// always has its raw match extend to the row's last byte — regardless
+    /// of whether `trim_trailing` then stripped a few trailing punctuation
+    /// bytes from the reported `byte_end`. A URL that ends naturally mid-row
+    /// (followed by whitespace, a control byte, or simply the end of typed
+    /// text) does not reach the buffer end and this is `false`.
+    pub touches_buffer_end: bool,
 }
 
 /// Regex matching plain URLs for any of the supported schemes.
@@ -94,11 +106,13 @@ pub fn find_urls_bytes(bytes: &[u8]) -> Vec<UrlMatch> {
     let mut out = Vec::new();
     for m in URL_REGEX.find_iter(bytes) {
         let start = m.start();
-        let end = trim_trailing(bytes, start, m.end());
+        let raw_end = m.end();
+        let end = trim_trailing(bytes, start, raw_end);
         if end > start {
             out.push(UrlMatch {
                 byte_start: start,
                 byte_end: end,
+                touches_buffer_end: raw_end == bytes.len(),
             });
         }
     }
@@ -274,5 +288,45 @@ mod tests {
         // `https://` alone has nothing after the slashes, regex requires at
         // least one non-whitespace byte → no match.
         assert!(detect("https:// is not a url").is_empty());
+    }
+
+    #[test]
+    fn touches_buffer_end_true_when_match_reaches_end_of_bytes() {
+        let s = "https://example.com";
+        let ranges = find_urls_bytes(s.as_bytes());
+        assert_eq!(ranges.len(), 1);
+        assert!(
+            ranges[0].touches_buffer_end,
+            "the match is the last thing in the buffer, so it must touch the end"
+        );
+    }
+
+    #[test]
+    fn touches_buffer_end_false_when_followed_by_more_text() {
+        let s = "https://example.com and more";
+        let ranges = find_urls_bytes(s.as_bytes());
+        assert_eq!(ranges.len(), 1);
+        assert!(
+            !ranges[0].touches_buffer_end,
+            "the match ends before trailing prose, so it must not touch the end"
+        );
+    }
+
+    #[test]
+    fn touches_buffer_end_true_even_when_trailing_punctuation_is_trimmed() {
+        // The raw regex match ("https://example.com.") reaches the buffer
+        // end even though the reported (trimmed) range does not include the
+        // trailing '.'. `touches_buffer_end` must reflect the *raw* match.
+        let s = "see https://example.com.";
+        let ranges = find_urls_bytes(s.as_bytes());
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(
+            &s[ranges[0].byte_start..ranges[0].byte_end],
+            "https://example.com"
+        );
+        assert!(
+            ranges[0].touches_buffer_end,
+            "trailing-punctuation trimming must not affect touches_buffer_end"
+        );
     }
 }

--- a/freminal-buffer/src/url_detect.rs
+++ b/freminal-buffer/src/url_detect.rs
@@ -94,6 +94,45 @@ fn build_url_regex() -> Regex {
     })
 }
 
+/// The scheme literals matched by [`URL_REGEX`] (kept in sync with
+/// `build_url_regex`'s `PATTERN` by hand — there is no single source of
+/// truth here since the regex alternation and this list serve different
+/// purposes: the regex needs the full literals, `row_tail_could_be_wrapped_scheme`
+/// needs partial prefixes of them).
+const SCHEMES: &[&[u8]] = &[b"https://", b"http://", b"ftp://", b"file://", b"mailto:"];
+
+/// Shortest partial-scheme-prefix length considered a signal that a soft
+/// wrap might have split a URL's *scheme* across the row boundary.
+///
+/// A wrap landing within the first `MIN_PARTIAL_SCHEME_LEN` bytes of a
+/// scheme (e.g. right after just "h" or "ht") is not caught by
+/// [`row_tail_could_be_wrapped_scheme`] — that would require the URL to
+/// start within the row's last 1-2 columns, an exceedingly narrow
+/// coincidence, and checking for it would mean flagging every wrapped row
+/// whose last byte happens to be 'h', 'f', or 'm' (all fairly common in
+/// ordinary wrapped prose) as a candidate. `3` catches the much more likely
+/// case of a wrap landing after most of the scheme identifier (e.g. after
+/// "htt", "ftp", "fil", "mai") while keeping coincidental matches on
+/// ordinary text rare.
+const MIN_PARTIAL_SCHEME_LEN: usize = 3;
+
+/// Returns `true` when `bytes` ends with a **partial** (incomplete) prefix
+/// of one of the schemes [`find_urls_bytes`] recognizes.
+///
+/// A `true` result means a soft wrap may have split the scheme itself across
+/// this row and the next, so [`find_urls_bytes`] found *no match at all* on
+/// this row (unlike a URL that wraps after the scheme is complete, which
+/// still produces a [`UrlMatch`] with [`UrlMatch::touches_buffer_end`] set).
+///
+/// See [`MIN_PARTIAL_SCHEME_LEN`] for the false-positive/completeness
+/// trade-off in how short a partial prefix is recognized.
+#[must_use]
+pub fn row_tail_could_be_wrapped_scheme(bytes: &[u8]) -> bool {
+    SCHEMES.iter().any(|scheme| {
+        (MIN_PARTIAL_SCHEME_LEN..scheme.len()).any(|len| bytes.ends_with(&scheme[..len]))
+    })
+}
+
 /// Find all URL matches in `bytes`.
 ///
 /// Returns ranges relative to `bytes`. Trailing sentence punctuation and
@@ -328,5 +367,34 @@ mod tests {
             ranges[0].touches_buffer_end,
             "trailing-punctuation trimming must not affect touches_buffer_end"
         );
+    }
+
+    #[test]
+    fn row_tail_partial_scheme_detects_each_scheme() {
+        assert!(row_tail_could_be_wrapped_scheme(b"see htt"));
+        assert!(row_tail_could_be_wrapped_scheme(b"see https:"));
+        assert!(row_tail_could_be_wrapped_scheme(b"see ftp"));
+        assert!(row_tail_could_be_wrapped_scheme(b"see ftp:/"));
+        assert!(row_tail_could_be_wrapped_scheme(b"see fil"));
+        assert!(row_tail_could_be_wrapped_scheme(b"see file:/"));
+        assert!(row_tail_could_be_wrapped_scheme(b"see mai"));
+        assert!(row_tail_could_be_wrapped_scheme(b"see mailto"));
+    }
+
+    #[test]
+    fn row_tail_partial_scheme_ignores_full_scheme() {
+        // A *complete* scheme is not this helper's job — `find_urls_bytes`
+        // already matches it and `UrlMatch::touches_buffer_end` covers the
+        // continuation signal for that case.
+        assert!(!row_tail_could_be_wrapped_scheme(b"see https://"));
+        assert!(!row_tail_could_be_wrapped_scheme(b"see mailto:"));
+    }
+
+    #[test]
+    fn row_tail_partial_scheme_ignores_short_or_unrelated_endings() {
+        assert!(!row_tail_could_be_wrapped_scheme(b"the light"));
+        assert!(!row_tail_could_be_wrapped_scheme(b"a gift"));
+        assert!(!row_tail_could_be_wrapped_scheme(b""));
+        assert!(!row_tail_could_be_wrapped_scheme(b"just prose"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #418.

Auto-detected plain-text URLs (`http`/`https`/`ftp`/`file`/`mailto`) were regex-matched independently per physical row, so a URL that DECAWM soft-wraps across two or more rows was split into several independent, truncated fragments -- each carrying its own partial `Arc<Url>`. Clicking/opening such a URL only opened whichever fragment covered the clicked cell.

A related, subtler bug: `url_detect::trim_trailing`'s trailing-punctuation heuristic assumed a row-local match's end was the URL's real end, so a wrap boundary landing right before a stripped character (e.g. the `.` in `index.html`) corrupted the fragment even before truncation.

OSC 8 hyperlinks were already unaffected (they carry one `Arc<Url>` across wraps via the cursor's persistent format state), so this is scoped to auto-detected plain-text URLs only.

## Fix (freminal-buffer only, no public API/GUI changes)

- Groups contiguous rows joined by `RowJoin::ContinueLogicalLine` (one DECAWM-wrapped logical line) during the existing per-row cache-build pass.
- Only for groups that show a genuine wrap-boundary signal (`UrlMatch::touches_buffer_end`, a new precise flag distinguishing "raw regex match reached the row's raw byte end" from "a self-contained URL happens to also exist somewhere in this soft-wrapped run"), re-runs URL detection once on the group's concatenated bytes and splices the resulting full-text `Arc<Url>` back across the contributing rows.
- The grouping/signal-check pass is fused into the existing per-row cache-refresh loop (no second full traversal), and the group-corrected ranges are a sparse, unallocated-when-empty structure, so the fix costs nothing when nothing wraps or a wrapped line has no URL content -- the overwhelming common case.

## Testing

- New regression tests in `flatten.rs`: two-row wrap, three-row wrap, trailing-punctuation-at-wrap-boundary, hard-break lines correctly NOT merging unrelated URLs, and wrapped lines with no URL content staying a no-op. Verified each fails without the fix and passes with it.
- New unit tests in `url_detect.rs` for `UrlMatch::touches_buffer_end`.
- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo machete`, `cargo fmt --check`, `cargo xtask check-windows` all green.

## Performance

Added `bench_flatten_wrapped_url_heavy` (no prior benchmark covered the wrapped-URL path) and fixed a latent construction bug in `bench_flatten_url_heavy` (it embedded `TChar::NewLine` as a printable cell instead of driving a real `handle_lf`/`handle_cr` break, so it never actually tested hard-broken lines as documented).

| Benchmark | Delta |
| --- | --- |
| bench_visible_flatten | ~0% (noise) |
| bench_scrollback_flatten | +2 to +6% |
| bench_flatten_url_heavy | ~0% (noise) |
| bench_flatten_wrapped_url_heavy (new; worst case: one URL wrapping the entire 80x50 screen) | ~0% (noise) |
| bench_scroll_into_compressed_region | ~0% (noise) |

All well under the 15% regression threshold.

🤖 Generated with [opencode](https://opencode.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL auto-detection for soft-wrapped links that span multiple terminal rows, reconstructing them as a single complete link.
  * Correctly preserves trailing punctuation at wrap boundaries.
  * Ensures hard line breaks still prevent URLs from being combined.
* **Tests**
  * Added regression coverage for multi-row wrapped URLs, punctuation behavior, and non-merging across hard breaks.
* **Performance / Benchmarks**
  * Added benchmarks for hard vs soft-wrapped, long URL scenarios to track wrapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->