### PR TITLE
perf: damage-aware present for cursor-only frames (#435)

### DIFF
--- a/freminal-windowing/src/egui_integration.rs
+++ b/freminal-windowing/src/egui_integration.rs
@@ -68,10 +68,11 @@ impl EguiState {
         gl_state: &GlState,
         clear_color: [f32; 4],
         raw_input: egui::RawInput,
+        present_flag: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
         ui_fn: F,
     ) -> FrameOutput
     where
-        F: FnMut(&egui::Context, &glow::Context),
+        F: FnMut(&egui::Context, &glow::Context) -> crate::FrameDamage,
     {
         let mut ui_fn = ui_fn;
 
@@ -79,8 +80,14 @@ impl EguiState {
         // `Context::run_ui` (closure takes the root `&mut Ui`).  Our `App`
         // trait still works in terms of `&Context`; `Ui` derefs to `Context`,
         // so deref explicitly rather than relying on a silent coercion.
+        //
+        // The closure both runs the app's `update` and returns this frame's
+        // damage report; we capture it here to decide the clear/present path
+        // below. Running both inside the one closure avoids two simultaneous
+        // `&mut app` borrows in the caller.
+        let mut frame_damage = crate::FrameDamage::Full;
         let full_output = self.ctx.run_ui(raw_input, |root_ui| {
-            ui_fn(&*root_ui, &gl_state.glow_context);
+            frame_damage = ui_fn(&*root_ui, &gl_state.glow_context);
         });
 
         self.winit_state
@@ -90,7 +97,38 @@ impl EguiState {
         let clipped_primitives = self.ctx.tessellate(full_output.shapes, pixels_per_point);
 
         let size = window.inner_size();
-        gl_state.clear(clear_color);
+
+        // Decide whether this frame may skip the full clear and present only
+        // its damaged region. This is a two-part gate:
+        //   1. The app reports the frame as `Partial` (only the listed rects
+        //      changed; everything else is identical to the previous frame).
+        //   2. The back buffer still holds the previous frame's contents
+        //      (`buffer_age() == 1`), and the surface can present a sub-region.
+        // If either fails we fall back to the always-correct full path:
+        // clear + full paint + full swap.
+        let partial = match frame_damage {
+            crate::FrameDamage::Partial(rects)
+                if !rects.is_empty()
+                    && gl_state.supports_partial_present()
+                    && gl_state.buffer_age() == 1 =>
+            {
+                Some(rects)
+            }
+            _ => None,
+        };
+
+        if partial.is_none() {
+            gl_state.clear(clear_color);
+        }
+
+        // Publish the authoritative decision BEFORE the paint callbacks run
+        // (they execute inside `paint_and_update_textures` below), so any
+        // callback that scissors to the damage region gates on the same
+        // value that decided whether the clear was skipped. Same-thread store
+        // immediately before the reads -> `Relaxed` is sufficient.
+        if let Some(flag) = present_flag {
+            flag.store(partial.is_some(), std::sync::atomic::Ordering::Relaxed);
+        }
 
         self.painter.paint_and_update_textures(
             [size.width, size.height],
@@ -102,7 +140,11 @@ impl EguiState {
         // Pre-present notify for Wayland frame pacing
         window.pre_present_notify();
 
-        if let Err(e) = gl_state.swap_buffers() {
+        let swap_result = partial.as_ref().map_or_else(
+            || gl_state.swap_buffers(),
+            |rects| gl_state.swap_buffers_with_damage(rects),
+        );
+        if let Err(e) = swap_result {
             tracing::error!("swap_buffers failed: {e}");
         }
 

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -583,13 +583,21 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                 let mut raw_input = state.egui.take_egui_input(&state.window);
                 app.raw_input_hook(window_id, &mut raw_input);
 
+                // Fetch the partial-present flag up front (immutable borrow of
+                // `app`, released before the `ui_fn` mutable borrow) so the
+                // windowing layer can publish the authoritative decision into
+                // it mid-frame without a second `&mut app` borrow.
+                let present_flag = app.present_partial_flag(window_id);
+
                 let frame_output = state.egui.run_frame(
                     &state.window,
                     &state.gl,
                     clear_color,
                     raw_input,
+                    present_flag.as_ref(),
                     |ctx, gl| {
                         app.update(window_id, ctx, gl, &handle);
+                        app.take_frame_damage(window_id)
                     },
                 );
 

--- a/freminal-windowing/src/gl_context.rs
+++ b/freminal-windowing/src/gl_context.rs
@@ -13,22 +13,54 @@ use std::sync::Arc;
 use glow::HasContext;
 use glutin::config::{Config, ConfigTemplateBuilder};
 use glutin::context::{ContextApi, ContextAttributesBuilder, PossiblyCurrentContext};
-use glutin::display::GetGlDisplay;
+use glutin::display::{AsRawDisplay, GetGlDisplay, RawDisplay};
 use glutin::prelude::*;
-use glutin::surface::{Surface, SurfaceAttributesBuilder, SwapInterval, WindowSurface};
+use glutin::surface::{
+    AsRawSurface, RawSurface, Surface, SurfaceAttributesBuilder, SwapInterval, WindowSurface,
+};
 use glutin_winit::DisplayBuilder;
 use raw_window_handle::HasWindowHandle;
 use tracing::{debug, warn};
 use winit::event_loop::ActiveEventLoop;
 use winit::window::Window;
 
+use crate::DamageRect;
 use crate::error::Error;
+
+/// The EGL `eglSwapBuffersWithDamageKHR` / `EXT` entry point signature.
+///
+/// `EGLBoolean eglSwapBuffersWithDamage(EGLDisplay dpy, EGLSurface surface,
+/// const EGLint *rects, EGLint n_rects)`. Each rect is 4 `EGLint`s
+/// (`x, y, width, height`), bottom-left origin, in physical pixels.
+type EglSwapBuffersWithDamageFn = unsafe extern "C" fn(
+    dpy: *const std::ffi::c_void,
+    surface: *const std::ffi::c_void,
+    rects: *const std::ffi::c_int,
+    n_rects: std::ffi::c_int,
+) -> std::ffi::c_uint;
+
+/// Optional EGL partial-present support probed at context-creation time.
+///
+/// Present only when the GL backend is EGL **and** the display advertises
+/// `EGL_KHR_swap_buffers_with_damage` (or the `EXT` variant). On any other
+/// backend (GLX, WGL on Windows, CGL on macOS) this stays `None` and the
+/// windowing layer falls back to a full [`GlState::swap_buffers`].
+struct EglDamageSupport {
+    /// Raw `EGLDisplay` handle (borrowed from glutin; valid for the lifetime
+    /// of the `GlState`'s display).
+    egl_display: *const std::ffi::c_void,
+    /// The resolved `eglSwapBuffersWithDamage{KHR,EXT}` function pointer.
+    swap_with_damage: EglSwapBuffersWithDamageFn,
+}
 
 /// Holds all GL state for a single window.
 pub struct GlState {
     pub(crate) surface: Surface<WindowSurface>,
     pub(crate) context: PossiblyCurrentContext,
     pub(crate) glow_context: Arc<glow::Context>,
+    /// EGL partial-present support, or `None` when unavailable (non-EGL
+    /// backend, or the damage extension is not advertised).
+    egl_damage: Option<EglDamageSupport>,
 }
 
 impl GlState {
@@ -121,10 +153,16 @@ impl GlState {
             glow::Context::from_loader_function_cstr(|name| gl_display.get_proc_address(name))
         });
 
+        // Probe optional EGL partial-present support. Absent on GLX / WGL /
+        // CGL and on EGL displays that do not advertise the damage extension;
+        // in all those cases we fall back to a full `swap_buffers`.
+        let egl_damage = probe_egl_damage_support(&gl_display, &surface);
+
         Ok(Self {
             surface,
             context,
             glow_context,
+            egl_damage,
         })
     }
 
@@ -159,6 +197,155 @@ impl GlState {
             self.glow_context.clear(glow::COLOR_BUFFER_BIT);
         }
     }
+
+    /// Age of the current back buffer.
+    ///
+    /// Returns `1` when the back buffer still holds the **previous** frame's
+    /// contents (so a skip-clear + partial redraw is safe), and `0` when the
+    /// buffer is new or its age is unknown (so the whole buffer must be
+    /// redrawn). Values `> 1` mean the buffer holds an older frame and is
+    /// likewise unsafe to treat as "last frame".
+    ///
+    /// On non-EGL backends and platforms without `EGL_EXT_buffer_age` this
+    /// returns `0`, which correctly forces the full-frame path.
+    pub(crate) fn buffer_age(&self) -> u32 {
+        self.surface.buffer_age()
+    }
+
+    /// Whether this surface can present only a damaged sub-region
+    /// (`eglSwapBuffersWithDamage`). When `false`, callers must use the full
+    /// [`GlState::swap_buffers`].
+    pub(crate) const fn supports_partial_present(&self) -> bool {
+        self.egl_damage.is_some()
+    }
+
+    /// Present only the damaged rectangles via `eglSwapBuffersWithDamage`.
+    ///
+    /// `rects` are in physical pixels with a bottom-left origin (EGL
+    /// convention). An empty slice damages the entire surface (per the EGL
+    /// spec), matching a normal swap.
+    ///
+    /// Falls back to a full [`GlState::swap_buffers`] when partial present is
+    /// unsupported, so callers may invoke it unconditionally.
+    pub(crate) fn swap_buffers_with_damage(&self, rects: &[DamageRect]) -> Result<(), Error> {
+        let Some(damage) = &self.egl_damage else {
+            return self.swap_buffers();
+        };
+
+        // Flatten to the EGL `EGLint[4 * n]` layout: x, y, width, height.
+        let mut flat: Vec<std::ffi::c_int> = Vec::with_capacity(rects.len() * 4);
+        for r in rects {
+            flat.push(r.x);
+            flat.push(r.y);
+            flat.push(r.width);
+            flat.push(r.height);
+        }
+
+        // `egl_damage` is only `Some` for an EGL surface, so this always
+        // matches; the `else` is a defensive fallback should the backend ever
+        // differ.
+        let RawSurface::Egl(raw_surface) = self.surface.raw_surface() else {
+            return self.swap_buffers();
+        };
+
+        // SAFETY: `damage.swap_with_damage` was resolved from this display's
+        // `get_proc_address` at creation time and is only `Some` when the EGL
+        // damage extension is advertised. `damage.egl_display` and
+        // `raw_surface` are the live EGL display/surface handles for this
+        // context (the surface handle is re-fetched here, not cached). `flat`
+        // outlives the call and its length in rects (`flat.len() / 4`) fits an
+        // `EGLint` for any realistic rect count. The context is current
+        // (callers `make_current` before rendering), as `swap_buffers` also
+        // requires.
+        let count: std::ffi::c_int = match (flat.len() / 4).try_into() {
+            Ok(n) => n,
+            // Absurd rect count; a full present is always correct.
+            Err(_) => return self.swap_buffers(),
+        };
+        let ok = unsafe {
+            (damage.swap_with_damage)(damage.egl_display, raw_surface, flat.as_ptr(), count)
+        };
+        if ok == 0 {
+            // EGL_FALSE — fall back to a normal swap so the frame still
+            // presents. (An eglGetError diagnostic is not worth a per-frame
+            // FFI call on the hot path.)
+            return self.swap_buffers();
+        }
+        Ok(())
+    }
+}
+
+/// EGL constant `EGL_EXTENSIONS` for `eglQueryString`.
+const EGL_EXTENSIONS: std::ffi::c_int = 0x3055;
+
+/// `const char *eglQueryString(EGLDisplay dpy, EGLint name)`.
+type EglQueryStringFn = unsafe extern "C" fn(
+    dpy: *const std::ffi::c_void,
+    name: std::ffi::c_int,
+) -> *const std::ffi::c_char;
+
+/// Probe whether the given display+surface support EGL partial present.
+///
+/// Returns `Some` only when (1) the backend is EGL, (2) the display
+/// advertises `EGL_KHR_swap_buffers_with_damage` or
+/// `EGL_EXT_swap_buffers_with_damage`, and (3) the corresponding function
+/// pointer resolves. On GLX / WGL / CGL the `RawDisplay`/`RawSurface`
+/// `Egl` variants are absent (or the match falls through), so this returns
+/// `None` and the caller uses the full-swap path.
+fn probe_egl_damage_support(
+    display: &glutin::display::Display,
+    surface: &Surface<WindowSurface>,
+) -> Option<EglDamageSupport> {
+    // Must be an EGL display and an EGL surface.
+    let RawDisplay::Egl(egl_display) = display.raw_display() else {
+        return None;
+    };
+    if !matches!(surface.raw_surface(), RawSurface::Egl(_)) {
+        return None;
+    }
+
+    // Query the display extension string.
+    let query_string_ptr = display.get_proc_address(c"eglQueryString");
+    if query_string_ptr.is_null() {
+        return None;
+    }
+    // SAFETY: `eglQueryString` resolved to a non-null pointer with the
+    // documented EGL signature; `egl_display` is this display's live
+    // `EGLDisplay`. `EGL_EXTENSIONS` returns a static, NUL-terminated string
+    // owned by EGL (not freed by us).
+    let query_string: EglQueryStringFn = unsafe { std::mem::transmute(query_string_ptr) };
+    let ext_ptr = unsafe { query_string(egl_display, EGL_EXTENSIONS) };
+    if ext_ptr.is_null() {
+        return None;
+    }
+    // SAFETY: EGL guarantees a NUL-terminated string here.
+    let extensions = unsafe { std::ffi::CStr::from_ptr(ext_ptr) }
+        .to_str()
+        .unwrap_or("");
+
+    // Prefer KHR, then EXT; both share the same signature.
+    let symbol = if extensions.contains("EGL_KHR_swap_buffers_with_damage") {
+        Some(c"eglSwapBuffersWithDamageKHR")
+    } else if extensions.contains("EGL_EXT_swap_buffers_with_damage") {
+        Some(c"eglSwapBuffersWithDamageEXT")
+    } else {
+        None
+    };
+    let symbol = symbol?;
+
+    let fn_ptr = display.get_proc_address(symbol);
+    if fn_ptr.is_null() {
+        return None;
+    }
+    // SAFETY: the pointer is non-null and resolved for a symbol whose
+    // advertised extension guarantees the documented signature.
+    let swap_with_damage: EglSwapBuffersWithDamageFn = unsafe { std::mem::transmute(fn_ptr) };
+
+    debug!("EGL partial present enabled ({})", symbol.to_string_lossy());
+    Some(EglDamageSupport {
+        egl_display,
+        swap_with_damage,
+    })
 }
 
 /// Pick the GL config with the highest multisample count.

--- a/freminal-windowing/src/gl_context.rs
+++ b/freminal-windowing/src/gl_context.rs
@@ -379,7 +379,11 @@ impl GlState {
     }
 
     /// Always `false` on Apple platforms — there is no EGL backend.
+    // `&self` is kept for call-site symmetry with the non-Apple variant (the
+    // caller does `self.supports_partial_present()`); the Apple answer is a
+    // constant, so `self` is genuinely unused here.
     #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[allow(clippy::unused_self)]
     pub(crate) const fn supports_partial_present(&self) -> bool {
         false
     }

--- a/freminal-windowing/src/gl_context.rs
+++ b/freminal-windowing/src/gl_context.rs
@@ -13,44 +13,175 @@ use std::sync::Arc;
 use glow::HasContext;
 use glutin::config::{Config, ConfigTemplateBuilder};
 use glutin::context::{ContextApi, ContextAttributesBuilder, PossiblyCurrentContext};
-use glutin::display::{AsRawDisplay, GetGlDisplay, RawDisplay};
+use glutin::display::GetGlDisplay;
 use glutin::prelude::*;
-use glutin::surface::{
-    AsRawSurface, RawSurface, Surface, SurfaceAttributesBuilder, SwapInterval, WindowSurface,
-};
+use glutin::surface::{Surface, SurfaceAttributesBuilder, SwapInterval, WindowSurface};
 use glutin_winit::DisplayBuilder;
 use raw_window_handle::HasWindowHandle;
-use tracing::{debug, warn};
+use tracing::warn;
 use winit::event_loop::ActiveEventLoop;
 use winit::window::Window;
 
 use crate::DamageRect;
 use crate::error::Error;
 
-/// The EGL `eglSwapBuffersWithDamageKHR` / `EXT` entry point signature.
-///
-/// `EGLBoolean eglSwapBuffersWithDamage(EGLDisplay dpy, EGLSurface surface,
-/// const EGLint *rects, EGLint n_rects)`. Each rect is 4 `EGLint`s
-/// (`x, y, width, height`), bottom-left origin, in physical pixels.
-type EglSwapBuffersWithDamageFn = unsafe extern "C" fn(
-    dpy: *const std::ffi::c_void,
-    surface: *const std::ffi::c_void,
-    rects: *const std::ffi::c_int,
-    n_rects: std::ffi::c_int,
-) -> std::ffi::c_uint;
+// EGL partial-present is only available on backends where glutin compiles its
+// EGL path — i.e. everywhere except the Apple platforms (which are CGL-only,
+// and where `glutin::{surface::RawSurface, display::RawDisplay}` do not even
+// have an `Egl` variant). Mirror glutin's own `egl_backend` cfg with an
+// OS-based alias so the entire EGL FFI compiles out on macOS/iOS and the code
+// falls back to a full `swap_buffers` there.
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+mod egl_damage {
+    use glutin::display::{AsRawDisplay, GlDisplay, RawDisplay};
+    use glutin::surface::{AsRawSurface, RawSurface, Surface, WindowSurface};
 
-/// Optional EGL partial-present support probed at context-creation time.
-///
-/// Present only when the GL backend is EGL **and** the display advertises
-/// `EGL_KHR_swap_buffers_with_damage` (or the `EXT` variant). On any other
-/// backend (GLX, WGL on Windows, CGL on macOS) this stays `None` and the
-/// windowing layer falls back to a full [`GlState::swap_buffers`].
-struct EglDamageSupport {
-    /// Raw `EGLDisplay` handle (borrowed from glutin; valid for the lifetime
-    /// of the `GlState`'s display).
-    egl_display: *const std::ffi::c_void,
-    /// The resolved `eglSwapBuffersWithDamage{KHR,EXT}` function pointer.
-    swap_with_damage: EglSwapBuffersWithDamageFn,
+    use crate::DamageRect;
+
+    /// The EGL `eglSwapBuffersWithDamageKHR` / `EXT` entry point signature.
+    ///
+    /// `EGLBoolean eglSwapBuffersWithDamage(EGLDisplay dpy, EGLSurface surface,
+    /// const EGLint *rects, EGLint n_rects)`. Each rect is 4 `EGLint`s
+    /// (`x, y, width, height`), bottom-left origin, in physical pixels.
+    type EglSwapBuffersWithDamageFn = unsafe extern "C" fn(
+        dpy: *const std::ffi::c_void,
+        surface: *const std::ffi::c_void,
+        rects: *const std::ffi::c_int,
+        n_rects: std::ffi::c_int,
+    ) -> std::ffi::c_uint;
+
+    /// `const char *eglQueryString(EGLDisplay dpy, EGLint name)`.
+    type EglQueryStringFn = unsafe extern "C" fn(
+        dpy: *const std::ffi::c_void,
+        name: std::ffi::c_int,
+    ) -> *const std::ffi::c_char;
+
+    /// EGL constant `EGL_EXTENSIONS` for `eglQueryString`.
+    const EGL_EXTENSIONS: std::ffi::c_int = 0x3055;
+
+    /// Optional EGL partial-present support probed at context-creation time.
+    ///
+    /// Present only when the display advertises
+    /// `EGL_KHR_swap_buffers_with_damage` (or the `EXT` variant). On any
+    /// backend without it this stays `None` and the caller falls back to a
+    /// full swap.
+    pub(super) struct EglDamageSupport {
+        /// Raw `EGLDisplay` handle (borrowed from glutin; valid for the
+        /// lifetime of the `GlState`'s display).
+        egl_display: *const std::ffi::c_void,
+        /// The resolved `eglSwapBuffersWithDamage{KHR,EXT}` function pointer.
+        swap_with_damage: EglSwapBuffersWithDamageFn,
+    }
+
+    /// Present only the damaged rectangles via `eglSwapBuffersWithDamage`.
+    ///
+    /// Returns `true` when the partial present succeeded, `false` when the
+    /// caller should fall back to a full swap (EGL returned false, the surface
+    /// backend was not EGL, or an absurd rect count). Never presents on its
+    /// own on the fallback path — the caller does the full swap.
+    pub(super) fn swap_with_damage(
+        support: &EglDamageSupport,
+        surface: &Surface<WindowSurface>,
+        rects: &[DamageRect],
+    ) -> bool {
+        // Flatten to the EGL `EGLint[4 * n]` layout: x, y, width, height.
+        let mut flat: Vec<std::ffi::c_int> = Vec::with_capacity(rects.len() * 4);
+        for r in rects {
+            flat.push(r.x);
+            flat.push(r.y);
+            flat.push(r.width);
+            flat.push(r.height);
+        }
+
+        // `support` is only constructed for an EGL surface, so this always
+        // matches; the `else` is a defensive fallback should the backend
+        // ever differ.
+        let RawSurface::Egl(raw_surface) = surface.raw_surface() else {
+            return false;
+        };
+
+        let count: std::ffi::c_int = match (flat.len() / 4).try_into() {
+            Ok(n) => n,
+            // Absurd rect count; a full present is always correct.
+            Err(_) => return false,
+        };
+        // SAFETY: `support.swap_with_damage` was resolved from this display's
+        // `get_proc_address` at creation time and only exists when the EGL
+        // damage extension is advertised. `support.egl_display` and
+        // `raw_surface` are the live EGL display/surface handles for this
+        // context (the surface handle is re-fetched here, not cached). `flat`
+        // outlives the call and `count` fits an `EGLint`. The context is
+        // current (callers `make_current` before rendering).
+        let ok = unsafe {
+            (support.swap_with_damage)(support.egl_display, raw_surface, flat.as_ptr(), count)
+        };
+        // `EGL_FALSE` -> tell the caller to do a normal swap.
+        ok != 0
+    }
+
+    /// Probe whether the given display+surface support EGL partial present.
+    ///
+    /// Returns `Some` only when (1) the backend is EGL, (2) the display
+    /// advertises `EGL_KHR_swap_buffers_with_damage` or the `EXT` variant, and
+    /// (3) the corresponding function pointer resolves.
+    pub(super) fn probe(
+        display: &glutin::display::Display,
+        surface: &Surface<WindowSurface>,
+    ) -> Option<EglDamageSupport> {
+        // Must be an EGL display and an EGL surface.
+        let RawDisplay::Egl(egl_display) = display.raw_display() else {
+            return None;
+        };
+        if !matches!(surface.raw_surface(), RawSurface::Egl(_)) {
+            return None;
+        }
+
+        // Query the display extension string.
+        let query_string_ptr = display.get_proc_address(c"eglQueryString");
+        if query_string_ptr.is_null() {
+            return None;
+        }
+        // SAFETY: `eglQueryString` resolved to a non-null pointer with the
+        // documented EGL signature; `egl_display` is this display's live
+        // `EGLDisplay`. `EGL_EXTENSIONS` returns a static, NUL-terminated
+        // string owned by EGL (not freed by us).
+        let query_string: EglQueryStringFn = unsafe { std::mem::transmute(query_string_ptr) };
+        let ext_ptr = unsafe { query_string(egl_display, EGL_EXTENSIONS) };
+        if ext_ptr.is_null() {
+            return None;
+        }
+        // SAFETY: EGL guarantees a NUL-terminated string here.
+        let extensions = unsafe { std::ffi::CStr::from_ptr(ext_ptr) }
+            .to_str()
+            .unwrap_or("");
+
+        // The EGL extension string is space-separated; match whole tokens
+        // rather than substrings so a longer extension name that merely
+        // contains one of ours as a substring can't produce a false positive.
+        let has_ext = |name: &str| extensions.split(' ').any(|tok| tok == name);
+        // Prefer KHR, then EXT; both share the same signature.
+        let symbol = if has_ext("EGL_KHR_swap_buffers_with_damage") {
+            Some(c"eglSwapBuffersWithDamageKHR")
+        } else if has_ext("EGL_EXT_swap_buffers_with_damage") {
+            Some(c"eglSwapBuffersWithDamageEXT")
+        } else {
+            None
+        };
+        let symbol = symbol?;
+
+        let fn_ptr = display.get_proc_address(symbol);
+        if fn_ptr.is_null() {
+            return None;
+        }
+        // SAFETY: the pointer is non-null and resolved for a symbol whose
+        // advertised extension guarantees the documented signature.
+        let swap_with_damage: EglSwapBuffersWithDamageFn = unsafe { std::mem::transmute(fn_ptr) };
+
+        Some(EglDamageSupport {
+            egl_display,
+            swap_with_damage,
+        })
+    }
 }
 
 /// Holds all GL state for a single window.
@@ -58,9 +189,10 @@ pub struct GlState {
     pub(crate) surface: Surface<WindowSurface>,
     pub(crate) context: PossiblyCurrentContext,
     pub(crate) glow_context: Arc<glow::Context>,
-    /// EGL partial-present support, or `None` when unavailable (non-EGL
-    /// backend, or the damage extension is not advertised).
-    egl_damage: Option<EglDamageSupport>,
+    /// EGL partial-present support, or `None` when unavailable (extension not
+    /// advertised). Absent entirely on Apple platforms (CGL, no EGL backend).
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    egl_damage: Option<egl_damage::EglDamageSupport>,
 }
 
 impl GlState {
@@ -94,7 +226,7 @@ impl GlState {
 
         let gl_display = gl_config.display();
 
-        debug!(
+        tracing::debug!(
             "Selected GL config: samples={}, alpha={}",
             gl_config.num_samples(),
             gl_config.alpha_size()
@@ -153,15 +285,41 @@ impl GlState {
             glow::Context::from_loader_function_cstr(|name| gl_display.get_proc_address(name))
         });
 
-        // Probe optional EGL partial-present support. Absent on GLX / WGL /
-        // CGL and on EGL displays that do not advertise the damage extension;
-        // in all those cases we fall back to a full `swap_buffers`.
-        let egl_damage = probe_egl_damage_support(&gl_display, &surface);
+        // Probe optional EGL partial-present support. Absent on GLX / WGL and
+        // on EGL displays that do not advertise the damage extension; in all
+        // those cases we fall back to a full `swap_buffers`. On Apple
+        // platforms (CGL) there is no EGL backend at all, so the field and the
+        // probe are compiled out.
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+        let egl_damage = egl_damage::probe(&gl_display, &surface);
+
+        // Report which present path was selected (#435). On Linux/EGL with a
+        // compositor advertising the swap-with-damage extension we get the
+        // fast path (skip-clear + partial present for cursor-only frames);
+        // everywhere else we do a full clear + full present every frame.
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+        if egl_damage.is_some() {
+            tracing::info!(
+                "Present path: damage-aware (EGL swap-with-damage) — cursor-only \
+                 frames will skip the full clear and present only the changed region"
+            );
+        } else {
+            tracing::info!(
+                "Present path: full-frame (EGL swap-with-damage unavailable) — \
+                 every frame does a full clear + present"
+            );
+        }
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        tracing::info!(
+            "Present path: full-frame (no EGL backend on this platform) — every \
+             frame does a full clear + present"
+        );
 
         Ok(Self {
             surface,
             context,
             glow_context,
+            #[cfg(not(any(target_os = "macos", target_os = "ios")))]
             egl_damage,
         })
     }
@@ -214,142 +372,45 @@ impl GlState {
 
     /// Whether this surface can present only a damaged sub-region
     /// (`eglSwapBuffersWithDamage`). When `false`, callers must use the full
-    /// [`GlState::swap_buffers`].
+    /// [`GlState::swap_buffers`]. Always `false` on Apple platforms (CGL).
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     pub(crate) const fn supports_partial_present(&self) -> bool {
         self.egl_damage.is_some()
+    }
+
+    /// Always `false` on Apple platforms — there is no EGL backend.
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    pub(crate) const fn supports_partial_present(&self) -> bool {
+        false
     }
 
     /// Present only the damaged rectangles via `eglSwapBuffersWithDamage`.
     ///
     /// `rects` are in physical pixels with a bottom-left origin (EGL
-    /// convention). An empty slice damages the entire surface (per the EGL
-    /// spec), matching a normal swap.
-    ///
-    /// Falls back to a full [`GlState::swap_buffers`] when partial present is
-    /// unsupported, so callers may invoke it unconditionally.
+    /// convention). Falls back to a full [`GlState::swap_buffers`] when
+    /// partial present is unsupported (extension absent, EGL returns false,
+    /// or — on Apple platforms — there is no EGL backend at all), so callers
+    /// may invoke it unconditionally.
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     pub(crate) fn swap_buffers_with_damage(&self, rects: &[DamageRect]) -> Result<(), Error> {
-        let Some(damage) = &self.egl_damage else {
+        let Some(support) = &self.egl_damage else {
             return self.swap_buffers();
         };
-
-        // Flatten to the EGL `EGLint[4 * n]` layout: x, y, width, height.
-        let mut flat: Vec<std::ffi::c_int> = Vec::with_capacity(rects.len() * 4);
-        for r in rects {
-            flat.push(r.x);
-            flat.push(r.y);
-            flat.push(r.width);
-            flat.push(r.height);
+        if egl_damage::swap_with_damage(support, &self.surface, rects) {
+            // Partial present succeeded.
+            Ok(())
+        } else {
+            // Extension said no / non-EGL surface / absurd rect count — do a
+            // normal full swap so the frame still presents.
+            self.swap_buffers()
         }
-
-        // `egl_damage` is only `Some` for an EGL surface, so this always
-        // matches; the `else` is a defensive fallback should the backend ever
-        // differ.
-        let RawSurface::Egl(raw_surface) = self.surface.raw_surface() else {
-            return self.swap_buffers();
-        };
-
-        // SAFETY: `damage.swap_with_damage` was resolved from this display's
-        // `get_proc_address` at creation time and is only `Some` when the EGL
-        // damage extension is advertised. `damage.egl_display` and
-        // `raw_surface` are the live EGL display/surface handles for this
-        // context (the surface handle is re-fetched here, not cached). `flat`
-        // outlives the call and its length in rects (`flat.len() / 4`) fits an
-        // `EGLint` for any realistic rect count. The context is current
-        // (callers `make_current` before rendering), as `swap_buffers` also
-        // requires.
-        let count: std::ffi::c_int = match (flat.len() / 4).try_into() {
-            Ok(n) => n,
-            // Absurd rect count; a full present is always correct.
-            Err(_) => return self.swap_buffers(),
-        };
-        let ok = unsafe {
-            (damage.swap_with_damage)(damage.egl_display, raw_surface, flat.as_ptr(), count)
-        };
-        if ok == 0 {
-            // EGL_FALSE — fall back to a normal swap so the frame still
-            // presents. (An eglGetError diagnostic is not worth a per-frame
-            // FFI call on the hot path.)
-            return self.swap_buffers();
-        }
-        Ok(())
-    }
-}
-
-/// EGL constant `EGL_EXTENSIONS` for `eglQueryString`.
-const EGL_EXTENSIONS: std::ffi::c_int = 0x3055;
-
-/// `const char *eglQueryString(EGLDisplay dpy, EGLint name)`.
-type EglQueryStringFn = unsafe extern "C" fn(
-    dpy: *const std::ffi::c_void,
-    name: std::ffi::c_int,
-) -> *const std::ffi::c_char;
-
-/// Probe whether the given display+surface support EGL partial present.
-///
-/// Returns `Some` only when (1) the backend is EGL, (2) the display
-/// advertises `EGL_KHR_swap_buffers_with_damage` or
-/// `EGL_EXT_swap_buffers_with_damage`, and (3) the corresponding function
-/// pointer resolves. On GLX / WGL / CGL the `RawDisplay`/`RawSurface`
-/// `Egl` variants are absent (or the match falls through), so this returns
-/// `None` and the caller uses the full-swap path.
-fn probe_egl_damage_support(
-    display: &glutin::display::Display,
-    surface: &Surface<WindowSurface>,
-) -> Option<EglDamageSupport> {
-    // Must be an EGL display and an EGL surface.
-    let RawDisplay::Egl(egl_display) = display.raw_display() else {
-        return None;
-    };
-    if !matches!(surface.raw_surface(), RawSurface::Egl(_)) {
-        return None;
     }
 
-    // Query the display extension string.
-    let query_string_ptr = display.get_proc_address(c"eglQueryString");
-    if query_string_ptr.is_null() {
-        return None;
+    /// On Apple platforms there is no EGL partial present; always full swap.
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    pub(crate) fn swap_buffers_with_damage(&self, _rects: &[DamageRect]) -> Result<(), Error> {
+        self.swap_buffers()
     }
-    // SAFETY: `eglQueryString` resolved to a non-null pointer with the
-    // documented EGL signature; `egl_display` is this display's live
-    // `EGLDisplay`. `EGL_EXTENSIONS` returns a static, NUL-terminated string
-    // owned by EGL (not freed by us).
-    let query_string: EglQueryStringFn = unsafe { std::mem::transmute(query_string_ptr) };
-    let ext_ptr = unsafe { query_string(egl_display, EGL_EXTENSIONS) };
-    if ext_ptr.is_null() {
-        return None;
-    }
-    // SAFETY: EGL guarantees a NUL-terminated string here.
-    let extensions = unsafe { std::ffi::CStr::from_ptr(ext_ptr) }
-        .to_str()
-        .unwrap_or("");
-
-    // The EGL extension string is space-separated; match whole tokens rather
-    // than substrings so a longer extension name that merely contains one of
-    // ours as a substring can't produce a false positive.
-    let has_ext = |name: &str| extensions.split(' ').any(|tok| tok == name);
-    // Prefer KHR, then EXT; both share the same signature.
-    let symbol = if has_ext("EGL_KHR_swap_buffers_with_damage") {
-        Some(c"eglSwapBuffersWithDamageKHR")
-    } else if has_ext("EGL_EXT_swap_buffers_with_damage") {
-        Some(c"eglSwapBuffersWithDamageEXT")
-    } else {
-        None
-    };
-    let symbol = symbol?;
-
-    let fn_ptr = display.get_proc_address(symbol);
-    if fn_ptr.is_null() {
-        return None;
-    }
-    // SAFETY: the pointer is non-null and resolved for a symbol whose
-    // advertised extension guarantees the documented signature.
-    let swap_with_damage: EglSwapBuffersWithDamageFn = unsafe { std::mem::transmute(fn_ptr) };
-
-    debug!("EGL partial present enabled ({})", symbol.to_string_lossy());
-    Some(EglDamageSupport {
-        egl_display,
-        swap_with_damage,
-    })
 }
 
 /// Pick the GL config with the highest multisample count.

--- a/freminal-windowing/src/gl_context.rs
+++ b/freminal-windowing/src/gl_context.rs
@@ -323,10 +323,14 @@ fn probe_egl_damage_support(
         .to_str()
         .unwrap_or("");
 
+    // The EGL extension string is space-separated; match whole tokens rather
+    // than substrings so a longer extension name that merely contains one of
+    // ours as a substring can't produce a false positive.
+    let has_ext = |name: &str| extensions.split(' ').any(|tok| tok == name);
     // Prefer KHR, then EXT; both share the same signature.
-    let symbol = if extensions.contains("EGL_KHR_swap_buffers_with_damage") {
+    let symbol = if has_ext("EGL_KHR_swap_buffers_with_damage") {
         Some(c"eglSwapBuffersWithDamageKHR")
-    } else if extensions.contains("EGL_EXT_swap_buffers_with_damage") {
+    } else if has_ext("EGL_EXT_swap_buffers_with_damage") {
         Some(c"eglSwapBuffersWithDamageEXT")
     } else {
         None

--- a/freminal-windowing/src/lib.rs
+++ b/freminal-windowing/src/lib.rs
@@ -43,6 +43,52 @@ use std::time::Duration;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WindowId(winit::window::WindowId);
 
+/// A rectangle in **physical framebuffer pixels**, origin at the
+/// **bottom-left** of the surface (OpenGL / EGL convention).
+///
+/// Used to describe the damaged (changed) region of a frame for
+/// partial-present and scissored-clear optimizations. The bottom-left
+/// origin matches both `glScissor` and `eglSwapBuffersWithDamageKHR`, so
+/// no coordinate flip is needed between the damage rect and either GL call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DamageRect {
+    /// X of the lower-left corner, in physical pixels.
+    pub x: i32,
+    /// Y of the lower-left corner, in physical pixels (bottom-left origin).
+    pub y: i32,
+    /// Width in physical pixels.
+    pub width: i32,
+    /// Height in physical pixels.
+    pub height: i32,
+}
+
+/// Describes how much of a rendered frame actually changed, so the
+/// windowing layer can decide whether it may skip the full-framebuffer
+/// clear and present only the changed region.
+///
+/// The default is [`FrameDamage::Full`]: the whole surface changed and
+/// must be cleared, redrawn, and presented. This is the conservative,
+/// always-correct behavior — an app that does not opt in gets exactly the
+/// pre-optimization path.
+///
+/// [`FrameDamage::Partial`] is a *hint*, honored only when the platform can
+/// prove the previous frame's contents are still in the back buffer (via
+/// `buffer_age() == 1`). When that proof is unavailable (non-EGL backends,
+/// a rotated/aged buffer, a resize) the windowing layer falls back to a
+/// full frame regardless.
+#[derive(Debug, Clone, Default)]
+pub enum FrameDamage {
+    /// The entire surface changed. Clear + full redraw + full present.
+    #[default]
+    Full,
+    /// Only the listed rectangles changed since the previous frame. The
+    /// caller guarantees every pixel outside these rects is identical to
+    /// the previous frame's, so — when the back buffer still holds that
+    /// previous frame — the clear may be skipped and the present may be
+    /// restricted to these rects.
+    Partial(Vec<DamageRect>),
+}
+
 /// Configuration for creating a new window.
 pub struct WindowConfig {
     /// Window title.
@@ -96,6 +142,50 @@ pub trait App {
 
     /// GL clear color for the given window (supports transparency via alpha).
     fn clear_color(&self, window_id: WindowId) -> [f32; 4];
+
+    /// Report how much of the frame just rendered in [`App::update`]
+    /// actually changed, so the windowing layer can decide whether to skip
+    /// the full-framebuffer clear and present only the damaged region.
+    ///
+    /// Called by the windowing layer **once per frame, immediately after
+    /// [`App::update`] returns** for that window. The app should compute the
+    /// answer during `update` and hand it back here (typically by draining a
+    /// per-window value it set during the UI pass).
+    ///
+    /// The default returns [`FrameDamage::Full`] — the conservative,
+    /// always-correct behavior. An app only needs to override this to opt
+    /// into partial-present / skip-clear optimizations, and returning `Full`
+    /// at any time is always safe.
+    fn take_frame_damage(&mut self, _window_id: WindowId) -> FrameDamage {
+        FrameDamage::Full
+    }
+
+    /// Shared flag through which the windowing layer publishes the
+    /// **authoritative** partial-present decision for each frame.
+    ///
+    /// Returning `Some(flag)` opts the window into damage-aware presentation.
+    /// Each frame, after the windowing layer resolves the partial-present gate
+    /// (the app's [`FrameDamage`] *and* buffer-age *and* platform support) and
+    /// **before** the paint callbacks execute, it stores the result into this
+    /// flag with [`Ordering::Relaxed`](std::sync::atomic::Ordering::Relaxed):
+    /// `true` when only the damaged region is being presented (the full clear
+    /// was skipped), `false` for a normal full clear + present.
+    ///
+    /// This is the single source of truth. An app that scissors its own draws
+    /// to the damage region must read this same flag inside its paint
+    /// callbacks, so the scissor can never disagree with whether the clear was
+    /// actually skipped (the black-cell hazard). Because the callbacks run on
+    /// the same thread immediately after the store, `Relaxed` ordering is
+    /// sufficient.
+    ///
+    /// The default returns `None`: the window is presented fully every frame
+    /// and no flag is published.
+    fn present_partial_flag(
+        &self,
+        _window_id: WindowId,
+    ) -> Option<std::sync::Arc<std::sync::atomic::AtomicBool>> {
+        None
+    }
 
     /// Hook to modify raw input before egui processes it.
     ///

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -1388,7 +1388,8 @@ impl freminal_windowing::App for FreminalGui {
             // clock is available. Only reset on an actual change so we don't
             // re-anchor (and cause a spurious extra blink) every frame.
             let active_pane_key = (win.tabs.active_tab().id, active_pane_id);
-            if win.previous_active_pane_key != Some(active_pane_key) {
+            let active_pane_changed = win.previous_active_pane_key != Some(active_pane_key);
+            if active_pane_changed {
                 if let Some(pane) = win.tabs.active_tab_mut().pane_tree.find_mut(active_pane_id) {
                     pane.view_state.cursor_blink_reset_pending = true;
                 }
@@ -2092,8 +2093,19 @@ impl freminal_windowing::App for FreminalGui {
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
                 wpr.is_active() || wpr.pending_shader.is_some()
             };
+            // The pane-border active-pane highlight, menu/tab-bar hover tints,
+            // and other chrome are painted by the plain egui painter every
+            // frame — outside the per-pane damage tracking. They only *change*
+            // pixels when the active pane changes (border moves) or the
+            // pointer moves (hover). Presenting only the cursor rect on such a
+            // frame would leave that chrome stale, so both force `Full`.
+            let pointer_moving = ctx.input(|i| i.pointer.is_moving());
             win.pending_frame_damage = 'damage: {
-                if ui_overlay_open || shader_recomposites {
+                if ui_overlay_open
+                    || shader_recomposites
+                    || active_pane_changed
+                    || pointer_moving
+                {
                     break 'damage freminal_windowing::FrameDamage::Full;
                 }
                 // A toast being visible animates its own region each frame.
@@ -2104,8 +2116,11 @@ impl freminal_windowing::App for FreminalGui {
                 if toast_active {
                     break 'damage freminal_windowing::FrameDamage::Full;
                 }
-                // Inspect every pane in the active tab (only the active tab is
-                // rendered). Per-pane outcomes (#435):
+                // Inspect only the panes actually rendered this frame — the
+                // entries in `pane_layout`. Under zoom, only the zoomed pane is
+                // rendered; iterating the whole tree would read stale
+                // `last_frame_cursor_damage` from non-rendered siblings and
+                // wrongly force `Full` every frame. Per-pane outcomes (#435):
                 //   - `Full`            -> that pane rebuilt content; whole
                 //                          frame must present fully.
                 //   - `CursorOnly(rect)`-> the (active) pane's cursor changed;
@@ -2118,18 +2133,25 @@ impl freminal_windowing::App for FreminalGui {
                 //                          valid rect; be cautious -> Full.
                 //   - `Unchanged`       -> inactive/idle pane; contributes no
                 //                          damage and does NOT force Full.
+                //   - a bell flash overlay on a pane animates a full-pane
+                //     region each frame -> force Full.
                 // Only the active pane ever draws a cursor, so a pure blink
                 // yields exactly one rect; a pane switch yields two.
                 let active_tab = win.tabs.active_tab();
-                let Ok(panes) = active_tab.pane_tree.iter_panes() else {
-                    break 'damage freminal_windowing::FrameDamage::Full;
-                };
                 let mut rects: Vec<freminal_windowing::DamageRect> = Vec::new();
-                for pane in panes {
-                    use crate::gui::renderer::PaneFrameDamage as Pfd;
+                for (pane_id, _) in &pane_layout {
+                    let Some(pane) = active_tab.pane_tree.find(*pane_id) else {
+                        // A pane in the layout we cannot resolve -> be safe.
+                        rects.clear();
+                        break;
+                    };
+                    if pane.view_state.bell_since.is_some() {
+                        rects.clear();
+                        break;
+                    }
                     match pane.render_cache.last_frame_cursor_damage {
-                        Pfd::Unchanged => {}
-                        Pfd::CursorOnly(Some(d)) => {
+                        crate::gui::renderer::PaneFrameDamage::Unchanged => {}
+                        crate::gui::renderer::PaneFrameDamage::CursorOnly(Some(d)) => {
                             rects.push(freminal_windowing::DamageRect {
                                 x: d.x,
                                 y: d.y,
@@ -2137,7 +2159,8 @@ impl freminal_windowing::App for FreminalGui {
                                 height: d.height,
                             });
                         }
-                        Pfd::CursorOnly(None) | Pfd::Full => {
+                        crate::gui::renderer::PaneFrameDamage::CursorOnly(None)
+                        | crate::gui::renderer::PaneFrameDamage::Full => {
                             rects.clear();
                             break;
                         }

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -300,6 +300,7 @@ impl freminal_windowing::App for FreminalGui {
                         present_is_partial: std::sync::Arc::new(
                             std::sync::atomic::AtomicBool::new(false),
                         ),
+                        previous_active_pane_key: None,
                     };
                     self.windows.insert(window_id, win);
 
@@ -1377,6 +1378,22 @@ impl freminal_windowing::App for FreminalGui {
             let active_pane_id = win.tabs.active_tab().active_pane;
             let zoomed_pane = win.tabs.active_tab().zoomed_pane;
             let has_multiple_panes = win.tabs.active_tab().pane_tree.pane_count().unwrap_or(1) > 1;
+
+            // Re-anchor the cursor blink phase when the active pane changes —
+            // by a pane switch within the tab OR a tab switch (both change the
+            // "which pane is active-and-visible" key). This makes the newly
+            // active pane's cursor appear immediately instead of inheriting the
+            // global blink cycle's current half (the cursor-appear lag). The
+            // flag is captured on that pane's next render, when the egui input
+            // clock is available. Only reset on an actual change so we don't
+            // re-anchor (and cause a spurious extra blink) every frame.
+            let active_pane_key = (win.tabs.active_tab().id, active_pane_id);
+            if win.previous_active_pane_key != Some(active_pane_key) {
+                if let Some(pane) = win.tabs.active_tab_mut().pane_tree.find_mut(active_pane_id) {
+                    pane.view_state.cursor_blink_reset_pending = true;
+                }
+                win.previous_active_pane_key = Some(active_pane_key);
+            }
 
             // Broadcast input (Task 74): when the active tab has broadcast
             // enabled, collect the (pane id, input sender) of every leaf pane
@@ -2711,6 +2728,7 @@ impl FreminalGui {
             pending_raw_keys: Vec::new(),
             pending_frame_damage: freminal_windowing::FrameDamage::Full,
             present_is_partial: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            previous_active_pane_key: None,
         }
     }
 

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -296,6 +296,10 @@ impl freminal_windowing::App for FreminalGui {
                         close_dialog: super::close_guard::CloseGuardDialog::default(),
                         pending_force_close: false,
                         pending_raw_keys: Vec::new(),
+                        pending_frame_damage: freminal_windowing::FrameDamage::Full,
+                        present_is_partial: std::sync::Arc::new(
+                            std::sync::atomic::AtomicBool::new(false),
+                        ),
                     };
                     self.windows.insert(window_id, win);
 
@@ -485,6 +489,29 @@ impl freminal_windowing::App for FreminalGui {
             let color = egui::Color32::from_rgb(r, g, b);
             color.to_normalized_gamma_f32()
         }
+    }
+
+    fn present_partial_flag(
+        &self,
+        window_id: WindowId,
+    ) -> Option<std::sync::Arc<std::sync::atomic::AtomicBool>> {
+        self.windows
+            .get(&window_id)
+            .map(|win| std::sync::Arc::clone(&win.present_is_partial))
+    }
+
+    fn take_frame_damage(&mut self, window_id: WindowId) -> freminal_windowing::FrameDamage {
+        // Drain the damage computed during `update()` for this window, leaving
+        // `Full` behind so a stale value can never be reused on a later frame
+        // that does not recompute it.
+        self.windows
+            .get_mut(&window_id)
+            .map_or(freminal_windowing::FrameDamage::Full, |win| {
+                std::mem::replace(
+                    &mut win.pending_frame_damage,
+                    freminal_windowing::FrameDamage::Full,
+                )
+            })
     }
 
     // Inherently large: the main per-frame UI function handles menu bar, settings modal, window
@@ -1664,6 +1691,12 @@ impl freminal_windowing::App for FreminalGui {
                 }
             }
 
+            // Clone the per-window partial-present flag once, before the pane
+            // loop, so each pane's `show()` can pass it into its PaintCallback
+            // without re-borrowing `win` while `win` is mutably borrowed in
+            // the loop (#435).
+            let present_is_partial_for_panes = std::sync::Arc::clone(&win.present_is_partial);
+
             for (pane_id, pane_rect) in &pane_layout {
                 // Shrink the pane rect slightly to leave room for borders.
                 // Each pane edge that is interior (shared with another pane)
@@ -1865,6 +1898,7 @@ impl freminal_windowing::App for FreminalGui {
                             rec_ctx.as_ref(),
                             &mut pane.pending_copy,
                             &key_broadcast_targets,
+                            &present_is_partial_for_panes,
                         )
                     });
                 let (left_clicked, deferred_actions) = show_result.inner;
@@ -2018,6 +2052,86 @@ impl freminal_windowing::App for FreminalGui {
                         Some(shortest_repaint_delay.map_or(delay, |prev| prev.min(delay)));
                 }
             }
+
+            // ── Frame-damage aggregation (#435) ───────────────────────
+            //
+            // Decide whether this whole frame was a pure cursor-only update,
+            // so the windowing layer may skip the full-framebuffer clear and
+            // present only the changed cursor region. This is deliberately
+            // conservative: `Partial` is emitted ONLY when every condition
+            // below positively proves nothing but the cursor blinked/moved.
+            // Any doubt falls through to `Full` (a normal clear + present),
+            // which is always correct. The windowing layer additionally
+            // requires `buffer_age() == 1` before honoring `Partial`, so a
+            // false positive here still cannot corrupt the frame on a fresh
+            // or aged back buffer — but we avoid false positives regardless.
+            //
+            // A window-post shader recomposites the entire window every frame,
+            // so it forces `Full`.
+            let shader_recomposites = {
+                let wpr = win
+                    .window_post
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                wpr.is_active() || wpr.pending_shader.is_some()
+            };
+            win.pending_frame_damage = 'damage: {
+                if ui_overlay_open || shader_recomposites {
+                    break 'damage freminal_windowing::FrameDamage::Full;
+                }
+                // A toast being visible animates its own region each frame.
+                let toast_active = self
+                    .toasts
+                    .try_borrow()
+                    .is_ok_and(|stack| !stack.is_empty());
+                if toast_active {
+                    break 'damage freminal_windowing::FrameDamage::Full;
+                }
+                // Inspect every pane in the active tab (only the active tab is
+                // rendered). Per-pane outcomes (#435):
+                //   - `Full`            -> that pane rebuilt content; whole
+                //                          frame must present fully.
+                //   - `CursorOnly(rect)`-> the (active) pane's cursor changed;
+                //                          add its rect to the damage set. On
+                //                          an active-pane switch, the old and
+                //                          new active panes both report this
+                //                          (old erases its cursor, new draws
+                //                          one), so both rects are collected.
+                //   - `CursorOnly(None)`-> cursor region did not resolve to a
+                //                          valid rect; be cautious -> Full.
+                //   - `Unchanged`       -> inactive/idle pane; contributes no
+                //                          damage and does NOT force Full.
+                // Only the active pane ever draws a cursor, so a pure blink
+                // yields exactly one rect; a pane switch yields two.
+                let active_tab = win.tabs.active_tab();
+                let Ok(panes) = active_tab.pane_tree.iter_panes() else {
+                    break 'damage freminal_windowing::FrameDamage::Full;
+                };
+                let mut rects: Vec<freminal_windowing::DamageRect> = Vec::new();
+                for pane in panes {
+                    use crate::gui::renderer::PaneFrameDamage as Pfd;
+                    match pane.render_cache.last_frame_cursor_damage {
+                        Pfd::Unchanged => {}
+                        Pfd::CursorOnly(Some(d)) => {
+                            rects.push(freminal_windowing::DamageRect {
+                                x: d.x,
+                                y: d.y,
+                                width: d.width,
+                                height: d.height,
+                            });
+                        }
+                        Pfd::CursorOnly(None) | Pfd::Full => {
+                            rects.clear();
+                            break;
+                        }
+                    }
+                }
+                if rects.is_empty() {
+                    freminal_windowing::FrameDamage::Full
+                } else {
+                    freminal_windowing::FrameDamage::Partial(rects)
+                }
+            };
 
             // ── Window-level post-processing pass ────────────────────
             //
@@ -2595,6 +2709,8 @@ impl FreminalGui {
             close_dialog: super::close_guard::CloseGuardDialog::default(),
             pending_force_close: false,
             pending_raw_keys: Vec::new(),
+            pending_frame_damage: freminal_windowing::FrameDamage::Full,
+            present_is_partial: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 

--- a/freminal/src/gui/layout_ops.rs
+++ b/freminal/src/gui/layout_ops.rs
@@ -722,6 +722,7 @@ impl FreminalGui {
             pending_raw_keys: Vec::new(),
             pending_frame_damage: freminal_windowing::FrameDamage::Full,
             present_is_partial: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            previous_active_pane_key: None,
         };
         self.windows.insert(window_id, win);
 

--- a/freminal/src/gui/layout_ops.rs
+++ b/freminal/src/gui/layout_ops.rs
@@ -720,6 +720,8 @@ impl FreminalGui {
             close_dialog: super::close_guard::CloseGuardDialog::default(),
             pending_force_close: false,
             pending_raw_keys: Vec::new(),
+            pending_frame_damage: freminal_windowing::FrameDamage::Full,
+            present_is_partial: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
         self.windows.insert(window_id, win);
 

--- a/freminal/src/gui/renderer/mod.rs
+++ b/freminal/src/gui/renderer/mod.rs
@@ -23,3 +23,207 @@ pub use vertex::{
     build_background_instances, build_cursor_verts_only, build_foreground_instances,
     build_image_verts,
 };
+
+use conv2::{ConvUtil, RoundToNearest};
+
+/// What a single pane contributed to the frame just rendered (#435).
+///
+/// Only the **active pane** ever draws a cursor, so a cursor blink/move — or
+/// a switch of which pane is active — only touches the active pane (and, on a
+/// switch, the previously-active pane, which erases its cursor). Every other
+/// pane whose content did not change contributes nothing to the frame. This
+/// enum lets the per-window aggregation distinguish those cases:
+///
+/// - [`PaneFrameDamage::Full`] — the pane did a full content rebuild; the
+///   frame must clear + present fully.
+/// - [`PaneFrameDamage::CursorOnly`] — the pane took the cursor-only fast
+///   path; the rect (if any) is the changed cursor region. `None` means the
+///   pane's cursor region did not resolve to a valid rect (degenerate size);
+///   the aggregator treats that as a full frame out of caution.
+/// - [`PaneFrameDamage::Unchanged`] — the pane re-drew its existing vertices
+///   with no change at all (the common inactive-pane case); it contributes no
+///   damage and does **not** force a full frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PaneFrameDamage {
+    /// The pane rebuilt its full content this frame.
+    Full,
+    /// The pane took the cursor-only fast path; carries the changed region.
+    CursorOnly(Option<CursorDamage>),
+    /// The pane rendered no change (reused existing vertices).
+    #[default]
+    Unchanged,
+}
+
+/// The changed screen region of a cursor-only frame (#435).
+///
+/// Coordinates are **physical framebuffer pixels with a bottom-left origin**
+/// (the OpenGL / EGL convention shared by `glScissor` and
+/// `eglSwapBuffersWithDamage`).
+///
+/// A cursor blink or a cursor move changes at most two cells (the old cursor
+/// cell, now revealing its glyph, and the new cursor cell). This rect is the
+/// tight bounding box of those cells; presenting only it — and skipping the
+/// full-framebuffer clear — is what turns a blink from a full-scene redraw
+/// into a one-region update.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CursorDamage {
+    /// X of the lower-left corner, physical pixels.
+    pub x: i32,
+    /// Y of the lower-left corner, physical pixels (bottom-left origin).
+    pub y: i32,
+    /// Width, physical pixels.
+    pub width: i32,
+    /// Height, physical pixels.
+    pub height: i32,
+}
+
+impl CursorDamage {
+    /// Build the damage bounding box for a cursor-only frame.
+    ///
+    /// Inputs are all in the terminal's own coordinate space:
+    /// - `viewport_left`, `viewport_bottom_from_top`: the terminal viewport's
+    ///   top-left corner in physical framebuffer pixels, measured from the
+    ///   **top-left** of the framebuffer (egui's origin convention).
+    /// - `fb_height`: the full framebuffer height in physical pixels, used to
+    ///   flip the Y axis into GL's bottom-left origin.
+    /// - `cursor_cells`: each `(px_x, px_y, w, h)` is a changed cell in
+    ///   physical pixels **relative to the viewport top-left**, top-left
+    ///   origin (matching `cursor_pixel_pos` / cell dimensions in `show`).
+    ///   Usually one entry (blink) or two (a move: old + new cell).
+    ///
+    /// Returns `None` when there are no changed cells (nothing to present).
+    #[must_use]
+    pub fn from_cursor_cells(
+        viewport_left: f32,
+        viewport_top: f32,
+        fb_height: i32,
+        cursor_cells: &[(f32, f32, f32, f32)],
+    ) -> Option<Self> {
+        if cursor_cells.is_empty() {
+            return None;
+        }
+
+        // Union the cells in top-left-origin framebuffer pixels first.
+        let mut min_x = f32::MAX;
+        let mut min_y = f32::MAX;
+        let mut max_x = f32::MIN;
+        let mut max_y = f32::MIN;
+        for &(cx, cy, cw, ch) in cursor_cells {
+            let left = viewport_left + cx;
+            let top = viewport_top + cy;
+            min_x = min_x.min(left);
+            min_y = min_y.min(top);
+            max_x = max_x.max(left + cw);
+            max_y = max_y.max(top + ch);
+        }
+
+        // Round outward to whole pixels so the rect never clips a partially
+        // covered edge pixel. The values are already integral (floor/ceil), so
+        // the rounding scheme only resolves the trait; `RoundToNearest` is
+        // exact here.
+        let px_min_x: i32 = min_x.floor().approx_as_by::<i32, RoundToNearest>().ok()?;
+        let px_min_y: i32 = min_y.floor().approx_as_by::<i32, RoundToNearest>().ok()?;
+        let px_max_x: i32 = max_x.ceil().approx_as_by::<i32, RoundToNearest>().ok()?;
+        let px_max_y: i32 = max_y.ceil().approx_as_by::<i32, RoundToNearest>().ok()?;
+
+        // Clamp to the framebuffer so we never emit a negative-origin or
+        // out-of-bounds rect (a cursor at row 0 / col 0, or sub-pixel slop).
+        let top_clamped = px_min_y.max(0);
+        let bottom_clamped = px_max_y.min(fb_height);
+        let height = bottom_clamped - top_clamped;
+        let left_clamped = px_min_x.max(0);
+        let width = px_max_x - left_clamped;
+        if width <= 0 || height <= 0 {
+            return None;
+        }
+
+        // Flip Y from top-left origin to GL/EGL bottom-left origin.
+        let y = fb_height - bottom_clamped;
+
+        Some(Self {
+            x: left_clamped,
+            y,
+            width,
+            height,
+        })
+    }
+}
+
+#[cfg(test)]
+mod cursor_damage_tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::CursorDamage;
+
+    #[test]
+    fn single_cell_blink_flips_y_to_bottom_left_origin() {
+        // Framebuffer 800x600. Terminal viewport at top-left (0,0). A cell of
+        // 10x20 px at column 0, row 0 (top-left corner of the viewport).
+        let d = CursorDamage::from_cursor_cells(0.0, 0.0, 600, &[(0.0, 0.0, 10.0, 20.0)])
+            .expect("one cell yields damage");
+        // Top-left cell spans y=[0,20] from the top; bottom-left origin y is
+        // 600 - 20 = 580, height 20.
+        assert_eq!(d.x, 0);
+        assert_eq!(d.width, 10);
+        assert_eq!(d.height, 20);
+        assert_eq!(d.y, 580);
+    }
+
+    #[test]
+    fn viewport_offset_is_added() {
+        // Viewport starts 100px right, 50px down (e.g. a gutter + menu bar).
+        let d = CursorDamage::from_cursor_cells(100.0, 50.0, 600, &[(30.0, 40.0, 10.0, 20.0)])
+            .expect("damage");
+        // Cell top-left in fb coords: x=130, top=90, bottom=110.
+        assert_eq!(d.x, 130);
+        assert_eq!(d.width, 10);
+        assert_eq!(d.height, 20);
+        // y (bottom-left) = 600 - 110 = 490.
+        assert_eq!(d.y, 490);
+    }
+
+    #[test]
+    fn cursor_move_unions_old_and_new_cells() {
+        // Old cell at col 0, new cell at col 5 (both row 0), 10x20 cells.
+        let d = CursorDamage::from_cursor_cells(
+            0.0,
+            0.0,
+            600,
+            &[(0.0, 0.0, 10.0, 20.0), (50.0, 0.0, 10.0, 20.0)],
+        )
+        .expect("damage");
+        // Union spans x=[0,60], so width 60.
+        assert_eq!(d.x, 0);
+        assert_eq!(d.width, 60);
+        assert_eq!(d.height, 20);
+        assert_eq!(d.y, 580);
+    }
+
+    #[test]
+    fn subpixel_edges_round_outward() {
+        // A cell at a fractional origin must not clip its edge pixels.
+        let d = CursorDamage::from_cursor_cells(0.0, 0.0, 600, &[(0.5, 0.5, 10.0, 20.0)])
+            .expect("damage");
+        // left floors to 0, right ceils to 11 -> width 11; top floors 0,
+        // bottom ceils 21 -> height 21.
+        assert_eq!(d.x, 0);
+        assert_eq!(d.width, 11);
+        assert_eq!(d.height, 21);
+        assert_eq!(d.y, 600 - 21);
+    }
+
+    #[test]
+    fn empty_cells_yield_no_damage() {
+        assert_eq!(CursorDamage::from_cursor_cells(0.0, 0.0, 600, &[]), None);
+    }
+
+    #[test]
+    fn cell_clamped_to_framebuffer_bounds() {
+        // A cell partly below the framebuffer bottom must clamp, not emit a
+        // negative-origin or oversized rect.
+        let d = CursorDamage::from_cursor_cells(0.0, 590.0, 600, &[(0.0, 0.0, 10.0, 20.0)])
+            .expect("damage");
+        // top=590, bottom clamps to 600 -> height 10; y = 600-600 = 0.
+        assert_eq!(d.height, 10);
+        assert_eq!(d.y, 0);
+    }
+}

--- a/freminal/src/gui/renderer/mod.rs
+++ b/freminal/src/gui/renderer/mod.rs
@@ -99,6 +99,10 @@ impl CursorDamage {
         fb_height: i32,
         cursor_cells: &[(f32, f32, f32, f32)],
     ) -> Option<Self> {
+        // 1px safety pad applied outward on every side before clamping (see
+        // below). Declared here to satisfy `items_after_statements`.
+        const PAD: i32 = 1;
+
         if cursor_cells.is_empty() {
             return None;
         }
@@ -117,14 +121,20 @@ impl CursorDamage {
             max_y = max_y.max(top + ch);
         }
 
-        // Round outward to whole pixels so the rect never clips a partially
-        // covered edge pixel. The values are already integral (floor/ceil), so
-        // the rounding scheme only resolves the trait; `RoundToNearest` is
-        // exact here.
-        let px_min_x: i32 = min_x.floor().approx_as_by::<i32, RoundToNearest>().ok()?;
-        let px_min_y: i32 = min_y.floor().approx_as_by::<i32, RoundToNearest>().ok()?;
-        let px_max_x: i32 = max_x.ceil().approx_as_by::<i32, RoundToNearest>().ok()?;
-        let px_max_y: i32 = max_y.ceil().approx_as_by::<i32, RoundToNearest>().ok()?;
+        // Round outward to whole pixels, then expand by a 1px safety pad on
+        // every side. The values are already integral (floor/ceil), so the
+        // rounding scheme only resolves the trait. The pad absorbs two sources
+        // of sub-pixel error without risk: (a) the framebuffer height fed in is
+        // reconstructed from egui's logical screen rect times the (possibly
+        // fractional) scale factor, which can be off by up to a pixel; (b) a
+        // cursor at a fractional cell origin. Over-presenting a slightly larger
+        // region is always correct — every pixel in it is the freshly-drawn,
+        // correct pixel — whereas under-covering leaves stale pixels. This also
+        // makes the (unclamped-on-the-right) X edge robust.
+        let px_min_x: i32 = min_x.floor().approx_as_by::<i32, RoundToNearest>().ok()? - PAD;
+        let px_min_y: i32 = min_y.floor().approx_as_by::<i32, RoundToNearest>().ok()? - PAD;
+        let px_max_x: i32 = max_x.ceil().approx_as_by::<i32, RoundToNearest>().ok()? + PAD;
+        let px_max_y: i32 = max_y.ceil().approx_as_by::<i32, RoundToNearest>().ok()? + PAD;
 
         // Clamp to the framebuffer so we never emit a negative-origin or
         // out-of-bounds rect (a cursor at row 0 / col 0, or sub-pixel slop).
@@ -154,18 +164,21 @@ mod cursor_damage_tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
     use super::CursorDamage;
 
+    // All expectations below include the 1px safety pad applied outward on
+    // every side before clamping (see `from_cursor_cells`).
+
     #[test]
     fn single_cell_blink_flips_y_to_bottom_left_origin() {
         // Framebuffer 800x600. Terminal viewport at top-left (0,0). A cell of
         // 10x20 px at column 0, row 0 (top-left corner of the viewport).
         let d = CursorDamage::from_cursor_cells(0.0, 0.0, 600, &[(0.0, 0.0, 10.0, 20.0)])
             .expect("one cell yields damage");
-        // Top-left cell spans y=[0,20] from the top; bottom-left origin y is
-        // 600 - 20 = 580, height 20.
+        // x: [-1,11] clamped-left to [0,11] -> x=0, width=11.
         assert_eq!(d.x, 0);
-        assert_eq!(d.width, 10);
-        assert_eq!(d.height, 20);
-        assert_eq!(d.y, 580);
+        assert_eq!(d.width, 11);
+        // top: -1 clamped to 0; bottom: 21 -> height 21; y = 600 - 21 = 579.
+        assert_eq!(d.height, 21);
+        assert_eq!(d.y, 579);
     }
 
     #[test]
@@ -173,12 +186,12 @@ mod cursor_damage_tests {
         // Viewport starts 100px right, 50px down (e.g. a gutter + menu bar).
         let d = CursorDamage::from_cursor_cells(100.0, 50.0, 600, &[(30.0, 40.0, 10.0, 20.0)])
             .expect("damage");
-        // Cell top-left in fb coords: x=130, top=90, bottom=110.
-        assert_eq!(d.x, 130);
-        assert_eq!(d.width, 10);
-        assert_eq!(d.height, 20);
-        // y (bottom-left) = 600 - 110 = 490.
-        assert_eq!(d.y, 490);
+        // Cell top-left in fb coords: x=130, top=90, bottom=110; +/-1 pad.
+        assert_eq!(d.x, 129);
+        assert_eq!(d.width, 12);
+        assert_eq!(d.height, 22);
+        // bottom 110 + pad 1 = 111; y = 600 - 111 = 489.
+        assert_eq!(d.y, 489);
     }
 
     #[test]
@@ -191,11 +204,11 @@ mod cursor_damage_tests {
             &[(0.0, 0.0, 10.0, 20.0), (50.0, 0.0, 10.0, 20.0)],
         )
         .expect("damage");
-        // Union spans x=[0,60], so width 60.
+        // Union x[0,60] -> pad [-1,61] -> clamp-left [0,61] -> width 61.
         assert_eq!(d.x, 0);
-        assert_eq!(d.width, 60);
-        assert_eq!(d.height, 20);
-        assert_eq!(d.y, 580);
+        assert_eq!(d.width, 61);
+        assert_eq!(d.height, 21);
+        assert_eq!(d.y, 579);
     }
 
     #[test]
@@ -203,12 +216,12 @@ mod cursor_damage_tests {
         // A cell at a fractional origin must not clip its edge pixels.
         let d = CursorDamage::from_cursor_cells(0.0, 0.0, 600, &[(0.5, 0.5, 10.0, 20.0)])
             .expect("damage");
-        // left floors to 0, right ceils to 11 -> width 11; top floors 0,
-        // bottom ceils 21 -> height 21.
+        // left floor 0 -1 = -1 -> clamp 0; right ceil 11 +1 = 12 -> width 12.
         assert_eq!(d.x, 0);
-        assert_eq!(d.width, 11);
-        assert_eq!(d.height, 21);
-        assert_eq!(d.y, 600 - 21);
+        assert_eq!(d.width, 12);
+        // top floor 0 -1 -> 0; bottom ceil 21 +1 = 22 -> height 22.
+        assert_eq!(d.height, 22);
+        assert_eq!(d.y, 600 - 22);
     }
 
     #[test]
@@ -222,8 +235,9 @@ mod cursor_damage_tests {
         // negative-origin or oversized rect.
         let d = CursorDamage::from_cursor_cells(0.0, 590.0, 600, &[(0.0, 0.0, 10.0, 20.0)])
             .expect("damage");
-        // top=590, bottom clamps to 600 -> height 10; y = 600-600 = 0.
-        assert_eq!(d.height, 10);
+        // top 590 - 1 = 589; bottom 610 + 1 = 611 clamped to 600 -> height 11;
+        // y = 600 - 600 = 0.
+        assert_eq!(d.height, 11);
         assert_eq!(d.y, 0);
     }
 }

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -1106,6 +1106,20 @@ pub struct PaneRenderCache {
     /// detects the change and forces a full rebuild + texture re-upload even
     /// though `content_changed`/`image_frame_changed` stay false.
     pub(super) last_rendered_image_pixel_ptrs: std::collections::HashMap<u64, usize>,
+    /// Damage report for the frame just rendered (#435).
+    ///
+    /// Records which render path this pane took, so the per-window
+    /// aggregation in `app_impl` can decide whether the whole frame was a
+    /// pure cursor-only update (skip-clear + partial present) or must clear
+    /// and present fully. See [`PaneFrameDamage`] for the three cases. Only
+    /// the active pane ever produces a cursor rect; inactive unchanged panes
+    /// report [`PaneFrameDamage::Unchanged`] and never force a full frame.
+    ///
+    /// Set every frame by [`FreminalTerminalWidget::show`].
+    ///
+    /// [`PaneFrameDamage`]: crate::gui::renderer::PaneFrameDamage
+    /// [`PaneFrameDamage::Unchanged`]: crate::gui::renderer::PaneFrameDamage::Unchanged
+    pub(crate) last_frame_cursor_damage: crate::gui::renderer::PaneFrameDamage,
 }
 
 impl PaneRenderCache {
@@ -1142,6 +1156,7 @@ impl PaneRenderCache {
             previous_fold_epoch: 0,
             placeholder_hit_rects: Vec::new(),
             last_rendered_image_pixel_ptrs: std::collections::HashMap::new(),
+            last_frame_cursor_damage: crate::gui::renderer::PaneFrameDamage::Unchanged,
         }
     }
 
@@ -1410,6 +1425,7 @@ impl FreminalTerminalWidget {
         recording_ctx: Option<&freminal_terminal_emulator::recording::RecordingContext<'_>>,
         pending_copy: &mut bool,
         key_broadcast_targets: &[Sender<InputEvent>],
+        present_is_partial: &Arc<std::sync::atomic::AtomicBool>,
     ) -> (bool, Vec<freminal_common::keybindings::KeyAction>) {
         const BLINK_TICK_SECONDS: f64 = 0.50;
 
@@ -1819,6 +1835,10 @@ impl FreminalTerminalWidget {
         // `cursor_only_verts` are moved into the closure below.
         let mut is_cursor_only = false;
         let mut cursor_only_verts: Vec<f32> = Vec::new();
+        // Damage rect (physical fb pixels, bottom-left origin) for the
+        // cursor-only path, used to scissor the GPU redraw to just the changed
+        // cell(s) (#435). `None` -> no scissor (draw the full grid).
+        let mut cursor_only_scissor: Option<crate::gui::renderer::CursorDamage> = None;
 
         // Suppress the cursor when:
         // - the terminal has hidden it (DECTCEM ?25l),
@@ -2153,6 +2173,11 @@ impl FreminalTerminalWidget {
                     .deco_verts
                     .is_empty();
 
+            // Default: this pane rendered no change (the no-op reuse branch).
+            // The cursor-only and full-rebuild branches below overwrite this
+            // with the appropriate `PaneFrameDamage` (#435).
+            cache.last_frame_cursor_damage = crate::gui::renderer::PaneFrameDamage::Unchanged;
+
             if cursor_only {
                 // Fast path: build just the cursor quad and stash it.
                 let cursor_verts = build_cursor_verts_only(
@@ -2168,6 +2193,51 @@ impl FreminalTerminalWidget {
                 );
                 is_cursor_only = true;
                 cursor_only_verts.clone_from(&cursor_verts);
+
+                // Compute the frame-damage rect (#435): the region that
+                // actually changed this frame, so the windowing layer can
+                // skip the full clear and present only this rect. The changed
+                // region is the union of the cursor's *previous* cell (whose
+                // glyph is revealed when the cursor moves or blinks off) and
+                // its *current* cell. Coordinates are physical framebuffer
+                // pixels; `CursorDamage` handles the Y-flip to GL origin.
+                //
+                // Convert the terminal viewport's logical top-left to physical
+                // pixels, and derive the framebuffer height from egui's screen
+                // rect (logical) scaled by `ppp`.
+                let vp_left_px = terminal_rect.min.x * ppp;
+                let vp_top_px = terminal_rect.min.y * ppp;
+                let screen_h_logical = ui
+                    .ctx()
+                    .input(|i| i.raw.screen_rect.map_or(0.0, |r| r.max.y));
+                let fb_height_px: i32 = (screen_h_logical * ppp)
+                    .ceil()
+                    .approx_as_by::<i32, conv2::RoundToNearest>()
+                    .unwrap_or(0);
+                let cell_w_px = cell_w_f * cursor_x_scale;
+                // Current cursor cell, relative to the viewport top-left.
+                let (cur_x, cur_y) = cursor_pixel_pos;
+                let mut damage_cells: Vec<(f32, f32, f32, f32)> =
+                    vec![(cur_x, cur_y, cell_w_px, row_h_f)];
+                // If the cursor moved since last frame, also damage the old
+                // cell so the present covers the revealed glyph there.
+                let prev = cache.previous_cursor_pos;
+                if prev != snap.cursor_pos {
+                    let prev_x =
+                        prev.x.approx_as::<f32>().unwrap_or(0.0) * cell_w_f * cursor_x_scale;
+                    let prev_y = prev.y.approx_as::<f32>().unwrap_or(0.0) * row_h_f;
+                    damage_cells.push((prev_x, prev_y, cell_w_px, row_h_f));
+                }
+                let cursor_damage = crate::gui::renderer::CursorDamage::from_cursor_cells(
+                    vp_left_px,
+                    vp_top_px,
+                    fb_height_px,
+                    &damage_cells,
+                );
+                cache.last_frame_cursor_damage =
+                    crate::gui::renderer::PaneFrameDamage::CursorOnly(cursor_damage);
+                cursor_only_scissor = cursor_damage;
+
                 let mut rs = render_state
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -2200,7 +2270,10 @@ impl FreminalTerminalWidget {
                     .deco_verts
                     .is_empty()
             {
-                // Full rebuild path.
+                // Full rebuild path: the whole pane changed, so the frame
+                // must clear + present fully (#435).
+                cache.last_frame_cursor_damage = crate::gui::renderer::PaneFrameDamage::Full;
+
                 let shaped_lines = cache.shaping_cache.shape_visible(
                     &snap.visible_chars,
                     &snap.visible_tags,
@@ -2520,6 +2593,11 @@ impl FreminalTerminalWidget {
         // data (not `FontManager`) may be captured here.  `is_cursor_only` and
         // `cursor_only_verts` are captured by value (bool is Copy; Vec is moved).
         let render_state_for_cb = Arc::clone(render_state);
+        // Authoritative partial-present flag (#435): the windowing layer sets
+        // it just before this callback runs. The cursor-only scissor is gated
+        // on it, so we never scissor a redraw on a frame where the full clear
+        // actually happened (which would black out the rest of the cell).
+        let present_is_partial_cb = Arc::clone(present_is_partial);
         // The MutexGuard inside the callback intentionally lives through
         // `draw_with_verts` because the renderer and atlas are refs into it.
         #[allow(clippy::significant_drop_tightening)]
@@ -2602,6 +2680,37 @@ impl FreminalTerminalWidget {
                     // image state, so this is the same list `draw_images`
                     // used to emit `rs_ref.image_verts` last time.
                     let draw_order = &rs_ref.image_draw_order;
+
+                    // Scissor the GPU redraw to just the changed cursor cell(s)
+                    // (#435). The rest of the framebuffer already holds the
+                    // previous (identical) frame — the windowing layer only
+                    // reaches this path when the whole frame is cursor-only and
+                    // `buffer_age() == 1`. Clipping the (still full-grid) draw
+                    // calls to the damage rect restricts the GPU's fragment/
+                    // fill + blend work to those cells. `CursorDamage` is in
+                    // physical framebuffer pixels, bottom-left origin — the
+                    // same convention as `glScissor`.
+                    //
+                    // egui disables `SCISSOR_TEST` after painting all
+                    // primitives, and this callback is self-contained, so we
+                    // enable it here and disable it again afterwards, leaving
+                    // GL scissor state as egui expects.
+                    //
+                    // Gate on the authoritative partial-present flag: only
+                    // scissor when the windowing layer actually SKIPPED the
+                    // full clear this frame. If the clear happened (full
+                    // present — e.g. buffer_age != 1, a shader recomposite, or
+                    // any other pane forcing a full frame), the whole grid
+                    // must be redrawn, so we must NOT scissor.
+                    let present_partial =
+                        present_is_partial_cb.load(std::sync::atomic::Ordering::Relaxed);
+                    let applied_scissor =
+                        cursor_only_scissor
+                            .filter(|_| present_partial)
+                            .map(|d| unsafe {
+                                gl.enable(glow::SCISSOR_TEST);
+                                gl.scissor(d.x, d.y, d.width, d.height);
+                            });
                     renderer.draw_with_cursor_only_update(
                         gl,
                         atlas,
@@ -2621,6 +2730,11 @@ impl FreminalTerminalWidget {
                         bg_image_mode,
                         restore_fbo,
                     );
+                    if applied_scissor.is_some() {
+                        unsafe {
+                            gl.disable(glow::SCISSOR_TEST);
+                        }
+                    }
                 } else {
                     // Full draw path: split-borrow RenderState to pass
                     // vertex slices by reference (no cloning) alongside

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -68,6 +68,32 @@ use tracing::error;
 /// appended.  When `width_cols` is too small to fit even the minimal
 /// `"▶ N lines…"` form, the helper falls back to `"▶…"` (or `""` if the
 /// width is zero).
+/// Compute the cursor blink phase (`true` = cursor visible) at `time`.
+///
+/// The phase toggles every `tick_seconds`. When `anchor` is `Some`, the phase
+/// is measured relative to that activation time, so the first `tick_seconds`
+/// after activation are always in the visible ("on") half — this makes a
+/// freshly-activated pane's cursor appear immediately instead of inheriting
+/// whichever half of the global cycle happens to be current. When `anchor` is
+/// `None`, the global wall-clock phase is used.
+///
+/// A conversion failure (absurd `time`) is treated as "visible", matching the
+/// pre-existing fallback: a shown cursor is always the safe default.
+#[must_use]
+fn cursor_blink_phase(time: f64, anchor: Option<f64>, tick_seconds: f64) -> bool {
+    let blink_time = anchor.map_or(time, |a| time - a);
+    match <i64 as ApproxFrom<f64, RoundToZero>>::approx_from((blink_time / tick_seconds).floor()) {
+        Ok(ticks) => ticks % 2 == 0,
+        Err(e) => {
+            error!("Failed to convert blink ticks to i64: {e}");
+            true
+        }
+    }
+}
+
+/// Format the fold-placeholder text for a collapsed command block.
+///
+/// See the render path (`show`) for how this is used.
 #[must_use]
 pub fn format_placeholder_text(hidden_rows: usize, width_cols: usize) -> String {
     let suffix = if hidden_rows == 1 { "line" } else { "lines" };
@@ -1746,15 +1772,21 @@ impl FreminalTerminalWidget {
         // Blink state must be computed here — cannot call `ui.input` inside
         // the `Arc<CallbackFn>` closure (it must be `Send + Sync`).
         let time = ui.input(|i| i.time);
-        let cursor_blink_on = match <i64 as ApproxFrom<f64, RoundToZero>>::approx_from(
-            (time / BLINK_TICK_SECONDS).floor(),
-        ) {
-            Ok(ticks) => ticks % 2 == 0,
-            Err(e) => {
-                error!("Failed to convert blink ticks to i64: {e}");
-                true
-            }
-        };
+
+        // The blink phase is derived relative to the activation anchor (if
+        // set), else the global wall clock. The anchor is (re)set by the GUI
+        // at the single point where the active pane or active tab changes (see
+        // `reset_blink_anchor_on_activation` in `app_impl`), so a
+        // freshly-activated OR freshly-revealed pane starts in the visible
+        // ("on") half regardless of the global cycle — no cursor-appear lag on
+        // pane switch or tab switch. The anchor is captured lazily on the
+        // first render after activation, when a valid `time` is available.
+        if view_state.cursor_blink_reset_pending {
+            view_state.cursor_blink_anchor = Some(time);
+            view_state.cursor_blink_reset_pending = false;
+        }
+        let cursor_blink_on =
+            cursor_blink_phase(time, view_state.cursor_blink_anchor, BLINK_TICK_SECONDS);
 
         // Search: request the full buffer from the PTY thread when needed,
         // then run (or re-run) the search against the cached corpus.
@@ -3379,6 +3411,55 @@ fn handle_file_drop(ui: &Ui, terminal_rect: Rect, input_tx: &Sender<InputEvent>)
             egui::FontId::proportional(20.0),
             Color32::WHITE,
         );
+    }
+}
+
+#[cfg(test)]
+mod cursor_blink_phase_tests {
+    use super::cursor_blink_phase;
+
+    const TICK: f64 = 0.50;
+
+    #[test]
+    fn global_phase_toggles_every_tick() {
+        // No anchor -> global wall-clock phase; on for [0,0.5), off for
+        // [0.5,1.0), on for [1.0,1.5), ...
+        assert!(cursor_blink_phase(0.0, None, TICK), "t=0 on");
+        assert!(cursor_blink_phase(0.25, None, TICK), "t=0.25 on");
+        assert!(!cursor_blink_phase(0.5, None, TICK), "t=0.5 off");
+        assert!(!cursor_blink_phase(0.75, None, TICK), "t=0.75 off");
+        assert!(cursor_blink_phase(1.0, None, TICK), "t=1.0 on");
+    }
+
+    #[test]
+    fn anchor_makes_cursor_visible_immediately_on_activation() {
+        // The bug: activating a pane at a "global-off" moment (t=0.7) would
+        // leave its cursor hidden until the global phase flipped. With an
+        // anchor at the activation time, the phase re-bases so the first
+        // half-cycle after activation is visible regardless of global phase.
+        let activation = 0.7; // global phase here is "off"
+        assert!(
+            !cursor_blink_phase(activation, None, TICK),
+            "global off at 0.7"
+        );
+        // Anchored: measured from activation, so t-anchor in [0,0.5) -> on.
+        assert!(
+            cursor_blink_phase(activation, Some(activation), TICK),
+            "anchored on at activation"
+        );
+        assert!(
+            cursor_blink_phase(activation + 0.4, Some(activation), TICK),
+            "anchored still on 0.4s after activation"
+        );
+    }
+
+    #[test]
+    fn anchored_phase_toggles_relative_to_activation() {
+        let anchor = 0.7;
+        // 0.5s after activation -> first "off" half.
+        assert!(!cursor_blink_phase(anchor + 0.5, Some(anchor), TICK));
+        // 1.0s after activation -> "on" again.
+        assert!(cursor_blink_phase(anchor + 1.0, Some(anchor), TICK));
     }
 }
 

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -2255,10 +2255,24 @@ impl FreminalTerminalWidget {
                 // cell so the present covers the revealed glyph there.
                 let prev = cache.previous_cursor_pos;
                 if prev != snap.cursor_pos {
-                    let prev_x =
-                        prev.x.approx_as::<f32>().unwrap_or(0.0) * cell_w_f * cursor_x_scale;
+                    // The vacated cell's horizontal scale is the PREVIOUS
+                    // row's line width, not the current row's — they can
+                    // differ (DECDWL/DECDHL), and using the current row's
+                    // scale would under-cover a revealed double-width glyph.
+                    let prev_x_scale = snap
+                        .visible_line_widths
+                        .get(prev.y)
+                        .copied()
+                        .unwrap_or(freminal_terminal_emulator::LineWidth::Normal);
+                    let prev_scale = if prev_x_scale.is_double_width() {
+                        2.0
+                    } else {
+                        1.0
+                    };
+                    let prev_x = prev.x.approx_as::<f32>().unwrap_or(0.0) * cell_w_f * prev_scale;
                     let prev_y = prev.y.approx_as::<f32>().unwrap_or(0.0) * row_h_f;
-                    damage_cells.push((prev_x, prev_y, cell_w_px, row_h_f));
+                    let prev_cell_w = cell_w_f * prev_scale;
+                    damage_cells.push((prev_x, prev_y, prev_cell_w, row_h_f));
                 }
                 let cursor_damage = crate::gui::renderer::CursorDamage::from_cursor_cells(
                     vp_left_px,

--- a/freminal/src/gui/toast.rs
+++ b/freminal/src/gui/toast.rs
@@ -172,6 +172,13 @@ impl ToastStack {
         self.entries.len()
     }
 
+    /// Whether the stack currently has no toasts. Used by the frame-damage
+    /// aggregation (#435): a visible toast animates its own region each
+    /// frame, so its presence forces a full-frame present.
+    pub(super) const fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
     fn push(&mut self, kind: ToastKind, title: String, detail: Option<String>) {
         let id = self.next_id;
         self.next_id = self.next_id.wrapping_add(1);

--- a/freminal/src/gui/view_state.rs
+++ b/freminal/src/gui/view_state.rs
@@ -585,6 +585,29 @@ pub struct ViewState {
     /// will record the timestamp without moving the cursor).
     pub cursor_last_frame: Option<Instant>,
 
+    /// egui-input-clock anchor for the cursor blink phase.
+    ///
+    /// The blink phase is normally derived from the global wall clock
+    /// (`ui.input().time`), shared by all panes. When a pane *becomes* the
+    /// active/visible pane, its cursor must appear immediately rather than
+    /// inheriting whatever half of the global blink cycle happens to be
+    /// current (which could leave a freshly-focused or freshly-revealed pane's
+    /// cursor invisible for up to one blink interval). Re-basing the phase to
+    /// the activation time makes the cursor start in the visible half. `None`
+    /// uses the global phase (steady state — once the first full cycle has
+    /// elapsed the anchored and global phases are indistinguishable).
+    pub cursor_blink_anchor: Option<f64>,
+
+    /// Set by the GUI when this pane becomes the active pane of the active tab
+    /// (a pane switch or a tab switch). Consumed on the next render, where the
+    /// egui input clock is available: [`Self::cursor_blink_anchor`] is set to
+    /// the current time so the cursor is immediately visible. Decoupling the
+    /// *request* (activation, GUI event time) from the *capture* (next render,
+    /// when `ui.input().time` exists) avoids needing the clock at activation
+    /// time and works uniformly for panes that were not being rendered (an
+    /// inactive tab's pane).
+    pub cursor_blink_reset_pending: bool,
+
     // ── Search overlay ───────────────────────────────────────────────
     /// Search overlay state: open/closed, query, matches, navigation.
     ///
@@ -643,6 +666,8 @@ impl Default for ViewState {
             cursor_target_col: 0.0,
             cursor_target_row: 0.0,
             cursor_last_frame: None,
+            cursor_blink_anchor: None,
+            cursor_blink_reset_pending: true,
             search_state: SearchState::default(),
             command_history: CommandHistoryState::default(),
             image_anim_clocks: HashMap::new(),

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -216,6 +216,15 @@ pub(super) struct PerWindowState {
     /// [`FrameDamage::Full`]: freminal_windowing::FrameDamage::Full
     pub(super) pending_frame_damage: freminal_windowing::FrameDamage,
 
+    /// The `(active tab, active pane)` shown on the previous frame.
+    ///
+    /// Compared each frame to detect when the active pane changes — whether by
+    /// a pane switch within a tab or by a tab switch (which changes the active
+    /// pane too). On a change, the newly-active pane's cursor blink phase is
+    /// re-anchored so its cursor appears immediately rather than inheriting the
+    /// global blink cycle's current half. `None` before the first frame.
+    pub(super) previous_active_pane_key: Option<(TabId, crate::gui::panes::PaneId)>,
+
     /// Authoritative partial-present flag for this window (#435).
     ///
     /// The windowing layer stores into this each frame — `true` when it

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -201,4 +201,30 @@ pub(super) struct PerWindowState {
         freminal_windowing::RawKeyEvent,
         freminal_windowing::RawKeyMods,
     )>,
+
+    /// Frame-damage report for the most recent `update()` of this window
+    /// (#435), drained by `App::take_frame_damage`.
+    ///
+    /// Set at the end of each `update()`: [`FrameDamage::Partial`] with the
+    /// cursor damage rect(s) when the frame was a pure cursor-only update
+    /// (every rendered pane took the cursor-only fast path and nothing else in
+    /// the window changed), otherwise [`FrameDamage::Full`]. Defaults to
+    /// `Full` so a window that has not yet rendered, or any frame the
+    /// aggregation does not positively prove cursor-only, presents fully.
+    ///
+    /// [`FrameDamage::Partial`]: freminal_windowing::FrameDamage::Partial
+    /// [`FrameDamage::Full`]: freminal_windowing::FrameDamage::Full
+    pub(super) pending_frame_damage: freminal_windowing::FrameDamage,
+
+    /// Authoritative partial-present flag for this window (#435).
+    ///
+    /// The windowing layer stores into this each frame — `true` when it
+    /// skipped the full clear and is presenting only the damage region,
+    /// `false` for a normal full clear + present — **before** the pane paint
+    /// callbacks run. The callbacks read it (a clone is captured into each)
+    /// to gate their scissor optimization, so a pane only scissors its redraw
+    /// when the clear was actually skipped. Shared via `Arc` because the pane
+    /// `PaintCallback` closures require `'static` captures; only ever touched
+    /// on the GUI thread, so `Relaxed` ordering suffices.
+    pub(super) present_is_partial: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }


### PR DESCRIPTION
## Summary

Fixes the idle-CPU cost in #435: on a static screen with a blinking cursor,
freminal woke every ~500ms and did a **full GPU frame** — full-framebuffer
clear + full-geometry redraw + full buffer swap — purely to toggle the cursor
block. The existing cursor-only CPU fast path skipped re-shaping, but every
GPU-visible cost survived because the cursor-only decision never escaped the
pane `PaintCallback`.

This makes a cursor-only frame **skip the full clear and present only the
changed cursor region**, using EGL's `buffer_age` + `eglSwapBuffersWithDamage`.

Closes #435.

## Approach

**Damage-aware present (Linux/EGL fast path).**

- `freminal-windowing`: new `FrameDamage` / `DamageRect`, plus `App` hooks
  `take_frame_damage` and `present_partial_flag`. `run_frame` skips the clear
  and presents with damage **only when** the app reports `Partial` **and**
  `buffer_age() == 1` **and** the surface supports partial present. EGL
  partial-present is probed at context creation (KHR/EXT), reached via the raw
  EGL surface/display handles (glutin does not expose
  `swap_buffers_with_damage` on its generic surface).
- `freminal`: `PaneFrameDamage` / `CursorDamage` classify each pane's frame
  (`Full` / `CursorOnly(rect)` / `Unchanged`). Only the active pane draws a
  cursor, so a blink yields one damage rect and an active-pane switch two (old
  cell erased + new cell drawn). Per-window aggregation emits `Partial` only
  when nothing but the cursor changed. The cursor-only GL redraw is scissored
  to the damage rect, gated on an authoritative partial-present flag so it can
  never scissor a frame where the clear actually ran.

**Cross-platform:** `buffer_age()` returns `0` on non-EGL backends (WGL on
Windows, CGL on macOS, GLX without the extension, software rasterizers), which
forces the full-frame path. Windows/macOS are therefore **unaffected by design**
— the optimization is a Linux/EGL fast path with a clean per-frame fallback.
`cargo xtask check-windows` passes.

**Also in this PR (pre-existing bug surfaced during testing):** the cursor blink
phase was a single global wall-clock phase shared by all panes, so activating a
pane (pane switch **or** tab switch) during the blink "off" half left its cursor
invisible for up to ~500ms. Re-based the phase to the activation moment so a
freshly-activated/revealed pane's cursor appears immediately.

## Performance (the point of the PR)

Profiling build, isolated repro from #435
(`freminal --config <cfg> -- sh -c 'clear; sleep N'`, the only variable being
`[cursor] blink`), `perf record -F 999 --call-graph dwarf`, 60s. Linux/Wayland/
Mesa (AMD).

| Run                | On-CPU samples (60s) |
| ------------------ | -------------------- |
| blink off (before) | 56  |
| blink on  (before) | 305 |
| blink off (after)  | 42  |
| blink on  (after)  | 207 |

Hot-symbol shift on the blink-on frame is the real story:

| Symbol | Before | After |
| ------ | ------ | ----- |
| `eglSwapBuffers` | 32.8% | **1.29%** |
| `gfx6_clear` / `util_blitter_clear` (full FBO clear) | in swap path (~31%) | **absent** (clear skipped) |

The full-framebuffer clear is eliminated and the present is ~25x cheaper
(damage rect only). The residual blink-on cost is now egui's immediate-mode
chrome re-record (`Hasher::write`, `Context::get_response`, `create_widget`) —
a **separate** cost tracked in #436, not this GPU-present issue.

## Measurement note

The existing Criterion benches measure CPU-side shaping/vertex-build, not GL
present / clear / the egui pass, so they cannot capture this cost. The
before/after gate is the #435 perf-capture methodology (static screen, blink on
vs off, on-CPU sample count + hot-symbol shares), reported above. Coordinate
math for the damage rect is unit-tested (`CursorDamage` + `cursor_blink_phase`).

## Verification

- `cargo test --all` — pass (incl. new `CursorDamage` and `cursor_blink_phase`
  tests)
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo machete` — clean
- `cargo fmt --all -- --check` — clean
- `cargo xtask check-windows` — clean (Windows falls through to the full-frame
  path, verified compiling)
- Live: idle blink, typing, command output, pane split + active-pane switch, tab
  switch, and menu/tab hover all render correctly with no stale pixels.
- Independent adversarial code review performed; all findings (chrome-outside-
  damage-tracking, zoom-disables-optimization, DECDWL vacated-cell width,
  fractional-DPI bias, EGL extension token match) addressed in the third commit.

## Commits

1. `perf: damage-aware present for cursor-only frames (#435)` — the core fix.
2. `fix: show cursor immediately on pane/tab activation` — the pre-existing
   blink-phase lag.
3. `fix: tighten cursor-only damage gate after review (#435)` — review fixes.

## No unsafe caveat waived

The EGL partial-present entry point is reached through a small, contained,
extension-probed `unsafe` FFI block (glutin's safe API does not expose it). This
was explicitly requested. It is EGL-only; on every other backend the code is
never reached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary full-frame presents by presenting only damaged regions when supported, with automatic fallback to full presents when needed.
  * Optimized cursor-only redraws by scissoring just the affected cursor area when safe, improving efficiency without changing visuals.
* **Bug Fixes**
  * Cursor blinking now reliably starts in the visible phase when switching or revealing panes, using an activation-aware phase anchor.
  * Improved handling of damage/present decisions and added safer swap behavior with fallback when partial present isn’t possible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->