### PR TITLE
perf: #436 -- cache egui chrome primitives (skip chrome re-record/tessellate when static)

### DIFF
--- a/.opencode/skills/freminal-egui-upgrade/SKILL.md
+++ b/.opencode/skills/freminal-egui-upgrade/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: freminal-egui-upgrade
+description: Use ONLY when working in the freminal repository AND bumping, unpinning, or otherwise changing the version of any crate in the egui rendering stack — `egui`, `epaint`, `egui_glow`, `egui-winit` (and closely-coupled `glow` / `glutin` / `winit` / `raw-window-handle`) — or editing their `=0.35.0` exact pins in the workspace `Cargo.toml`, or touching the Renovate "egui + windowing stack" group. The chrome-caching work (#435/#436) relies on undocumented internal behaviour of egui 0.35.0; this skill mandates walking the `Documents/EGUI_UPGRADE_ASSUMPTIONS.md` re-verification checklist and running the pixel-level smoke before any such bump lands, and explains why the exact pins and the no-auto-merge Renovate rule are deliberate.
+---
+
+# Freminal: verify the egui stack before bumping it
+
+The chrome-caching work (issues #435 and #436) makes the GUI skip
+re-recording / re-tessellating / re-painting chrome on frames where the
+chrome did not change. To do this it depends on a set of **undocumented,
+internal behaviours** of the egui stack (`egui`, `epaint`, `egui_glow`,
+`egui-winit`) at version **0.35.0** — things that are not part of any
+crate's public API contract and can change silently across versions.
+
+The failure mode is the dangerous kind: **no compile error, no headless
+test failure** (the repo has no headless-GL harness), just wrong pixels,
+ghosted chrome, or stale overlays at runtime.
+
+## The rules
+
+1. **`egui`, `egui_glow`, and `egui-winit` are exact-pinned (`=0.35.0`) as a
+   matched set** in the workspace `Cargo.toml`. This is deliberate. Do **not**
+   relax them to a caret range as a "cleanup". A patch bump can change the
+   internal behaviour we rely on.
+
+2. **Never auto-merge an egui-stack bump.** Renovate's "egui + windowing
+   stack" group is configured with `automerge: false` and
+   `dependencyDashboardApproval: true`, so a bump PR is not even opened until a
+   human approves it on the Dependency Dashboard. Do not remove those settings.
+   (Dependabot cargo updates are disabled entirely via
+   `open-pull-requests-limit: 0`.)
+
+3. **Before bumping any crate in the egui stack, walk every row of
+   `Documents/EGUI_UPGRADE_ASSUMPTIONS.md`** against the new version's source.
+   For each assumption:
+   - Read the new version's equivalent upstream code (line numbers will have
+     drifted — find the equivalent, do not trust the old line number).
+   - Confirm the behaviour still holds.
+   - If it changed, fix the corresponding `Our code` site and update the
+     assumptions doc _in the same PR_.
+
+4. **A green `cargo test --all` is NOT sufficient.** It only catches the
+   headless-verifiable subset (callback ordering, atlas-growth detection logic,
+   the FULL/REPLAY decision, the damage composition). The load-bearing failures
+   are pixel-only. You must additionally run the pixel-level verification:
+   - the 436.9 pixel harness once it exists, OR
+   - until then, a manual visual smoke of every "Symptom if broken" scenario in
+     the assumptions doc (idle blink, multi-pane + active post-process shader,
+     atlas growth from a never-before-seen glyph, an open context
+     menu / search bar / command palette / URL-hover tooltip left idle, an OS
+     dark/light switch, a DPI/scale-factor change).
+
+5. **Only after all of the above passes may the `=0.35.0` pins move.**
+
+## Why this is worth the friction
+
+The whole point of #436 is to _not_ redraw chrome unless it changed. The
+mechanism leans on egui internals that the egui authors are free to change
+without warning (they are not public API). If one of those changes and we bump
+blindly, the terminal ships with visibly broken or ghosted chrome and no test
+tells us. The exact pins plus the manual gate make an egui bump a conscious,
+verified act rather than an automated one.
+
+## When to stop and ask
+
+- The new egui version changed one of the assumptions and the fix is
+  non-trivial (e.g. the atlas now relocates glyphs, invalidating A6's
+  soundness). Stop and surface it — this may require redesigning part of the
+  chrome-cache, not a quick patch.
+- You are tempted to unpin or auto-merge "just this once" to unblock something.
+  Don't. Surface the need instead.
+
+See `Documents/EGUI_UPGRADE_ASSUMPTIONS.md` for the full assumption table
+(A1–A12): what we rely on, where our code depends on it, the upstream source
+that proves it in 0.35.0, and the visible symptom if a bump breaks it.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,14 @@ crossbeam-channel = "0.5.16"
 directories = "6.0.0"
 downcast-rs = "2.0.2"
 duct = "1.1.1"
-egui = { version = "0.35.0", default-features = false, features = ["default_fonts", "persistence"] }
-egui_glow = { version = "0.35.0", default-features = false }
-egui-winit = "0.35.0"
+# Exact-pinned (`=`) as a matched set: #436 relies on egui_glow 0.35.0's
+# (undocumented) tolerance of multiple `paint_primitives` calls per frame for
+# the chrome-cache head/band/tail split, so even a patch bump must be a
+# deliberate, re-verified change. egui / egui_glow / egui-winit must move in
+# lockstep, so all three are exact-pinned together.
+egui = { version = "=0.35.0", default-features = false, features = ["default_fonts", "persistence"] }
+egui_glow = { version = "=0.35.0", default-features = false }
+egui-winit = "=0.35.0"
 filedescriptor = "0.8.3"
 flate2 = "1.1.9"
 fontdb = "0.23.0"

--- a/Documents/EGUI_UPGRADE_ASSUMPTIONS.md
+++ b/Documents/EGUI_UPGRADE_ASSUMPTIONS.md
@@ -1,0 +1,286 @@
+# egui Stack Upgrade Assumptions
+
+**Status:** Authoritative reference. Update this file whenever an assumption
+below is added, removed, or changed — it is a living checklist, not a
+work log.
+
+## Why this file exists
+
+The chrome-caching work (issues #435 and #436) makes the GUI skip re-recording,
+re-tessellating, and re-painting the "chrome" (menu bar, tab bar, borders,
+overlays) on frames where the chrome provably did not change, while always
+freshly rebuilding the terminal band. To do this correctly it relies on a
+number of **undocumented, internal behaviours** of the egui stack
+(`egui`, `epaint`, `egui_glow`, `egui-winit`) at version **0.35.0**.
+
+These behaviours are not part of any crate's public API contract. A version
+bump — even a patch bump — could silently change one of them. The failure mode
+is nasty: **no compile error and no headless test failure** (the repo has no
+headless-GL harness), just wrong pixels, ghosted chrome, or stale overlays at
+runtime.
+
+To contain that risk:
+
+- `egui`, `egui_glow`, and `egui-winit` are **exact-pinned** (`=0.35.0`) in the
+  workspace `Cargo.toml`, as a matched set. This is deliberate — do not "clean
+  it up" to a caret range.
+- Renovate is configured so the "egui + windowing stack" group **never
+  auto-merges** and requires explicit Dependency-Dashboard approval before a
+  bump PR is even opened (see `renovate.json`). Dependabot cargo updates are
+  disabled (`open-pull-requests-limit: 0`).
+- **Before bumping any crate in the egui stack, walk every row of the table
+  below** against the new version's source, and run the pixel-level
+  verification (the 436.9 pixel harness, once it exists — until then, a manual
+  visual smoke of the scenarios in the "Symptom if broken" column is
+  mandatory).
+
+If any assumption no longer holds in the new version, the chrome-cache code
+must be adapted (and this file updated) before the bump can land.
+
+## How to use this on a bump
+
+1. Read the new version's source for each `Upstream (0.35.0)` location below
+   and confirm the behaviour still holds. Line numbers will drift between
+   versions; find the equivalent code, do not trust the line number blindly.
+2. For any assumption that changed, fix the corresponding `Our code` site and
+   update this table.
+3. Run `cargo test --all` (catches the headless-verifiable subset — callback
+   ordering, atlas-growth detection logic, the FULL/REPLAY decision, the
+   damage composition).
+4. Run the pixel-level verification for every "Symptom if broken" scenario. A
+   green `cargo test` is **not** sufficient — the load-bearing failures are
+   pixel-only.
+5. Only then update the `=0.35.0` pins.
+
+## The assumptions
+
+Each row: what we rely on, where our code depends on it, the upstream source
+that proves it in 0.35.0, and what breaks (visibly) if a bump invalidates it.
+
+### A1 — `paint_primitives` fully re-establishes GL state per call (except FBO)
+
+We split one frame's paint into three sequential `paint_primitives` calls
+(head, band, tail). This is only equivalent to one call because
+`prepare_painting` re-establishes every piece of managed GL state
+(scissor, blend, viewport, program, VAO, EBO, texture unit) at the _start_ of
+every call, and again after every callback. The one thing it does **not** reset
+is the bound framebuffer — the terminal band's own callbacks are responsible
+for restoring that.
+
+- **Our code:** `freminal-windowing/src/egui_integration.rs` (the three
+  `paint_primitives` calls in `run_frame`, head/band/tail).
+- **Upstream (0.35.0):** `egui_glow/src/painter.rs` — `prepare_painting`
+  (`~300-349`), called at `paint_primitives` entry (`~405`) and after each
+  callback (`~450`). No `bind_framebuffer` anywhere in `prepare_painting`.
+- **Symptom if broken:** garbled / mis-clipped / wrongly-blended chrome or
+  terminal content; state from the band leaking into chrome paint (or vice
+  versa). Multi-pane with an active post-process shader is the sharpest test.
+
+### A2 — `paint_and_update_textures` is set-all then paint then free-all
+
+We do not call `paint_and_update_textures`; we hand-inline its three phases
+(upload every `textures_delta.set`, then our three `paint_primitives` calls,
+then free every `textures_delta.free`) so the band can be painted separately.
+This is only correct if that is exactly what the upstream method does.
+
+- **Our code:** `freminal-windowing/src/egui_integration.rs` (the
+  `set_texture` loop, three paints, `free_texture` loop in `run_frame`).
+- **Upstream (0.35.0):** `egui_glow/src/painter.rs` —
+  `paint_and_update_textures` (`~356-374`).
+- **Symptom if broken:** a texture referenced by a primitive is freed too
+  early or uploaded too late — missing glyphs, blank text, or a use-after-free
+  crash in the GL layer.
+
+### A3 — the background layer drains first and contiguously into `FullOutput.shapes`
+
+The terminal band is captured as a contiguous index range within
+`LayerId::background()`'s `PaintList`. We then slice `full_output.shapes` by
+that same range. This is valid only because `Order::Background` is drained
+first and whole into `full_output.shapes`, AND because freminal never creates a
+second `Order::Background` layer (an application-level invariant, not enforced
+by egui).
+
+- **Our code:** `freminal/src/gui/app_impl.rs` (`band_shape_start` /
+  `band_shape_end` capture); `freminal-windowing/src/egui_integration.rs`
+  (the head/band/tail slice of `full_output.shapes`).
+- **Upstream (0.35.0):** `egui/src/layers.rs` — `enum Order` (`Background`
+  first), `Order::ALL`, `GraphicLayers::drain` (`~213-260`, iterates
+  `Order::ALL`, appends into one `Vec`).
+- **Symptom if broken:** the band paints at the wrong z-position (under chrome,
+  or over overlays), or the sliced range picks up chrome/overlay shapes.
+  Guarded partly by the `dedicated_background_layer_hides_contained_widget...`
+  regression test.
+
+### A4 — the tessellator never merges callbacks and preserves their order
+
+Each `Shape::Callback` becomes its own `Primitive::Callback`, never fused into
+an adjacent mesh, in input order. This keeps the band's pre-clear /
+per-pane / post-shader GL callbacks contiguous and correctly ordered across the
+split. The parallel (rayon) tessellation path both excludes callbacks and is
+not compiled (rayon is not in the dependency graph — only `criterion`'s dev
+dependency pulls a `rayon` we never build against).
+
+- **Our code:** `freminal/src/gui/app_impl.rs` (pre-clear, post-shader
+  callbacks), `freminal/src/gui/terminal/widget.rs` (per-pane callback); test
+  `band_gl_callbacks_stay_contiguous_and_ordered_across_the_split` in
+  `freminal-windowing/src/egui_integration.rs`.
+- **Upstream (0.35.0):** `epaint/src/tessellator.rs` —
+  `tessellate_clipped_shape` callback branch (`~1375-1394`), the
+  `Primitive::Callback(_) => true` merge-break, the sequential
+  `tessellate_shapes` loop (`~2230`), and the rayon `should_parallelize`
+  callback exclusion (`~2287`, `#[cfg(feature = "rayon")]`).
+- **Symptom if broken:** the offscreen-FBO round-trip (pre-clear then panes
+  then post-shader) is reordered or split — shader post-processing renders
+  wrong, or panes draw into the wrong target.
+
+### A5 — glyph UVs are normalized by the live atlas size at tessellate time
+
+`ctx.tessellate` normalizes each glyph's UV by the font atlas size current at
+the moment of the call, and bakes that into the mesh vertex. A mesh tessellated
+before the atlas grows therefore holds stale UVs. This is the entire premise of
+the atlas-resize self-heal (A6).
+
+- **Our code:** `freminal-windowing/src/egui_integration.rs` (the REPLAY
+  atlas-grow self-heal re-tessellating cached chrome shapes); test
+  `atlas_growth_invalidates_cached_text_uvs_and_retessellation_fixes_it`.
+- **Upstream (0.35.0):** `egui/src/context.rs` — `tessellate` (`~2757-2795`,
+  reads `texture_atlas.size()` fresh, builds a new `Tessellator`);
+  `epaint/src/tessellator.rs` — `tessellate_text` UV normalization by
+  `font_tex_size` (`~2029-2030`).
+- **Symptom if broken:** cached chrome text shows garbled / wrong glyphs after
+  a new glyph or larger font grows the atlas mid-session.
+
+### A6 — atlas growth always yields a whole-upload delta on the font atlas
+
+Detecting "cached chrome UVs may be stale" is done by watching for a
+whole-texture upload (`ImageDelta::is_whole()` / `pos: None`) on
+`TextureId::default()`. This is sound _and complete_ only because the atlas
+never relocates already-allocated glyphs and only marks the whole image dirty
+on a resize/recreate — so there is no way for existing UVs to become stale
+without a whole-upload delta.
+
+- **Our code:** `freminal-windowing/src/egui_integration.rs` — the
+  `atlas_grew` helper.
+- **Upstream (0.35.0):** `epaint/src/texture_atlas.rs` — `allocate`
+  (`~220-263`, forward-only cursor, never repositions), `resize_to_min_height`
+  (sets `dirty = Rectu::EVERYTHING`), `take_delta` (turns `EVERYTHING` into
+  `ImageDelta::full`); `epaint/src/image.rs` — `ImageDelta::is_whole`
+  (`~493-495`), `ImageDelta::full` sets `pos: None` (`~474-480`).
+- **Symptom if broken:** if a future atlas repacks/relocates glyphs with a
+  _partial_ delta, `atlas_grew` misses it and cached chrome text garbles with
+  no self-heal. This is the most dangerous assumption to lose — re-read
+  `allocate` carefully on any bump.
+
+### A7 — `TextureId::default()` is the font atlas for the Context's lifetime
+
+`TextureId::default() == TextureId::Managed(0)` is the font atlas, allocated
+first and stable for the whole `Context` lifetime. A6's detector keys on it.
+
+- **Our code:** `freminal-windowing/src/egui_integration.rs` — `atlas_grew`.
+- **Upstream (0.35.0):** `egui/src/context.rs` —
+  `WrappedTextureManager::default` (`~73-91`, allocates the font texture first
+  with an `assert_eq!(font_id, TextureId::default())`);
+  `epaint/src/textures.rs` — `TextureManager::alloc` doc (`~24-28`).
+- **Symptom if broken:** `atlas_grew` watches the wrong texture; either never
+  self-heals (garbled chrome text) or self-heals spuriously (wasted work).
+
+### A8 — `ctx.graphics()` is readable mid-frame and reflects the live layers
+
+We read the background layer's shape count mid-`update` (inside the `run_ui`
+closure) to bracket the band range. This works because `ctx.graphics()` /
+`graphics_mut()` operate on the live per-viewport `GraphicLayers` that
+`end_pass` later drains.
+
+- **Our code:** `freminal/src/gui/app_impl.rs` — `band_shape_start` /
+  `band_shape_end` captures via `ctx.graphics(...)`.
+- **Upstream (0.35.0):** `egui/src/context.rs` — `graphics` / `graphics_mut`
+  (`~971-981`), and `end_pass` draining `viewport.graphics` (`~2617-2619`).
+- **Symptom if broken:** the band range is captured against the wrong or an
+  empty layer set — the band is mis-sliced (blank terminal or duplicated
+  chrome).
+
+### A9 — child Uis inherit the parent painter's layer; top-level Ui defaults to background
+
+The REPLAY path builds the band's `Ui` directly at a cached rect; the FULL path
+uses the `CentralPanel`'s child `Ui`. Both must land in `LayerId::background()`.
+A top-level `Ui::new` with no explicit layer defaults to `background()`, and
+`new_child` / `scope_builder` inherit the parent painter's layer unless
+overridden.
+
+- **Our code:** `freminal/src/gui/app_impl.rs` — the root Ui construction and
+  the REPLAY `band_ui` construction (explicit `.layer_id(background())`).
+- **Upstream (0.35.0):** `egui/src/ui.rs` — `Ui::new`
+  (`layer_id.unwrap_or_else(LayerId::background)`, `~124`), `Ui::new_child`
+  (`~224-231`, clones parent painter, only overrides layer if the builder
+  supplies one).
+- **Symptom if broken:** REPLAY-frame band shapes land in a different layer
+  than FULL-frame band shapes — z-order / hit-test divergence between the two
+  frame kinds.
+
+### A10 — `repaint_delay` is one shared per-viewport field
+
+The FULL/REPLAY decision cannot use a literal `repaint_delay == Duration::MAX`
+gate, because `ctx.request_repaint_after` (which freminal calls every frame for
+cursor blink) writes the _same_ per-viewport `repaint_delay` field that
+egui-internal animations do. So we gate on `repaint_delay >=
+terminal_requested_delay` (our own request) instead — i.e. "nothing other than
+our own blink/content scheduling wants an earlier wake."
+
+- **Our code:** `freminal-windowing/src/egui_integration.rs` —
+  `chrome_repaint_settled`; `freminal/src/gui/app_impl.rs` —
+  `shortest_repaint_delay` / `request_repaint_after` /
+  `take_terminal_requested_delay`.
+- **Upstream (0.35.0):** `egui/src/context.rs` — `request_repaint_after`
+  effect writes `viewport.repaint.repaint_delay` (`~158-159`); the same field
+  is read into `ViewportOutput.repaint_delay` (`~2719`); egui-internal
+  scheduling writes it too (`~111`, `~113`).
+- **Symptom if broken:** either REPLAY never fires while the cursor blinks
+  (the optimization does nothing on the headline idle case), or REPLAY fires
+  when an egui chrome animation still wants to run (stale chrome). If the field
+  semantics change, revisit the whole `chrome_repaint_settled` gate.
+
+### A11 — cross-layer hit-test "hidden" rule forces the band into the background layer
+
+egui hides a widget from hover/click/drag if a _later_ widget on a
+_different layer_ fully contains its rect. This is exactly why the terminal band
+must stay in the shared background layer rather than a dedicated one: the
+`CentralPanel`'s content-area widget (background layer) contains every band
+widget, and a dedicated band layer would let hash-ordered layer tie-breaking
+hide the gutter-hover / interaction widgets.
+
+- **Our code:** `freminal/src/gui/app_impl.rs` — the 436.2a index-range
+  approach (band stays in background layer); regression tests
+  `same_layer_widget_is_not_hidden_by_containing_widget` and
+  `dedicated_background_layer_hides_contained_widget_cross_layer`.
+- **Upstream (0.35.0):** `egui/src/hit_test.rs` — the hidden-rule loop
+  (`~143-151`: `contains_rect(...) && current.layer_id != next.layer_id =>
+  hidden.insert(...)`).
+- **Symptom if broken:** if the rule is removed or changed, the "band must stay
+  in background layer" constraint may relax — but do not rely on that; the
+  regression tests pin the current behaviour. If they fail on a bump, the
+  band-layer strategy needs re-evaluation.
+
+### A12 — egui-winit flags a repaint for scale-factor (and similar) events
+
+The FULL/REPLAY input gate forces FULL on chrome-affecting input. It relies in
+part on `egui-winit` returning `EventResponse { repaint: true }` for events like
+`ScaleFactorChanged`, so a DPI change forces FULL via the `response.repaint`
+branch even though `is_potential_chrome_input` does not enumerate every such
+event.
+
+- **Our code:** `freminal-windowing/src/event_loop.rs` —
+  `is_potential_chrome_input` plus the `|| response.repaint` OR at the general
+  event arm.
+- **Upstream (0.35.0):** `egui-winit/src/lib.rs` —
+  `WindowEvent::ScaleFactorChanged { .. }` arm returning `EventResponse {
+  repaint: true, .. }` (`~311-324`).
+- **Symptom if broken:** a DPI / scale-factor change is not forced FULL — the
+  chrome renders at the wrong scale on a REPLAY frame until an unrelated FULL
+  frame fixes it.
+
+## What is NOT covered here
+
+Behaviours that _are_ part of a stable public API (e.g. `Context::run_ui`,
+`Context::tessellate` signatures, `PaintCallback` shape) are not listed — a
+version bump that changes those is a compile error and needs no special
+checklist. This file is only for the silent, undocumented, internal behaviours.

--- a/Documents/EGUI_UPGRADE_ASSUMPTIONS.md
+++ b/Documents/EGUI_UPGRADE_ASSUMPTIONS.md
@@ -265,18 +265,43 @@ hide the gutter-hover / interaction widgets.
 The FULL/REPLAY input gate forces FULL on chrome-affecting input. It relies in
 part on `egui-winit` returning `EventResponse { repaint: true }` for events like
 `ScaleFactorChanged`, so a DPI change forces FULL via the `response.repaint`
-branch even though `is_potential_chrome_input` does not enumerate every such
+branch even though `is_unconditional_chrome_input` does not enumerate every such
 event.
 
 - **Our code:** `freminal-windowing/src/event_loop.rs` —
-  `is_potential_chrome_input` plus the `|| response.repaint` OR at the general
-  event arm.
+  `is_unconditional_chrome_input` plus the `|| response.repaint` OR at the
+  general event arm.
 - **Upstream (0.35.0):** `egui-winit/src/lib.rs` —
   `WindowEvent::ScaleFactorChanged { .. }` arm returning `EventResponse {
   repaint: true, .. }` (`~311-324`).
 - **Symptom if broken:** a DPI / scale-factor change is not forced FULL — the
   chrome renders at the wrong scale on a REPLAY frame until an unrelated FULL
   frame fixes it.
+
+### A13 — egui `pixels_per_point` equals winit `scale_factor` (zoom is off)
+
+The #436.8 region-aware pointer gate hit-tests the physical cursor position
+against chrome rects captured in egui **logical points**. It converts physical
+to logical by dividing by `window.scale_factor()`. This is only correct while
+egui's own `pixels_per_point()` equals `window.scale_factor()` — i.e. while
+egui's zoom factor is exactly `1.0` (egui-winit computes
+`pixels_per_point = scale_factor * ctx.zoom_factor()`). Freminal guarantees
+this by setting `Options::zoom_with_keyboard = false` and never calling
+`Context::set_zoom_factor`.
+
+- **Our code:** `freminal-windowing/src/event_loop.rs` —
+  `physical_to_logical_pos` (divides by `window.scale_factor()`);
+  `freminal/src/gui/rendering.rs` — `options.zoom_with_keyboard = false`.
+- **Upstream (0.35.0):** `egui-winit/src/lib.rs` — `pixels_per_point(ctx,
+  window) = window.scale_factor() * ctx.zoom_factor()`; egui zoom is driven
+  only by `egui::gui_zoom::zoom_with_keyboard` (gated on the option) or an
+  explicit `set_zoom_factor`.
+- **Symptom if broken:** if egui zoom is ever enabled, the pointer gate divides
+  by the wrong factor and silently misclassifies chrome as terminal — pointer
+  interaction with chrome (menu/tab/border) stops forcing FULL, so chrome can
+  go stale under live interaction. No test catches this (the pure-fn tests only
+  exercise the conversion math, not the zoom invariant). Fix: derive the
+  divisor from `ctx.pixels_per_point()` instead of `window.scale_factor()`.
 
 ## What is NOT covered here
 

--- a/freminal-windowing/examples/hello.rs
+++ b/freminal-windowing/examples/hello.rs
@@ -1,6 +1,6 @@
 //! Minimal example: opens a window with an egui label.
 
-use freminal_windowing::{App, WindowConfig, WindowHandle, WindowId};
+use freminal_windowing::{App, ChromeMode, WindowConfig, WindowHandle, WindowId};
 
 struct HelloApp;
 
@@ -11,6 +11,7 @@ impl App for HelloApp {
         ctx: &egui::Context,
         _gl: &glow::Context,
         _handle: &WindowHandle<'_>,
+        _chrome_mode: ChromeMode,
     ) {
         let mut root_ui = egui::Ui::new(
             ctx.clone(),

--- a/freminal-windowing/src/egui_integration.rs
+++ b/freminal-windowing/src/egui_integration.rs
@@ -21,36 +21,32 @@ pub struct FrameOutput {
     pub repaint_delay: std::time::Duration,
 }
 
-/// Cached chrome (head + tail) shapes and tessellated primitives from the
-/// most recent FULL frame (#436.4a scaffolding).
+/// Cached tessellated chrome (head + tail) primitives from the most recent
+/// FULL frame (#436.4a/#436.4b).
 ///
-/// Populated at the end of every frame (which, in this subtask, is always a
-/// FULL frame — replay does not exist yet) but never read to decide replay;
-/// 436.4b is what starts consulting this cache to skip re-tessellating
-/// chrome on eligible frames.
-// TODO(#436.4b): every field here is read once the replay decision path
-// lands (cache-validity check against `ppp`/`size`, then reuse of
-// `head_primitives`/`tail_primitives` in place of re-tessellating
-// `head_shapes`/`tail_shapes`). Until then the fields are write-only
-// scaffolding, landed in 436.4a alongside the paint-order split they
-// describe so the two changes review together.
-#[allow(dead_code)]
+/// Populated at the end of every FULL frame; consulted (via
+/// [`decide_chrome_mode`]) to decide whether a later frame may REPLAY, and
+/// when it does, `run_frame` paints `head_primitives`/`tail_primitives`
+/// directly instead of re-tessellating. Only the tessellated primitives are
+/// retained — not the source shapes — because #436.4b invalidates the
+/// whole cache (forcing `ChromeMode::Full`) on any `ppp`/`size` mismatch
+/// rather than re-tessellating the same shapes at a new `ppp`; a future
+/// subtask that wants that finer-grained recovery would need to retain the
+/// shapes too.
 struct ChromeCache {
-    /// Chrome shapes painted *before* the terminal band in `full_output.shapes`
-    /// (e.g. the `CentralPanel` background fill, menu bar, tab bar).
-    head_shapes: Vec<egui::epaint::ClippedShape>,
-    /// Chrome shapes painted *after* the terminal band (overlays, pane
-    /// borders drawn as part of chrome, modals, tooltips).
-    tail_shapes: Vec<egui::epaint::ClippedShape>,
-    /// Tessellation of `head_shapes` at `ppp`/`size`.
+    /// Tessellation of the chrome shapes painted *before* the terminal band
+    /// in `full_output.shapes` (e.g. the `CentralPanel` background fill,
+    /// menu bar, tab bar), at `ppp`/`size`.
     head_primitives: Vec<egui::ClippedPrimitive>,
-    /// Tessellation of `tail_shapes` at `ppp`/`size`.
+    /// Tessellation of the chrome shapes painted *after* the terminal band
+    /// (overlays, pane borders drawn as part of chrome, modals, tooltips),
+    /// at `ppp`/`size`.
     tail_primitives: Vec<egui::ClippedPrimitive>,
     /// `pixels_per_point` the cached primitives were tessellated at. A
-    /// mismatch on a later frame invalidates the cache (436.4b).
+    /// mismatch on a later frame invalidates the cache.
     ppp: f32,
     /// Physical framebuffer size the cached primitives were tessellated
-    /// for. A mismatch on a later frame invalidates the cache (436.4b).
+    /// for. A mismatch on a later frame invalidates the cache.
     size: [u32; 2],
 }
 
@@ -59,20 +55,93 @@ pub struct EguiState {
     pub(crate) ctx: egui::Context,
     pub(crate) winit_state: egui_winit::State,
     pub(crate) painter: egui_glow::Painter,
-    /// Cached chrome primitives from the last FULL frame (#436.4a). Not yet
-    /// consulted for replay decisions — see [`ChromeCache`].
+    /// Cached chrome primitives from the last FULL frame — see [`ChromeCache`].
     chrome_cache: Option<ChromeCache>,
-    /// The repaint delay `run_frame` returned last frame (#436.4a
-    /// scaffolding). Not yet consulted — 436.4b uses this alongside
-    /// `prev_chrome_damage` to help decide replay eligibility.
+    /// The repaint delay `run_frame` returned last frame. Consulted, via
+    /// [`chrome_repaint_settled`], to decide this frame's [`crate::ChromeMode`].
     prev_repaint_delay: std::time::Duration,
-    /// The chrome-damage decision drained last frame (#436.4a scaffolding).
-    /// Not yet updated per-frame or consulted — 436.4b wires both the write
-    /// (from `App::take_chrome_damage`) and the read (replay gate).
-    // TODO(#436.4b): read (and start writing, per-frame) to gate the
-    // chrome-replay decision. Write-only scaffolding until then.
-    #[allow(dead_code)]
+    /// The chrome-damage decision drained last frame (from
+    /// `App::take_chrome_damage`). Consulted to decide this frame's
+    /// [`crate::ChromeMode`]: a REPLAY is only permitted when the PREVIOUS
+    /// frame reported [`crate::ChromeDamage::Unchanged`].
     prev_chrome_damage: crate::ChromeDamage,
+    /// The delay the app itself requested via `ctx.request_repaint_after`
+    /// last frame (from `App::take_terminal_requested_delay`), if any.
+    /// Consulted, via [`chrome_repaint_settled`], alongside
+    /// `prev_repaint_delay` to decide this frame's [`crate::ChromeMode`].
+    prev_terminal_requested_delay: Option<std::time::Duration>,
+}
+
+/// #436 §3.1 (amended): a REPLAY is permitted only if nothing OTHER than
+/// freminal's own blink/content repaint scheduling asked egui for a wake this
+/// frame. `repaint_delay` is egui's per-viewport requested delay (`Duration::MAX`
+/// = egui itself wants no further repaint); `terminal_requested_delay` is what
+/// the app itself passed to `ctx.request_repaint_after` this frame (its blink /
+/// content / shader-anim scheduling). If egui's delay is SHORTER than what the
+/// app requested, something egui-internal (a hover-fade, menu animation, a
+/// cursor blink in a focused `TextEdit`, etc.) also wants a wake -> chrome is
+/// not settled -> no replay. A literal `== Duration::MAX` gate would never
+/// pass while a cursor blinks (the app calls `request_repaint_after(500ms)`
+/// every frame), defeating the headline blink-under-idle case; comparing
+/// against the app's own request is exact, not a heuristic.
+fn chrome_repaint_settled(
+    repaint_delay: std::time::Duration,
+    terminal_requested_delay: Option<std::time::Duration>,
+) -> bool {
+    terminal_requested_delay.map_or_else(
+        || repaint_delay == std::time::Duration::MAX,
+        |app_delay| repaint_delay >= app_delay,
+    )
+}
+
+/// #436.4b: decide this frame's [`crate::ChromeMode`].
+///
+/// A REPLAY is permitted only when ALL of the following hold:
+///   - `cache_valid` — a chrome cache exists from a prior FULL frame.
+///   - `cache_size`/`cache_ppp` match `cur_size`/`cur_ppp` — the cached
+///     primitives were tessellated at this frame's framebuffer size and
+///     scale factor (a mismatch, e.g. a resize or DPI change, invalidates
+///     the whole cache rather than attempting a partial re-tessellation).
+///   - [`chrome_repaint_settled`] — nothing egui-internal wants a wake
+///     sooner than the app's own scheduling this frame (§3.1 amendment).
+///   - `prev_chrome_damage` is [`crate::ChromeDamage::Unchanged`] — the
+///     PREVIOUS frame proved static chrome did not change (§3.3/§3.5).
+///   - `!chrome_input_this_frame` — no window input event this frame could
+///     plausibly have affected chrome (§3.2, conservative: any qualifying
+///     input forces `Full`, refined region-aware in #436.8).
+///
+/// Any failure forces `ChromeMode::Full` — the always-correct, conservative
+/// default. Pure (no `self`/`egui` state), so directly unit-testable.
+// Nine independent, unrelated gate inputs (cache validity/size/ppp, this
+// frame's size/ppp, the two settle-rule delays, prior chrome damage, and the
+// input gate) -- bundling them into a struct would just relocate the same
+// fields without adding clarity, and this function exists specifically so
+// tests can drive each one independently.
+#[allow(clippy::too_many_arguments)]
+fn decide_chrome_mode(
+    cache_valid: bool,
+    cache_size: [u32; 2],
+    cache_ppp: f32,
+    cur_size: [u32; 2],
+    cur_ppp: f32,
+    prev_repaint_delay: std::time::Duration,
+    prev_terminal_requested_delay: Option<std::time::Duration>,
+    prev_chrome_damage: crate::ChromeDamage,
+    chrome_input_this_frame: bool,
+) -> crate::ChromeMode {
+    let cache_matches =
+        cache_valid && cache_size == cur_size && (cache_ppp - cur_ppp).abs() < f32::EPSILON;
+
+    let replay_allowed = cache_matches
+        && chrome_repaint_settled(prev_repaint_delay, prev_terminal_requested_delay)
+        && prev_chrome_damage == crate::ChromeDamage::Unchanged
+        && !chrome_input_this_frame;
+
+    if replay_allowed {
+        crate::ChromeMode::Replay
+    } else {
+        crate::ChromeMode::Full
+    }
 }
 
 impl EguiState {
@@ -101,6 +170,7 @@ impl EguiState {
             chrome_cache: None,
             prev_repaint_delay: std::time::Duration::MAX,
             prev_chrome_damage: crate::ChromeDamage::Changed,
+            prev_terminal_requested_delay: None,
         })
     }
 
@@ -111,7 +181,27 @@ impl EguiState {
 
     /// Run a single egui frame and paint, using pre-collected raw input.
     ///
+    /// `chrome_input_this_frame` is the #436.4b §3.2 conservative input gate:
+    /// `true` if ANY window input event this frame could plausibly affect
+    /// chrome (pointer/keyboard/scroll/focus/IME — see `event_loop`'s
+    /// `is_potential_chrome_input`). `true` unconditionally forces
+    /// `ChromeMode::Full` this frame; the region-aware refinement (only
+    /// input actually over chrome, not the terminal band, forces `Full`) is
+    /// deferred to #436.8.
+    ///
     /// Returns [`FrameOutput`] containing viewport commands and repaint timing.
+    // too_many_arguments: `chrome_input_this_frame` (#436.4b) is the one
+    // parameter pushing this over the threshold; the others are pre-existing
+    // (window/gl/clear_color/raw_input/present_flag/ui_fn), each independent
+    // and already load-bearing -- bundling them into a struct would only
+    // relocate the count, not reduce it.
+    // too_many_lines: this is the single frame-lifecycle function (decide
+    // chrome_mode -> run_ui -> tessellate head/band/tail -> present -> stash
+    // next frame's signals); splitting it would scatter a single atomic
+    // sequence across artificial sub-functions without reducing coupling
+    // (mirrors the existing `too_many_lines` allows on `event_loop.rs`'s
+    // `window_event`/`run` and `app_impl.rs`'s `update`).
+    #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
     pub(crate) fn run_frame<F>(
         &mut self,
         window: &Window,
@@ -119,6 +209,7 @@ impl EguiState {
         clear_color: [f32; 4],
         raw_input: egui::RawInput,
         present_flag: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
+        chrome_input_this_frame: bool,
         ui_fn: F,
     ) -> FrameOutput
     where
@@ -126,30 +217,86 @@ impl EguiState {
     {
         let mut ui_fn = ui_fn;
 
+        // ── #436.4b: decide this frame's `ChromeMode` BEFORE `run_ui` ──────
+        //
+        // The decision must be made before `run_ui` because `chrome_mode` is
+        // passed INTO the app's `update()` call (inside the `run_ui`
+        // closure below), which is what lets the app skip chrome-widget
+        // construction on an eligible frame. It is therefore based on LAST
+        // frame's signals (`prev_repaint_delay`, `prev_terminal_requested_delay`,
+        // `prev_chrome_damage`) plus THIS frame's cache-validity inputs
+        // (`size`, `pixels_per_point`) and input gate — never on anything
+        // only knowable from this frame's own `update()` call (that data
+        // does not exist yet).
+        //
+        // `pixels_per_point()` is read here BEFORE `run_ui`, which returns
+        // whatever was in effect as of the END of the previous frame's
+        // `begin_pass` (egui only updates its stored `pixels_per_point` file
+        // during `begin_pass`, which is inside `run_ui`) — i.e. exactly the
+        // value the chrome cache was tessellated at, UNLESS the incoming
+        // `raw_input` we are about to feed into `run_ui` carries a changed
+        // scale factor for THIS frame. In that rare case this pre-`run_ui`
+        // read is stale by one frame: `decide_chrome_mode` would (wrongly)
+        // see `cur_ppp == cache.ppp` and permit `Replay`, while the
+        // definitive post-`run_ui` `pixels_per_point()` used below to
+        // tessellate the band would reflect the NEW value. The visible
+        // consequence is bounded to a single frame — cached chrome painted
+        // at the old scale while the freshly-tessellated band paints at the
+        // new one — because this frame's own `ChromeDamage` (driven by the
+        // app's `ppp_changed` signal, sourced from the same post-`run_ui`
+        // value) reports `Changed`, forcing the NEXT frame back to `Full`.
+        // `window.inner_size()` has no such caveat: it is a direct winit
+        // query, always current.
+        let size = window.inner_size();
+        let size_arr = [size.width, size.height];
+        let ppp_before_run_ui = self.ctx.pixels_per_point();
+        let (cache_valid, cache_size, cache_ppp) = self
+            .chrome_cache
+            .as_ref()
+            .map_or((false, [0, 0], 0.0), |cache| (true, cache.size, cache.ppp));
+        let chrome_mode = decide_chrome_mode(
+            cache_valid,
+            cache_size,
+            cache_ppp,
+            size_arr,
+            ppp_before_run_ui,
+            self.prev_repaint_delay,
+            self.prev_terminal_requested_delay,
+            self.prev_chrome_damage,
+            chrome_input_this_frame,
+        );
+
         // egui 0.35 replaced `Context::run` (closure took `&Context`) with
         // `Context::run_ui` (closure takes the root `&mut Ui`).  Our `App`
         // trait still works in terms of `&Context`; `Ui` derefs to `Context`,
         // so deref explicitly rather than relying on a silent coercion.
         //
         // The closure both runs the app's `update` and returns this frame's
-        // signals (damage report + terminal-band range, #436.4a); we capture
-        // them here to decide the clear/present path and the head/band/tail
-        // split below. Running both inside the one closure avoids two
-        // simultaneous `&mut app` borrows in the caller.
-        //
-        // `chrome_mode` is always `Full` in this subtask — 436.4b is what
-        // starts computing a real replay decision and passing `Replay`.
+        // signals (damage report, terminal-band range, chrome-damage
+        // decision, and the app's own requested repaint delay); we capture
+        // them here to decide the clear/present path, the head/band/tail
+        // split below, and next frame's `chrome_mode` decision. Running both
+        // inside the one closure avoids two simultaneous `&mut app` borrows
+        // in the caller.
         let mut frame_damage = crate::FrameDamage::Full;
         let mut band_range: std::ops::Range<usize> = 0..0;
+        let mut chrome_damage = crate::ChromeDamage::Changed;
+        let mut terminal_requested_delay: Option<std::time::Duration> = None;
         let full_output = self.ctx.run_ui(raw_input, |root_ui| {
-            let signals = ui_fn(&*root_ui, &gl_state.glow_context, crate::ChromeMode::Full);
+            let signals = ui_fn(&*root_ui, &gl_state.glow_context, chrome_mode);
             frame_damage = signals.frame_damage;
             band_range = signals.band_range;
+            chrome_damage = signals.chrome_damage;
+            terminal_requested_delay = signals.terminal_requested_delay;
         });
 
         self.winit_state
             .handle_platform_output(window, full_output.platform_output);
 
+        // Definitive `pixels_per_point` for THIS frame — read AFTER `run_ui`
+        // has processed `raw_input` via `begin_pass`, so (unlike
+        // `ppp_before_run_ui` above) this always reflects a scale-factor
+        // change delivered this frame. Used for all tessellation below.
         let pixels_per_point = self.ctx.pixels_per_point();
 
         // ── 3-way paint-order split (#436.4a) ──────────────────────────
@@ -173,32 +320,53 @@ impl EguiState {
         let shapes = full_output.shapes;
         let start = band_range.start.min(shapes.len());
         let end = band_range.end.clamp(start, shapes.len());
-        let head_shapes: Vec<egui::epaint::ClippedShape> = shapes[..start].to_vec();
         let band_shapes: Vec<egui::epaint::ClippedShape> = shapes[start..end].to_vec();
-        let tail_shapes: Vec<egui::epaint::ClippedShape> = shapes[end..].to_vec();
 
-        // When `band_range` is the default `0..0` (an app that has not
-        // wired up the band range), `start == end == 0`, so `head_shapes`
-        // and `band_shapes` are empty and `tail_shapes` is the ENTIRE shape
-        // list. Painting all shapes as a single "tail" `paint_primitives`
-        // call is exactly what the pre-#436.4a single-call path did —
-        // byte-identical rendering for an app that does not participate.
-        let head_primitives = self.ctx.tessellate(head_shapes.clone(), pixels_per_point);
+        // The band is ALWAYS fresh — tessellated from this frame's own
+        // shapes regardless of `chrome_mode` — since the terminal band is
+        // rebuilt every frame whether or not chrome was.
         let band_primitives = self.ctx.tessellate(band_shapes, pixels_per_point);
-        let tail_primitives = self.ctx.tessellate(tail_shapes.clone(), pixels_per_point);
 
-        let size = window.inner_size();
-
-        // Populate the chrome cache (#436.4a scaffolding). Never read to
-        // decide replay yet — that is 436.4b.
-        self.chrome_cache = Some(ChromeCache {
-            head_shapes,
-            tail_shapes,
-            head_primitives: head_primitives.clone(),
-            tail_primitives: tail_primitives.clone(),
-            ppp: pixels_per_point,
-            size: [size.width, size.height],
-        });
+        // Head/tail: FULL re-tessellates from this frame's shapes (and
+        // repopulates the cache for a future REPLAY); REPLAY reuses the
+        // cached primitives from the last FULL frame instead. On a REPLAY
+        // frame the app skipped chrome-widget construction, so
+        // `shapes[..start]`/`shapes[end..]` are expected to be empty (or, for
+        // an app that has not wired up the band range, `shapes[..start]` is
+        // trivially empty per the `0..0` default) — but even if the app
+        // painted something there, a REPLAY frame must ignore it: the whole
+        // point of replay is that head/tail are NOT re-tessellated, so
+        // painting anything from `shapes[..start]`/`shapes[end..]` here
+        // would silently diverge from what the cache (and therefore this
+        // frame's actual pixels) represents.
+        let (head_primitives, tail_primitives) = match chrome_mode {
+            crate::ChromeMode::Full => {
+                let head_shapes: Vec<egui::epaint::ClippedShape> = shapes[..start].to_vec();
+                let tail_shapes: Vec<egui::epaint::ClippedShape> = shapes[end..].to_vec();
+                let head_primitives = self.ctx.tessellate(head_shapes, pixels_per_point);
+                let tail_primitives = self.ctx.tessellate(tail_shapes, pixels_per_point);
+                self.chrome_cache = Some(ChromeCache {
+                    head_primitives: head_primitives.clone(),
+                    tail_primitives: tail_primitives.clone(),
+                    ppp: pixels_per_point,
+                    size: size_arr,
+                });
+                (head_primitives, tail_primitives)
+            }
+            crate::ChromeMode::Replay => {
+                self.chrome_cache.as_ref().map_or_else(
+                    || {
+                        // Defensive fallback: `decide_chrome_mode` proved
+                        // `cache_valid` (`self.chrome_cache.is_some()`) before
+                        // choosing `Replay`, so this should be unreachable —
+                        // but degrade gracefully (empty chrome this frame)
+                        // rather than panic if it ever is.
+                        (Vec::new(), Vec::new())
+                    },
+                    |cache| (cache.head_primitives.clone(), cache.tail_primitives.clone()),
+                )
+            }
+        };
 
         // Decide whether this frame may skip the full clear and present only
         // its damaged region. This is a two-part gate:
@@ -283,9 +451,10 @@ impl EguiState {
         // causes an unbounded render loop on platforms where `swap_buffers`
         // returns immediately (macOS with vsync disabled).
 
-        // Stash this frame's repaint delay for 436.4b's replay-eligibility
-        // gate. Not consumed yet.
+        // Stash this frame's signals for next frame's `chrome_mode` decision.
         self.prev_repaint_delay = repaint_delay;
+        self.prev_chrome_damage = chrome_damage;
+        self.prev_terminal_requested_delay = terminal_requested_delay;
 
         FrameOutput {
             commands,
@@ -334,8 +503,195 @@ impl EguiState {
 
 #[cfg(test)]
 mod tests {
+    use super::{chrome_repaint_settled, decide_chrome_mode};
     use egui::epaint::Primitive;
     use egui::{Color32, Rect, pos2, vec2};
+    use std::time::Duration;
+
+    // ── #436.4b: `chrome_repaint_settled` ──────────────────────────────
+
+    #[test]
+    fn settled_when_egui_wants_no_repaint_and_app_requested_none() {
+        assert!(chrome_repaint_settled(Duration::MAX, None));
+    }
+
+    #[test]
+    fn settled_when_egui_wants_no_repaint_even_if_app_requested_a_blink_delay() {
+        // Nothing is shorter than "no repaint at all" (Duration::MAX) --
+        // the app's own 500ms blink request is not itself evidence of an
+        // unsettled chrome.
+        assert!(chrome_repaint_settled(
+            Duration::MAX,
+            Some(Duration::from_millis(500))
+        ));
+    }
+
+    #[test]
+    fn not_settled_when_egui_wants_repaint_sooner_than_the_apps_own_request() {
+        // Something egui-internal (hover fade, menu animation, a focused
+        // TextEdit's cursor blink) wants a wake sooner than the app's own
+        // 500ms blink schedule -- not settled.
+        assert!(!chrome_repaint_settled(
+            Duration::from_millis(16),
+            Some(Duration::from_millis(500))
+        ));
+    }
+
+    #[test]
+    fn settled_when_egui_delay_exactly_matches_the_apps_own_request() {
+        // Nothing SHORTER than what the app itself asked for -- settled.
+        assert!(chrome_repaint_settled(
+            Duration::from_millis(500),
+            Some(Duration::from_millis(500))
+        ));
+    }
+
+    #[test]
+    fn settled_when_egui_delay_is_longer_than_the_apps_own_request() {
+        assert!(chrome_repaint_settled(
+            Duration::from_secs(1),
+            Some(Duration::from_millis(500))
+        ));
+    }
+
+    #[test]
+    fn not_settled_when_app_requested_nothing_but_egui_still_wants_a_repaint() {
+        assert!(!chrome_repaint_settled(Duration::from_millis(16), None));
+    }
+
+    // ── #436.4b: `decide_chrome_mode` ──────────────────────────────────
+
+    /// Bundles `decide_chrome_mode`'s nine gate inputs so each test can
+    /// start from an all-clear baseline (which decides `Replay`) and flip
+    /// exactly one field to prove that field alone forces `Full`. A plain
+    /// tuple would work too but trips `clippy::type_complexity`; a named
+    /// struct is also more readable at each call site below.
+    struct Inputs {
+        cache_valid: bool,
+        cache_size: [u32; 2],
+        cache_ppp: f32,
+        cur_size: [u32; 2],
+        cur_ppp: f32,
+        prev_repaint_delay: Duration,
+        prev_terminal_requested_delay: Option<Duration>,
+        prev_chrome_damage: crate::ChromeDamage,
+        chrome_input_this_frame: bool,
+    }
+
+    impl Inputs {
+        /// An all-clear input set that should decide `Replay`.
+        fn all_clear() -> Self {
+            Self {
+                cache_valid: true,
+                cache_size: [800, 600],
+                cache_ppp: 1.0,
+                cur_size: [800, 600],
+                cur_ppp: 1.0,
+                prev_repaint_delay: Duration::MAX,
+                prev_terminal_requested_delay: None,
+                prev_chrome_damage: crate::ChromeDamage::Unchanged,
+                chrome_input_this_frame: false,
+            }
+        }
+
+        fn decide(&self) -> crate::ChromeMode {
+            decide_chrome_mode(
+                self.cache_valid,
+                self.cache_size,
+                self.cache_ppp,
+                self.cur_size,
+                self.cur_ppp,
+                self.prev_repaint_delay,
+                self.prev_terminal_requested_delay,
+                self.prev_chrome_damage,
+                self.chrome_input_this_frame,
+            )
+        }
+    }
+
+    #[test]
+    fn all_clear_decides_replay() {
+        assert_eq!(Inputs::all_clear().decide(), crate::ChromeMode::Replay);
+    }
+
+    #[test]
+    fn invalid_cache_decides_full() {
+        let inputs = Inputs {
+            cache_valid: false, // no cache yet (e.g. frame 0)
+            ..Inputs::all_clear()
+        };
+        assert_eq!(inputs.decide(), crate::ChromeMode::Full);
+    }
+
+    #[test]
+    fn size_mismatch_decides_full() {
+        let inputs = Inputs {
+            cur_size: [801, 600], // resized since the cache was built
+            ..Inputs::all_clear()
+        };
+        assert_eq!(inputs.decide(), crate::ChromeMode::Full);
+    }
+
+    #[test]
+    fn ppp_mismatch_decides_full() {
+        let inputs = Inputs {
+            cur_ppp: 1.25, // DPI/zoom changed since the cache was built
+            ..Inputs::all_clear()
+        };
+        assert_eq!(inputs.decide(), crate::ChromeMode::Full);
+    }
+
+    #[test]
+    fn prev_chrome_damage_changed_decides_full() {
+        let inputs = Inputs {
+            prev_chrome_damage: crate::ChromeDamage::Changed,
+            ..Inputs::all_clear()
+        };
+        assert_eq!(inputs.decide(), crate::ChromeMode::Full);
+    }
+
+    #[test]
+    fn chrome_input_this_frame_decides_full() {
+        let inputs = Inputs {
+            chrome_input_this_frame: true, // e.g. a mouse click landed this frame
+            ..Inputs::all_clear()
+        };
+        assert_eq!(inputs.decide(), crate::ChromeMode::Full);
+    }
+
+    #[test]
+    fn not_settled_repaint_decides_full() {
+        let inputs = Inputs {
+            // egui wants a wake sooner than what the app itself requested.
+            prev_repaint_delay: Duration::from_millis(16),
+            prev_terminal_requested_delay: Some(Duration::from_millis(500)),
+            ..Inputs::all_clear()
+        };
+        assert_eq!(inputs.decide(), crate::ChromeMode::Full);
+    }
+
+    /// The headline #436 case (design's test #2): a blinking cursor with
+    /// nothing else happening -- egui's delay matches exactly what the app
+    /// itself requested (its own blink schedule), chrome is provably
+    /// unchanged, and there is no chrome input this frame -- decides
+    /// `Replay`.
+    #[test]
+    fn blinking_cursor_idle_frame_decides_replay() {
+        assert_eq!(
+            decide_chrome_mode(
+                true,
+                [800, 600],
+                1.0,
+                [800, 600],
+                1.0,
+                Duration::from_millis(500),
+                Some(Duration::from_millis(500)),
+                crate::ChromeDamage::Unchanged,
+                false,
+            ),
+            crate::ChromeMode::Replay
+        );
+    }
 
     /// Sum the vertex/index counts across every `Mesh` primitive in a
     /// tessellation result. `Callback` primitives (paint callbacks) carry no

--- a/freminal-windowing/src/egui_integration.rs
+++ b/freminal-windowing/src/egui_integration.rs
@@ -22,25 +22,32 @@ pub struct FrameOutput {
 }
 
 /// Cached tessellated chrome (head + tail) primitives from the most recent
-/// FULL frame (#436.4a/#436.4b).
+/// FULL frame (#436.4a/#436.4b/#436.4c).
 ///
 /// Populated at the end of every FULL frame; consulted (via
 /// [`decide_chrome_mode`]) to decide whether a later frame may REPLAY, and
 /// when it does, `run_frame` paints `head_primitives`/`tail_primitives`
-/// directly instead of re-tessellating. Only the tessellated primitives are
-/// retained — not the source shapes — because #436.4b invalidates the
-/// whole cache (forcing `ChromeMode::Full`) on any `ppp`/`size` mismatch
-/// rather than re-tessellating the same shapes at a new `ppp`; a future
-/// subtask that wants that finer-grained recovery would need to retain the
-/// shapes too.
+/// directly instead of re-tessellating. The source `head_shapes`/
+/// `tail_shapes` are retained too (#436.4c, §5.2): a REPLAY frame that
+/// detects the font atlas grew this frame (a new glyph shaped by the
+/// terminal band, e.g.) re-tessellates these cached shapes against the
+/// now-current atlas rather than painting stale UVs baked against the old
+/// (smaller) atlas — see the `atlas_grew`/self-heal handling in
+/// [`EguiState::run_frame`].
 struct ChromeCache {
-    /// Tessellation of the chrome shapes painted *before* the terminal band
-    /// in `full_output.shapes` (e.g. the `CentralPanel` background fill,
-    /// menu bar, tab bar), at `ppp`/`size`.
+    /// The chrome shapes painted *before* the terminal band in
+    /// `full_output.shapes` (e.g. the `CentralPanel` background fill, menu
+    /// bar, tab bar), as recorded on the last FULL frame. Retained (#436.4c)
+    /// so the §5.2 atlas-resize self-heal can re-tessellate them without
+    /// re-running `update()`.
+    head_shapes: Vec<egui::epaint::ClippedShape>,
+    /// The chrome shapes painted *after* the terminal band (overlays, pane
+    /// borders drawn as part of chrome, modals, tooltips), as recorded on
+    /// the last FULL frame. Retained for the same reason as `head_shapes`.
+    tail_shapes: Vec<egui::epaint::ClippedShape>,
+    /// Tessellation of `head_shapes`, at `ppp`/`size`.
     head_primitives: Vec<egui::ClippedPrimitive>,
-    /// Tessellation of the chrome shapes painted *after* the terminal band
-    /// (overlays, pane borders drawn as part of chrome, modals, tooltips),
-    /// at `ppp`/`size`.
+    /// Tessellation of `tail_shapes`, at `ppp`/`size`.
     tail_primitives: Vec<egui::ClippedPrimitive>,
     /// `pixels_per_point` the cached primitives were tessellated at. A
     /// mismatch on a later frame invalidates the cache.
@@ -92,6 +99,31 @@ fn chrome_repaint_settled(
         || repaint_delay == std::time::Duration::MAX,
         |app_delay| repaint_delay >= app_delay,
     )
+}
+
+/// #436.4c §5.2: did the font atlas (`TextureId::default()`) grow this
+/// frame?
+///
+/// `egui`'s `TextureAtlas::allocate` grows the shared font atlas by
+/// doubling its height when a not-yet-shaped glyph needs room; glyph UVs
+/// are normalized to `[0, 1]` at tessellation time by dividing by the
+/// atlas size *current at that call* and baked into the mesh — so a mesh
+/// tessellated before a resize samples the wrong rows if painted after
+/// one. `ImageDelta::is_whole()` (`pos.is_none()`) distinguishes a
+/// whole-texture upload (initial allocation or a resize/respecify) from
+/// an incremental patch (`pos: Some(_)`, a normal new-glyph-added-to-the-
+/// existing-atlas upload that does NOT invalidate previously baked UVs).
+/// Only `TextureId::default()` — the font atlas — is relevant; a whole
+/// upload of some other (e.g. image-protocol) texture does not affect
+/// chrome glyph UVs.
+///
+/// Pure (no `self`/`egui::Context` state needed beyond the delta itself),
+/// so directly unit-testable.
+fn atlas_grew(textures_delta: &egui::TexturesDelta) -> bool {
+    textures_delta
+        .set
+        .iter()
+        .any(|(id, delta)| *id == egui::TextureId::default() && delta.is_whole())
 }
 
 /// #436.4b: decide this frame's [`crate::ChromeMode`].
@@ -299,6 +331,15 @@ impl EguiState {
         // change delivered this frame. Used for all tessellation below.
         let pixels_per_point = self.ctx.pixels_per_point();
 
+        // #436.4c §5.2: did the font atlas grow (or otherwise get wholly
+        // re-specified) THIS frame? Glyph shaping happens during `run_ui`
+        // (layout/galley creation), so `full_output.textures_delta` already
+        // reflects any atlas growth caused by this frame's chrome OR
+        // terminal-band content — read this once, up front, before the
+        // head/band/tail split below, since it drives the REPLAY self-heal
+        // path and is irrelevant (see below) on the FULL path.
+        let atlas_grew_this_frame = atlas_grew(&full_output.textures_delta);
+
         // ── 3-way paint-order split (#436.4a) ──────────────────────────
         //
         // Slice `full_output.shapes` into head (chrome painted before the
@@ -339,13 +380,19 @@ impl EguiState {
         // painting anything from `shapes[..start]`/`shapes[end..]` here
         // would silently diverge from what the cache (and therefore this
         // frame's actual pixels) represents.
+        // On a FULL frame `atlas_grew_this_frame` is irrelevant: every band
+        // is re-tessellated fresh from this frame's own shapes regardless,
+        // so there is no stale-UV hazard to self-heal — the self-heal below
+        // is REPLAY-only.
         let (head_primitives, tail_primitives) = match chrome_mode {
             crate::ChromeMode::Full => {
                 let head_shapes: Vec<egui::epaint::ClippedShape> = shapes[..start].to_vec();
                 let tail_shapes: Vec<egui::epaint::ClippedShape> = shapes[end..].to_vec();
-                let head_primitives = self.ctx.tessellate(head_shapes, pixels_per_point);
-                let tail_primitives = self.ctx.tessellate(tail_shapes, pixels_per_point);
+                let head_primitives = self.ctx.tessellate(head_shapes.clone(), pixels_per_point);
+                let tail_primitives = self.ctx.tessellate(tail_shapes.clone(), pixels_per_point);
                 self.chrome_cache = Some(ChromeCache {
+                    head_shapes,
+                    tail_shapes,
                     head_primitives: head_primitives.clone(),
                     tail_primitives: tail_primitives.clone(),
                     ppp: pixels_per_point,
@@ -353,7 +400,52 @@ impl EguiState {
                 });
                 (head_primitives, tail_primitives)
             }
+            crate::ChromeMode::Replay if atlas_grew_this_frame => {
+                // #436.4c §5.2 self-heal: the font atlas grew this frame (a
+                // new glyph shaped by the band or an overlay). The cached
+                // chrome primitives' UVs were baked against the SMALLER
+                // atlas that existed when they were last tessellated;
+                // painting them now would sample the wrong texture rows
+                // (garbled chrome text). Re-tessellate the cached SHAPES
+                // (not `update()`, which is not idempotent and must never
+                // be re-run mid-frame) against the current atlas and
+                // refresh the cached primitives so the NEXT replay reuses
+                // correct UVs too. One rare extra tessellate, zero visible
+                // glitch.
+                //
+                // Clone the shapes out of an immutable borrow first (and
+                // let that borrow end) before tessellating via `self.ctx`
+                // and then re-borrowing `self.chrome_cache` mutably to
+                // store the refreshed primitives — holding the cache borrow
+                // across the `self.ctx.tessellate` calls would conflict
+                // with `&self.ctx` while `self.chrome_cache` is exclusively
+                // borrowed.
+                let cached_shapes = self
+                    .chrome_cache
+                    .as_ref()
+                    .map(|cache| (cache.head_shapes.clone(), cache.tail_shapes.clone()));
+                cached_shapes.map_or_else(
+                    || {
+                        // Defensive fallback: `decide_chrome_mode` proved
+                        // `cache_valid` before choosing `Replay`, so this
+                        // should be unreachable — but degrade gracefully
+                        // (empty chrome this frame) rather than panic.
+                        (Vec::new(), Vec::new())
+                    },
+                    |(head_shapes, tail_shapes)| {
+                        let head_primitives = self.ctx.tessellate(head_shapes, pixels_per_point);
+                        let tail_primitives = self.ctx.tessellate(tail_shapes, pixels_per_point);
+                        if let Some(cache) = self.chrome_cache.as_mut() {
+                            cache.head_primitives.clone_from(&head_primitives);
+                            cache.tail_primitives.clone_from(&tail_primitives);
+                        }
+                        (head_primitives, tail_primitives)
+                    },
+                )
+            }
             crate::ChromeMode::Replay => {
+                // Normal replay: no atlas growth this frame, cached
+                // primitives' UVs remain valid — reuse them directly.
                 self.chrome_cache.as_ref().map_or_else(
                     || {
                         // Defensive fallback: `decide_chrome_mode` proved
@@ -503,9 +595,10 @@ impl EguiState {
 
 #[cfg(test)]
 mod tests {
-    use super::{chrome_repaint_settled, decide_chrome_mode};
-    use egui::epaint::Primitive;
-    use egui::{Color32, Rect, pos2, vec2};
+    use super::{atlas_grew, chrome_repaint_settled, decide_chrome_mode};
+    use egui::ImageData;
+    use egui::epaint::{ImageDelta, Primitive};
+    use egui::{Color32, ColorImage, Rect, TextureId, TextureOptions, TexturesDelta, pos2, vec2};
     use std::time::Duration;
 
     // ── #436.4b: `chrome_repaint_settled` ──────────────────────────────
@@ -690,6 +783,197 @@ mod tests {
                 false,
             ),
             crate::ChromeMode::Replay
+        );
+    }
+
+    // ── #436.4c §5.2: `atlas_grew` ──────────────────────────────────────
+
+    /// A tiny 2x2 filled `ImageData`, sufficient to build `ImageDelta`
+    /// values without depending on any real font/image data.
+    fn tiny_image() -> egui::ImageData {
+        ImageData::Color(std::sync::Arc::new(ColorImage::filled(
+            [2, 2],
+            Color32::WHITE,
+        )))
+    }
+
+    #[test]
+    fn atlas_grew_false_on_empty_delta() {
+        assert!(!atlas_grew(&TexturesDelta::default()));
+    }
+
+    #[test]
+    fn atlas_grew_true_on_font_atlas_whole_upload() {
+        // `ImageDelta::full` sets `pos: None` -- `is_whole() == true` --
+        // exactly the resize/respecify marker the self-heal watches for,
+        // on `TextureId::default()` (the font atlas).
+        let delta = ImageDelta::full(tiny_image(), TextureOptions::default());
+        assert!(delta.is_whole(), "sanity: ImageDelta::full is whole");
+        let mut textures_delta = TexturesDelta::default();
+        textures_delta.set.push((TextureId::default(), delta));
+        assert!(atlas_grew(&textures_delta));
+    }
+
+    #[test]
+    fn atlas_grew_false_on_font_atlas_incremental_patch() {
+        // `ImageDelta::partial` sets `pos: Some(_)` -- a normal
+        // new-glyph-added-to-the-existing-atlas upload, NOT a resize. Must
+        // NOT be mistaken for atlas growth.
+        let delta = ImageDelta::partial([0, 0], tiny_image(), TextureOptions::default());
+        assert!(
+            !delta.is_whole(),
+            "sanity: ImageDelta::partial is not whole"
+        );
+        let mut textures_delta = TexturesDelta::default();
+        textures_delta.set.push((TextureId::default(), delta));
+        assert!(!atlas_grew(&textures_delta));
+    }
+
+    #[test]
+    fn atlas_grew_false_on_whole_upload_of_a_non_font_texture() {
+        // A whole-texture upload of some OTHER texture (e.g. an
+        // image-protocol texture) is not the font atlas and must not
+        // trigger the chrome-UV self-heal.
+        let delta = ImageDelta::full(tiny_image(), TextureOptions::default());
+        let mut textures_delta = TexturesDelta::default();
+        textures_delta.set.push((TextureId::User(42), delta));
+        assert!(!atlas_grew(&textures_delta));
+    }
+
+    #[test]
+    fn atlas_grew_true_when_font_atlas_whole_upload_mixed_with_other_entries() {
+        // A realistic frame may carry multiple texture deltas; growth must
+        // be detected even when the font-atlas entry is not the only one
+        // (or not first).
+        let mut textures_delta = TexturesDelta::default();
+        textures_delta.set.push((
+            TextureId::User(7),
+            ImageDelta::partial([0, 0], tiny_image(), TextureOptions::default()),
+        ));
+        textures_delta.set.push((
+            TextureId::default(),
+            ImageDelta::full(tiny_image(), TextureOptions::default()),
+        ));
+        assert!(atlas_grew(&textures_delta));
+    }
+
+    /// Reproduces the exact §5.2 hazard end-to-end using only
+    /// `egui::Context` (pure CPU, no GL/painter needed — this does NOT
+    /// require the 436.9 pixel harness) and proves the self-heal's core
+    /// operation — re-tessellating cached shapes against the current atlas
+    /// — actually fixes it.
+    ///
+    /// Mechanics (see `atlas_grew`'s doc comment): a `rect_filled` shape's
+    /// UV is the constant `WHITE_UV` (invariant to atlas size — verified
+    /// against `epaint::WHITE_UV`/`Mesh::add_colored_rect`), but a TEXT
+    /// shape's glyph UVs are normalized by the LIVE atlas size at the
+    /// moment `ctx.tessellate` is called
+    /// (`epaint::tessellator::Tessellator::tessellate_text`).
+    /// `TextureAtlas::allocate` doubles the atlas height *in place*
+    /// whenever a glyph's row does not fit, marking the WHOLE image dirty
+    /// (`ImageDelta::full`, `pos: None`) for that frame's `textures_delta`
+    /// — so cached chrome text tessellated *before* a resize holds
+    /// different glyph UVs than tessellating the identical shapes again
+    /// *afterward*.
+    ///
+    /// How this test forces the resize: it rasterizes a large run of glyphs
+    /// at a font size (80pt) far taller than the freshly-initialized atlas's
+    /// first row, which reliably overflows the initial atlas height and
+    /// triggers the in-place doubling on the very next frame. The *specific*
+    /// glyphs are immaterial — the trigger is atlas-space exhaustion, not
+    /// glyph novelty per se (the bundled egui fonts have no CJK coverage, so
+    /// the U+4E00.. codepoints below actually rasterize as the fallback/tofu
+    /// glyph; that does not matter, since a single tall glyph is enough to
+    /// overflow the tiny initial row). In production the same resize is
+    /// driven by any glyph the terminal band or an overlay shapes that does
+    /// not fit the current atlas — a normal-size never-before-seen glyph is
+    /// the common case; a large one is simply the most reliable way to force
+    /// it deterministically in a test. The `atlas_grew` sanity assert below
+    /// fails loudly (never vacuously passes) if the resize ever stops
+    /// happening, so the test cannot silently rot into a no-op.
+    #[test]
+    fn atlas_growth_invalidates_cached_text_uvs_and_retessellation_fixes_it() {
+        let ctx = egui::Context::default();
+        let ppp = 1.0;
+
+        // Frame 1 ("chrome"): a small text label. Establishes a baseline
+        // atlas and a cached shape list + its tessellation — this stands
+        // in for `ChromeCache::{head_shapes, head_primitives}` after a
+        // FULL frame.
+        let chrome_output = ctx.run_ui(egui::RawInput::default(), |ui| {
+            ui.label("Chrome");
+        });
+        let cached_shapes = chrome_output.shapes;
+        let cached_primitives_before = ctx.tessellate(cached_shapes.clone(), ppp);
+
+        // Frame 2 ("terminal band"): a large run of glyphs at a font size
+        // (80pt) far taller than the freshly-initialized atlas's first row,
+        // which overflows the initial atlas height and forces the in-place
+        // doubling. This is NOT a chrome trigger (#436 §3.3 — terminal
+        // content never forces FULL on its own) — exactly the
+        // REPLAY-candidate scenario §5.2 describes: the band grows the shared
+        // font atlas mid-REPLAY. (The codepoints are in the CJK range but the
+        // bundled fonts lack CJK coverage, so they rasterize as the fallback
+        // glyph — immaterial, since the resize is driven by glyph SIZE
+        // overflowing the atlas row, not by which glyph it is; see the fn
+        // doc comment.)
+        let big_text: String = (0x4E00u32..0x4E00u32 + 300)
+            .filter_map(char::from_u32)
+            .collect();
+        let band_output = ctx.run_ui(egui::RawInput::default(), |ui| {
+            ui.label(egui::RichText::new(big_text.clone()).size(80.0));
+        });
+
+        assert!(
+            atlas_grew(&band_output.textures_delta),
+            "sanity: the band frame must actually grow the font atlas for \
+             this test to exercise the hazard"
+        );
+
+        // The hazard: painting `cached_primitives_before` now (after
+        // growth, without re-tessellating) would sample the WRONG atlas
+        // rows — prove it by re-tessellating the IDENTICAL cached shapes
+        // and observing at least one glyph UV changed. `WHITE_UV`-only
+        // vertices (rect fills) are excluded since they are
+        // atlas-size-invariant by construction.
+        let cached_primitives_after = ctx.tessellate(cached_shapes.clone(), ppp);
+        let mut any_glyph_uv_changed = false;
+        for (before, after) in cached_primitives_before
+            .iter()
+            .zip(cached_primitives_after.iter())
+        {
+            if let (Primitive::Mesh(mesh_before), Primitive::Mesh(mesh_after)) =
+                (&before.primitive, &after.primitive)
+            {
+                for (vb, va) in mesh_before.vertices.iter().zip(mesh_after.vertices.iter()) {
+                    if vb.uv != egui::epaint::WHITE_UV && vb.uv != va.uv {
+                        any_glyph_uv_changed = true;
+                    }
+                }
+            }
+        }
+        assert!(
+            any_glyph_uv_changed,
+            "the cached chrome text's glyph UVs must differ before/after \
+             atlas growth -- this is the exact staleness `run_frame`'s \
+             REPLAY self-heal (re-tessellating `cache.head_shapes`/\
+             `cache.tail_shapes`) corrects"
+        );
+
+        // The fix: this IS the self-heal's operation
+        // (`self.ctx.tessellate(cache.head_shapes.clone(), pixels_per_point)`
+        // in `run_frame`). Prove it converges: tessellating the cached
+        // shapes AGAIN, with no further atlas change, reproduces the exact
+        // same (correct, current-atlas) primitives — i.e. the self-heal
+        // result is stable once applied, matching what `run_frame` stores
+        // back into `cache.head_primitives`/`cache.tail_primitives`.
+        let cached_primitives_after_again = ctx.tessellate(cached_shapes, ppp);
+        assert_eq!(
+            flatten_mesh_geometry(&cached_primitives_after),
+            flatten_mesh_geometry(&cached_primitives_after_again),
+            "re-tessellating the self-healed shapes again (no further atlas \
+             change) must reproduce identical geometry -- the self-heal \
+             result is stable"
         );
     }
 

--- a/freminal-windowing/src/egui_integration.rs
+++ b/freminal-windowing/src/egui_integration.rs
@@ -786,6 +786,149 @@ mod tests {
         );
     }
 
+    // ── #436.7: multi-frame FULL/REPLAY sequence properties ─────────────
+    //
+    // `decide_chrome_mode` is pure and consumes only last-frame signals, so
+    // a frame sequence is faithfully modelled by chaining calls and threading
+    // each frame's outputs into the next frame's `prev_*` inputs — exactly
+    // what `run_frame` does (see the `self.prev_* = ...` stashes at the end
+    // of `run_frame`). These tests drive the design's mandatory sequence
+    // scenarios (#436 §9 tests #6-#8 + OQ-4) at the decision layer. The
+    // pixel-level halves (byte-identical framebuffer, real texture isolation,
+    // real ghost-free rendering) need the GPU harness and are 436.9's.
+
+    /// Design test #8: the settings window NEVER REPLAYs. It has no
+    /// `PerWindowState`, so `App::take_chrome_damage` returns its
+    /// `ChromeDamage::Changed` default every frame; `run_frame` stashes that
+    /// into `prev_chrome_damage`. Even once its own cache is valid at a stable
+    /// size/ppp and egui is settled, `prev_chrome_damage == Changed` forces
+    /// `Full` on every single frame, forever — never `Replay`.
+    #[test]
+    fn settings_window_never_replays_over_a_frame_sequence() {
+        // Frame 0: no cache yet -> Full regardless of everything else.
+        let frame0 = Inputs {
+            cache_valid: false,
+            ..Inputs::all_clear()
+        };
+        assert_eq!(frame0.decide(), crate::ChromeMode::Full);
+
+        // Frames 1..N: cache is now valid at a stable size/ppp and egui is
+        // fully settled — the ONLY thing keeping it Full is that
+        // `take_chrome_damage` always returns `Changed` for a window with no
+        // `PerWindowState`, which `run_frame` fed back as `prev_chrome_damage`.
+        for frame in 1..8 {
+            let inputs = Inputs {
+                cache_valid: true,
+                prev_chrome_damage: crate::ChromeDamage::Changed,
+                ..Inputs::all_clear()
+            };
+            assert_eq!(
+                inputs.decide(),
+                crate::ChromeMode::Full,
+                "settings-window frame {frame} must be Full (stuck on Changed forever)"
+            );
+        }
+    }
+
+    /// Design test #7 (decision-layer half): two windows decide independently.
+    /// `decide_chrome_mode` takes only explicit per-window inputs and holds no
+    /// shared state, so one window's decision cannot influence another's. The
+    /// GPU/texture-isolation half is 436.9's.
+    #[test]
+    fn two_windows_decide_independently() {
+        // Window A: fully idle/settled -> Replay.
+        let window_a = Inputs::all_clear();
+        // Window B: mid-resize (size mismatch) and chrome changed last frame
+        // -> Full. Same frame, different window, independent inputs.
+        let window_b = Inputs {
+            cur_size: [1024, 768],
+            prev_chrome_damage: crate::ChromeDamage::Changed,
+            ..Inputs::all_clear()
+        };
+        assert_eq!(window_a.decide(), crate::ChromeMode::Replay);
+        assert_eq!(window_b.decide(), crate::ChromeMode::Full);
+        // Re-decide A after B to prove B left no residue (pure fn, but pin it).
+        assert_eq!(window_a.decide(), crate::ChromeMode::Replay);
+    }
+
+    /// OQ-4 golden idle sequence: after startup, a steady idle screen yields
+    /// exactly ONE Full frame (frame 0, cache not yet built) and then all
+    /// REPLAY. Models warm-up completing and the cache arming.
+    #[test]
+    fn golden_idle_sequence_is_one_full_then_all_replay() {
+        // Frame 0: cache not yet built -> Full (builds the cache).
+        let frame0 = Inputs {
+            cache_valid: false,
+            ..Inputs::all_clear()
+        };
+        assert_eq!(frame0.decide(), crate::ChromeMode::Full);
+
+        // Frames 1..N: cache valid, nothing changed, egui settled, no input
+        // -> Replay every frame. (Warm-up's extra forced-Full frames are
+        // modelled via `prev_chrome_damage`; here we start from the
+        // post-warm-up steady state where chrome has gone Unchanged.)
+        for frame in 1..10 {
+            let inputs = Inputs::all_clear();
+            assert_eq!(
+                inputs.decide(),
+                crate::ChromeMode::Replay,
+                "idle frame {frame} after warm-up must be Replay"
+            );
+        }
+    }
+
+    /// Design test #6 (decision-layer half): an overlay opening then closing
+    /// re-arms the cache only after chrome has been quiet through the settle
+    /// window — the decision sequence never permits a REPLAY frame that would
+    /// paint a stale "overlay still open" tail. Models the `ChromeDamage`
+    /// sequence a modal open->close produces (§3.5 settle rule keeps the
+    /// close frame AND the next frame `Changed`).
+    #[test]
+    fn overlay_open_close_rearms_cache_only_after_settle() {
+        // A helper: decide this frame given the chrome_damage the PREVIOUS
+        // frame reported (that is what run_frame threads into prev_chrome_damage).
+        let decide_with_prev = |prev: crate::ChromeDamage| {
+            Inputs {
+                prev_chrome_damage: prev,
+                ..Inputs::all_clear()
+            }
+            .decide()
+        };
+
+        // The chrome_damage each frame REPORTS (as decide_chrome_damage would):
+        //   f1 modal opens          -> Changed
+        //   f2 modal still open      -> Changed
+        //   f3 modal closes (transition) -> Changed
+        //   f4 settle frame (§3.5)   -> Changed
+        //   f5 quiet                 -> Unchanged
+        //   f6 quiet                 -> Unchanged
+        // run_frame decides frame N using frame N-1's reported chrome_damage.
+        // So the earliest REPLAY is the frame whose PREVIOUS frame reported
+        // Unchanged — i.e. f6 (prev = f5 = Unchanged).
+        assert_eq!(
+            decide_with_prev(crate::ChromeDamage::Changed),
+            crate::ChromeMode::Full
+        ); // during f2 (prev f1)
+        assert_eq!(
+            decide_with_prev(crate::ChromeDamage::Changed),
+            crate::ChromeMode::Full
+        ); // during f3 (prev f2)
+        assert_eq!(
+            decide_with_prev(crate::ChromeDamage::Changed),
+            crate::ChromeMode::Full
+        ); // during f4 (prev f3, the close)
+        assert_eq!(
+            decide_with_prev(crate::ChromeDamage::Changed),
+            crate::ChromeMode::Full
+        ); // during f5 (prev f4, the settle)
+        // Only now, after a fully-quiet previous frame, may the cache re-arm:
+        assert_eq!(
+            decide_with_prev(crate::ChromeDamage::Unchanged),
+            crate::ChromeMode::Replay,
+            "cache may re-arm to Replay only after chrome was quiet last frame"
+        );
+    }
+
     // ── #436.4c §5.2: `atlas_grew` ──────────────────────────────────────
 
     /// A tiny 2x2 filled `ImageData`, sufficient to build `ImageDelta`

--- a/freminal-windowing/src/egui_integration.rs
+++ b/freminal-windowing/src/egui_integration.rs
@@ -1176,4 +1176,130 @@ mod tests {
         assert!(band_shapes.is_empty());
         assert_eq!(tail_shapes.len(), shapes.len());
     }
+
+    /// Extract, in order, the `rect` of every `Primitive::Callback` in a
+    /// tessellated primitive list. `run_frame`'s band contains GL
+    /// `PaintCallback`s (the pre-clear FBO callback, one per-pane draw
+    /// callback per pane, and the post-shader composite callback); their
+    /// `rect` is a stable, headlessly-observable identity we can assert
+    /// order/containment against without a GL context.
+    fn callback_rects(primitives: &[egui::ClippedPrimitive]) -> Vec<Rect> {
+        primitives
+            .iter()
+            .filter_map(|clipped| match &clipped.primitive {
+                Primitive::Callback(cb) => Some(cb.rect),
+                Primitive::Mesh(_) => None,
+            })
+            .collect()
+    }
+
+    /// #436.5: the terminal band's GL `PaintCallback`s (pre-clear FBO,
+    /// per-pane draw(s), post-shader composite) must stay CONTIGUOUS and IN
+    /// ORDER inside the band slice across the head/band/tail split, so their
+    /// offscreen-FBO round-trip is never interrupted by a chrome
+    /// `paint_primitives` call. This is the property "Finding A" relies on:
+    /// because `band_shape_start` is captured before the pre-clear callback
+    /// and `band_shape_end` after the post-shader callback (`app_impl.rs`),
+    /// all three callback kinds fall inside the band's contiguous shape
+    /// range by construction, and egui's tessellator (verified against
+    /// epaint 0.35: `tessellate_clipped_shape` emits each `Shape::Callback`
+    /// as its own `Primitive::Callback`, never merged into an adjacent mesh,
+    /// in input order) preserves that.
+    ///
+    /// This is a data-shape/ordering test only — it does NOT invoke the
+    /// callbacks or exercise any GL. The closures are inert. Real FBO-state
+    /// atomicity and pixel output are GPU-bound and deferred to 436.9's
+    /// pixel harness (no headless-GL harness exists in-repo).
+    #[test]
+    fn band_gl_callbacks_stay_contiguous_and_ordered_across_the_split() {
+        use std::sync::Arc;
+
+        // Distinguishable rects identify each callback by position in the
+        // tessellated output (their `rect` survives tessellation verbatim).
+        let preclear_rect = Rect::from_min_size(pos2(1.0, 0.0), vec2(100.0, 100.0));
+        let pane0_rect = Rect::from_min_size(pos2(2.0, 0.0), vec2(40.0, 40.0));
+        let pane1_rect = Rect::from_min_size(pos2(3.0, 0.0), vec2(40.0, 40.0));
+        let postshader_rect = Rect::from_min_size(pos2(4.0, 0.0), vec2(100.0, 100.0));
+
+        let make_cb = |rect: Rect| egui::PaintCallback {
+            rect,
+            // Inert closure — never invoked in this headless test; mirrors
+            // production's `Arc::new(egui_glow::CallbackFn::new(move |info,
+            // painter| { .. }))` construction shape (app_impl.rs:1876,2427).
+            callback: Arc::new(egui_glow::CallbackFn::new(|_info, _painter| {})),
+        };
+
+        let ctx = egui::Context::default();
+        let pixels_per_point = 1.0;
+
+        let full_output = ctx.run_ui(egui::RawInput::default(), |ui| {
+            // HEAD: chrome painted before the band (menu/tab bar stand-in).
+            ui.painter().rect_filled(
+                Rect::from_min_size(pos2(0.0, 0.0), vec2(5.0, 5.0)),
+                0.0,
+                Color32::RED,
+            );
+
+            // BAND begins here — mirrors app_impl.rs's terminal-band order:
+            // pre-clear FBO callback, then per-pane draw callbacks, then the
+            // post-shader composite callback, then a pane-border rect
+            // (Band-C chrome, still inside the band range).
+            ui.painter().add(make_cb(preclear_rect));
+            ui.painter().add(make_cb(pane0_rect));
+            ui.painter().add(make_cb(pane1_rect));
+            ui.painter().add(make_cb(postshader_rect));
+            ui.painter().rect_filled(
+                Rect::from_min_size(pos2(10.0, 10.0), vec2(5.0, 5.0)),
+                0.0,
+                Color32::GREEN,
+            );
+
+            // TAIL: chrome painted after the band (overlay/tooltip stand-in).
+            ui.painter().rect_filled(
+                Rect::from_min_size(pos2(30.0, 30.0), vec2(5.0, 5.0)),
+                0.0,
+                Color32::YELLOW,
+            );
+        });
+
+        let shapes = full_output.shapes;
+        // 1 head rect + 4 callbacks + 1 border rect + 1 tail rect.
+        assert_eq!(shapes.len(), 7, "sanity: exactly the shapes painted");
+
+        // Band range: from the first callback (index 1) through the border
+        // rect (index 5, exclusive end 6) — as `band_shape_start`/
+        // `band_shape_end` would bracket it in production.
+        let start = 1;
+        let end = 6;
+        let head_primitives = ctx.tessellate(shapes[..start].to_vec(), pixels_per_point);
+        let band_primitives = ctx.tessellate(shapes[start..end].to_vec(), pixels_per_point);
+        let tail_primitives = ctx.tessellate(shapes[end..].to_vec(), pixels_per_point);
+
+        // The band slice contains exactly the four callbacks, in order.
+        assert_eq!(
+            callback_rects(&band_primitives),
+            vec![preclear_rect, pane0_rect, pane1_rect, postshader_rect],
+            "the band must contain pre-clear -> pane0 -> pane1 -> post-shader \
+             callbacks, contiguous and in order"
+        );
+        // No callback leaks into head or tail.
+        assert!(
+            callback_rects(&head_primitives).is_empty(),
+            "no GL callback may fall in the chrome_head slice"
+        );
+        assert!(
+            callback_rects(&tail_primitives).is_empty(),
+            "no GL callback may fall in the chrome_tail slice"
+        );
+
+        // Splitting must not drop, duplicate, or reorder callbacks vs.
+        // tessellating the whole list at once.
+        let whole_primitives = ctx.tessellate(shapes, pixels_per_point);
+        assert_eq!(
+            callback_rects(&whole_primitives),
+            vec![preclear_rect, pane0_rect, pane1_rect, postshader_rect],
+            "the whole-list tessellation must carry the same callbacks in the \
+             same order the split does"
+        );
+    }
 }

--- a/freminal-windowing/src/egui_integration.rs
+++ b/freminal-windowing/src/egui_integration.rs
@@ -21,11 +21,58 @@ pub struct FrameOutput {
     pub repaint_delay: std::time::Duration,
 }
 
+/// Cached chrome (head + tail) shapes and tessellated primitives from the
+/// most recent FULL frame (#436.4a scaffolding).
+///
+/// Populated at the end of every frame (which, in this subtask, is always a
+/// FULL frame — replay does not exist yet) but never read to decide replay;
+/// 436.4b is what starts consulting this cache to skip re-tessellating
+/// chrome on eligible frames.
+// TODO(#436.4b): every field here is read once the replay decision path
+// lands (cache-validity check against `ppp`/`size`, then reuse of
+// `head_primitives`/`tail_primitives` in place of re-tessellating
+// `head_shapes`/`tail_shapes`). Until then the fields are write-only
+// scaffolding, landed in 436.4a alongside the paint-order split they
+// describe so the two changes review together.
+#[allow(dead_code)]
+struct ChromeCache {
+    /// Chrome shapes painted *before* the terminal band in `full_output.shapes`
+    /// (e.g. the `CentralPanel` background fill, menu bar, tab bar).
+    head_shapes: Vec<egui::epaint::ClippedShape>,
+    /// Chrome shapes painted *after* the terminal band (overlays, pane
+    /// borders drawn as part of chrome, modals, tooltips).
+    tail_shapes: Vec<egui::epaint::ClippedShape>,
+    /// Tessellation of `head_shapes` at `ppp`/`size`.
+    head_primitives: Vec<egui::ClippedPrimitive>,
+    /// Tessellation of `tail_shapes` at `ppp`/`size`.
+    tail_primitives: Vec<egui::ClippedPrimitive>,
+    /// `pixels_per_point` the cached primitives were tessellated at. A
+    /// mismatch on a later frame invalidates the cache (436.4b).
+    ppp: f32,
+    /// Physical framebuffer size the cached primitives were tessellated
+    /// for. A mismatch on a later frame invalidates the cache (436.4b).
+    size: [u32; 2],
+}
+
 /// Per-window egui state.
 pub struct EguiState {
     pub(crate) ctx: egui::Context,
     pub(crate) winit_state: egui_winit::State,
     pub(crate) painter: egui_glow::Painter,
+    /// Cached chrome primitives from the last FULL frame (#436.4a). Not yet
+    /// consulted for replay decisions — see [`ChromeCache`].
+    chrome_cache: Option<ChromeCache>,
+    /// The repaint delay `run_frame` returned last frame (#436.4a
+    /// scaffolding). Not yet consulted — 436.4b uses this alongside
+    /// `prev_chrome_damage` to help decide replay eligibility.
+    prev_repaint_delay: std::time::Duration,
+    /// The chrome-damage decision drained last frame (#436.4a scaffolding).
+    /// Not yet updated per-frame or consulted — 436.4b wires both the write
+    /// (from `App::take_chrome_damage`) and the read (replay gate).
+    // TODO(#436.4b): read (and start writing, per-frame) to gate the
+    // chrome-replay decision. Write-only scaffolding until then.
+    #[allow(dead_code)]
+    prev_chrome_damage: crate::ChromeDamage,
 }
 
 impl EguiState {
@@ -51,6 +98,9 @@ impl EguiState {
             ctx,
             winit_state,
             painter,
+            chrome_cache: None,
+            prev_repaint_delay: std::time::Duration::MAX,
+            prev_chrome_damage: crate::ChromeDamage::Changed,
         })
     }
 
@@ -72,7 +122,7 @@ impl EguiState {
         ui_fn: F,
     ) -> FrameOutput
     where
-        F: FnMut(&egui::Context, &glow::Context) -> crate::FrameDamage,
+        F: FnMut(&egui::Context, &glow::Context, crate::ChromeMode) -> crate::FrameSignals,
     {
         let mut ui_fn = ui_fn;
 
@@ -82,21 +132,73 @@ impl EguiState {
         // so deref explicitly rather than relying on a silent coercion.
         //
         // The closure both runs the app's `update` and returns this frame's
-        // damage report; we capture it here to decide the clear/present path
-        // below. Running both inside the one closure avoids two simultaneous
-        // `&mut app` borrows in the caller.
+        // signals (damage report + terminal-band range, #436.4a); we capture
+        // them here to decide the clear/present path and the head/band/tail
+        // split below. Running both inside the one closure avoids two
+        // simultaneous `&mut app` borrows in the caller.
+        //
+        // `chrome_mode` is always `Full` in this subtask — 436.4b is what
+        // starts computing a real replay decision and passing `Replay`.
         let mut frame_damage = crate::FrameDamage::Full;
+        let mut band_range: std::ops::Range<usize> = 0..0;
         let full_output = self.ctx.run_ui(raw_input, |root_ui| {
-            frame_damage = ui_fn(&*root_ui, &gl_state.glow_context);
+            let signals = ui_fn(&*root_ui, &gl_state.glow_context, crate::ChromeMode::Full);
+            frame_damage = signals.frame_damage;
+            band_range = signals.band_range;
         });
 
         self.winit_state
             .handle_platform_output(window, full_output.platform_output);
 
         let pixels_per_point = self.ctx.pixels_per_point();
-        let clipped_primitives = self.ctx.tessellate(full_output.shapes, pixels_per_point);
+
+        // ── 3-way paint-order split (#436.4a) ──────────────────────────
+        //
+        // Slice `full_output.shapes` into head (chrome painted before the
+        // terminal band — e.g. the `CentralPanel` background fill, menu
+        // bar, tab bar), band (terminal content, rebuilt every frame), and
+        // tail (chrome painted after the band — overlays, borders, modals)
+        // by `band_range`, then tessellate and paint each slice separately,
+        // in that order. `LayerId::background()`'s `PaintList` drains
+        // first into `full_output.shapes`, and the band occupies a
+        // contiguous range within it (see `App::take_terminal_band_range`),
+        // so `band_range` is valid as an index range into `full_output.shapes`
+        // directly.
+        //
+        // Clamp defensively: an app that reports a range referring to a
+        // shape count larger than what actually drained (e.g. stale state)
+        // must never panic on the slice below. `start` is clamped to the
+        // shape count; `end` is then clamped to `[start, shape count]`, so
+        // `start <= end <= shapes.len()` always holds.
+        let shapes = full_output.shapes;
+        let start = band_range.start.min(shapes.len());
+        let end = band_range.end.clamp(start, shapes.len());
+        let head_shapes: Vec<egui::epaint::ClippedShape> = shapes[..start].to_vec();
+        let band_shapes: Vec<egui::epaint::ClippedShape> = shapes[start..end].to_vec();
+        let tail_shapes: Vec<egui::epaint::ClippedShape> = shapes[end..].to_vec();
+
+        // When `band_range` is the default `0..0` (an app that has not
+        // wired up the band range), `start == end == 0`, so `head_shapes`
+        // and `band_shapes` are empty and `tail_shapes` is the ENTIRE shape
+        // list. Painting all shapes as a single "tail" `paint_primitives`
+        // call is exactly what the pre-#436.4a single-call path did —
+        // byte-identical rendering for an app that does not participate.
+        let head_primitives = self.ctx.tessellate(head_shapes.clone(), pixels_per_point);
+        let band_primitives = self.ctx.tessellate(band_shapes, pixels_per_point);
+        let tail_primitives = self.ctx.tessellate(tail_shapes.clone(), pixels_per_point);
 
         let size = window.inner_size();
+
+        // Populate the chrome cache (#436.4a scaffolding). Never read to
+        // decide replay yet — that is 436.4b.
+        self.chrome_cache = Some(ChromeCache {
+            head_shapes,
+            tail_shapes,
+            head_primitives: head_primitives.clone(),
+            tail_primitives: tail_primitives.clone(),
+            ppp: pixels_per_point,
+            size: [size.width, size.height],
+        });
 
         // Decide whether this frame may skip the full clear and present only
         // its damaged region. This is a two-part gate:
@@ -122,7 +224,7 @@ impl EguiState {
         }
 
         // Publish the authoritative decision BEFORE the paint callbacks run
-        // (they execute inside `paint_and_update_textures` below), so any
+        // (they execute inside the `paint_primitives` calls below), so any
         // callback that scissors to the damage region gates on the same
         // value that decided whether the clear was skipped. Same-thread store
         // immediately before the reads -> `Relaxed` is sufficient.
@@ -130,12 +232,31 @@ impl EguiState {
             flag.store(partial.is_some(), std::sync::atomic::Ordering::Relaxed);
         }
 
-        self.painter.paint_and_update_textures(
-            [size.width, size.height],
-            pixels_per_point,
-            &clipped_primitives,
-            &full_output.textures_delta,
-        );
+        // Paint: set all textures, then three `paint_primitives` calls in
+        // head -> band -> tail order, then free all textures. This is
+        // exactly what `paint_and_update_textures` does internally (set
+        // all -> paint -> free all), just split across three paint calls so
+        // the band can be painted independently of chrome. Order matters:
+        // `paint_primitives` re-establishes GL state (scissor/blend, unbound
+        // VBO/EBO/texture/program) independently on every call, so three
+        // sequential calls over a partition of the same shape list paint
+        // identically to one call over the concatenation — head paints
+        // first (e.g. the `CentralPanel` background fill, which must be
+        // UNDER the band), then band, then tail (overlays/borders, which
+        // must be OVER the band).
+        let size_px = [size.width, size.height];
+        for (id, image_delta) in &full_output.textures_delta.set {
+            self.painter.set_texture(*id, image_delta);
+        }
+        self.painter
+            .paint_primitives(size_px, pixels_per_point, &head_primitives);
+        self.painter
+            .paint_primitives(size_px, pixels_per_point, &band_primitives);
+        self.painter
+            .paint_primitives(size_px, pixels_per_point, &tail_primitives);
+        for id in &full_output.textures_delta.free {
+            self.painter.free_texture(*id);
+        }
 
         // Pre-present notify for Wayland frame pacing
         window.pre_present_notify();
@@ -161,6 +282,10 @@ impl EguiState {
         // `request_redraw()` directly bypasses `ControlFlow::WaitUntil` and
         // causes an unbounded render loop on platforms where `swap_buffers`
         // returns immediately (macOS with vsync disabled).
+
+        // Stash this frame's repaint delay for 436.4b's replay-eligibility
+        // gate. Not consumed yet.
+        self.prev_repaint_delay = repaint_delay;
 
         FrameOutput {
             commands,
@@ -204,5 +329,211 @@ impl EguiState {
     /// by an internal `destroyed` flag), so calling it more than once is safe.
     pub(crate) fn destroy_painter(&mut self) {
         self.painter.destroy();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use egui::epaint::Primitive;
+    use egui::{Color32, Rect, pos2, vec2};
+
+    /// Sum the vertex/index counts across every `Mesh` primitive in a
+    /// tessellation result. `Callback` primitives (paint callbacks) carry no
+    /// mesh data of their own, so they are not part of this count; the test
+    /// below paints only `rect_filled` shapes, which always tessellate to
+    /// `Mesh` primitives, so no callback primitives appear.
+    fn total_verts_indices(primitives: &[egui::ClippedPrimitive]) -> (usize, usize) {
+        let mut vertices = 0;
+        let mut indices = 0;
+        for clipped in primitives {
+            if let Primitive::Mesh(mesh) = &clipped.primitive {
+                vertices += mesh.vertices.len();
+                indices += mesh.indices.len();
+            }
+        }
+        (vertices, indices)
+    }
+
+    /// A single mesh vertex flattened to comparable primitives (egui's
+    /// `Vertex`/`Pos2`/`Color32` are `PartialEq`, but bundling the fields
+    /// makes the assertion failure message readable and avoids depending on
+    /// `Vertex: PartialEq` staying derived). Field order: position, uv, color.
+    type FlatVertex = ([f32; 2], [f32; 2], [u8; 4]);
+
+    /// Flatten a primitive list into an ORDERED sequence of vertices and an
+    /// ORDERED sequence of indices (offset so indices are global across the
+    /// whole list, matching how the meshes would be drawn back-to-back).
+    /// Comparing these sequences — not just their lengths — pins that the
+    /// 3-call split preserves geometry *order*, which is the exact property
+    /// `paint_primitives`' head->band->tail sequencing depends on.
+    fn flatten_mesh_geometry(primitives: &[egui::ClippedPrimitive]) -> (Vec<FlatVertex>, Vec<u32>) {
+        let mut verts: Vec<FlatVertex> = Vec::new();
+        let mut idxs: Vec<u32> = Vec::new();
+        for clipped in primitives {
+            if let Primitive::Mesh(mesh) = &clipped.primitive {
+                let base = u32::try_from(verts.len()).unwrap_or(u32::MAX);
+                for v in &mesh.vertices {
+                    verts.push((
+                        [v.pos.x, v.pos.y],
+                        [v.uv.x, v.uv.y],
+                        [v.color.r(), v.color.g(), v.color.b(), v.color.a()],
+                    ));
+                }
+                for &i in &mesh.indices {
+                    idxs.push(base + i);
+                }
+            }
+        }
+        (verts, idxs)
+    }
+
+    /// Pins the losslessness of `run_frame`'s head/band/tail split
+    /// (#436.4a): tessellating `full_output.shapes` as three slices
+    /// (`[..start]`, `[start..end]`, `[end..]`) and summing the resulting
+    /// primitives' vertex/index counts must equal tessellating the whole
+    /// list at once. `egui::Context::tessellate` builds a fresh
+    /// `Tessellator` per call from only `pixels_per_point`,
+    /// `tessellation_options`, and the font texture atlas size — none of
+    /// which vary between the whole-list call and the three sliced calls —
+    /// so per-shape tessellation is independent of what else is in the
+    /// list. The *batching* of tessellated meshes into `ClippedPrimitive`s
+    /// may differ (adjacent same-clip-rect shapes can merge into fewer,
+    /// larger meshes when tessellated together), but the underlying vertex
+    /// and index data — and therefore the pixels drawn — must be identical
+    /// either way. This is the property `run_frame`'s 3-call paint depends
+    /// on for byte-identical rendering.
+    #[test]
+    fn head_band_tail_split_is_lossless_vs_whole_tessellation() {
+        let ctx = egui::Context::default();
+        let pixels_per_point = 1.0;
+
+        let full_output = ctx.run_ui(egui::RawInput::default(), |ui| {
+            // Shape 0: "head" (chrome painted before the band).
+            ui.painter().rect_filled(
+                Rect::from_min_size(pos2(0.0, 0.0), vec2(5.0, 5.0)),
+                0.0,
+                Color32::RED,
+            );
+            // Shapes 1-2: "band" (terminal content).
+            ui.painter().rect_filled(
+                Rect::from_min_size(pos2(10.0, 10.0), vec2(5.0, 5.0)),
+                0.0,
+                Color32::GREEN,
+            );
+            ui.painter().rect_filled(
+                Rect::from_min_size(pos2(20.0, 20.0), vec2(5.0, 5.0)),
+                0.0,
+                Color32::BLUE,
+            );
+            // Shape 3: "tail" (chrome painted after the band).
+            ui.painter().rect_filled(
+                Rect::from_min_size(pos2(30.0, 30.0), vec2(5.0, 5.0)),
+                0.0,
+                Color32::YELLOW,
+            );
+        });
+
+        let shapes = full_output.shapes;
+        assert_eq!(shapes.len(), 4, "sanity: exactly the four shapes painted");
+
+        let whole_primitives = ctx.tessellate(shapes.clone(), pixels_per_point);
+
+        // Band range covering shapes 1..3 (the green and blue rects), as
+        // `App::take_terminal_band_range` would report.
+        let start = 1;
+        let end = 3;
+        let head_shapes = shapes[..start].to_vec();
+        let band_shapes = shapes[start..end].to_vec();
+        let tail_shapes = shapes[end..].to_vec();
+
+        let head_primitives = ctx.tessellate(head_shapes, pixels_per_point);
+        let band_primitives = ctx.tessellate(band_shapes, pixels_per_point);
+        let tail_primitives = ctx.tessellate(tail_shapes, pixels_per_point);
+
+        let (whole_vertices, whole_indices) = total_verts_indices(&whole_primitives);
+        let (head_vertices, head_indices) = total_verts_indices(&head_primitives);
+        let (band_vertices, band_indices) = total_verts_indices(&band_primitives);
+        let (tail_vertices, tail_indices) = total_verts_indices(&tail_primitives);
+
+        assert_eq!(
+            whole_vertices,
+            head_vertices + band_vertices + tail_vertices,
+            "split tessellation must produce the same total vertex count as \
+             tessellating the whole shape list at once"
+        );
+        assert_eq!(
+            whole_indices,
+            head_indices + band_indices + tail_indices,
+            "split tessellation must produce the same total index count as \
+             tessellating the whole shape list at once"
+        );
+        assert!(
+            whole_vertices > 0,
+            "sanity: the shapes actually tessellated to something"
+        );
+
+        // Stronger than counts: the ORDERED vertex/index sequences must be
+        // identical. head ++ band ++ tail (concatenated in paint order, with
+        // indices re-based across the concatenation) must equal the whole
+        // list's geometry vertex-for-vertex and index-for-index. This is the
+        // exact property `run_frame`'s head->band->tail `paint_primitives`
+        // sequence relies on for byte-identical pixels — counts matching
+        // alone would not rule out a reordering.
+        let (whole_verts, whole_idxs) = flatten_mesh_geometry(&whole_primitives);
+
+        let mut split_primitives = head_primitives;
+        split_primitives.extend(band_primitives);
+        split_primitives.extend(tail_primitives);
+        let (split_verts, split_idxs) = flatten_mesh_geometry(&split_primitives);
+
+        assert_eq!(
+            whole_verts, split_verts,
+            "split tessellation must produce the same vertex SEQUENCE (order \
+             included) as the whole-list tessellation"
+        );
+        assert_eq!(
+            whole_idxs, split_idxs,
+            "split tessellation must produce the same index SEQUENCE (order \
+             included) as the whole-list tessellation"
+        );
+    }
+
+    /// Confirms the `0..0` default `band_range` (an app that has not wired
+    /// up `App::take_terminal_band_range`) behaves as `run_frame` assumes:
+    /// `head_shapes` and `band_shapes` are empty, and `tail_shapes` is the
+    /// ENTIRE shape list — i.e. painting all shapes as a single "tail"
+    /// `paint_primitives` call, byte-identical to the pre-#436.4a
+    /// single-call path.
+    #[test]
+    fn default_band_range_puts_everything_in_tail() {
+        let ctx = egui::Context::default();
+
+        let full_output = ctx.run_ui(egui::RawInput::default(), |ui| {
+            ui.painter().rect_filled(
+                Rect::from_min_size(pos2(0.0, 0.0), vec2(5.0, 5.0)),
+                0.0,
+                Color32::RED,
+            );
+            ui.painter().rect_filled(
+                Rect::from_min_size(pos2(10.0, 10.0), vec2(5.0, 5.0)),
+                0.0,
+                Color32::GREEN,
+            );
+        });
+
+        let shapes = full_output.shapes;
+        assert_eq!(shapes.len(), 2, "sanity: exactly the two shapes painted");
+
+        let band_range: std::ops::Range<usize> = 0..0;
+        let start = band_range.start.min(shapes.len());
+        let end = band_range.end.clamp(start, shapes.len());
+
+        let head_shapes = &shapes[..start];
+        let band_shapes = &shapes[start..end];
+        let tail_shapes = &shapes[end..];
+
+        assert!(head_shapes.is_empty());
+        assert!(band_shapes.is_empty());
+        assert_eq!(tail_shapes.len(), shapes.len());
     }
 }

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -24,7 +24,7 @@ use crate::{
     WindowHandle, WindowId, WindowOp,
 };
 
-use conv2::{ApproxFrom, RoundToZero};
+use conv2::{ApproxFrom, ConvUtil, RoundToZero};
 
 /// Convert an `f64` logical dimension to `u32`, clamping non-positive and
 /// non-finite values to 0 and saturating on overflow.  Used for logical
@@ -104,20 +104,25 @@ const fn is_blocked_key(key_code: winit::keyboard::KeyCode) -> bool {
     )
 }
 
-/// Returns `true` for `WindowEvent`s that could plausibly affect chrome
-/// state (hover, focus, click, drag, scroll, text/IME input) — the
-/// CONSERVATIVE #436.4b §3.2 input gate. Any `true` here forces
-/// `ChromeMode::Full` for that frame via `WindowState::chrome_input_pending`;
-/// deliberately over-broad (any window input, not just input actually over
-/// chrome rather than the terminal band) — refined region-aware in #436.8.
-const fn is_potential_chrome_input(event: &WindowEvent) -> bool {
+/// Returns `true` for `WindowEvent`s that unconditionally force
+/// `ChromeMode::Full` for the frame they arrive in, via
+/// `WindowState::chrome_input_pending` — the non-pointer half of the
+/// #436.4b §3.2 input gate.
+///
+/// Pointer events (`CursorMoved` / `MouseInput` / `MouseWheel`) are
+/// deliberately EXCLUDED here (#436.8): they are region-tested instead (see
+/// [`should_force_chrome_full_for_pointer`]), so that pointer motion purely
+/// over terminal content does not force a chrome rebuild every frame (the
+/// CPU-spike-under-btop complaint). `CursorEntered`/`CursorLeft` stay here
+/// (rare events; not worth region-testing) alongside keyboard, IME, focus,
+/// theme, and touch/gesture input — the maintainer decided pointer-only
+/// narrowing for this subtask, no keyboard narrowing (avoids a one-frame lag
+/// on keyboard-triggered chrome actions).
+const fn is_unconditional_chrome_input(event: &WindowEvent) -> bool {
     matches!(
         event,
-        WindowEvent::CursorMoved { .. }
-            | WindowEvent::CursorEntered { .. }
+        WindowEvent::CursorEntered { .. }
             | WindowEvent::CursorLeft { .. }
-            | WindowEvent::MouseInput { .. }
-            | WindowEvent::MouseWheel { .. }
             | WindowEvent::KeyboardInput { .. }
             | WindowEvent::ModifiersChanged(_)
             | WindowEvent::Ime(_)
@@ -139,6 +144,72 @@ const fn is_potential_chrome_input(event: &WindowEvent) -> bool {
     )
 }
 
+/// Convert a winit physical cursor position to egui logical points (lossy
+/// `f64` -> `f32` narrowing via `conv2`'s default approximation, matching the
+/// `window.scale_factor().approx_as::<f32>()` conversion in
+/// `egui_integration.rs`). Returns `None` for a non-finite or non-positive
+/// scale factor — the caller treats an unknown position conservatively (see
+/// [`should_force_chrome_full_for_pointer`]).
+///
+/// LOAD-BEARING ASSUMPTION (#436.8): the chrome-interactive rects this
+/// position is hit-tested against are captured in egui **logical points**,
+/// which equal `physical / egui.pixels_per_point()`. We divide by
+/// `window.scale_factor()` instead, and those are only equal while
+/// `egui.pixels_per_point() == window.scale_factor()` — i.e. while egui's
+/// zoom factor is exactly 1.0. Freminal guarantees this by setting
+/// `Options::zoom_with_keyboard = false` (`gui/rendering.rs`) and never
+/// calling `Context::set_zoom_factor`. If egui zoom is ever enabled, this
+/// divisor is wrong and the region hit-test silently misclassifies chrome as
+/// terminal (a stale-chrome-under-interaction bug) — see
+/// `Documents/EGUI_UPGRADE_ASSUMPTIONS.md` A13. Fix then: derive the divisor
+/// from `ctx.pixels_per_point()` rather than `window.scale_factor()`.
+fn physical_to_logical_pos(
+    pos: winit::dpi::PhysicalPosition<f64>,
+    scale: f64,
+) -> Option<egui::Pos2> {
+    if !scale.is_finite() || scale <= 0.0 {
+        return None;
+    }
+    let x = (pos.x / scale).approx_as::<f32>().ok()?;
+    let y = (pos.y / scale).approx_as::<f32>().ok()?;
+    Some(egui::pos2(x, y))
+}
+
+/// #436.8 region-aware pointer chrome-gate decision: should this pointer
+/// event force `ChromeMode::Full`?
+///
+/// `true` when a chrome-border drag is latched (`drag_latched` — the pointer
+/// may have moved off the sensor mid-drag, but the drag itself is still
+/// chrome-affecting), OR the pointer position is known to be over a
+/// chrome-interactive region (`is_over_chrome == Some(true)`), OR the
+/// position is unknown (`None` — conservative: force `Full` rather than risk
+/// silently starving a chrome interaction of repaints).
+fn should_force_chrome_full_for_pointer(is_over_chrome: Option<bool>, drag_latched: bool) -> bool {
+    drag_latched || is_over_chrome.unwrap_or(true)
+}
+
+/// #436.8 chrome-border drag latch update: tracks presses that started over
+/// a chrome-interactive region so a drag that later moves the pointer off
+/// that region (still forcing `Full` via the latch) is not mistaken for
+/// terminal-content motion. Saturating in both directions so an unbalanced
+/// press/release sequence (e.g. a release delivered to a different window)
+/// can never underflow or runaway-accumulate.
+fn update_chrome_drag_latch(
+    current: u32,
+    button_state: winit::event::ElementState,
+    is_over_chrome: Option<bool>,
+) -> u32 {
+    match button_state {
+        // Conservative: an unknown position (`None`) counts as "over chrome"
+        // for latch purposes, same as the force-Full decision itself.
+        winit::event::ElementState::Pressed if is_over_chrome.unwrap_or(true) => {
+            current.saturating_add(1)
+        }
+        winit::event::ElementState::Pressed => current,
+        winit::event::ElementState::Released => current.saturating_sub(1),
+    }
+}
+
 /// Per-window state.
 struct WindowState {
     window: Window,
@@ -146,15 +217,28 @@ struct WindowState {
     egui: EguiState,
     /// Next scheduled repaint time (if any).
     repaint_at: Option<Instant>,
-    /// #436.4b §3.2 conservative chrome-input gate: set `true` by any window
-    /// input event this frame that could plausibly affect chrome (pointer,
-    /// keyboard, scroll, focus, IME — see [`is_potential_chrome_input`]).
-    /// Drained (`mem::take`) into `run_frame`'s `chrome_input_this_frame`
-    /// parameter at `RedrawRequested`, so a `true` unconditionally forces
-    /// `ChromeMode::Full` for that frame. Deliberately over-broad (ANY
-    /// window input, not just input over chrome) — the region-aware
-    /// refinement is #436.8.
+    /// #436.4b §3.2 chrome-input gate: set `true` by a window input event
+    /// this frame that forces `ChromeMode::Full` — either unconditionally
+    /// (keyboard, focus, IME, theme — see [`is_unconditional_chrome_input`])
+    /// or, for pointer events, only when the pointer is over (or mid-drag on)
+    /// a chrome-interactive region (#436.8, see
+    /// [`should_force_chrome_full_for_pointer`]). Drained (`mem::take`) into
+    /// `run_frame`'s `chrome_input_this_frame` parameter at
+    /// `RedrawRequested`.
     chrome_input_pending: bool,
+    /// #436.8: last-known pointer position in egui logical points, updated on
+    /// every `CursorMoved` and cleared on `CursorLeft`. `None` before the
+    /// first `CursorMoved` (or after the pointer has left the window) — the
+    /// region hit-test then has no position to test and callers treat that
+    /// conservatively (force `Full`).
+    last_cursor_pos: Option<egui::Pos2>,
+    /// #436.8 chrome-border drag latch: incremented on a button press whose
+    /// position is over (or unknown, conservatively) a chrome-interactive
+    /// region, decremented on release. While `> 0`, pointer motion/wheel
+    /// events force `ChromeMode::Full` regardless of the current pointer
+    /// position, so a drag that moves off the sensor mid-drag is not
+    /// mistaken for terminal-content motion.
+    chrome_drag_pressed_count: u32,
 }
 
 impl WindowState {
@@ -262,6 +346,8 @@ impl<A: App> Handler<A> {
             egui,
             repaint_at: Some(Instant::now()),
             chrome_input_pending: false,
+            last_cursor_pos: None,
+            chrome_drag_pressed_count: 0,
         };
 
         self.windows.insert(winit_id, state);
@@ -421,18 +507,77 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
         // egui for pointer position tracking but only schedule a repaint if
         // egui actually wants one (e.g. menu hover highlight).  We skip the
         // full window_event path to avoid unnecessary work.
+        //
+        // #436.8: pointer events (`CursorMoved`/`MouseInput`/`MouseWheel`)
+        // handle the chrome-input gate here, region-tested against
+        // `App::is_chrome_interactive_at`, instead of the general path's
+        // `is_unconditional_chrome_input` — see that function's doc for why
+        // pointer events are excluded from it.
         if matches!(
             event,
             WindowEvent::CursorMoved { .. }
                 | WindowEvent::CursorEntered { .. }
                 | WindowEvent::CursorLeft { .. }
+                | WindowEvent::MouseInput { .. }
+                | WindowEvent::MouseWheel { .. }
         ) {
             if let Some(state) = self.windows.get_mut(&winit_id) {
                 let response = state.egui.on_window_event(&state.window, &event);
-                // These are all pointer events by construction (the `matches!`
-                // guard above) — always a potential-chrome-input, regardless
-                // of whether egui itself wants a repaint (#436.4b §3.2).
-                state.chrome_input_pending = true;
+                match event {
+                    WindowEvent::CursorMoved { position, .. } => {
+                        let scale = state.window.scale_factor();
+                        state.last_cursor_pos = physical_to_logical_pos(position, scale);
+                        let is_over_chrome = state
+                            .last_cursor_pos
+                            .map(|pos| self.app.is_chrome_interactive_at(WindowId(winit_id), pos));
+                        state.chrome_input_pending |= should_force_chrome_full_for_pointer(
+                            is_over_chrome,
+                            state.chrome_drag_pressed_count > 0,
+                        );
+                    }
+                    WindowEvent::CursorEntered { .. } => {
+                        // Unconditional (matches `is_unconditional_chrome_input`).
+                        state.chrome_input_pending = true;
+                    }
+                    WindowEvent::CursorLeft { .. } => {
+                        // The pointer is gone — a stale position must not be
+                        // used to wrongly classify a later event.
+                        state.last_cursor_pos = None;
+                        // Unconditional (matches `is_unconditional_chrome_input`).
+                        state.chrome_input_pending = true;
+                    }
+                    WindowEvent::MouseInput {
+                        state: btn_state, ..
+                    } => {
+                        let is_over_chrome = state
+                            .last_cursor_pos
+                            .map(|pos| self.app.is_chrome_interactive_at(WindowId(winit_id), pos));
+                        // Decide using the PRE-update latch first, so the
+                        // release event that ends a chrome-border drag still
+                        // forces `Full` before the latch drops to 0.
+                        state.chrome_input_pending |= should_force_chrome_full_for_pointer(
+                            is_over_chrome,
+                            state.chrome_drag_pressed_count > 0,
+                        );
+                        state.chrome_drag_pressed_count = update_chrome_drag_latch(
+                            state.chrome_drag_pressed_count,
+                            btn_state,
+                            is_over_chrome,
+                        );
+                    }
+                    WindowEvent::MouseWheel { .. } => {
+                        let is_over_chrome = state
+                            .last_cursor_pos
+                            .map(|pos| self.app.is_chrome_interactive_at(WindowId(winit_id), pos));
+                        state.chrome_input_pending |= should_force_chrome_full_for_pointer(
+                            is_over_chrome,
+                            state.chrome_drag_pressed_count > 0,
+                        );
+                    }
+                    _ => unreachable!(
+                        "matches! guard above restricts event to the five pointer variants"
+                    ),
+                }
                 if response.repaint {
                     let deadline = Instant::now() + std::time::Duration::from_millis(16);
                     state.repaint_at = Some(
@@ -548,12 +693,13 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
         let egui_consumed = if let Some(state) = self.windows.get_mut(&winit_id) {
             let response = state.egui.on_window_event(&state.window, &event);
 
-            // #436.4b §3.2: any window input event that could plausibly
-            // affect chrome (or that egui itself says caused a repaint,
-            // covering event kinds `is_potential_chrome_input` doesn't
-            // enumerate) forces `ChromeMode::Full` for the frame this event
-            // is delivered in.
-            if is_potential_chrome_input(&event) || response.repaint {
+            // #436.4b §3.2: any non-pointer window input event that could
+            // plausibly affect chrome (or that egui itself says caused a
+            // repaint, covering event kinds `is_unconditional_chrome_input`
+            // doesn't enumerate) forces `ChromeMode::Full` for the frame this
+            // event is delivered in. Pointer events never reach this arm —
+            // they're handled, region-tested, in the fast path above (#436.8).
+            if is_unconditional_chrome_input(&event) || response.repaint {
                 state.chrome_input_pending = true;
             }
 
@@ -574,6 +720,15 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                     if self.windows.is_empty() {
                         event_loop.exit();
                     }
+                }
+            }
+            WindowEvent::Focused(false) => {
+                // #436.8 safety net: a chrome-border drag interrupted by
+                // focus loss (e.g. alt-tab mid-drag) must not leave the latch
+                // stuck non-zero, which would force every subsequent pointer
+                // event `Full` forever.
+                if let Some(state) = self.windows.get_mut(&winit_id) {
+                    state.chrome_drag_pressed_count = 0;
                 }
             }
             WindowEvent::Resized(size) => {
@@ -973,8 +1128,9 @@ pub fn run(config: WindowConfig, app: impl App + 'static) -> Result<(), Error> {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::{
-        ViewportCommandFlags, is_blocked_key, is_potential_chrome_input, logical_coord_to_i32,
-        logical_dim_to_u32, viewport_command_flags,
+        ViewportCommandFlags, is_blocked_key, is_unconditional_chrome_input, logical_coord_to_i32,
+        logical_dim_to_u32, physical_to_logical_pos, should_force_chrome_full_for_pointer,
+        update_chrome_drag_latch, viewport_command_flags,
     };
     use winit::event::{DeviceId, WindowEvent};
     use winit::keyboard::KeyCode;
@@ -1108,30 +1264,17 @@ mod tests {
         assert!(!is_blocked_key(KeyCode::AltRight));
     }
 
-    /// #436.4b §3.2: a representative event from each "potential chrome
-    /// input" category (pointer, keyboard, scroll, focus, IME) forces
-    /// `chrome_input_pending`.
+    /// #436.4b §3.2 / #436.8: a representative event from each
+    /// unconditional-chrome-input category (keyboard, scroll-adjacent focus/
+    /// IME/theme, `CursorEntered`/`CursorLeft`) forces `chrome_input_pending`
+    /// via [`is_unconditional_chrome_input`].
     #[test]
-    fn is_potential_chrome_input_covers_pointer_keyboard_scroll_focus_ime() {
-        assert!(is_potential_chrome_input(&WindowEvent::CursorMoved {
-            device_id: DeviceId::dummy(),
-            position: winit::dpi::PhysicalPosition::new(0.0, 0.0),
-        }));
-        assert!(is_potential_chrome_input(&WindowEvent::CursorEntered {
+    fn is_unconditional_chrome_input_covers_keyboard_ime_focus_theme_entered_left() {
+        assert!(is_unconditional_chrome_input(&WindowEvent::CursorEntered {
             device_id: DeviceId::dummy(),
         }));
-        assert!(is_potential_chrome_input(&WindowEvent::CursorLeft {
+        assert!(is_unconditional_chrome_input(&WindowEvent::CursorLeft {
             device_id: DeviceId::dummy(),
-        }));
-        assert!(is_potential_chrome_input(&WindowEvent::MouseInput {
-            device_id: DeviceId::dummy(),
-            state: winit::event::ElementState::Pressed,
-            button: winit::event::MouseButton::Left,
-        }));
-        assert!(is_potential_chrome_input(&WindowEvent::MouseWheel {
-            device_id: DeviceId::dummy(),
-            delta: winit::event::MouseScrollDelta::LineDelta(0.0, 1.0),
-            phase: winit::event::TouchPhase::Moved,
         }));
         // `KeyEvent` has a private `platform_specific` field (no public
         // constructor), so `KeyboardInput` itself cannot be built outside
@@ -1139,28 +1282,142 @@ mod tests {
         // interception / blocked-key tests elsewhere in this module, both
         // of which set `chrome_input_pending` directly at their early-return
         // sites (see `window_event`) rather than through this helper.
-        assert!(is_potential_chrome_input(&WindowEvent::ModifiersChanged(
-            winit::event::Modifiers::default(),
-        )));
-        assert!(is_potential_chrome_input(&WindowEvent::Focused(true)));
+        assert!(is_unconditional_chrome_input(
+            &WindowEvent::ModifiersChanged(winit::event::Modifiers::default(),)
+        ));
+        assert!(is_unconditional_chrome_input(&WindowEvent::Focused(true)));
         // An OS dark/light switch rebuilds egui chrome visuals synchronously
         // (#436.6): it must force `ChromeMode::Full`.
-        assert!(is_potential_chrome_input(&WindowEvent::ThemeChanged(
+        assert!(is_unconditional_chrome_input(&WindowEvent::ThemeChanged(
             winit::window::Theme::Dark,
         )));
+    }
+
+    /// #436.8: pointer motion/click/scroll events are region-tested instead
+    /// of unconditional — they must NOT be classified as unconditional
+    /// chrome input any more, or region-testing would never actually apply
+    /// (the unconditional check runs first in the general path).
+    #[test]
+    fn is_unconditional_chrome_input_excludes_pointer_events() {
+        assert!(!is_unconditional_chrome_input(&WindowEvent::CursorMoved {
+            device_id: DeviceId::dummy(),
+            position: winit::dpi::PhysicalPosition::new(0.0, 0.0),
+        }));
+        assert!(!is_unconditional_chrome_input(&WindowEvent::MouseInput {
+            device_id: DeviceId::dummy(),
+            state: winit::event::ElementState::Pressed,
+            button: winit::event::MouseButton::Left,
+        }));
+        assert!(!is_unconditional_chrome_input(&WindowEvent::MouseWheel {
+            device_id: DeviceId::dummy(),
+            delta: winit::event::MouseScrollDelta::LineDelta(0.0, 1.0),
+            phase: winit::event::TouchPhase::Moved,
+        }));
     }
 
     /// Events unrelated to chrome-affecting input do NOT set the gate —
     /// otherwise every frame would be forced `Full` and REPLAY would never
     /// fire.
     #[test]
-    fn is_potential_chrome_input_excludes_unrelated_events() {
-        assert!(!is_potential_chrome_input(&WindowEvent::RedrawRequested));
-        assert!(!is_potential_chrome_input(&WindowEvent::CloseRequested));
-        assert!(!is_potential_chrome_input(&WindowEvent::Destroyed));
-        assert!(!is_potential_chrome_input(
+    fn is_unconditional_chrome_input_excludes_unrelated_events() {
+        assert!(!is_unconditional_chrome_input(
+            &WindowEvent::RedrawRequested
+        ));
+        assert!(!is_unconditional_chrome_input(&WindowEvent::CloseRequested));
+        assert!(!is_unconditional_chrome_input(&WindowEvent::Destroyed));
+        assert!(!is_unconditional_chrome_input(
             &WindowEvent::HoveredFileCancelled
         ));
-        assert!(!is_potential_chrome_input(&WindowEvent::Occluded(true)));
+        assert!(!is_unconditional_chrome_input(&WindowEvent::Occluded(true)));
+    }
+
+    // ── #436.8 region-aware pointer gate: pure helpers ───────────────────
+
+    #[test]
+    fn should_force_chrome_full_for_pointer_latched_forces_true_regardless_of_position() {
+        assert!(should_force_chrome_full_for_pointer(Some(false), true));
+        assert!(should_force_chrome_full_for_pointer(None, true));
+    }
+
+    #[test]
+    fn should_force_chrome_full_for_pointer_unlatched_unknown_position_is_conservative_true() {
+        assert!(should_force_chrome_full_for_pointer(None, false));
+    }
+
+    #[test]
+    fn should_force_chrome_full_for_pointer_unlatched_over_chrome_is_true() {
+        assert!(should_force_chrome_full_for_pointer(Some(true), false));
+    }
+
+    #[test]
+    fn should_force_chrome_full_for_pointer_unlatched_over_terminal_is_false() {
+        assert!(!should_force_chrome_full_for_pointer(Some(false), false));
+    }
+
+    #[test]
+    fn update_chrome_drag_latch_press_over_chrome_increments() {
+        assert_eq!(
+            update_chrome_drag_latch(0, winit::event::ElementState::Pressed, Some(true)),
+            1
+        );
+    }
+
+    #[test]
+    fn update_chrome_drag_latch_press_off_chrome_is_unchanged() {
+        assert_eq!(
+            update_chrome_drag_latch(0, winit::event::ElementState::Pressed, Some(false)),
+            0
+        );
+    }
+
+    #[test]
+    fn update_chrome_drag_latch_press_unknown_position_is_conservative_increment() {
+        assert_eq!(
+            update_chrome_drag_latch(0, winit::event::ElementState::Pressed, None),
+            1
+        );
+    }
+
+    #[test]
+    fn update_chrome_drag_latch_release_decrements() {
+        assert_eq!(
+            update_chrome_drag_latch(1, winit::event::ElementState::Released, Some(true)),
+            0
+        );
+    }
+
+    #[test]
+    fn update_chrome_drag_latch_release_at_zero_saturates() {
+        assert_eq!(
+            update_chrome_drag_latch(0, winit::event::ElementState::Released, Some(true)),
+            0
+        );
+    }
+
+    // ── #436.8 physical -> logical pointer position conversion ──────────
+
+    #[test]
+    fn physical_to_logical_pos_normal_scale_halves_at_scale_two() {
+        let pos = winit::dpi::PhysicalPosition::new(100.0, 50.0);
+        let logical = physical_to_logical_pos(pos, 2.0).expect("scale 2.0 is valid");
+        assert!((logical.x - 50.0).abs() < f32::EPSILON);
+        assert!((logical.y - 25.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn physical_to_logical_pos_scale_one_is_identity() {
+        let pos = winit::dpi::PhysicalPosition::new(123.0, 45.0);
+        let logical = physical_to_logical_pos(pos, 1.0).expect("scale 1.0 is valid");
+        assert!((logical.x - 123.0).abs() < f32::EPSILON);
+        assert!((logical.y - 45.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn physical_to_logical_pos_invalid_scale_is_none() {
+        let pos = winit::dpi::PhysicalPosition::new(10.0, 10.0);
+        assert!(physical_to_logical_pos(pos, 0.0).is_none());
+        assert!(physical_to_logical_pos(pos, -1.0).is_none());
+        assert!(physical_to_logical_pos(pos, f64::NAN).is_none());
+        assert!(physical_to_logical_pos(pos, f64::INFINITY).is_none());
     }
 }

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -20,8 +20,8 @@ use crate::egui_integration::EguiState;
 use crate::error::Error;
 use crate::gl_context::GlState;
 use crate::{
-    App, RawKeyEvent, RawKeyMods, UserEvent, WindowConfig, WindowGeometry, WindowHandle, WindowId,
-    WindowOp,
+    App, FrameSignals, RawKeyEvent, RawKeyMods, UserEvent, WindowConfig, WindowGeometry,
+    WindowHandle, WindowId, WindowOp,
 };
 
 use conv2::{ApproxFrom, RoundToZero};
@@ -595,9 +595,12 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                     clear_color,
                     raw_input,
                     present_flag.as_ref(),
-                    |ctx, gl| {
-                        app.update(window_id, ctx, gl, &handle);
-                        app.take_frame_damage(window_id)
+                    |ctx, gl, chrome_mode| {
+                        app.update(window_id, ctx, gl, &handle, chrome_mode);
+                        FrameSignals {
+                            frame_damage: app.take_frame_damage(window_id),
+                            band_range: app.take_terminal_band_range(window_id),
+                        }
                     },
                 );
 

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -1394,6 +1394,121 @@ mod tests {
         );
     }
 
+    // ── #436.8 drag-latch multi-press/multi-release SEQUENCES (436.9 follow-up) ──
+    //
+    // The single-call tests above pin each transition in isolation. These
+    // chain `update_chrome_drag_latch` across realistic event sequences,
+    // asserting the latch value AND, at each step, what
+    // `should_force_chrome_full_for_pointer` decides given the pre-update
+    // latch (the ordering `event_loop.rs` uses: decide with the PRE-update
+    // latch, then update — so a release ending a chrome drag still forces
+    // Full before the latch drops).
+
+    /// Press ON chrome -> pointer moves OFF chrome mid-drag -> release.
+    /// The mandate-critical case: the whole drag must force Full (latch keeps
+    /// it Full even while the pointer is over terminal content), and the latch
+    /// must land back at exactly 0 after release.
+    #[test]
+    fn drag_latch_sequence_press_on_chrome_move_off_release_stays_full_throughout() {
+        use winit::event::ElementState::{Pressed, Released};
+
+        let mut latch = 0u32;
+
+        // Press over chrome. Decide with pre-update latch (0) but is_over_chrome
+        // = Some(true) -> Full. Then latch -> 1.
+        assert!(should_force_chrome_full_for_pointer(Some(true), latch > 0));
+        latch = update_chrome_drag_latch(latch, Pressed, Some(true));
+        assert_eq!(latch, 1);
+
+        // Pointer moves OFF chrome (over terminal content) while dragging.
+        // is_over_chrome = Some(false), but latch (1) > 0 -> still Full.
+        assert!(should_force_chrome_full_for_pointer(Some(false), latch > 0));
+        // (motion doesn't touch the latch)
+        assert_eq!(latch, 1);
+
+        // Release (delivered while pointer is off chrome). Decide with the
+        // PRE-update latch (1 > 0) -> Full, THEN decrement.
+        assert!(should_force_chrome_full_for_pointer(Some(false), latch > 0));
+        latch = update_chrome_drag_latch(latch, Released, Some(false));
+        assert_eq!(latch, 0);
+
+        // Post-drag: pointer still over terminal content, latch 0 -> NOT Full.
+        assert!(!should_force_chrome_full_for_pointer(
+            Some(false),
+            latch > 0
+        ));
+    }
+
+    /// Nested/rapid presses (e.g. a second button pressed before the first
+    /// releases) must balance out to exactly 0 and force Full throughout.
+    #[test]
+    fn drag_latch_sequence_nested_presses_balance_to_zero() {
+        use winit::event::ElementState::{Pressed, Released};
+
+        let mut latch = 0u32;
+        latch = update_chrome_drag_latch(latch, Pressed, Some(true));
+        latch = update_chrome_drag_latch(latch, Pressed, Some(true));
+        assert_eq!(latch, 2);
+        // Both buttons held -> Full.
+        assert!(should_force_chrome_full_for_pointer(Some(false), latch > 0));
+
+        latch = update_chrome_drag_latch(latch, Released, Some(false));
+        assert_eq!(latch, 1);
+        // One button still held -> still Full.
+        assert!(should_force_chrome_full_for_pointer(Some(false), latch > 0));
+
+        latch = update_chrome_drag_latch(latch, Released, Some(false));
+        assert_eq!(latch, 0);
+        assert!(!should_force_chrome_full_for_pointer(
+            Some(false),
+            latch > 0
+        ));
+    }
+
+    /// A press that STARTS over terminal content does not latch, so subsequent
+    /// motion over terminal content stays REPLAY (the "helps normal mouse use"
+    /// mandate piece: text-selection drags must not force chrome Full).
+    #[test]
+    fn drag_latch_sequence_press_on_terminal_never_latches() {
+        use winit::event::ElementState::{Pressed, Released};
+
+        let mut latch = 0u32;
+        // Press over terminal content -> no latch.
+        latch = update_chrome_drag_latch(latch, Pressed, Some(false));
+        assert_eq!(latch, 0);
+        // Dragging (text selection) over terminal content -> NOT Full.
+        assert!(!should_force_chrome_full_for_pointer(
+            Some(false),
+            latch > 0
+        ));
+        // Release over terminal content -> still 0, still not Full.
+        latch = update_chrome_drag_latch(latch, Released, Some(false));
+        assert_eq!(latch, 0);
+        assert!(!should_force_chrome_full_for_pointer(
+            Some(false),
+            latch > 0
+        ));
+    }
+
+    /// An unbalanced release (delivered without a matching press, e.g. to a
+    /// different window) must saturate at 0, never underflow to `u32::MAX` (which
+    /// would force Full forever).
+    #[test]
+    fn drag_latch_sequence_unbalanced_release_saturates_not_underflows() {
+        use winit::event::ElementState::{Pressed, Released};
+
+        let mut latch = 0u32;
+        // Spurious release first.
+        latch = update_chrome_drag_latch(latch, Released, Some(true));
+        assert_eq!(latch, 0);
+        // A subsequent real press still latches correctly (not offset by the
+        // spurious release).
+        latch = update_chrome_drag_latch(latch, Pressed, Some(true));
+        assert_eq!(latch, 1);
+        latch = update_chrome_drag_latch(latch, Released, Some(true));
+        assert_eq!(latch, 0);
+    }
+
     // ── #436.8 physical -> logical pointer position conversion ──────────
 
     #[test]

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -122,6 +122,14 @@ const fn is_potential_chrome_input(event: &WindowEvent) -> bool {
             | WindowEvent::ModifiersChanged(_)
             | WindowEvent::Ime(_)
             | WindowEvent::Focused(_)
+            // An OS dark/light theme switch synchronously rebuilds egui's
+            // chrome visuals (see the `ThemeMode::Auto` path in the app's
+            // `update`), so it must force `ChromeMode::Full` — otherwise the
+            // app-level `style_changed` signal (which lags a frame, keyed off
+            // the terminal snapshot's theme rather than the OS state) could
+            // miss it and a REPLAY frame would paint stale-theme chrome
+            // (#436.6 / §6 safety-net completeness).
+            | WindowEvent::ThemeChanged(_)
             | WindowEvent::Touch(_)
             | WindowEvent::PinchGesture { .. }
             | WindowEvent::PanGesture { .. }
@@ -1135,6 +1143,11 @@ mod tests {
             winit::event::Modifiers::default(),
         )));
         assert!(is_potential_chrome_input(&WindowEvent::Focused(true)));
+        // An OS dark/light switch rebuilds egui chrome visuals synchronously
+        // (#436.6): it must force `ChromeMode::Full`.
+        assert!(is_potential_chrome_input(&WindowEvent::ThemeChanged(
+            winit::window::Theme::Dark,
+        )));
     }
 
     /// Events unrelated to chrome-affecting input do NOT set the gate —

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -104,6 +104,33 @@ const fn is_blocked_key(key_code: winit::keyboard::KeyCode) -> bool {
     )
 }
 
+/// Returns `true` for `WindowEvent`s that could plausibly affect chrome
+/// state (hover, focus, click, drag, scroll, text/IME input) — the
+/// CONSERVATIVE #436.4b §3.2 input gate. Any `true` here forces
+/// `ChromeMode::Full` for that frame via `WindowState::chrome_input_pending`;
+/// deliberately over-broad (any window input, not just input actually over
+/// chrome rather than the terminal band) — refined region-aware in #436.8.
+const fn is_potential_chrome_input(event: &WindowEvent) -> bool {
+    matches!(
+        event,
+        WindowEvent::CursorMoved { .. }
+            | WindowEvent::CursorEntered { .. }
+            | WindowEvent::CursorLeft { .. }
+            | WindowEvent::MouseInput { .. }
+            | WindowEvent::MouseWheel { .. }
+            | WindowEvent::KeyboardInput { .. }
+            | WindowEvent::ModifiersChanged(_)
+            | WindowEvent::Ime(_)
+            | WindowEvent::Focused(_)
+            | WindowEvent::Touch(_)
+            | WindowEvent::PinchGesture { .. }
+            | WindowEvent::PanGesture { .. }
+            | WindowEvent::DoubleTapGesture { .. }
+            | WindowEvent::RotationGesture { .. }
+            | WindowEvent::TouchpadPressure { .. }
+    )
+}
+
 /// Per-window state.
 struct WindowState {
     window: Window,
@@ -111,6 +138,15 @@ struct WindowState {
     egui: EguiState,
     /// Next scheduled repaint time (if any).
     repaint_at: Option<Instant>,
+    /// #436.4b §3.2 conservative chrome-input gate: set `true` by any window
+    /// input event this frame that could plausibly affect chrome (pointer,
+    /// keyboard, scroll, focus, IME — see [`is_potential_chrome_input`]).
+    /// Drained (`mem::take`) into `run_frame`'s `chrome_input_this_frame`
+    /// parameter at `RedrawRequested`, so a `true` unconditionally forces
+    /// `ChromeMode::Full` for that frame. Deliberately over-broad (ANY
+    /// window input, not just input over chrome) — the region-aware
+    /// refinement is #436.8.
+    chrome_input_pending: bool,
 }
 
 impl WindowState {
@@ -217,6 +253,7 @@ impl<A: App> Handler<A> {
             gl,
             egui,
             repaint_at: Some(Instant::now()),
+            chrome_input_pending: false,
         };
 
         self.windows.insert(winit_id, state);
@@ -384,6 +421,10 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
         ) {
             if let Some(state) = self.windows.get_mut(&winit_id) {
                 let response = state.egui.on_window_event(&state.window, &event);
+                // These are all pointer events by construction (the `matches!`
+                // guard above) — always a potential-chrome-input, regardless
+                // of whether egui itself wants a repaint (#436.4b §3.2).
+                state.chrome_input_pending = true;
                 if response.repaint {
                     let deadline = Instant::now() + std::time::Duration::from_millis(16);
                     state.repaint_at = Some(
@@ -440,6 +481,9 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                     {
                         state.egui.inject_paste(text);
                         state.repaint_at = Some(Instant::now());
+                        // A keyboard event, and it just mutated pane content
+                        // via a paste — a potential-chrome-input (#436.4b §3.2).
+                        state.chrome_input_pending = true;
                         // Don't pass to egui-winit — it would produce a
                         // duplicate paste on windows where its clipboard works.
                         self.update_control_flow(event_loop);
@@ -482,6 +526,9 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                 self.app
                     .on_raw_key_event(WindowId(winit_id), raw_event, raw_mods);
                 state.repaint_at = Some(Instant::now());
+                // A keyboard event, routed straight to the app — a
+                // potential-chrome-input (#436.4b §3.2).
+                state.chrome_input_pending = true;
             }
             // Don't pass to egui-winit — this key has no egui `Key` variant
             // and would otherwise be silently dropped.
@@ -492,6 +539,15 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
         // Pass to egui first
         let egui_consumed = if let Some(state) = self.windows.get_mut(&winit_id) {
             let response = state.egui.on_window_event(&state.window, &event);
+
+            // #436.4b §3.2: any window input event that could plausibly
+            // affect chrome (or that egui itself says caused a repaint,
+            // covering event kinds `is_potential_chrome_input` doesn't
+            // enumerate) forces `ChromeMode::Full` for the frame this event
+            // is delivered in.
+            if is_potential_chrome_input(&event) || response.repaint {
+                state.chrome_input_pending = true;
+            }
 
             if response.repaint {
                 state.repaint_at = Some(Instant::now());
@@ -589,17 +645,25 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                 // it mid-frame without a second `&mut app` borrow.
                 let present_flag = app.present_partial_flag(window_id);
 
+                // Drain this frame's #436.4b §3.2 chrome-input gate,
+                // resetting it so a later frame with no new input events
+                // never inherits a stale `true`.
+                let chrome_input_this_frame = std::mem::take(&mut state.chrome_input_pending);
+
                 let frame_output = state.egui.run_frame(
                     &state.window,
                     &state.gl,
                     clear_color,
                     raw_input,
                     present_flag.as_ref(),
+                    chrome_input_this_frame,
                     |ctx, gl, chrome_mode| {
                         app.update(window_id, ctx, gl, &handle, chrome_mode);
                         FrameSignals {
                             frame_damage: app.take_frame_damage(window_id),
                             band_range: app.take_terminal_band_range(window_id),
+                            chrome_damage: app.take_chrome_damage(window_id),
+                            terminal_requested_delay: app.take_terminal_requested_delay(window_id),
                         }
                     },
                 );
@@ -901,9 +965,10 @@ pub fn run(config: WindowConfig, app: impl App + 'static) -> Result<(), Error> {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::{
-        ViewportCommandFlags, is_blocked_key, logical_coord_to_i32, logical_dim_to_u32,
-        viewport_command_flags,
+        ViewportCommandFlags, is_blocked_key, is_potential_chrome_input, logical_coord_to_i32,
+        logical_dim_to_u32, viewport_command_flags,
     };
+    use winit::event::{DeviceId, WindowEvent};
     use winit::keyboard::KeyCode;
 
     #[test]
@@ -1033,5 +1098,56 @@ mod tests {
         assert!(!is_blocked_key(KeyCode::Space));
         assert!(!is_blocked_key(KeyCode::Escape));
         assert!(!is_blocked_key(KeyCode::AltRight));
+    }
+
+    /// #436.4b §3.2: a representative event from each "potential chrome
+    /// input" category (pointer, keyboard, scroll, focus, IME) forces
+    /// `chrome_input_pending`.
+    #[test]
+    fn is_potential_chrome_input_covers_pointer_keyboard_scroll_focus_ime() {
+        assert!(is_potential_chrome_input(&WindowEvent::CursorMoved {
+            device_id: DeviceId::dummy(),
+            position: winit::dpi::PhysicalPosition::new(0.0, 0.0),
+        }));
+        assert!(is_potential_chrome_input(&WindowEvent::CursorEntered {
+            device_id: DeviceId::dummy(),
+        }));
+        assert!(is_potential_chrome_input(&WindowEvent::CursorLeft {
+            device_id: DeviceId::dummy(),
+        }));
+        assert!(is_potential_chrome_input(&WindowEvent::MouseInput {
+            device_id: DeviceId::dummy(),
+            state: winit::event::ElementState::Pressed,
+            button: winit::event::MouseButton::Left,
+        }));
+        assert!(is_potential_chrome_input(&WindowEvent::MouseWheel {
+            device_id: DeviceId::dummy(),
+            delta: winit::event::MouseScrollDelta::LineDelta(0.0, 1.0),
+            phase: winit::event::TouchPhase::Moved,
+        }));
+        // `KeyEvent` has a private `platform_specific` field (no public
+        // constructor), so `KeyboardInput` itself cannot be built outside
+        // winit; it is exercised in a real frame instead via the paste-
+        // interception / blocked-key tests elsewhere in this module, both
+        // of which set `chrome_input_pending` directly at their early-return
+        // sites (see `window_event`) rather than through this helper.
+        assert!(is_potential_chrome_input(&WindowEvent::ModifiersChanged(
+            winit::event::Modifiers::default(),
+        )));
+        assert!(is_potential_chrome_input(&WindowEvent::Focused(true)));
+    }
+
+    /// Events unrelated to chrome-affecting input do NOT set the gate —
+    /// otherwise every frame would be forced `Full` and REPLAY would never
+    /// fire.
+    #[test]
+    fn is_potential_chrome_input_excludes_unrelated_events() {
+        assert!(!is_potential_chrome_input(&WindowEvent::RedrawRequested));
+        assert!(!is_potential_chrome_input(&WindowEvent::CloseRequested));
+        assert!(!is_potential_chrome_input(&WindowEvent::Destroyed));
+        assert!(!is_potential_chrome_input(
+            &WindowEvent::HoveredFileCancelled
+        ));
+        assert!(!is_potential_chrome_input(&WindowEvent::Occluded(true)));
     }
 }

--- a/freminal-windowing/src/lib.rs
+++ b/freminal-windowing/src/lib.rs
@@ -160,6 +160,33 @@ pub trait App {
         FrameDamage::Full
     }
 
+    /// Drain the terminal-band egui shapes produced during [`App::update`]
+    /// for this window (#436.2a).
+    ///
+    /// The "terminal band" is the region of the frame — pane content, pane
+    /// borders, and related overlays — that is rebuilt every frame and is
+    /// intended to be tessellated/painted separately from the rest of the
+    /// chrome (menu bar, tab bar, modals) in a later optimization. An app
+    /// that wants to participate paints the band into the SAME egui layer as
+    /// the rest of its chrome during `update()` (routing it into a dedicated
+    /// layer instead trips egui's cross-layer hit-test "hidden" rule and can
+    /// suppress hover/click/drag on band widgets), remembers the band's
+    /// shape-index range within that layer's `PaintList`, and returns a
+    /// clone of exactly that range here.
+    ///
+    /// Called by the windowing layer once per frame, after [`App::update`]
+    /// returns for that window, mirroring [`App::take_frame_damage`].
+    ///
+    /// The default returns an empty `Vec` — the conservative, always-correct
+    /// behavior for an app that does not participate in this optimization
+    /// (or has not yet wired it up).
+    fn take_terminal_band_shapes(
+        &mut self,
+        _window_id: WindowId,
+    ) -> Vec<egui::epaint::ClippedShape> {
+        Vec::new()
+    }
+
     /// Shared flag through which the windowing layer publishes the
     /// **authoritative** partial-present decision for each frame.
     ///
@@ -438,5 +465,54 @@ mod tests {
 
         let err = Error::SwapBuffers("swap fail".to_owned());
         assert!(err.to_string().contains("swap fail"));
+    }
+
+    /// Minimal `App` implementer that relies entirely on default method
+    /// bodies, used to pin the default behavior of
+    /// `App::take_terminal_band_shapes` (#436.2a) — mirroring the
+    /// pre-existing `take_frame_damage` default — without constructing a
+    /// full `freminal::gui::FreminalGui`, which is impractical headlessly
+    /// (its windows are keyed by a real winit `WindowId`).
+    struct DummyApp;
+
+    impl App for DummyApp {
+        fn update(
+            &mut self,
+            _window_id: WindowId,
+            _ctx: &egui::Context,
+            _gl: &glow::Context,
+            _handle: &WindowHandle<'_>,
+        ) {
+        }
+
+        fn on_window_created(
+            &mut self,
+            _window_id: WindowId,
+            _ctx: &egui::Context,
+            _handle: &WindowHandle<'_>,
+            _inner_size: (u32, u32),
+        ) {
+        }
+
+        fn on_close_requested(&mut self, _window_id: WindowId) -> bool {
+            true
+        }
+
+        fn clear_color(&self, _window_id: WindowId) -> [f32; 4] {
+            [0.0, 0.0, 0.0, 1.0]
+        }
+    }
+
+    #[test]
+    fn take_terminal_band_shapes_default_is_empty_and_reset_on_read() {
+        let mut app = DummyApp;
+        let window_id = WindowId(winit::window::WindowId::dummy());
+
+        // Empty by default (no `update()` has run / default trait body).
+        assert!(app.take_terminal_band_shapes(window_id).is_empty());
+
+        // Reset-on-read: a second call still returns empty, never a stale
+        // or accumulated value.
+        assert!(app.take_terminal_band_shapes(window_id).is_empty());
     }
 }

--- a/freminal-windowing/src/lib.rs
+++ b/freminal-windowing/src/lib.rs
@@ -132,7 +132,7 @@ pub enum ChromeMode {
 
 /// Per-frame signals drained from the [`App`] immediately after
 /// [`App::update`] returns, consumed by the windowing layer to decide
-/// paint-order splitting (#436.4a) and, in later subtasks, chrome replay.
+/// paint-order splitting (#436.4a) and chrome replay (#436.4b).
 #[derive(Debug, Clone)]
 pub struct FrameSignals {
     /// How much of the frame changed (see [`FrameDamage`]).
@@ -145,6 +145,19 @@ pub struct FrameSignals {
     /// `paint_primitives` call, byte-identical to the pre-#436.4a
     /// single-call path.
     pub band_range: std::ops::Range<usize>,
+    /// Whether static chrome changed this frame (#436.3/#436.4b) — mirrors
+    /// [`App::take_chrome_damage`]. Consulted, together with cache validity
+    /// and the §3.1 settle gate, to decide next frame's [`ChromeMode`].
+    pub chrome_damage: ChromeDamage,
+    /// The delay the app itself requested via `ctx.request_repaint_after`
+    /// during this frame's `update()` (#436.4b §3.1 amendment), if any.
+    /// `None` when the app made no such request this frame. Compared
+    /// against egui's own requested repaint delay (returned by `run_frame`)
+    /// to distinguish "only our own blink/content scheduling wants a wake"
+    /// from "something egui-internal (hover fade, menu animation, a
+    /// focused `TextEdit`'s cursor blink) also wants one" — see
+    /// `egui_integration::chrome_repaint_settled`.
+    pub terminal_requested_delay: Option<std::time::Duration>,
 }
 
 /// Configuration for creating a new window.
@@ -265,6 +278,22 @@ pub trait App {
     /// stale `Unchanged` can never be reused by a frame that didn't recompute it.
     fn take_chrome_damage(&mut self, _window_id: WindowId) -> ChromeDamage {
         ChromeDamage::Changed
+    }
+
+    /// Drain the delay the app itself requested via `ctx.request_repaint_after`
+    /// during this frame's `update()` (#436.4b §3.1 amendment), for this
+    /// window. Called once per frame after `update()` returns, mirroring
+    /// `take_frame_damage`/`take_chrome_damage`/`take_terminal_band_range`.
+    ///
+    /// The default returns `None` — the conservative, always-correct
+    /// behavior: paired with `chrome_repaint_settled`'s `None` branch (which
+    /// requires egui's own `repaint_delay` to be exactly `Duration::MAX`),
+    /// an app that does not opt in never falsely reports "settled" while it
+    /// is still driving its own blink/content repaint schedule under the
+    /// hood some other way. Reset-on-read: the app leaves `None` behind so a
+    /// stale delay can never be reused by a frame that didn't recompute it.
+    fn take_terminal_requested_delay(&mut self, _window_id: WindowId) -> Option<Duration> {
+        None
     }
 
     /// Shared flag through which the windowing layer publishes the
@@ -615,5 +644,18 @@ mod tests {
         // Reset-on-read: a second call still returns `Changed`, never a
         // stale `Unchanged` a prior frame might have left behind.
         assert_eq!(app.take_chrome_damage(window_id), ChromeDamage::Changed);
+    }
+
+    /// Pins the default behavior of `App::take_terminal_requested_delay`
+    /// (#436.4b) — mirroring the `take_chrome_damage` default discipline
+    /// above, using the same `DummyApp`.
+    #[test]
+    fn take_terminal_requested_delay_default_is_none_and_reset_on_read() {
+        let mut app = DummyApp;
+        let window_id = WindowId(winit::window::WindowId::dummy());
+
+        assert_eq!(app.take_terminal_requested_delay(window_id), None);
+        // Reset-on-read: a second call still returns `None`.
+        assert_eq!(app.take_terminal_requested_delay(window_id), None);
     }
 }

--- a/freminal-windowing/src/lib.rs
+++ b/freminal-windowing/src/lib.rs
@@ -323,6 +323,16 @@ pub trait App {
         None
     }
 
+    /// #436.8: whether `pos` (egui LOGICAL points, top-left origin) is over a
+    /// chrome-interactive region of this window (menu bar, tab bar, split-border
+    /// drag sensors) — the region-aware pointer gate. Pointer motion over such a
+    /// region forces `ChromeMode::Full`; motion purely over terminal content does
+    /// not. Default `true` (conservative: an app that hasn't wired this up keeps
+    /// the pre-436.8 "any pointer event forces Full" behavior).
+    fn is_chrome_interactive_at(&self, _window_id: WindowId, _pos: egui::Pos2) -> bool {
+        true
+    }
+
     /// Hook to modify raw input before egui processes it.
     ///
     /// Default implementation does nothing.

--- a/freminal-windowing/src/lib.rs
+++ b/freminal-windowing/src/lib.rs
@@ -89,6 +89,27 @@ pub enum FrameDamage {
     Partial(Vec<DamageRect>),
 }
 
+/// Whether the static chrome changed on the frame just rendered.
+///
+/// "Chrome" is the menu bar, tab bar, pane borders, broadcast label, and all
+/// overlays (modals/toasts/tooltips/popups) — the #436 decision input for
+/// whether a frame may REPLAY cached chrome primitives or must do a FULL
+/// chrome rebuild.
+///
+/// The default is [`ChromeDamage::Changed`]: the conservative,
+/// always-correct behavior. An app that does not opt in (or has not yet
+/// wired up the #436 §3.3/§3.5 signals) always reports `Changed`, so a
+/// consumer of this signal (436.4) never mistakenly REPLAYs stale chrome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ChromeDamage {
+    /// Chrome changed (or we can't prove it didn't) — the next frame must be FULL.
+    #[default]
+    Changed,
+    /// Chrome provably did not change this frame — a REPLAY is permitted
+    /// (subject to the other #436 gates in §3.4).
+    Unchanged,
+}
+
 /// Configuration for creating a new window.
 pub struct WindowConfig {
     /// Window title.
@@ -185,6 +206,15 @@ pub trait App {
         _window_id: WindowId,
     ) -> Vec<egui::epaint::ClippedShape> {
         Vec::new()
+    }
+
+    /// Drain the chrome-damage decision computed during `update()` for this
+    /// window (#436). Called once per frame after `update()` returns, mirroring
+    /// `take_frame_damage`. Default returns `ChromeDamage::Changed` (always safe:
+    /// forces a FULL frame). Reset-on-read: the app leaves `Changed` behind so a
+    /// stale `Unchanged` can never be reused by a frame that didn't recompute it.
+    fn take_chrome_damage(&mut self, _window_id: WindowId) -> ChromeDamage {
+        ChromeDamage::Changed
     }
 
     /// Shared flag through which the windowing layer publishes the
@@ -514,5 +544,23 @@ mod tests {
         // Reset-on-read: a second call still returns empty, never a stale
         // or accumulated value.
         assert!(app.take_terminal_band_shapes(window_id).is_empty());
+    }
+
+    /// Pins the default behavior of `App::take_chrome_damage` (#436.3) —
+    /// mirroring the `take_frame_damage`/`take_terminal_band_shapes` default
+    /// discipline above — using the same `DummyApp` (real `FreminalGui`
+    /// windows are keyed by a real winit `WindowId`, impractical headlessly).
+    #[test]
+    fn take_chrome_damage_default_is_changed_and_reset_on_read() {
+        let mut app = DummyApp;
+        let window_id = WindowId(winit::window::WindowId::dummy());
+
+        // Conservative default: `Changed` (no `update()` has run / default
+        // trait body), so a consumer never mistakenly REPLAYs stale chrome.
+        assert_eq!(app.take_chrome_damage(window_id), ChromeDamage::Changed);
+
+        // Reset-on-read: a second call still returns `Changed`, never a
+        // stale `Unchanged` a prior frame might have left behind.
+        assert_eq!(app.take_chrome_damage(window_id), ChromeDamage::Changed);
     }
 }

--- a/freminal-windowing/src/lib.rs
+++ b/freminal-windowing/src/lib.rs
@@ -110,6 +110,43 @@ pub enum ChromeDamage {
     Unchanged,
 }
 
+/// Whether the app should rebuild chrome widgets this frame or may reuse
+/// cached chrome primitives from a previous frame (#436.4a scaffolding).
+///
+/// The default, [`ChromeMode::Full`], is the always-correct behavior: the
+/// app re-records and re-tessellates every widget, exactly as it always
+/// has. [`ChromeMode::Replay`] is not yet produced by `run_frame` — 436.4b
+/// wires up the decision (chrome-damage + cache-validity gates) that flips
+/// this to `Replay` for eligible frames. An app that has not been updated
+/// to consult this parameter may simply ignore it; doing so is always safe
+/// because the windowing layer only passes `Full` until then.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ChromeMode {
+    /// Rebuild chrome widgets this frame (re-record + re-tessellate).
+    #[default]
+    Full,
+    /// Reuse cached chrome primitives; skip chrome-widget construction.
+    /// (Not yet produced by `run_frame` — 436.4b flips this on.)
+    Replay,
+}
+
+/// Per-frame signals drained from the [`App`] immediately after
+/// [`App::update`] returns, consumed by the windowing layer to decide
+/// paint-order splitting (#436.4a) and, in later subtasks, chrome replay.
+#[derive(Debug, Clone)]
+pub struct FrameSignals {
+    /// How much of the frame changed (see [`FrameDamage`]).
+    pub frame_damage: FrameDamage,
+    /// The terminal band's shape-index range within this frame's
+    /// `full_output.shapes` (#436.4a) — the contiguous `[start, end)` slice
+    /// painted separately from chrome. Defaults to `0..0` (empty) for an
+    /// app that has not wired up the band range; in that case the whole
+    /// shape list is treated as "tail" and painted in a single
+    /// `paint_primitives` call, byte-identical to the pre-#436.4a
+    /// single-call path.
+    pub band_range: std::ops::Range<usize>,
+}
+
 /// Configuration for creating a new window.
 pub struct WindowConfig {
     /// Window title.
@@ -134,12 +171,20 @@ pub trait App {
     ///
     /// `handle` allows queuing window operations (title, close, repaint, etc.)
     /// that are executed after this callback returns.
+    ///
+    /// `chrome_mode` is the #436.4a scaffold for chrome-primitive replay: the
+    /// app should skip chrome-widget construction (menu bar, tab bar, and
+    /// other static chrome) when it is [`ChromeMode::Replay`], rebuilding
+    /// only the terminal band. As of this subtask the windowing layer always
+    /// passes [`ChromeMode::Full`] — 436.4b is what starts passing `Replay`
+    /// — so an implementer may ignore this parameter for now.
     fn update(
         &mut self,
         window_id: WindowId,
         ctx: &egui::Context,
         gl: &glow::Context,
         handle: &WindowHandle<'_>,
+        chrome_mode: ChromeMode,
     );
 
     /// Called when a window is created.
@@ -181,31 +226,36 @@ pub trait App {
         FrameDamage::Full
     }
 
-    /// Drain the terminal-band egui shapes produced during [`App::update`]
-    /// for this window (#436.2a).
+    /// Drain the terminal band's shape-index range within this frame's
+    /// `full_output.shapes` (#436.4a).
     ///
     /// The "terminal band" is the region of the frame — pane content, pane
     /// borders, and related overlays — that is rebuilt every frame and is
-    /// intended to be tessellated/painted separately from the rest of the
-    /// chrome (menu bar, tab bar, modals) in a later optimization. An app
+    /// tessellated/painted separately from the rest of the chrome (menu bar,
+    /// tab bar, modals) by `run_frame`'s 3-way head/band/tail split. An app
     /// that wants to participate paints the band into the SAME egui layer as
     /// the rest of its chrome during `update()` (routing it into a dedicated
     /// layer instead trips egui's cross-layer hit-test "hidden" rule and can
     /// suppress hover/click/drag on band widgets), remembers the band's
     /// shape-index range within that layer's `PaintList`, and returns a
-    /// clone of exactly that range here.
+    /// clone of exactly that range here. This range is interpreted as an
+    /// index range into `full_output.shapes` (the background layer drains
+    /// first, so the two coincide) — supersedes the shape-cloning approach
+    /// of the prior `take_terminal_band_shapes` (#436.2a), which is no
+    /// longer needed once `run_frame` slices by range directly.
     ///
     /// Called by the windowing layer once per frame, after [`App::update`]
     /// returns for that window, mirroring [`App::take_frame_damage`].
+    /// Reset-on-read: the app leaves `0..0` behind so a stale range can
+    /// never be reused by a frame that didn't recompute it.
     ///
-    /// The default returns an empty `Vec` — the conservative, always-correct
+    /// The default returns `0..0` — the conservative, always-correct
     /// behavior for an app that does not participate in this optimization
-    /// (or has not yet wired it up).
-    fn take_terminal_band_shapes(
-        &mut self,
-        _window_id: WindowId,
-    ) -> Vec<egui::epaint::ClippedShape> {
-        Vec::new()
+    /// (or has not yet wired it up): `run_frame` treats an empty range as
+    /// "everything is tail", painting the whole frame in one call, exactly
+    /// as before #436.4a.
+    fn take_terminal_band_range(&mut self, _window_id: WindowId) -> std::ops::Range<usize> {
+        0..0
     }
 
     /// Drain the chrome-damage decision computed during `update()` for this
@@ -499,10 +549,11 @@ mod tests {
 
     /// Minimal `App` implementer that relies entirely on default method
     /// bodies, used to pin the default behavior of
-    /// `App::take_terminal_band_shapes` (#436.2a) — mirroring the
-    /// pre-existing `take_frame_damage` default — without constructing a
-    /// full `freminal::gui::FreminalGui`, which is impractical headlessly
-    /// (its windows are keyed by a real winit `WindowId`).
+    /// `App::take_terminal_band_range` (#436.4a, superseding the removed
+    /// #436.2a `take_terminal_band_shapes`) — mirroring the pre-existing
+    /// `take_frame_damage` default — without constructing a full
+    /// `freminal::gui::FreminalGui`, which is impractical headlessly (its
+    /// windows are keyed by a real winit `WindowId`).
     struct DummyApp;
 
     impl App for DummyApp {
@@ -512,6 +563,7 @@ mod tests {
             _ctx: &egui::Context,
             _gl: &glow::Context,
             _handle: &WindowHandle<'_>,
+            _chrome_mode: ChromeMode,
         ) {
         }
 
@@ -534,20 +586,21 @@ mod tests {
     }
 
     #[test]
-    fn take_terminal_band_shapes_default_is_empty_and_reset_on_read() {
+    fn take_terminal_band_range_default_is_empty_and_reset_on_read() {
         let mut app = DummyApp;
         let window_id = WindowId(winit::window::WindowId::dummy());
 
-        // Empty by default (no `update()` has run / default trait body).
-        assert!(app.take_terminal_band_shapes(window_id).is_empty());
+        // Empty (`0..0`) by default (no `update()` has run / default trait
+        // body).
+        assert_eq!(app.take_terminal_band_range(window_id), 0..0);
 
-        // Reset-on-read: a second call still returns empty, never a stale
+        // Reset-on-read: a second call still returns `0..0`, never a stale
         // or accumulated value.
-        assert!(app.take_terminal_band_shapes(window_id).is_empty());
+        assert_eq!(app.take_terminal_band_range(window_id), 0..0);
     }
 
     /// Pins the default behavior of `App::take_chrome_damage` (#436.3) —
-    /// mirroring the `take_frame_damage`/`take_terminal_band_shapes` default
+    /// mirroring the `take_frame_damage`/`take_terminal_band_range` default
     /// discipline above — using the same `DummyApp` (real `FreminalGui`
     /// windows are keyed by a real winit `WindowId`, impractical headlessly).
     #[test]

--- a/freminal/benches/render_loop_bench.rs
+++ b/freminal/benches/render_loop_bench.rs
@@ -1156,6 +1156,101 @@ fn bench_build_image_verts(c: &mut Criterion) {
 }
 
 // ---------------------------------------------------------------
+// bench_chrome_frame_record — "replay frame" chrome-only cost (Issue #436)
+// ---------------------------------------------------------------
+//
+// Issue #436 caches egui chrome primitives and skips `run_ui` + `tessellate`
+// on a REPLAY frame (chrome unchanged, only terminal content/cursor changed).
+// This benchmark measures the CPU cost that a REPLAY frame *avoids*: running
+// the egui UI closure and tessellating the resulting shapes for a
+// representative chrome layout (menu bar + tab bar + empty central area), with
+// NO GL paint callbacks and NO terminal content.
+//
+// It mirrors `freminal-windowing`'s frame path — `EguiState::new` constructs a
+// bare `egui::Context::default()` (no GL), and `run_frame` does
+// `ctx.run_ui(raw_input, ...)` then `ctx.tessellate(shapes, ppp)`. Only the
+// `egui_glow::Painter` needs a GL context; `run_ui`/`tessellate` are pure CPU
+// and run headless (like every other bench in this file).
+//
+// The chrome is a **synthetic approximation** of freminal's real menu/tab bars
+// (`show_menu_bar` / `show_tab_bar` in `gui::menu`), which are private methods
+// on the non-`pub` `FreminalGui`/`PerWindowState` and cannot be reached from a
+// bench. It uses the same egui panel/widget shape (`Panel::top` menu row,
+// `Panel::top` tab row, `CentralPanel`) so the tessellation cost is
+// directionally representative of the cost a REPLAY frame elides. After #436,
+// the REPLAY path performs none of this work.
+//
+// The `egui::Context` is warmed once (outside the timed region) so the
+// steady-state recurring per-frame cost is measured, not the one-time
+// first-pass font-atlas population that only happens on the very first frame.
+
+/// Physical/logical screen size for the synthetic chrome frame.
+const CHROME_BENCH_WIDTH: f32 = 1280.0;
+const CHROME_BENCH_HEIGHT: f32 = 800.0;
+/// Representative number of open tabs in the synthetic tab bar.
+const CHROME_BENCH_NUM_TABS: usize = 6;
+
+/// Build the `RawInput` for one synthetic chrome frame at a fixed size / scale.
+fn chrome_bench_raw_input() -> egui::RawInput {
+    let mut raw_input = egui::RawInput {
+        screen_rect: Some(egui::Rect::from_min_size(
+            egui::Pos2::ZERO,
+            egui::vec2(CHROME_BENCH_WIDTH, CHROME_BENCH_HEIGHT),
+        )),
+        ..Default::default()
+    };
+    if let Some(vp) = raw_input.viewports.get_mut(&egui::ViewportId::ROOT) {
+        vp.native_pixels_per_point = Some(1.0);
+    }
+    raw_input
+}
+
+/// Draw the synthetic chrome (menu bar + tab bar + empty central area) into a
+/// running egui frame. Matches freminal's real panel shape (`Panel::top` for
+/// both bars, `CentralPanel` for the terminal viewport) without terminal
+/// content or GL callbacks.
+fn chrome_bench_ui(root_ui: &mut egui::Ui) {
+    egui::Panel::top("bench_menu_bar").show(root_ui, |ui| {
+        ui.horizontal(|ui| {
+            for label in ["Freminal", "Tab", "View", "Help"] {
+                let _ = ui.button(label);
+            }
+        });
+    });
+
+    egui::Panel::top("bench_tab_bar").show(root_ui, |ui| {
+        ui.horizontal(|ui| {
+            for i in 0..CHROME_BENCH_NUM_TABS {
+                let _ = ui.button(format!("tab {i}"));
+            }
+        });
+    });
+
+    egui::CentralPanel::default().show(root_ui, |_ui| {});
+}
+
+fn bench_chrome_frame_record(c: &mut Criterion) {
+    let mut group = c.benchmark_group("chrome_frame_record");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function("run_ui_and_tessellate", |b| {
+        // Warm the context once so the timed region measures the recurring
+        // steady-state cost, not the first-frame font-atlas population.
+        let ctx = egui::Context::default();
+        let _ = ctx.run_ui(chrome_bench_raw_input(), chrome_bench_ui);
+
+        b.iter(|| {
+            let full_output = ctx.run_ui(chrome_bench_raw_input(), chrome_bench_ui);
+            let ppp = ctx.pixels_per_point();
+            let clipped = ctx.tessellate(full_output.shapes, ppp);
+            std::hint::black_box(clipped);
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------
 // Criterion bootstrap
 // ---------------------------------------------------------------
 criterion_group!(
@@ -1177,6 +1272,7 @@ criterion_group!(
         bench_build_visuals,
         bench_image_animation_tick,
         bench_build_image_verts,
+        bench_chrome_frame_record,
 );
 
 criterion_main!(benches);

--- a/freminal/examples/chrome_gallery.rs
+++ b/freminal/examples/chrome_gallery.rs
@@ -31,7 +31,7 @@
 use freminal::gui::chrome_style::build_visuals;
 use freminal_common::gui_theme::{GuiTheme, StyleProfile};
 use freminal_common::themes::{self, ThemePalette};
-use freminal_windowing::{App, WindowConfig, WindowHandle, WindowId};
+use freminal_windowing::{App, ChromeMode, WindowConfig, WindowHandle, WindowId};
 
 /// All built-in themes, in registry order, so every theme can be audited
 /// (112.3f/g) — not a curated subset.
@@ -253,6 +253,7 @@ impl App for ChromeGallery {
         ctx: &egui::Context,
         _gl: &glow::Context,
         _handle: &WindowHandle<'_>,
+        _chrome_mode: ChromeMode,
     ) {
         // Apply the draft style as the window's GLOBAL visuals so that
         // top-level popup surfaces (combo dropdowns, context menus) — which

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -2841,6 +2841,24 @@ impl freminal_windowing::App for FreminalGui {
             chrome_settle_frame_pending,
         );
 
+        // ── #435/#436 composition (§6): chrome change forces FrameDamage::Full ──
+        //
+        // The #435 partial-present decision (`pending_frame_damage`, computed
+        // in `central_body`) and the #436 chrome-cache decision
+        // (`pending_chrome_damage`, just computed) are separate but MUST
+        // agree. See `frame_damage::compose_with_chrome_damage` for the full
+        // rationale; in short, a frame that changed chrome pixels must not be
+        // presented `Partial` (it would leave chrome outside the cursor rect
+        // stale under #435's `buffer_age() == 1` assumption). Reconciled here,
+        // after both decisions are final, via the pure helper.
+        win.pending_frame_damage = frame_damage::compose_with_chrome_damage(
+            std::mem::replace(
+                &mut win.pending_frame_damage,
+                freminal_windowing::FrameDamage::Full,
+            ),
+            win.pending_chrome_damage,
+        );
+
         let elapsed = now.elapsed();
         let frame_time = if elapsed.as_millis() > 0 {
             format!("Frame time={}ms", elapsed.as_millis())

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -297,6 +297,7 @@ impl freminal_windowing::App for FreminalGui {
                         pending_force_close: false,
                         pending_raw_keys: Vec::new(),
                         pending_frame_damage: freminal_windowing::FrameDamage::Full,
+                        pending_terminal_band_shapes: Vec::new(),
                         present_is_partial: std::sync::Arc::new(
                             std::sync::atomic::AtomicBool::new(false),
                         ),
@@ -512,6 +513,20 @@ impl freminal_windowing::App for FreminalGui {
                     &mut win.pending_frame_damage,
                     freminal_windowing::FrameDamage::Full,
                 )
+            })
+    }
+
+    fn take_terminal_band_shapes(
+        &mut self,
+        window_id: WindowId,
+    ) -> Vec<egui::epaint::ClippedShape> {
+        // Drain the terminal-band shapes captured during `update()` for this
+        // window, leaving an empty `Vec` behind so a stale frame's shapes can
+        // never be reused by a later caller that does not recompute them.
+        self.windows
+            .get_mut(&window_id)
+            .map_or_else(Vec::new, |win| {
+                std::mem::take(&mut win.pending_terminal_band_shapes)
             })
     }
 
@@ -1375,6 +1390,7 @@ impl freminal_windowing::App for FreminalGui {
             // the loop.
 
             let available_rect = ui.available_rect_before_wrap();
+
             let active_pane_id = win.tabs.active_tab().active_pane;
             let zoomed_pane = win.tabs.active_tab().zoomed_pane;
             let has_multiple_panes = win.tabs.active_tab().pane_tree.pane_count().unwrap_or(1) > 1;
@@ -1660,6 +1676,51 @@ impl freminal_windowing::App for FreminalGui {
                     }
                 }
             }
+
+            // ── Terminal band: shape-index range capture (#436.2a) ───
+            //
+            // Everything from here through the broadcast label that paints
+            // via `ui` — pane content (GL callbacks), pane borders, and the
+            // per-pane decorations — lands in the SAME `LayerId::background()`
+            // layer chrome (menu bar, tab bar) already paints into, and is
+            // therefore captured in the shape-index range below. (Per-pane
+            // pop-ups reached from inside this region — the context menu,
+            // command-history palette, and search bar — deliberately use
+            // their own `Order::Foreground` `egui::Area`s, so they live in a
+            // different layer and are correctly excluded from the captured
+            // background range.) An earlier version of this subtask routed
+            // the band into a dedicated second `Order::Background` layer
+            // instead, but that
+            // trips egui 0.35's cross-layer hit-test "hidden" rule
+            // (`hit_test.rs:145`): a widget is hidden from hover/click/drag
+            // if a later widget on a DIFFERENT layer contains its rect, and
+            // two untracked same-`Order` layers tie-break by hash iteration
+            // order — nondeterministically hiding every `ui.interact()`
+            // widget in the band (e.g. the command-block gutter hover
+            // highlight). Staying in the shared background layer keeps both
+            // paint topology and hit-test topology identical to `main`; we
+            // instead remember where the band's shapes start and end within
+            // that single `PaintList` so they can be cloned out below for
+            // `App::take_terminal_band_shapes` (436.4 will tessellate/paint
+            // them separately).
+            //
+            // Capture point justification: nothing between `available_rect`
+            // above and here paints into the background layer. The
+            // intervening code only reads window-manipulation state, shows
+            // dialogs (save-layout prompt, paste/broadcast/close guards,
+            // about window, welcome overlay — all `egui::Window`, which is
+            // backed by an `Area` with its own distinct `LayerId`, never
+            // `LayerId::background()`), dispatches queued menu actions (no
+            // painting), and registers pane-border drag sensors via
+            // `ui.interact()` (which does not append any shape). So the
+            // background layer's `PaintList` has not grown since the menu
+            // bar / tab bar chrome painted (before this `CentralPanel`
+            // closure began); capturing the count here bounds the range to
+            // exactly the band.
+            let band_shape_start = ctx.graphics(|g| {
+                g.get(egui::LayerId::background())
+                    .map_or(0, |list| list.all_entries().len())
+            });
 
             // ── Pre-clear the window post-processing FBO ──────────
             //
@@ -2413,6 +2474,39 @@ impl freminal_windowing::App for FreminalGui {
                     );
                 }
             }
+            // ── Terminal band: clone the captured shape range (#436.2a) ──
+            //
+            // Clone the band's shapes — the range appended to the background
+            // layer's `PaintList` since `band_shape_start` above — out for
+            // `App::take_terminal_band_shapes`, for a later subtask (436.4)
+            // to tessellate/paint independently of chrome.
+            //
+            // This subtask deliberately does NOT remove/neutralize the
+            // originals: separate painting of the band does not exist yet,
+            // so neutralizing here would blank the terminal (the only
+            // remaining copy of the geometry would go nowhere). The clone is
+            // a pure read — the real shapes are left in place in
+            // `LayerId::background()`'s `PaintList` and drain into
+            // `FullOutput.shapes` exactly as before, so this frame renders
+            // byte-identically to before this subtask (and to `main`, since
+            // the band paints into the same layer, in the same call order,
+            // as it always has). Neutralization is introduced in 436.4 at
+            // the same time as the separate band paint call, so the two
+            // changes land together and a blank or double-painted frame is
+            // never observable in between.
+            //
+            // Capture point justification (end): nothing between the
+            // broadcast-label loop above and here paints into the background
+            // layer either — this is the very next statement — so
+            // `all_entries().skip(band_shape_start)` is exactly the shapes
+            // painted by the pre-clear callback through the broadcast label,
+            // i.e. exactly the band.
+            let band_shapes: Vec<egui::epaint::ClippedShape> = ctx.graphics(|g| {
+                g.get(egui::LayerId::background()).map_or_else(Vec::new, |list| {
+                    list.all_entries().skip(band_shape_start).cloned().collect()
+                })
+            });
+            win.pending_terminal_band_shapes = band_shapes;
 
             // Handle key actions that couldn't be dispatched at the input
             // layer because they require full GUI state.
@@ -2750,6 +2844,7 @@ impl FreminalGui {
             pending_force_close: false,
             pending_raw_keys: Vec::new(),
             pending_frame_damage: freminal_windowing::FrameDamage::Full,
+            pending_terminal_band_shapes: Vec::new(),
             present_is_partial: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             previous_active_pane_key: None,
         }
@@ -2991,6 +3086,274 @@ mod tests {
         assert_eq!(
             settings_owner_close_decision(true, true),
             SettingsOwnerCloseDecision::VetoWithPrompt
+        );
+    }
+
+    // ── Terminal band shape-index-range extraction (#436.2a) ────────────
+    //
+    // These tests pin the mechanism `update()` uses for the `band_shapes`
+    // binding: paint the band into the SAME `LayerId::background()` layer
+    // chrome already uses (no dedicated layer), remember the shape count
+    // before ("`band_shape_start`") and read `all_entries().skip(start)` to
+    // clone out exactly the range appended since. A full
+    // `FreminalGui`/`PerWindowState` cannot be constructed headlessly
+    // (`freminal_windowing::WindowId` has no public constructor outside the
+    // real winit event loop), so this validates the extraction primitive
+    // directly against a bare `egui::Context`, independent of the app.
+
+    #[test]
+    fn band_shape_range_extraction_finds_only_shapes_painted_after_start() {
+        let ctx = egui::Context::default();
+
+        // A shape painted *before* `band_shape_start` is captured (mirrors
+        // chrome — menu bar, tab bar — painting into the background layer
+        // earlier in the same pass) must NOT be included in the extracted
+        // range.
+        let mut extracted: Vec<egui::epaint::ClippedShape> = Vec::new();
+        let mut chrome_shape_count = 0usize;
+        let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
+            // "Chrome" shape, painted before the band region starts.
+            ui.painter().rect_filled(
+                egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(5.0, 5.0)),
+                0.0,
+                egui::Color32::BLUE,
+            );
+            chrome_shape_count = ui.ctx().graphics(|g| {
+                g.get(egui::LayerId::background())
+                    .map_or(0, |list| list.all_entries().len())
+            });
+
+            // Capture point, exactly as production does immediately before
+            // the band region.
+            let band_shape_start = ui.ctx().graphics(|g| {
+                g.get(egui::LayerId::background())
+                    .map_or(0, |list| list.all_entries().len())
+            });
+
+            // Band shapes, painted into the same `ui` (background layer).
+            ui.painter().rect_filled(
+                egui::Rect::from_min_size(egui::pos2(10.0, 10.0), egui::vec2(10.0, 10.0)),
+                0.0,
+                egui::Color32::RED,
+            );
+            ui.painter().rect_filled(
+                egui::Rect::from_min_size(egui::pos2(30.0, 30.0), egui::vec2(10.0, 10.0)),
+                0.0,
+                egui::Color32::GREEN,
+            );
+
+            extracted = ui.ctx().graphics(|g| {
+                g.get(egui::LayerId::background())
+                    .map_or_else(Vec::new, |list| {
+                        list.all_entries().skip(band_shape_start).cloned().collect()
+                    })
+            });
+        });
+
+        assert_eq!(
+            chrome_shape_count, 1,
+            "sanity: exactly one chrome shape painted before the band"
+        );
+        assert_eq!(
+            extracted.len(),
+            2,
+            "expected exactly the two band shapes, none of the chrome shape painted \
+             before `band_shape_start`"
+        );
+    }
+
+    #[test]
+    fn band_shape_range_extraction_is_a_clone_not_a_drain() {
+        // 436.2a's correctness requirement: extraction must NOT remove the
+        // shapes from the background layer (that is deferred to 436.4,
+        // alongside separate band painting). Confirms the real shapes are
+        // still present after our clone-only extraction, and that egui's
+        // own `end_pass` still drains them into `FullOutput.shapes` — i.e.
+        // rendering is unaffected by the extraction seam existing.
+        let ctx = egui::Context::default();
+
+        let full_output = ctx.run_ui(egui::RawInput::default(), |ui| {
+            let band_shape_start = ui.ctx().graphics(|g| {
+                g.get(egui::LayerId::background())
+                    .map_or(0, |list| list.all_entries().len())
+            });
+
+            ui.painter().rect_filled(
+                egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(10.0, 10.0)),
+                0.0,
+                egui::Color32::RED,
+            );
+
+            // Clone-only extraction (no removal from the layer), exactly as
+            // production does in this subtask.
+            let extracted: Vec<egui::epaint::ClippedShape> = ui.ctx().graphics(|g| {
+                g.get(egui::LayerId::background())
+                    .map_or_else(Vec::new, |list| {
+                        list.all_entries().skip(band_shape_start).cloned().collect()
+                    })
+            });
+            assert!(!extracted.is_empty());
+        });
+
+        assert!(
+            !full_output.shapes.is_empty(),
+            "the background layer's shapes must still drain into FullOutput.shapes \
+             (byte-identical rendering) because this subtask does not remove them \
+             — that is 436.4's job, done together with separate band painting"
+        );
+    }
+
+    // ── Regression test: same-layer widgets are not cross-layer-hidden ──
+    //
+    // This is the blocker the adversarial review caught in the FIRST attempt
+    // at 436.2a: routing the terminal band into a *second*
+    // `Order::Background` layer (distinct from `LayerId::background()`,
+    // which chrome — menu bar, tab bar, and the `CentralPanel`'s own root
+    // widget rect — paints into) trips egui 0.35's cross-layer hit-test
+    // "hidden" rule (`egui-0.35.0/src/hit_test.rs:145-148`): a widget is
+    // hidden from hover/click/drag if a LATER widget on a DIFFERENT layer
+    // contains its rect. `CentralPanel`'s content-area widget rect covers
+    // the whole band, so once the band moved to its own layer, every
+    // `ui.interact()` widget inside the band (e.g. the command-block gutter
+    // hover highlight) was liable to be permanently hidden — the two
+    // untracked `Order::Background` layers tie-break by `IdMap` (hash)
+    // iteration order (`nohash_hasher::IntMap`), which the second test below
+    // reproduces deterministically for the exact `band_layer_id` scheme the
+    // first attempt used, and is NOT controlled by paint call order.
+    //
+    // This is a real behavioral test (not merely structural): it drives two
+    // full `egui::Context::run_ui` passes with an injected
+    // `Event::PointerMoved`, exactly as a real frame would, and reads
+    // `Response::hovered()` — which is the same mechanism the failing
+    // command-block gutter hover highlight relies on.
+    #[test]
+    fn same_layer_widget_is_not_hidden_by_containing_widget() {
+        let big_rect = egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(200.0, 200.0));
+        let small_rect = egui::Rect::from_min_size(egui::pos2(50.0, 50.0), egui::vec2(20.0, 20.0));
+        let pointer_pos = small_rect.center();
+
+        let ctx = egui::Context::default();
+
+        // Frame 1: register both widgets on the SAME layer as `ui`
+        // (`LayerId::background()`) — mirroring the fixed `update()`, where
+        // the band paints directly into `ui` rather than a dedicated
+        // `band_layer_id`. `big` mimics `CentralPanel`'s content-area
+        // widget rect (which fully contains the band); `small` mimics a
+        // band-region interactive widget (e.g. the command-block gutter).
+        let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
+            let _big = ui.interact(
+                big_rect,
+                egui::Id::new("root_content_area"),
+                egui::Sense::hover(),
+            );
+            let _small = ui.interact(
+                small_rect,
+                egui::Id::new("band_widget"),
+                egui::Sense::click(),
+            );
+        });
+
+        // Frame 2: pointer is over `small_rect`. Hit-testing (computed at
+        // the start of this frame from frame 1's registered widget rects)
+        // must find `band_widget` hovered — same-layer widgets are never
+        // subject to the cross-layer "hidden" rule, regardless of paint
+        // order, since `hit_test.rs` only hides a widget when
+        // `current.layer_id != next.layer_id`.
+        let raw_input = egui::RawInput {
+            events: vec![egui::Event::PointerMoved(pointer_pos)],
+            ..Default::default()
+        };
+        let mut small_hovered = false;
+        let _ = ctx.run_ui(raw_input, |ui| {
+            let _big = ui.interact(
+                big_rect,
+                egui::Id::new("root_content_area"),
+                egui::Sense::hover(),
+            );
+            let small_response = ui.interact(
+                small_rect,
+                egui::Id::new("band_widget"),
+                egui::Sense::click(),
+            );
+            small_hovered = small_response.hovered();
+        });
+
+        assert!(
+            small_hovered,
+            "a widget fully contained by another widget on the SAME layer must \
+             still be hoverable — this is the invariant the terminal band relies \
+             on by staying in `LayerId::background()` rather than a dedicated layer"
+        );
+    }
+
+    #[test]
+    fn dedicated_background_layer_hides_contained_widget_cross_layer() {
+        // Reproduces the actual blocker: the FIRST 436.2a attempt routed the
+        // band into `band_layer_id` (a second `Order::Background` layer,
+        // keyed by window id, exactly as constructed below) instead of
+        // `LayerId::background()`. This deterministically demonstrates that
+        // scheme hides a band widget behind the root content-area widget,
+        // for this pinned egui/ahash version (the `IdMap` hash tie-break
+        // ordering between two `Order::Background` layers is fixed for a
+        // given ahash seed/version but is an internal implementation detail
+        // — NOT something application code controls or should rely on,
+        // which is precisely why the band must not use a second layer at
+        // all, in either tie-break order).
+        let big_rect = egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(200.0, 200.0));
+        let small_rect = egui::Rect::from_min_size(egui::pos2(50.0, 50.0), egui::vec2(20.0, 20.0));
+        let pointer_pos = small_rect.center();
+        let band_layer_id = egui::LayerId::new(
+            egui::Order::Background,
+            egui::Id::new("freminal_terminal_band").with(egui::Id::new("probe_window")),
+        );
+
+        let ctx = egui::Context::default();
+        let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
+            let _big = ui.interact(
+                big_rect,
+                egui::Id::new("root_content_area"),
+                egui::Sense::hover(),
+            );
+            let band_ui = ui.new_child(
+                egui::UiBuilder::new()
+                    .max_rect(big_rect)
+                    .layer_id(band_layer_id),
+            );
+            let _small = band_ui.interact(
+                small_rect,
+                egui::Id::new("band_widget"),
+                egui::Sense::click(),
+            );
+        });
+
+        let raw_input = egui::RawInput {
+            events: vec![egui::Event::PointerMoved(pointer_pos)],
+            ..Default::default()
+        };
+        let mut small_hovered = false;
+        let _ = ctx.run_ui(raw_input, |ui| {
+            let _big = ui.interact(
+                big_rect,
+                egui::Id::new("root_content_area"),
+                egui::Sense::hover(),
+            );
+            let band_ui = ui.new_child(
+                egui::UiBuilder::new()
+                    .max_rect(big_rect)
+                    .layer_id(band_layer_id),
+            );
+            let small_response = band_ui.interact(
+                small_rect,
+                egui::Id::new("band_widget"),
+                egui::Sense::click(),
+            );
+            small_hovered = small_response.hovered();
+        });
+
+        assert!(
+            !small_hovered,
+            "expected the dedicated-layer scheme to reproduce the cross-layer \
+             hidden-widget blocker (this pins down WHY that approach was reverted)"
         );
     }
 }

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -17,6 +17,7 @@ use freminal_windowing::WindowId;
 use glow::HasContext;
 use tracing::{debug, error, trace, warn};
 
+use super::frame_damage;
 use super::panes;
 use super::renderer::WindowPostRenderer;
 use super::rendering;
@@ -2161,78 +2162,41 @@ impl freminal_windowing::App for FreminalGui {
             // pointer moves (hover). Presenting only the cursor rect on such a
             // frame would leave that chrome stale, so both force `Full`.
             let pointer_moving = ctx.input(|i| i.pointer.is_moving());
-            win.pending_frame_damage = 'damage: {
-                if ui_overlay_open
-                    || shader_recomposites
-                    || active_pane_changed
-                    || pointer_moving
-                {
-                    break 'damage freminal_windowing::FrameDamage::Full;
-                }
-                // A toast being visible animates its own region each frame.
-                let toast_active = self
-                    .toasts
-                    .try_borrow()
-                    .is_ok_and(|stack| !stack.is_empty());
-                if toast_active {
-                    break 'damage freminal_windowing::FrameDamage::Full;
-                }
-                // Inspect only the panes actually rendered this frame — the
-                // entries in `pane_layout`. Under zoom, only the zoomed pane is
-                // rendered; iterating the whole tree would read stale
-                // `last_frame_cursor_damage` from non-rendered siblings and
-                // wrongly force `Full` every frame. Per-pane outcomes (#435):
-                //   - `Full`            -> that pane rebuilt content; whole
-                //                          frame must present fully.
-                //   - `CursorOnly(rect)`-> the (active) pane's cursor changed;
-                //                          add its rect to the damage set. On
-                //                          an active-pane switch, the old and
-                //                          new active panes both report this
-                //                          (old erases its cursor, new draws
-                //                          one), so both rects are collected.
-                //   - `CursorOnly(None)`-> cursor region did not resolve to a
-                //                          valid rect; be cautious -> Full.
-                //   - `Unchanged`       -> inactive/idle pane; contributes no
-                //                          damage and does NOT force Full.
-                //   - a bell flash overlay on a pane animates a full-pane
-                //     region each frame -> force Full.
-                // Only the active pane ever draws a cursor, so a pure blink
-                // yields exactly one rect; a pane switch yields two.
-                let active_tab = win.tabs.active_tab();
-                let mut rects: Vec<freminal_windowing::DamageRect> = Vec::new();
-                for (pane_id, _) in &pane_layout {
-                    let Some(pane) = active_tab.pane_tree.find(*pane_id) else {
-                        // A pane in the layout we cannot resolve -> be safe.
-                        rects.clear();
-                        break;
-                    };
-                    if pane.view_state.bell_since.is_some() {
-                        rects.clear();
-                        break;
-                    }
-                    match pane.render_cache.last_frame_cursor_damage {
-                        crate::gui::renderer::PaneFrameDamage::Unchanged => {}
-                        crate::gui::renderer::PaneFrameDamage::CursorOnly(Some(d)) => {
-                            rects.push(freminal_windowing::DamageRect {
-                                x: d.x,
-                                y: d.y,
-                                width: d.width,
-                                height: d.height,
-                            });
-                        }
-                        crate::gui::renderer::PaneFrameDamage::CursorOnly(None)
-                        | crate::gui::renderer::PaneFrameDamage::Full => {
-                            rects.clear();
-                            break;
-                        }
-                    }
-                }
-                if rects.is_empty() {
-                    freminal_windowing::FrameDamage::Full
-                } else {
-                    freminal_windowing::FrameDamage::Partial(rects)
-                }
-            };
+            let force_full =
+                ui_overlay_open || shader_recomposites || active_pane_changed || pointer_moving;
+            // A toast being visible animates its own region each frame.
+            let toast_active = self
+                .toasts
+                .try_borrow()
+                .is_ok_and(|stack| !stack.is_empty());
+            // Inspect only the panes actually rendered this frame — the
+            // entries in `pane_layout`. Under zoom, only the zoomed pane is
+            // rendered; iterating the whole tree would read stale
+            // `last_frame_cursor_damage` from non-rendered siblings and
+            // wrongly force `Full` every frame. The per-pane -> `FrameDamage`
+            // decision itself (and its full case-by-case rationale) is
+            // extracted into `decide_frame_damage` (#436.2b) so both this
+            // path and the future REPLAY path compute it identically.
+            let active_tab = win.tabs.active_tab();
+            let mut unresolved_pane = false;
+            let mut per_pane_damage: Vec<frame_damage::PaneDamageInput> =
+                Vec::with_capacity(pane_layout.len());
+            for (pane_id, _) in &pane_layout {
+                let Some(pane) = active_tab.pane_tree.find(*pane_id) else {
+                    // A pane in the layout we cannot resolve -> be safe.
+                    unresolved_pane = true;
+                    break;
+                };
+                per_pane_damage.push(frame_damage::PaneDamageInput {
+                    bell_active: pane.view_state.bell_since.is_some(),
+                    cursor_damage: pane.render_cache.last_frame_cursor_damage,
+                });
+            }
+            win.pending_frame_damage = frame_damage::decide_frame_damage(
+                force_full || unresolved_pane,
+                toast_active,
+                &per_pane_damage,
+            );
 
             // ── Window-level post-processing pass ────────────────────
             //

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -717,7 +717,7 @@ impl freminal_windowing::App for FreminalGui {
         // #436 §7 warm-up: force `Changed` for the first few frames after
         // window creation, while font atlas / layout / PanelState id-maps
         // are still settling.
-        let chrome_warming_up = win.chrome_frames_rendered < chrome_damage::WARMUP_FRAMES;
+        let chrome_warming_up = chrome_damage::is_chrome_warming_up(win.chrome_frames_rendered);
         win.chrome_frames_rendered = win.chrome_frames_rendered.saturating_add(1);
 
         // ── Drain shader/renderer errors stashed by last frame's PaintCallback ──

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -299,7 +299,7 @@ impl freminal_windowing::App for FreminalGui {
                         pending_force_close: false,
                         pending_raw_keys: Vec::new(),
                         pending_frame_damage: freminal_windowing::FrameDamage::Full,
-                        pending_terminal_band_shapes: Vec::new(),
+                        pending_terminal_band_range: 0..0,
                         present_is_partial: std::sync::Arc::new(
                             std::sync::atomic::AtomicBool::new(false),
                         ),
@@ -525,18 +525,13 @@ impl freminal_windowing::App for FreminalGui {
             })
     }
 
-    fn take_terminal_band_shapes(
-        &mut self,
-        window_id: WindowId,
-    ) -> Vec<egui::epaint::ClippedShape> {
-        // Drain the terminal-band shapes captured during `update()` for this
-        // window, leaving an empty `Vec` behind so a stale frame's shapes can
-        // never be reused by a later caller that does not recompute them.
-        self.windows
-            .get_mut(&window_id)
-            .map_or_else(Vec::new, |win| {
-                std::mem::take(&mut win.pending_terminal_band_shapes)
-            })
+    fn take_terminal_band_range(&mut self, window_id: WindowId) -> std::ops::Range<usize> {
+        // Drain the terminal-band range captured during `update()` for this
+        // window, leaving `0..0` behind so a stale frame's range can never
+        // be reused by a later caller that does not recompute it.
+        self.windows.get_mut(&window_id).map_or(0..0, |win| {
+            std::mem::replace(&mut win.pending_terminal_band_range, 0..0)
+        })
     }
 
     fn take_chrome_damage(&mut self, window_id: WindowId) -> freminal_windowing::ChromeDamage {
@@ -563,7 +558,13 @@ impl freminal_windowing::App for FreminalGui {
         ctx: &egui::Context,
         _gl: &glow::Context,
         handle: &freminal_windowing::WindowHandle<'_>,
+        chrome_mode: freminal_windowing::ChromeMode,
     ) {
+        // 436.4b consumes this to skip chrome-widget construction on
+        // `ChromeMode::Replay` frames. `run_frame` only passes `Full` as of
+        // 436.4a, so there is nothing to branch on yet.
+        let _ = chrome_mode;
+
         trace!("Starting new frame");
         let now = std::time::Instant::now();
 
@@ -1730,7 +1731,8 @@ impl freminal_windowing::App for FreminalGui {
                 }
             }
 
-            // ── Terminal band: shape-index range capture (#436.2a) ───
+            // ── Terminal band: shape-index range capture (#436.2a, range
+            // exposed via `App::take_terminal_band_range` as of #436.4a) ───
             //
             // Everything from here through the broadcast label that paints
             // via `ui` — pane content (GL callbacks), pane borders, and the
@@ -1753,9 +1755,10 @@ impl freminal_windowing::App for FreminalGui {
             // highlight). Staying in the shared background layer keeps both
             // paint topology and hit-test topology identical to `main`; we
             // instead remember where the band's shapes start and end within
-            // that single `PaintList` so they can be cloned out below for
-            // `App::take_terminal_band_shapes` (436.4 will tessellate/paint
-            // them separately).
+            // that single `PaintList` and hand back that `[start, end)` range
+            // for `App::take_terminal_band_range`, which `run_frame` uses to
+            // slice `full_output.shapes` into head/band/tail and paint each
+            // separately (#436.4a).
             //
             // Capture point justification: nothing between `available_rect`
             // above and here paints into the background layer. The
@@ -2541,39 +2544,34 @@ impl freminal_windowing::App for FreminalGui {
                     );
                 }
             }
-            // ── Terminal band: clone the captured shape range (#436.2a) ──
+            // ── Terminal band: capture the end of the shape range (#436.4a) ──
             //
-            // Clone the band's shapes — the range appended to the background
-            // layer's `PaintList` since `band_shape_start` above — out for
-            // `App::take_terminal_band_shapes`, for a later subtask (436.4)
-            // to tessellate/paint independently of chrome.
-            //
-            // This subtask deliberately does NOT remove/neutralize the
-            // originals: separate painting of the band does not exist yet,
-            // so neutralizing here would blank the terminal (the only
-            // remaining copy of the geometry would go nowhere). The clone is
-            // a pure read — the real shapes are left in place in
+            // Read the background layer's current shape count as
+            // `band_shape_end`, so `[band_shape_start, band_shape_end)` is
+            // exactly the band's range within `LayerId::background()`'s
+            // `PaintList`. `run_frame` slices `full_output.shapes` by this
+            // range directly (the background layer drains first into
+            // `full_output.shapes`), so — unlike 436.2a's approach — nothing
+            // is cloned here: this is a pure read of the shape count, and
+            // the real shapes are left in place in
             // `LayerId::background()`'s `PaintList` and drain into
-            // `FullOutput.shapes` exactly as before, so this frame renders
-            // byte-identically to before this subtask (and to `main`, since
-            // the band paints into the same layer, in the same call order,
-            // as it always has). Neutralization is introduced in 436.4 at
-            // the same time as the separate band paint call, so the two
-            // changes land together and a blank or double-painted frame is
-            // never observable in between.
+            // `FullOutput.shapes` exactly as before. `run_frame`'s 3-way
+            // split (head/band/tail, each tessellated and painted
+            // separately, in that order) reconstructs the same total shape
+            // set with the same paint order as the pre-#436.4a single-call
+            // path, so this frame renders byte-identically to before.
             //
             // Capture point justification (end): nothing between the
             // broadcast-label loop above and here paints into the background
             // layer either — this is the very next statement — so
-            // `all_entries().skip(band_shape_start)` is exactly the shapes
-            // painted by the pre-clear callback through the broadcast label,
-            // i.e. exactly the band.
-            let band_shapes: Vec<egui::epaint::ClippedShape> = ctx.graphics(|g| {
-                g.get(egui::LayerId::background()).map_or_else(Vec::new, |list| {
-                    list.all_entries().skip(band_shape_start).cloned().collect()
-                })
+            // `band_shape_end` is exactly the count after the pre-clear
+            // callback through the broadcast label, i.e. exactly the end of
+            // the band.
+            let band_shape_end = ctx.graphics(|g| {
+                g.get(egui::LayerId::background())
+                    .map_or(band_shape_start, |list| list.all_entries().len())
             });
-            win.pending_terminal_band_shapes = band_shapes;
+            win.pending_terminal_band_range = band_shape_start..band_shape_end;
 
             // Handle key actions that couldn't be dispatched at the input
             // layer because they require full GUI state.
@@ -2975,7 +2973,7 @@ impl FreminalGui {
             pending_force_close: false,
             pending_raw_keys: Vec::new(),
             pending_frame_damage: freminal_windowing::FrameDamage::Full,
-            pending_terminal_band_shapes: Vec::new(),
+            pending_terminal_band_range: 0..0,
             present_is_partial: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             previous_active_pane_key: None,
             pending_chrome_damage: freminal_windowing::ChromeDamage::Changed,
@@ -3227,17 +3225,22 @@ mod tests {
         );
     }
 
-    // ── Terminal band shape-index-range extraction (#436.2a) ────────────
+    // ── Terminal band shape-index-range extraction (#436.2a / #436.4a) ──
     //
-    // These tests pin the mechanism `update()` uses for the `band_shapes`
-    // binding: paint the band into the SAME `LayerId::background()` layer
-    // chrome already uses (no dedicated layer), remember the shape count
-    // before ("`band_shape_start`") and read `all_entries().skip(start)` to
-    // clone out exactly the range appended since. A full
-    // `FreminalGui`/`PerWindowState` cannot be constructed headlessly
-    // (`freminal_windowing::WindowId` has no public constructor outside the
-    // real winit event loop), so this validates the extraction primitive
-    // directly against a bare `egui::Context`, independent of the app.
+    // These tests pin the underlying mechanism `update()` uses to bound the
+    // terminal band's shape-index range: paint the band into the SAME
+    // `LayerId::background()` layer chrome already uses (no dedicated
+    // layer), remember the shape count before ("`band_shape_start`"), and
+    // read `all_entries().skip(start)` to identify exactly the range
+    // appended since. Production (as of #436.4a) captures `band_shape_end`
+    // the same way and hands back `[band_shape_start, band_shape_end)` as a
+    // range via `App::take_terminal_band_range`, rather than cloning the
+    // shapes out here — but the boundary-counting primitive these tests
+    // exercise is identical either way. A full `FreminalGui`/`PerWindowState`
+    // cannot be constructed headlessly (`freminal_windowing::WindowId` has
+    // no public constructor outside the real winit event loop), so this
+    // validates the extraction primitive directly against a bare
+    // `egui::Context`, independent of the app.
 
     #[test]
     fn band_shape_range_extraction_finds_only_shapes_painted_after_start() {

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -1093,6 +1093,15 @@ impl freminal_windowing::App for FreminalGui {
         let (snap, pane_scroll_offset) = {
             let Some(active_pane_ref) = win.tabs.active_tab().active_pane() else {
                 warn!("update: active tab has no active pane; skipping render frame");
+                // CLEANUP-436-A: `win` was moved out of `self.windows` at the
+                // top of this frame (`self.windows.remove(&window_id)`); every
+                // early return after that point must reinsert it (see the
+                // `CannotCloseLastPane` arm above, which does). Skipping the
+                // reinsert here permanently orphans this window's
+                // `PerWindowState` — including, since #436, its chrome cache and
+                // self-dismissal settle state — leaving the window rendering a
+                // blank/fatal-error surface forever. Reinsert before returning.
+                self.windows.insert(window_id, win);
                 return;
             };
             (

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -311,6 +311,8 @@ impl freminal_windowing::App for FreminalGui {
                         prev_chrome_tab_snapshot: chrome_damage::ChromeTabSnapshot::default(),
                         prev_window_focused: false,
                         chrome_frames_rendered: 0,
+                        pending_terminal_requested_delay: None,
+                        cached_central_rect: None,
                     };
                     self.windows.insert(window_id, win);
 
@@ -548,6 +550,19 @@ impl freminal_windowing::App for FreminalGui {
             })
     }
 
+    fn take_terminal_requested_delay(
+        &mut self,
+        window_id: WindowId,
+    ) -> Option<std::time::Duration> {
+        // Drain the delay `update()` itself requested via
+        // `ctx.request_repaint_after` this window's most recent frame,
+        // leaving `None` behind so a stale delay can never be reused by a
+        // later frame that does not recompute it.
+        self.windows
+            .get_mut(&window_id)
+            .and_then(|win| win.pending_terminal_requested_delay.take())
+    }
+
     // Inherently large: the main per-frame UI function handles menu bar, settings modal, window
     // manipulation drain, terminal widget layout, and resize detection — all in one pass over
     // the shared snapshot. Artificial sub-functions would not reduce the coupling.
@@ -560,11 +575,6 @@ impl freminal_windowing::App for FreminalGui {
         handle: &freminal_windowing::WindowHandle<'_>,
         chrome_mode: freminal_windowing::ChromeMode,
     ) {
-        // 436.4b consumes this to skip chrome-widget construction on
-        // `ChromeMode::Replay` frames. `run_frame` only passes `Full` as of
-        // 436.4a, so there is nothing to branch on yet.
-        let _ = chrome_mode;
-
         trace!("Starting new frame");
         let now = std::time::Instant::now();
 
@@ -1136,32 +1146,70 @@ impl freminal_windowing::App for FreminalGui {
             }
         }
 
-        // Create a root Ui covering the full available area.  Panels reserve
-        // space from this Ui via `show` (the non-deprecated API; `show_inside`
-        // was renamed to `show` in egui 0.35).
-        let mut root_ui = egui::Ui::new(
-            ctx.clone(),
-            egui::Id::new("freminal_root"),
-            egui::UiBuilder::default(),
-        );
+        // ── #436.4b: FULL vs REPLAY chrome construction ──────────────────────
+        //
+        // On `ChromeMode::Full` the root Ui, menu bar, and tab bar are built
+        // exactly as before, and `CentralPanel` reserves the remaining space
+        // for `central_body` below. On `ChromeMode::Replay` the windowing
+        // layer has already proven chrome (including window size) is
+        // unchanged since the last FULL frame, so none of that is rebuilt —
+        // `central_body` runs directly against a `Ui` constructed at the
+        // cached content rect instead, in the SAME background layer chrome
+        // uses (so the terminal band's shapes land exactly where `run_frame`
+        // expects them). `any_menu_open` (read inside `central_body` to
+        // compute `ui_overlay_open`) is `false` on Replay: with no menu bar
+        // built, no menu can be open.
+        let (any_menu_open, chrome_root_ui): (bool, Option<egui::Ui>) =
+            if chrome_mode == freminal_windowing::ChromeMode::Full {
+                // Create a root Ui covering the full available area.  Panels
+                // reserve space from this Ui via `show` (the non-deprecated
+                // API; `show_inside` was renamed to `show` in egui 0.35).
+                let mut root_ui = egui::Ui::new(
+                    ctx.clone(),
+                    egui::Id::new("freminal_root"),
+                    egui::UiBuilder::default(),
+                );
 
-        // Menu bar at the top of the window.
-        let mut any_menu_open = false;
-        if !self.config.ui.hide_menu_bar {
-            let (menu_action, menu_open) = Panel::top("menu_bar")
-                .show(&mut root_ui, |ui| {
-                    self.show_menu_bar(ui, &mut win, window_id)
-                })
-                .inner;
-            any_menu_open = menu_open;
-            self.dispatch_tab_bar_action(menu_action, &mut win);
-        }
+                // Menu bar at the top of the window.
+                let menu_open = if self.config.ui.hide_menu_bar {
+                    false
+                } else {
+                    let (menu_action, menu_open) = Panel::top("menu_bar")
+                        .show(&mut root_ui, |ui| {
+                            self.show_menu_bar(ui, &mut win, window_id)
+                        })
+                        .inner;
+                    self.dispatch_tab_bar_action(menu_action, &mut win);
+                    menu_open
+                };
+
+                // Tab bar: shown when multiple tabs are open, or when the
+                // config option `tabs.show_single_tab` is enabled.
+                let show_tab_bar = win.tabs.tab_count() > 1 || self.config.tabs.show_single_tab;
+
+                if show_tab_bar {
+                    let panel = match self.config.tabs.position {
+                        freminal_common::config::TabBarPosition::Top => Panel::top("tab_bar"),
+                        freminal_common::config::TabBarPosition::Bottom => Panel::bottom("tab_bar"),
+                    };
+                    let tab_action = panel
+                        .show(&mut root_ui, |ui| self.show_tab_bar(&mut win, ui))
+                        .inner;
+                    self.dispatch_tab_bar_action(tab_action, &mut win);
+                }
+
+                (menu_open, Some(root_ui))
+            } else {
+                (false, None)
+            };
 
         // Help menu → "Keybindings..." routes here.  Opens the Settings
         // Modal with the Keybindings tab preselected, or focuses the
         // existing settings window if one is already open.  Mirrors the
         // Settings menu item in `show_menu_bar`, but jumps to the
-        // Keybindings tab instead of the default Font tab.
+        // Keybindings tab instead of the default Font tab. Independent of
+        // `chrome_mode`: it only mutates modal-open state (no painting), so
+        // it runs every frame regardless of whether chrome was rebuilt.
         if self.pending_open_keybindings {
             self.pending_open_keybindings = false;
             if self.settings_window_id.is_some() {
@@ -1183,22 +1231,24 @@ impl freminal_windowing::App for FreminalGui {
             }
         }
 
-        // Tab bar: shown when multiple tabs are open, or when the config
-        // option `tabs.show_single_tab` is enabled.
-        let show_tab_bar = win.tabs.tab_count() > 1 || self.config.tabs.show_single_tab;
+        // Copy the cached content rect (`egui::Rect` is `Copy`) out of `win`
+        // BEFORE `central_body` captures `win` by mutable reference below —
+        // reading `win.cached_central_rect` after that point (e.g. inside
+        // the REPLAY arm further down) would conflict with the closure's
+        // borrow. Only actually used on a REPLAY frame; harmless (and cheap)
+        // to compute unconditionally otherwise. Falls back to egui's own
+        // content rect in the unreachable case described where it is used.
+        let cached_central_rect_for_replay = win
+            .cached_central_rect
+            .unwrap_or_else(|| ctx.input(egui::InputState::content_rect));
 
-        if show_tab_bar {
-            let panel = match self.config.tabs.position {
-                freminal_common::config::TabBarPosition::Top => Panel::top("tab_bar"),
-                freminal_common::config::TabBarPosition::Bottom => Panel::bottom("tab_bar"),
-            };
-            let tab_action = panel
-                .show(&mut root_ui, |ui| self.show_tab_bar(&mut win, ui))
-                .inner;
-            self.dispatch_tab_bar_action(tab_action, &mut win);
-        }
-
-        let _panel_response = CentralPanel::default().show(&mut root_ui, |ui| {
+        // The terminal band + (on Full only) chrome dialogs/overlays. Shared
+        // between the FULL path (called via `CentralPanel::show`, below) and
+        // the REPLAY path (called directly against a `Ui` built at the
+        // cached content rect) so the band's rendering logic — the per-pane
+        // loop, borders, broadcast label, band-range capture, chrome-damage
+        // signal staging, and repaint scheduling — is defined exactly once.
+        let mut central_body = |ui: &mut egui::Ui| {
             // Synchronise font metrics with the current display scale *before*
             // reading `cell_size()`.  Without this, the first frame after a DPI
             // change would use stale pixel metrics for the resize calculation.
@@ -1355,8 +1405,7 @@ impl freminal_windowing::App for FreminalGui {
             // stack, and the OSC 99 session maps are borrowable without
             // conflicting with the `win.tabs` borrow.
             if !osc99_notifications.is_empty() {
-                let window_minimized =
-                    ui.ctx().input(|i| i.viewport().minimized.unwrap_or(false));
+                let window_minimized = ui.ctx().input(|i| i.viewport().minimized.unwrap_or(false));
                 if let (Ok(mut toasts), Ok(mut icon_cache), Ok(mut live)) = (
                     self.toasts.try_borrow_mut(),
                     self.osc99_icon_cache.try_borrow_mut(),
@@ -1424,9 +1473,8 @@ impl freminal_windowing::App for FreminalGui {
                         // OSC 99 p=? capability handshake (Task 99.7): answer
                         // with freminal's truthfully-advertised OSC 99
                         // capabilities.
-                        let bytes = crate::gui::notifications::osc99_query_response(
-                            control.id.as_deref(),
-                        );
+                        let bytes =
+                            crate::gui::notifications::osc99_query_response(control.id.as_deref());
                         send_or_log!(
                             tx,
                             PtyWrite::Write(bytes),
@@ -1444,6 +1492,13 @@ impl freminal_windowing::App for FreminalGui {
             // the loop.
 
             let available_rect = ui.available_rect_before_wrap();
+
+            // #436.4b: cache the content rect so a later REPLAY frame can
+            // reconstruct an equivalent `Ui` without rebuilding the menu
+            // bar / tab bar / `CentralPanel` chrome that produced it.
+            // Idempotent on a REPLAY frame itself (`available_rect` is then
+            // already exactly the cached value).
+            win.cached_central_rect = Some(available_rect);
 
             let active_pane_id = win.tabs.active_tab().active_pane;
             let zoomed_pane = win.tabs.active_tab().zoomed_pane;
@@ -1506,111 +1561,127 @@ impl freminal_windowing::App for FreminalGui {
 
             let mut all_deferred_actions = Vec::new();
 
-            // Floating "Save Layout" name-entry prompt.  Shown whenever the
-            // user clicked "Save Layout" in the Layouts menu.  Returns true
-            // exactly once (the frame the user confirms), at which point we
-            // enqueue the SaveLayout action for dispatch.
-            if self.show_save_layout_prompt(ctx) {
-                all_deferred_actions.push(freminal_common::keybindings::KeyAction::SaveLayout);
-            }
-
-            // Smart paste guard confirm dialog (Task 77).  Shown whenever a
-            // flagged paste is pending for this window.  On confirm, the
-            // resolved (possibly edited) payload is sent to the active pane;
-            // on cancel the paste is discarded.
-            match win.paste_dialog.show(ctx) {
-                super::paste_guard::PasteDialogOutcome::Paste { payload, target } => {
-                    // Route to the pane captured when the dialog opened, not
-                    // the currently-active pane: focus-follows-mouse can change
-                    // the active pane when the cursor moves onto the dialog
-                    // buttons (Task 106 bug).
-                    Self::send_paste_to_target(&mut win, target, payload);
+            // ── #436.4b: chrome dialogs/overlays — FULL only ──────────────
+            //
+            // These are all cached TAIL chrome (each uses its own
+            // `egui::Window`/`Area`, a distinct layer from the terminal
+            // band's `LayerId::background()`). A REPLAY frame is only ever
+            // entered when the PREVIOUS frame proved `ui_overlay_open` was
+            // `false` (any dialog open forces `ChromeDamage::Changed` every
+            // frame it is — see `ChromeSignals::any_fired`) and no chrome
+            // input landed this frame, so by construction none of these can
+            // be open (or becoming open) on a REPLAY frame. Skipping their
+            // `.show()` calls is therefore safe; running them would be
+            // wasted work whose freshly-painted shapes `run_frame` would
+            // discard anyway (REPLAY reuses the cached tail primitives, not
+            // this frame's own tail shapes).
+            if chrome_mode == freminal_windowing::ChromeMode::Full {
+                // Floating "Save Layout" name-entry prompt.  Shown whenever the
+                // user clicked "Save Layout" in the Layouts menu.  Returns true
+                // exactly once (the frame the user confirms), at which point we
+                // enqueue the SaveLayout action for dispatch.
+                if self.show_save_layout_prompt(ctx) {
+                    all_deferred_actions.push(freminal_common::keybindings::KeyAction::SaveLayout);
                 }
-                super::paste_guard::PasteDialogOutcome::Cancelled
-                | super::paste_guard::PasteDialogOutcome::Idle => {}
-            }
 
-            // Broadcast-input confirm dialog (Task 74.5).  Shown when the user
-            // tried to enable broadcast and `[tabs] confirm_broadcast` is set.
-            // On confirm, broadcast is enabled on the dialog's target tab.
-            match win.broadcast_dialog.show(ctx) {
-                super::broadcast_guard::BroadcastDialogOutcome::Confirmed(tab_id) => {
-                    if let Some(tab) = win.tabs.iter_mut().find(|t| t.id == tab_id) {
-                        tab.broadcast_input = true;
-                        let pane_count = tab.pane_tree.iter_panes().map_or(1, |p| p.len());
-                        self.push_info_toast(
-                            "Broadcast input enabled",
-                            Some(format!(
-                                "Keyboard input is now sent to all {pane_count} pane(s) in this tab."
-                            )),
-                        );
+                // Smart paste guard confirm dialog (Task 77).  Shown whenever a
+                // flagged paste is pending for this window.  On confirm, the
+                // resolved (possibly edited) payload is sent to the active pane;
+                // on cancel the paste is discarded.
+                match win.paste_dialog.show(ctx) {
+                    super::paste_guard::PasteDialogOutcome::Paste { payload, target } => {
+                        // Route to the pane captured when the dialog opened, not
+                        // the currently-active pane: focus-follows-mouse can change
+                        // the active pane when the cursor moves onto the dialog
+                        // buttons (Task 106 bug).
+                        Self::send_paste_to_target(&mut win, target, payload);
+                    }
+                    super::paste_guard::PasteDialogOutcome::Cancelled
+                    | super::paste_guard::PasteDialogOutcome::Idle => {}
+                }
+
+                // Broadcast-input confirm dialog (Task 74.5).  Shown when the user
+                // tried to enable broadcast and `[tabs] confirm_broadcast` is set.
+                // On confirm, broadcast is enabled on the dialog's target tab.
+                match win.broadcast_dialog.show(ctx) {
+                    super::broadcast_guard::BroadcastDialogOutcome::Confirmed(tab_id) => {
+                        if let Some(tab) = win.tabs.iter_mut().find(|t| t.id == tab_id) {
+                            tab.broadcast_input = true;
+                            let pane_count = tab.pane_tree.iter_panes().map_or(1, |p| p.len());
+                            self.push_info_toast(
+                                "Broadcast input enabled",
+                                Some(format!(
+                                    "Keyboard input is now sent to all {pane_count} pane(s) in this tab."
+                                )),
+                            );
+                        }
+                    }
+                    super::broadcast_guard::BroadcastDialogOutcome::Cancelled
+                    | super::broadcast_guard::BroadcastDialogOutcome::Idle => {}
+                }
+
+                // Close-on-running-command guard dialog (Task 98).  Shown while a
+                // pane / tab / window close is suspended pending confirmation.  On
+                // Force Close the original close is executed with the guard
+                // bypassed; on Cancel the close is abandoned.
+                // A pending ForceClose key action resolves an open close-guard
+                // dialog as Force Close; harmless no-op when nothing is open.
+                let force_close_requested = std::mem::take(&mut win.pending_force_close);
+                if let Some(scope) = win.close_dialog.scope() {
+                    let outcome = if force_close_requested {
+                        win.close_dialog.force_close_now();
+                        super::close_guard::CloseDialogOutcome::ForceClose
+                    } else {
+                        win.close_dialog.show(ctx)
+                    };
+                    match outcome {
+                        super::close_guard::CloseDialogOutcome::ForceClose => match scope {
+                            super::close_guard::CloseScope::Pane => {
+                                Self::close_focused_pane(ui, &mut win);
+                            }
+                            super::close_guard::CloseScope::Tab(index) => {
+                                win.close_tab(index);
+                            }
+                            super::close_guard::CloseScope::Window => {
+                                // Mark this window as user-confirmed so the
+                                // on_close_requested guard lets the resulting
+                                // ViewportCommand::Close through without re-prompting.
+                                self.force_close_windows.insert(window_id);
+                                ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                            }
+                            super::close_guard::CloseScope::WindowUnsavedSettings => {
+                                // User chose to discard the unsaved settings
+                                // edits. Close the settings OS window directly —
+                                // `handle` is available right here, unlike in
+                                // `on_close_requested` — then re-issue this
+                                // window's close. Clearing `settings_owner` here
+                                // (rather than a separate "confirmed" flag) is
+                                // what makes the retry's `on_close_requested`
+                                // call see `is_owner == false` and skip the
+                                // guard without re-prompting (issue #401).
+                                self.settings_modal.is_open = false;
+                                self.settings_owner = None;
+                                if let Some(sid) = self.settings_window_id.take() {
+                                    handle.close_window(sid);
+                                }
+                                ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                            }
+                        },
+                        super::close_guard::CloseDialogOutcome::Cancelled
+                        | super::close_guard::CloseDialogOutcome::Idle => {}
                     }
                 }
-                super::broadcast_guard::BroadcastDialogOutcome::Cancelled
-                | super::broadcast_guard::BroadcastDialogOutcome::Idle => {}
+
+                // Floating "About Freminal" dialog.  Shown whenever the user
+                // clicked "About Freminal" in the Help menu.  Self-dismissing
+                // via its own Close button or title-bar X.
+                self.show_about_window(ctx);
+
+                // First-run welcome overlay (subtask 71.20).  Opened on first
+                // launch or from Help -> Show Welcome; persists
+                // `first_run_complete = true` on dismissal.
+                self.show_welcome_overlay(ctx);
             }
-
-            // Close-on-running-command guard dialog (Task 98).  Shown while a
-            // pane / tab / window close is suspended pending confirmation.  On
-            // Force Close the original close is executed with the guard
-            // bypassed; on Cancel the close is abandoned.
-            // A pending ForceClose key action resolves an open close-guard
-            // dialog as Force Close; harmless no-op when nothing is open.
-            let force_close_requested = std::mem::take(&mut win.pending_force_close);
-            if let Some(scope) = win.close_dialog.scope() {
-                let outcome = if force_close_requested {
-                    win.close_dialog.force_close_now();
-                    super::close_guard::CloseDialogOutcome::ForceClose
-                } else {
-                    win.close_dialog.show(ctx)
-                };
-                match outcome {
-                    super::close_guard::CloseDialogOutcome::ForceClose => match scope {
-                        super::close_guard::CloseScope::Pane => {
-                            Self::close_focused_pane(ui, &mut win);
-                        }
-                        super::close_guard::CloseScope::Tab(index) => {
-                            win.close_tab(index);
-                        }
-                        super::close_guard::CloseScope::Window => {
-                            // Mark this window as user-confirmed so the
-                            // on_close_requested guard lets the resulting
-                            // ViewportCommand::Close through without re-prompting.
-                            self.force_close_windows.insert(window_id);
-                            ctx.send_viewport_cmd(egui::ViewportCommand::Close);
-                        }
-                        super::close_guard::CloseScope::WindowUnsavedSettings => {
-                            // User chose to discard the unsaved settings
-                            // edits. Close the settings OS window directly —
-                            // `handle` is available right here, unlike in
-                            // `on_close_requested` — then re-issue this
-                            // window's close. Clearing `settings_owner` here
-                            // (rather than a separate "confirmed" flag) is
-                            // what makes the retry's `on_close_requested`
-                            // call see `is_owner == false` and skip the
-                            // guard without re-prompting (issue #401).
-                            self.settings_modal.is_open = false;
-                            self.settings_owner = None;
-                            if let Some(sid) = self.settings_window_id.take() {
-                                handle.close_window(sid);
-                            }
-                            ctx.send_viewport_cmd(egui::ViewportCommand::Close);
-                        }
-                    },
-                    super::close_guard::CloseDialogOutcome::Cancelled
-                    | super::close_guard::CloseDialogOutcome::Idle => {}
-                }
-            }
-
-            // Floating "About Freminal" dialog.  Shown whenever the user
-            // clicked "About Freminal" in the Help menu.  Self-dismissing
-            // via its own Close button or title-bar X.
-            self.show_about_window(ctx);
-
-            // First-run welcome overlay (subtask 71.20).  Opened on first
-            // launch or from Help -> Show Welcome; persists
-            // `first_run_complete = true` on dismissal.
-            self.show_welcome_overlay(ctx);
 
             // Drain pending menu actions (Edit menu clicks: Copy, Paste,
             // Select All, Find...).  These were queued during
@@ -2234,14 +2305,39 @@ impl freminal_windowing::App for FreminalGui {
             // path and the future REPLAY path compute it identically.
             let active_tab = win.tabs.active_tab();
             let mut unresolved_pane = false;
+            // OR-accumulated across every rendered pane: does ANY of them
+            // have an open overlay that paints ABOVE the terminal band —
+            // the `Order::Foreground` context menu, in-terminal search bar,
+            // or command-history palette, OR the `Order::Tooltip` URL-hover
+            // tooltip? All of these paint as TAIL chrome outside the captured
+            // terminal-band range, so a REPLAY frame (which reuses the stale
+            // cached tail) must not be permitted while one is open, or it
+            // would vanish/ghost (#436.4b fix — see
+            // `ChromeSignals::foreground_overlay_open`). The URL tooltip is
+            // driven by `render_cache.cached_hovered_url`, which is recomputed
+            // even under a STATIONARY mouse when PTY output scrolls new
+            // content under the cursor — i.e. it can change on a frame with
+            // no window input event, exactly the frame a REPLAY would
+            // otherwise be chosen.
+            let mut foreground_overlay_open = false;
             let mut per_pane_damage: Vec<frame_damage::PaneDamageInput> =
                 Vec::with_capacity(pane_layout.len());
             for (pane_id, _) in &pane_layout {
                 let Some(pane) = active_tab.pane_tree.find(*pane_id) else {
-                    // A pane in the layout we cannot resolve -> be safe.
+                    // A pane in the layout we cannot resolve -> be safe. This
+                    // also aborts the `foreground_overlay_open` scan before
+                    // every pane has been inspected, so conservatively treat
+                    // an unresolved pane as if a foreground overlay were open
+                    // — it already forces `FrameDamage::Full` below, and the
+                    // chrome decision must be at least as conservative.
                     unresolved_pane = true;
+                    foreground_overlay_open = true;
                     break;
                 };
+                foreground_overlay_open |= pane.view_state.context_menu_pos.is_some()
+                    || pane.view_state.search_state.is_open
+                    || pane.view_state.command_history.is_open
+                    || pane.render_cache.hover_tooltip_active();
                 per_pane_damage.push(frame_damage::PaneDamageInput {
                     bell_active: pane.view_state.bell_since.is_some(),
                     cursor_damage: pane.render_cache.last_frame_cursor_damage,
@@ -2283,8 +2379,10 @@ impl freminal_windowing::App for FreminalGui {
                 zoomed_pane,
                 broadcast_input: win.tabs.active_tab().broadcast_input,
             };
-            let chrome_tab_diff =
-                chrome_damage::diff_tab_snapshots(&win.prev_chrome_tab_snapshot, &chrome_tab_snapshot);
+            let chrome_tab_diff = chrome_damage::diff_tab_snapshots(
+                &win.prev_chrome_tab_snapshot,
+                &chrome_tab_snapshot,
+            );
             win.prev_chrome_tab_snapshot = chrome_tab_snapshot;
 
             win.pending_chrome_signals = chrome_damage::ChromeSignals {
@@ -2302,6 +2400,7 @@ impl freminal_windowing::App for FreminalGui {
                 ppp_changed,
                 focus_changed: chrome_focus_changed,
                 warming_up: chrome_warming_up,
+                foreground_overlay_open,
             };
 
             // ── Window-level post-processing pass ────────────────────
@@ -2637,16 +2736,70 @@ impl freminal_windowing::App for FreminalGui {
                 ctx.send_viewport_cmd(egui::ViewportCommand::Title(win.last_window_title.clone()));
             }
 
+            // Stash this frame's own repaint request for #436.4b's
+            // `chrome_repaint_settled` gate (drained by
+            // `App::take_terminal_requested_delay`): the NEXT frame's replay
+            // decision needs to know what delay THIS frame itself asked for,
+            // to distinguish "only our own blink/content scheduling wants a
+            // wake" from "something egui-internal also wants one sooner".
+            win.pending_terminal_requested_delay = shortest_repaint_delay;
+
             // Schedule a repaint at the shortest interval needed by any pane.
             if let Some(delay) = shortest_repaint_delay {
                 ctx.request_repaint_after(delay);
             }
-        });
+        };
+
+        if let Some(mut root_ui) = chrome_root_ui {
+            let _panel_response = CentralPanel::default().show(&mut root_ui, central_body);
+        } else {
+            // REPLAY: construct the band's `Ui` directly at the cached
+            // content rect, in the SAME background layer chrome uses, so the
+            // terminal band's shapes land where a FULL frame's `CentralPanel`
+            // content would have put them. The id is NOT the same, though:
+            // this uses `Id::new("freminal_root")` directly (the root Ui's
+            // own id), while the FULL path's `CentralPanel::show` allocates
+            // its content `Ui` via `root_ui.new_child(..)` with no explicit
+            // id salt, which egui auto-derives from `root_ui`'s id plus a
+            // per-frame child-index counter — a different, and not
+            // necessarily stable, id. This is a known accepted limitation:
+            // any widget that keys persistent state off its `Ui`-derived id
+            // (e.g. collapsing-header open state) could in principle churn
+            // that state across a Full<->Replay mode toggle. In practice
+            // this is inert, because real user interaction with such a
+            // widget forces `ChromeMode::Full` on the same frame (via
+            // `ui_overlay_open`/pointer-motion/etc.), so REPLAY is only ever
+            // entered while nothing is interacting with mismatched-id
+            // widgets. Tracked as a follow-up if a concrete widget is ever
+            // found to rely on cross-mode id stability.
+            // `decide_chrome_mode` only chooses `Replay` when the chrome
+            // cache is valid at this frame's size/ppp, which is only ever
+            // populated on a FULL frame — and every FULL frame sets
+            // `cached_central_rect` (via `central_body`) before that cache is
+            // populated — so falling back to egui's own content rect
+            // (`cached_central_rect_for_replay`'s fallback, computed above)
+            // should be unreachable in practice.
+            let mut band_ui = egui::Ui::new(
+                ctx.clone(),
+                egui::Id::new("freminal_root"),
+                egui::UiBuilder::new()
+                    .layer_id(egui::LayerId::background())
+                    .max_rect(cached_central_rect_for_replay),
+            );
+            central_body(&mut band_ui);
+        }
 
         // Render the app-level toast stack as an overlay on top of all panels.
         // Toasts are shared across every window, so they appear consistently
-        // regardless of which window the user is looking at.
-        if let Ok(mut stack) = self.toasts.try_borrow_mut() {
+        // regardless of which window the user is looking at. TAIL chrome
+        // (#436.4b): skipped on REPLAY for the same reason as the dialogs
+        // above — a toast being visible forces `ChromeDamage::Changed` every
+        // frame it is (`ChromeSignals::toast_active`), so a REPLAY frame can
+        // only ever be entered while the stack is provably empty, making
+        // `.show()` a no-op here anyway.
+        if chrome_mode == freminal_windowing::ChromeMode::Full
+            && let Ok(mut stack) = self.toasts.try_borrow_mut()
+        {
             stack.show(ctx);
         }
 
@@ -2983,6 +3136,8 @@ impl FreminalGui {
             prev_chrome_tab_snapshot: chrome_damage::ChromeTabSnapshot::default(),
             prev_window_focused: false,
             chrome_frames_rendered: 0,
+            pending_terminal_requested_delay: None,
+            cached_central_rect: None,
         }
     }
 

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -313,6 +313,8 @@ impl freminal_windowing::App for FreminalGui {
                         chrome_frames_rendered: 0,
                         pending_terminal_requested_delay: None,
                         cached_central_rect: None,
+                        chrome_head_rects: None,
+                        chrome_border_rects: Vec::new(),
                     };
                     self.windows.insert(window_id, win);
 
@@ -511,6 +513,16 @@ impl freminal_windowing::App for FreminalGui {
         self.windows
             .get(&window_id)
             .map(|win| std::sync::Arc::clone(&win.present_is_partial))
+    }
+
+    fn is_chrome_interactive_at(&self, window_id: WindowId, pos: egui::Pos2) -> bool {
+        self.windows.get(&window_id).is_none_or(|win| {
+            crate::gui::chrome_damage::point_in_chrome_rects(
+                pos,
+                win.chrome_head_rects.as_deref(),
+                &win.chrome_border_rects,
+            )
+        })
     }
 
     fn take_frame_damage(&mut self, window_id: WindowId) -> freminal_windowing::FrameDamage {
@@ -1159,49 +1171,61 @@ impl freminal_windowing::App for FreminalGui {
         // expects them). `any_menu_open` (read inside `central_body` to
         // compute `ui_overlay_open`) is `false` on Replay: with no menu bar
         // built, no menu can be open.
-        let (any_menu_open, chrome_root_ui): (bool, Option<egui::Ui>) =
-            if chrome_mode == freminal_windowing::ChromeMode::Full {
-                // Create a root Ui covering the full available area.  Panels
-                // reserve space from this Ui via `show` (the non-deprecated
-                // API; `show_inside` was renamed to `show` in egui 0.35).
-                let mut root_ui = egui::Ui::new(
-                    ctx.clone(),
-                    egui::Id::new("freminal_root"),
-                    egui::UiBuilder::default(),
-                );
+        let (any_menu_open, chrome_root_ui): (bool, Option<egui::Ui>) = if chrome_mode
+            == freminal_windowing::ChromeMode::Full
+        {
+            // Create a root Ui covering the full available area.  Panels
+            // reserve space from this Ui via `show` (the non-deprecated
+            // API; `show_inside` was renamed to `show` in egui 0.35).
+            let mut root_ui = egui::Ui::new(
+                ctx.clone(),
+                egui::Id::new("freminal_root"),
+                egui::UiBuilder::default(),
+            );
 
-                // Menu bar at the top of the window.
-                let menu_open = if self.config.ui.hide_menu_bar {
-                    false
-                } else {
-                    let (menu_action, menu_open) = Panel::top("menu_bar")
-                        .show(&mut root_ui, |ui| {
-                            self.show_menu_bar(ui, &mut win, window_id)
-                        })
-                        .inner;
-                    self.dispatch_tab_bar_action(menu_action, &mut win);
-                    menu_open
-                };
+            // #436.8: menu-bar / tab-bar rects, captured for the
+            // region-aware pointer chrome-gate (`is_chrome_interactive_at`).
+            // Only ever populated on a FULL frame — a REPLAY frame builds
+            // neither panel, so `win.chrome_head_rects` is left untouched
+            // (stale-but-still-correct: chrome hasn't moved since the
+            // FULL frame that last set it, by the same invariant that
+            // makes REPLAY safe at all).
+            let mut head_rects: Vec<egui::Rect> = Vec::new();
 
-                // Tab bar: shown when multiple tabs are open, or when the
-                // config option `tabs.show_single_tab` is enabled.
-                let show_tab_bar = win.tabs.tab_count() > 1 || self.config.tabs.show_single_tab;
-
-                if show_tab_bar {
-                    let panel = match self.config.tabs.position {
-                        freminal_common::config::TabBarPosition::Top => Panel::top("tab_bar"),
-                        freminal_common::config::TabBarPosition::Bottom => Panel::bottom("tab_bar"),
-                    };
-                    let tab_action = panel
-                        .show(&mut root_ui, |ui| self.show_tab_bar(&mut win, ui))
-                        .inner;
-                    self.dispatch_tab_bar_action(tab_action, &mut win);
-                }
-
-                (menu_open, Some(root_ui))
+            // Menu bar at the top of the window.
+            let menu_open = if self.config.ui.hide_menu_bar {
+                false
             } else {
-                (false, None)
+                let menu_response = Panel::top("menu_bar").show(&mut root_ui, |ui| {
+                    self.show_menu_bar(ui, &mut win, window_id)
+                });
+                head_rects.push(menu_response.response.rect);
+                let (menu_action, menu_open) = menu_response.inner;
+                self.dispatch_tab_bar_action(menu_action, &mut win);
+                menu_open
             };
+
+            // Tab bar: shown when multiple tabs are open, or when the
+            // config option `tabs.show_single_tab` is enabled.
+            let show_tab_bar = win.tabs.tab_count() > 1 || self.config.tabs.show_single_tab;
+
+            if show_tab_bar {
+                let panel = match self.config.tabs.position {
+                    freminal_common::config::TabBarPosition::Top => Panel::top("tab_bar"),
+                    freminal_common::config::TabBarPosition::Bottom => Panel::bottom("tab_bar"),
+                };
+                let tab_response = panel.show(&mut root_ui, |ui| self.show_tab_bar(&mut win, ui));
+                head_rects.push(tab_response.response.rect);
+                let tab_action = tab_response.inner;
+                self.dispatch_tab_bar_action(tab_action, &mut win);
+            }
+
+            win.chrome_head_rects = Some(head_rects);
+
+            (menu_open, Some(root_ui))
+        } else {
+            (false, None)
+        };
 
         // Help menu → "Keybindings..." routes here.  Opens the Settings
         // Modal with the Keybindings tab preselected, or focuses the
@@ -1727,6 +1751,11 @@ impl freminal_windowing::App for FreminalGui {
                 // on each side of the 1px border line).
                 let sensor_half: f32 = 3.0;
 
+                // #436.8: split-border drag-sensor rects, rebuilt fresh every
+                // frame this branch runs, for the region-aware pointer
+                // chrome-gate (`is_chrome_interactive_at`).
+                let mut border_rects: Vec<egui::Rect> = Vec::with_capacity(borders.len());
+
                 for (border_idx, border) in borders.iter().enumerate() {
                     // Expand the thin 1px border rect into a wider sensor rect.
                     let sensor_rect = match border.direction {
@@ -1747,6 +1776,8 @@ impl freminal_windowing::App for FreminalGui {
                             )
                         }
                     };
+
+                    border_rects.push(sensor_rect);
 
                     let sensor_id = ui.id().with("pane_border_sensor").with(border_idx);
                     let response =
@@ -1800,6 +1831,14 @@ impl freminal_windowing::App for FreminalGui {
                         win.border_drag = None;
                     }
                 }
+
+                win.chrome_border_rects = border_rects;
+            } else {
+                // No sensors built this frame (single pane / zoomed / overlay
+                // open): clear any stale rects from a since-changed layout so
+                // they can't keep classifying terminal content as chrome
+                // (#436.8).
+                win.chrome_border_rects.clear();
             }
 
             // ── Terminal band: shape-index range capture (#436.2a, range
@@ -3156,6 +3195,8 @@ impl FreminalGui {
             chrome_frames_rendered: 0,
             pending_terminal_requested_delay: None,
             cached_central_rect: None,
+            chrome_head_rects: None,
+            chrome_border_rects: Vec::new(),
         }
     }
 

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -17,6 +17,7 @@ use freminal_windowing::WindowId;
 use glow::HasContext;
 use tracing::{debug, error, trace, warn};
 
+use super::chrome_damage;
 use super::frame_damage;
 use super::panes;
 use super::renderer::WindowPostRenderer;
@@ -303,6 +304,13 @@ impl freminal_windowing::App for FreminalGui {
                             std::sync::atomic::AtomicBool::new(false),
                         ),
                         previous_active_pane_key: None,
+                        pending_chrome_damage: freminal_windowing::ChromeDamage::Changed,
+                        pending_chrome_signals: chrome_damage::ChromeSignals::default(),
+                        chrome_settle_pending: false,
+                        prev_dismissible_presence: chrome_damage::DismissiblePresence::default(),
+                        prev_chrome_tab_snapshot: chrome_damage::ChromeTabSnapshot::default(),
+                        prev_window_focused: false,
+                        chrome_frames_rendered: 0,
                     };
                     self.windows.insert(window_id, win);
 
@@ -531,6 +539,20 @@ impl freminal_windowing::App for FreminalGui {
             })
     }
 
+    fn take_chrome_damage(&mut self, window_id: WindowId) -> freminal_windowing::ChromeDamage {
+        // Drain the chrome-damage decision computed during `update()` for
+        // this window, leaving `Changed` behind so a stale `Unchanged` can
+        // never be reused by a later frame that does not recompute it.
+        self.windows
+            .get_mut(&window_id)
+            .map_or(freminal_windowing::ChromeDamage::Changed, |win| {
+                std::mem::replace(
+                    &mut win.pending_chrome_damage,
+                    freminal_windowing::ChromeDamage::Changed,
+                )
+            })
+    }
+
     // Inherently large: the main per-frame UI function handles menu bar, settings modal, window
     // manipulation drain, terminal widget layout, and resize detection — all in one pass over
     // the shared snapshot. Artificial sub-functions would not reduce the coupling.
@@ -670,6 +692,23 @@ impl freminal_windowing::App for FreminalGui {
             return;
         };
 
+        // ── Chrome-damage (#436.3): §3.5 "before" sample + warm-up counter ───
+        //
+        // Sampled as early as possible in `update()` — before ANY dialog's
+        // `.show(ctx)` this frame (including the toast stack's, which runs
+        // after `win` is reinserted at the end of this function) — so it
+        // reflects presence strictly BEFORE this frame's rendering can
+        // mutate it. Compared against the "after" sample taken once
+        // everything dismissible has shown (see the end of this function) to
+        // catch a self-dismissal that happens DURING this frame's rendering
+        // (adversarial finding 1; see `chrome_damage`'s module doc).
+        let chrome_dismissible_before = self.sample_dismissible_presence(&win);
+        // #436 §7 warm-up: force `Changed` for the first few frames after
+        // window creation, while font atlas / layout / PanelState id-maps
+        // are still settling.
+        let chrome_warming_up = win.chrome_frames_rendered < chrome_damage::WARMUP_FRAMES;
+        win.chrome_frames_rendered = win.chrome_frames_rendered.saturating_add(1);
+
         // ── Drain shader/renderer errors stashed by last frame's PaintCallback ──
         // PaintCallbacks run on the render thread and can't access `self`, so
         // they stash compile/init errors in `WindowPostRenderer::last_error`.
@@ -715,6 +754,11 @@ impl freminal_windowing::App for FreminalGui {
         // ── Track last known window geometry (for save_layout) ───────────────
         // Query the windowing layer directly.  See the settings-window branch
         // above for why `ctx.input().viewport()` is not reliable here.
+        //
+        // `chrome_size_before` is captured for the #436.3 §3.3 "window
+        // resize" chrome signal: compared against `win.last_known_size`
+        // after this block updates it.
+        let chrome_size_before = win.last_known_size;
         if let Some(geom) = handle.window_geometry(window_id) {
             if let Some(size) = geom.size {
                 win.last_known_size = Some(<[u32; 2]>::from(size));
@@ -723,6 +767,7 @@ impl freminal_windowing::App for FreminalGui {
                 win.last_known_position = Some(<[i32; 2]>::from(pos));
             }
         }
+        let chrome_size_changed = win.last_known_size != chrome_size_before;
 
         // ── Deferred egui font update from standalone settings window ────────
         win.terminal_widget
@@ -1064,10 +1109,14 @@ impl freminal_windowing::App for FreminalGui {
         // read the post-`ThemeChange` snapshot (a race that left the
         // background/chrome stale until a mouseover repaint).
         let bg_opacity = self.config.ui.background_opacity;
+        // Hoisted out of the block below (rather than a plain `let` inside
+        // it) so the #436.3 chrome-damage signal computed further down can
+        // read this frame's style-change verdict too.
+        let chrome_style_changed;
         {
             let gui_theme = self.gui_theme;
             let chrome_theme = self.preview_theme.unwrap_or(snap.theme);
-            let style_changed = match win.style_cache {
+            chrome_style_changed = match win.style_cache {
                 Some((prev_theme, prev_opacity, prev_gui_theme)) => {
                     !std::ptr::eq(prev_theme, chrome_theme)
                         || prev_opacity.to_bits() != bg_opacity.to_bits()
@@ -1075,7 +1124,7 @@ impl freminal_windowing::App for FreminalGui {
                 }
                 None => true,
             };
-            if style_changed {
+            if chrome_style_changed {
                 let visuals =
                     crate::gui::chrome_style::build_visuals(&gui_theme, chrome_theme, bg_opacity);
                 ctx.global_style_mut(|style| {
@@ -1215,6 +1264,9 @@ impl freminal_windowing::App for FreminalGui {
                 .active_tab()
                 .active_pane()
                 .is_some_and(|p| p.view_state.window_focused);
+            // #436.3 §3.3 "Window focus change" chrome signal.
+            let chrome_focus_changed = window_focused != win.prev_window_focused;
+            win.prev_window_focused = window_focused;
             // OSC 9 / OSC 777 notifications collected from every pane this
             // frame, routed after the loop (Task 76.4).
             let mut osc_notifications: Vec<crate::gui::notifications::NotificationRequest> =
@@ -2198,6 +2250,57 @@ impl freminal_windowing::App for FreminalGui {
                 &per_pane_damage,
             );
 
+            // ── Chrome-damage signals (#436.3 §3.3) ───────────────────
+            //
+            // Stage the individual §3.3 signals this frame, computed from
+            // values already available here (several — `ui_overlay_open`,
+            // `active_pane_changed`, `shader_recomposites`, `ppp_changed`,
+            // `chrome_focus_changed`, per-pane bell state — only exist inside
+            // this `CentralPanel` closure). The final `ChromeDamage` decision
+            // additionally needs the after-toast-render dismissible-presence
+            // sample, which can only be taken once this closure returns (the
+            // toast overlay renders after it) — so `win.pending_chrome_signals`
+            // is a staging value, combined into `win.pending_chrome_damage`
+            // near the end of `update()`.
+            let chrome_tab_snapshot = chrome_damage::ChromeTabSnapshot {
+                tab_ids: win.tabs.iter().map(|t| t.id).collect(),
+                active_tab_id: Some(win.tabs.active_tab().id),
+                tab_titles: win
+                    .tabs
+                    .iter()
+                    .map(|t| {
+                        t.display_name(
+                            self.config.tab_title.policy,
+                            &self.config.tab_title.separator,
+                        )
+                        .into_owned()
+                    })
+                    .collect(),
+                pane_ids: pane_layout.iter().map(|(id, _)| *id).collect(),
+                zoomed_pane,
+                broadcast_input: win.tabs.active_tab().broadcast_input,
+            };
+            let chrome_tab_diff =
+                chrome_damage::diff_tab_snapshots(&win.prev_chrome_tab_snapshot, &chrome_tab_snapshot);
+            win.prev_chrome_tab_snapshot = chrome_tab_snapshot;
+
+            win.pending_chrome_signals = chrome_damage::ChromeSignals {
+                any_overlay_open: ui_overlay_open,
+                style_changed: chrome_style_changed,
+                active_pane_changed,
+                tab_set_changed: chrome_tab_diff.tab_set_changed,
+                tab_title_changed: chrome_tab_diff.tab_title_changed,
+                pane_layout_changed: chrome_tab_diff.pane_layout_changed,
+                broadcast_state_changed: chrome_tab_diff.broadcast_state_changed,
+                shader_active: shader_recomposites,
+                bell_active: per_pane_damage.iter().any(|p| p.bell_active),
+                toast_active,
+                size_changed: chrome_size_changed,
+                ppp_changed,
+                focus_changed: chrome_focus_changed,
+                warming_up: chrome_warming_up,
+            };
+
             // ── Window-level post-processing pass ────────────────────
             //
             // When a user GLSL shader is active, the window FBO now contains
@@ -2549,6 +2652,44 @@ impl freminal_windowing::App for FreminalGui {
             stack.show(ctx);
         }
 
+        // ── Chrome-damage (#436.3): §3.5 "after" sample + final decision ─────
+        //
+        // Taken here — after every dismissible element's `.show(ctx)` this
+        // frame, including the toast stack's above — and diffed against
+        // `chrome_dismissible_before` (sampled at the very top of this
+        // function, before any of them showed) to catch a self-dismissal
+        // that happened DURING this frame's rendering (adversarial finding
+        // 1: e.g. a toast expiring in its own `.show()` and requesting no
+        // further repaint because the stack is now empty). Also diffed
+        // against `win.prev_dismissible_presence` (last frame's own "after"
+        // sample) to catch a transition caused by something other than the
+        // element's own self-dismissal (e.g. a menu action closing a
+        // dialog). Either comparison finding a difference counts as a
+        // transition — see `chrome_damage::dismissible_presence_transitioned`'s
+        // doc for why the intra-frame comparison is the load-bearing one.
+        let chrome_dismissible_after = self.sample_dismissible_presence(&win);
+        let chrome_presence_transitioned = chrome_damage::dismissible_presence_transitioned(
+            chrome_dismissible_before,
+            chrome_dismissible_after,
+        ) || chrome_damage::dismissible_presence_transitioned(
+            win.prev_dismissible_presence,
+            chrome_dismissible_after,
+        );
+        win.prev_dismissible_presence = chrome_dismissible_after;
+
+        // §3.5's "+ next frame FULL" half: read last frame's pending flag as
+        // this frame's settle input, then reassign it to THIS frame's own
+        // transition result for the next frame to read (no separate "reset"
+        // step — see `decide_chrome_damage`'s doc).
+        let chrome_settle_frame_pending = win.chrome_settle_pending;
+        win.chrome_settle_pending = chrome_presence_transitioned;
+
+        win.pending_chrome_damage = chrome_damage::decide_chrome_damage(
+            &win.pending_chrome_signals,
+            chrome_presence_transitioned,
+            chrome_settle_frame_pending,
+        );
+
         let elapsed = now.elapsed();
         let frame_time = if elapsed.as_millis() > 0 {
             format!("Frame time={}ms", elapsed.as_millis())
@@ -2613,6 +2754,32 @@ impl freminal_windowing::App for FreminalGui {
 }
 
 impl FreminalGui {
+    /// Sample the presence of every dismissible chrome element (#436 §3.5).
+    ///
+    /// Called twice per `update()` for the window being rendered — once as
+    /// early as possible (before any dialog's `.show(ctx)` this frame) and
+    /// once after all of them (including the shared toast stack's `.show`,
+    /// which runs after `win` is reinserted — see the call site) — so the
+    /// two samples can be diffed to catch a self-dismissal that happens
+    /// DURING a `.show()` call this same frame (adversarial finding 1).
+    fn sample_dismissible_presence(
+        &self,
+        win: &PerWindowState,
+    ) -> chrome_damage::DismissiblePresence {
+        chrome_damage::DismissiblePresence {
+            about: self.about_window_open,
+            welcome: self.welcome.is_open(),
+            paste_dialog: win.paste_dialog.is_open(),
+            broadcast_dialog: win.broadcast_dialog.is_open(),
+            close_dialog: win.close_dialog.is_open(),
+            save_layout_prompt: self.pending_save_layout.is_some(),
+            any_toast: self
+                .toasts
+                .try_borrow()
+                .is_ok_and(|stack| !stack.is_empty()),
+        }
+    }
+
     /// First-window spawn path when no layout or session restore will apply.
     ///
     /// Spawns a default single-pane PTY.  PTY-spawn failures surface as a
@@ -2811,6 +2978,13 @@ impl FreminalGui {
             pending_terminal_band_shapes: Vec::new(),
             present_is_partial: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             previous_active_pane_key: None,
+            pending_chrome_damage: freminal_windowing::ChromeDamage::Changed,
+            pending_chrome_signals: chrome_damage::ChromeSignals::default(),
+            chrome_settle_pending: false,
+            prev_dismissible_presence: chrome_damage::DismissiblePresence::default(),
+            prev_chrome_tab_snapshot: chrome_damage::ChromeTabSnapshot::default(),
+            prev_window_focused: false,
+            chrome_frames_rendered: 0,
         }
     }
 

--- a/freminal/src/gui/chrome_damage.rs
+++ b/freminal/src/gui/chrome_damage.rs
@@ -110,6 +110,17 @@ pub struct ChromeSignals {
     /// creation (#436 §7) — force `Changed` unconditionally until steady
     /// state.
     pub warming_up: bool,
+    /// Any rendered pane has an open overlay that paints ABOVE the terminal
+    /// band: the `Order::Foreground` right-click context menu, in-terminal
+    /// search bar, or command-history palette, OR the `Order::Tooltip`
+    /// URL-hover tooltip. These all paint outside the captured terminal-band
+    /// range (TAIL chrome), so a REPLAY frame would otherwise discard their
+    /// freshly-built shapes and repaint the stale cached tail from before the
+    /// overlay opened — making the open overlay vanish or ghost. Issue #436 §1
+    /// names context-menu/command-history and the URL tooltip as chrome that
+    /// must be covered. (The name predates the tooltip addition; it covers all
+    /// above-band per-pane terminal overlays, not only `Order::Foreground`.)
+    pub foreground_overlay_open: bool,
 }
 
 impl ChromeSignals {
@@ -131,6 +142,7 @@ impl ChromeSignals {
             || self.ppp_changed
             || self.focus_changed
             || self.warming_up
+            || self.foreground_overlay_open
     }
 }
 
@@ -297,7 +309,7 @@ mod tests {
     #[test]
     fn each_signal_field_alone_forces_changed() {
         type Setter = fn(&mut ChromeSignals);
-        let setters: [(&str, Setter); 14] = [
+        let setters: [(&str, Setter); 15] = [
             ("any_overlay_open", |s| s.any_overlay_open = true),
             ("style_changed", |s| s.style_changed = true),
             ("active_pane_changed", |s| s.active_pane_changed = true),
@@ -314,6 +326,9 @@ mod tests {
             ("ppp_changed", |s| s.ppp_changed = true),
             ("focus_changed", |s| s.focus_changed = true),
             ("warming_up", |s| s.warming_up = true),
+            ("foreground_overlay_open", |s| {
+                s.foreground_overlay_open = true;
+            }),
         ];
 
         for (name, set) in setters {
@@ -325,6 +340,27 @@ mod tests {
                 "expected field `{name}` alone to force Changed"
             );
         }
+    }
+
+    /// Regression test for the #436.4b defect: an open per-pane
+    /// `Order::Foreground` overlay (context menu, in-terminal search bar, or
+    /// command-history palette) must alone force `Changed`, so a REPLAY
+    /// frame never discards its freshly-built shapes in favor of the stale
+    /// cached tail chrome from before the overlay opened. The table test
+    /// above also covers this row; this test documents the fix intent
+    /// explicitly since it is a targeted regression fix rather than a
+    /// generic table entry.
+    #[test]
+    fn foreground_overlay_open_alone_forces_changed() {
+        let signals = ChromeSignals {
+            foreground_overlay_open: true,
+            ..ChromeSignals::default()
+        };
+        assert_eq!(
+            decide_chrome_damage(&signals, false, false),
+            ChromeDamage::Changed,
+            "an open context-menu/search-bar/command-history overlay must force Changed"
+        );
     }
 
     #[test]

--- a/freminal/src/gui/chrome_damage.rs
+++ b/freminal/src/gui/chrome_damage.rs
@@ -836,4 +836,47 @@ mod tests {
             &border,
         ));
     }
+
+    // ── #436.8 `is_chrome_interactive_at` wrapper decision (436.9 follow-up) ──
+    //
+    // `FreminalGui::is_chrome_interactive_at` (app_impl.rs) is
+    //   `self.windows.get(&window_id).is_none_or(|win|
+    //        point_in_chrome_rects(pos, win.chrome_head_rects, win.chrome_border_rects))`
+    // The point-in-rects half is pinned exhaustively above. The distinct
+    // behavior the wrapper adds is the `is_none_or` fallback: an UNKNOWN
+    // `window_id` (no `PerWindowState` entry) is conservatively chrome-
+    // interactive (`true`), same discipline as `None` head rects. A full
+    // wrapper test needs a `FreminalGui` (no headless constructor — see the
+    // 436.2a/436.4 notes and `app_impl.rs` test-module doc comment), so we
+    // model the composed `is_none_or` decision here with a local closure that
+    // mirrors the wrapper exactly, guarding against a regression in that
+    // composition (e.g. flipping the unknown-window default to `false`, which
+    // would silently starve a chrome interaction of repaints on a window whose
+    // state is mid-teardown).
+    #[test]
+    fn is_chrome_interactive_at_unknown_window_is_conservative_true() {
+        // Mirror of the wrapper: `None` window => true, else delegate.
+        let decide = |window_present: Option<(Option<&[egui::Rect]>, &[egui::Rect])>,
+                      pos: egui::Pos2|
+         -> bool {
+            window_present.is_none_or(|(head, border)| point_in_chrome_rects(pos, head, border))
+        };
+
+        // Unknown window (None) -> true regardless of position.
+        assert!(decide(None, egui::pos2(500.0, 500.0)));
+
+        // Known window, point over terminal content, captured (empty) rects
+        // -> false (delegates to point_in_chrome_rects, which is false).
+        assert!(!decide(Some((Some(&[]), &[])), egui::pos2(500.0, 500.0)));
+
+        // Known window, point inside a captured head rect -> true.
+        let head = [egui::Rect::from_min_max(
+            egui::pos2(0.0, 0.0),
+            egui::pos2(100.0, 20.0),
+        )];
+        assert!(decide(Some((Some(&head), &[])), egui::pos2(50.0, 10.0)));
+
+        // Known window, head rects not yet captured (None) -> conservative true.
+        assert!(decide(Some((None, &[])), egui::pos2(50.0, 10.0)));
+    }
 }

--- a/freminal/src/gui/chrome_damage.rs
+++ b/freminal/src/gui/chrome_damage.rs
@@ -50,6 +50,16 @@ use crate::gui::tabs::TabId;
 /// steady state.
 pub const WARMUP_FRAMES: u32 = 3;
 
+/// Whether a window is still in its startup warm-up window (#436 §7): the
+/// first [`WARMUP_FRAMES`] rendered frames are always forced `Changed` while
+/// the font atlas / layout / `PanelState` id-maps settle. `frames_rendered`
+/// is the count of frames rendered so far for this window (0 on the very
+/// first frame).
+#[must_use]
+pub const fn is_chrome_warming_up(frames_rendered: u32) -> bool {
+    frames_rendered < WARMUP_FRAMES
+}
+
 /// Everything the app measured this frame that bears on whether static
 /// chrome changed (#436 §3.3). Each field maps to a row of the §3.3 table
 /// that the app can compute without any `run_frame`-side state; see the
@@ -280,8 +290,8 @@ pub const fn decide_chrome_damage(
 #[cfg(test)]
 mod tests {
     use super::{
-        ChromeSignals, ChromeTabSnapshot, DismissiblePresence, decide_chrome_damage,
-        diff_tab_snapshots, dismissible_presence_transitioned,
+        ChromeSignals, ChromeTabSnapshot, DismissiblePresence, WARMUP_FRAMES, decide_chrome_damage,
+        diff_tab_snapshots, dismissible_presence_transitioned, is_chrome_warming_up,
     };
     use crate::gui::panes::{PaneId, PaneIdGenerator};
     use crate::gui::tabs::TabId;
@@ -691,5 +701,38 @@ mod tests {
         assert!(!diff.tab_set_changed);
         assert!(!diff.tab_title_changed);
         assert!(!diff.pane_layout_changed);
+    }
+
+    // ── #436.7 §7 warm-up ───────────────────────────────────────────────
+
+    #[test]
+    fn warming_up_covers_exactly_the_first_warmup_frames() {
+        // Frames 0..WARMUP_FRAMES are warming up; WARMUP_FRAMES onward are not.
+        for frames_rendered in 0..WARMUP_FRAMES {
+            assert!(
+                is_chrome_warming_up(frames_rendered),
+                "frame {frames_rendered} (< {WARMUP_FRAMES}) must still be warming up"
+            );
+        }
+        for frames_rendered in WARMUP_FRAMES..(WARMUP_FRAMES + 3) {
+            assert!(
+                !is_chrome_warming_up(frames_rendered),
+                "frame {frames_rendered} (>= {WARMUP_FRAMES}) must be past warm-up"
+            );
+        }
+    }
+
+    #[test]
+    fn warming_up_forces_chrome_damage_changed() {
+        // The warm-up signal, alone, must force Changed (so the first frames
+        // are never REPLAYed before steady state).
+        let signals = ChromeSignals {
+            warming_up: true,
+            ..ChromeSignals::default()
+        };
+        assert_eq!(
+            decide_chrome_damage(&signals, false, false),
+            ChromeDamage::Changed
+        );
     }
 }

--- a/freminal/src/gui/chrome_damage.rs
+++ b/freminal/src/gui/chrome_damage.rs
@@ -287,11 +287,24 @@ pub const fn decide_chrome_damage(
     }
 }
 
+/// #436.8: is `pos` over any chrome-interactive rect? `head_rects == None`
+/// means no FULL frame has captured them yet -> conservative `true`.
+#[must_use]
+pub fn point_in_chrome_rects(
+    pos: egui::Pos2,
+    head_rects: Option<&[egui::Rect]>,
+    border_rects: &[egui::Rect],
+) -> bool {
+    let Some(head) = head_rects else { return true };
+    head.iter().any(|r| r.contains(pos)) || border_rects.iter().any(|r| r.contains(pos))
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         ChromeSignals, ChromeTabSnapshot, DismissiblePresence, WARMUP_FRAMES, decide_chrome_damage,
         diff_tab_snapshots, dismissible_presence_transitioned, is_chrome_warming_up,
+        point_in_chrome_rects,
     };
     use crate::gui::panes::{PaneId, PaneIdGenerator};
     use crate::gui::tabs::TabId;
@@ -734,5 +747,93 @@ mod tests {
             decide_chrome_damage(&signals, false, false),
             ChromeDamage::Changed
         );
+    }
+
+    // ── #436.8 region-aware pointer gate ─────────────────────────────────
+
+    #[test]
+    fn point_in_chrome_rects_none_head_is_conservative_true() {
+        // No FULL frame has captured head rects yet -> unknown -> true.
+        assert!(point_in_chrome_rects(egui::pos2(10.0, 10.0), None, &[],));
+    }
+
+    #[test]
+    fn point_in_chrome_rects_empty_rects_is_false() {
+        // A FULL frame captured (empty) head rects (e.g. hidden menu bar, no
+        // tab bar) and there are no border sensors: nothing is chrome.
+        assert!(!point_in_chrome_rects(
+            egui::pos2(10.0, 10.0),
+            Some(&[]),
+            &[],
+        ));
+    }
+
+    #[test]
+    fn point_in_chrome_rects_inside_head_rect_is_true() {
+        let head = [egui::Rect::from_min_max(
+            egui::pos2(0.0, 0.0),
+            egui::pos2(100.0, 20.0),
+        )];
+        assert!(point_in_chrome_rects(
+            egui::pos2(50.0, 10.0),
+            Some(&head),
+            &[],
+        ));
+    }
+
+    #[test]
+    fn point_in_chrome_rects_outside_head_rect_is_false() {
+        let head = [egui::Rect::from_min_max(
+            egui::pos2(0.0, 0.0),
+            egui::pos2(100.0, 20.0),
+        )];
+        assert!(!point_in_chrome_rects(
+            egui::pos2(50.0, 100.0),
+            Some(&head),
+            &[],
+        ));
+    }
+
+    #[test]
+    fn point_in_chrome_rects_inside_border_rect_is_true() {
+        let border = [egui::Rect::from_min_max(
+            egui::pos2(97.0, 0.0),
+            egui::pos2(103.0, 200.0),
+        )];
+        assert!(point_in_chrome_rects(
+            egui::pos2(100.0, 50.0),
+            Some(&[]),
+            &border,
+        ));
+    }
+
+    #[test]
+    fn point_in_chrome_rects_outside_border_rect_is_false() {
+        let border = [egui::Rect::from_min_max(
+            egui::pos2(97.0, 0.0),
+            egui::pos2(103.0, 200.0),
+        )];
+        assert!(!point_in_chrome_rects(
+            egui::pos2(300.0, 50.0),
+            Some(&[]),
+            &border,
+        ));
+    }
+
+    #[test]
+    fn point_in_chrome_rects_inside_neither_is_false() {
+        let head = [egui::Rect::from_min_max(
+            egui::pos2(0.0, 0.0),
+            egui::pos2(100.0, 20.0),
+        )];
+        let border = [egui::Rect::from_min_max(
+            egui::pos2(97.0, 0.0),
+            egui::pos2(103.0, 200.0),
+        )];
+        assert!(!point_in_chrome_rects(
+            egui::pos2(500.0, 500.0),
+            Some(&head),
+            &border,
+        ));
     }
 }

--- a/freminal/src/gui/chrome_damage.rs
+++ b/freminal/src/gui/chrome_damage.rs
@@ -1,0 +1,659 @@
+// Copyright (C) 2024-2026 Fred Clausen
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Chrome-damage decision (#436.3), extracted for reuse and unit testing.
+//!
+//! This module produces [`freminal_windowing::ChromeDamage`] — the #436
+//! decision input for whether static chrome (menu bar, tab bar, pane
+//! borders, broadcast label, and every overlay: modals/toasts/tooltips/
+//! popups) changed on the frame just rendered. It implements two of the
+//! three signal families from the design (`gh issue view 436`):
+//!
+//! - **§3.3 "app-level chrome-change signals"**: [`ChromeSignals`] bundles
+//!   the individual per-frame booleans the app already computes (or can
+//!   cheaply compute) for each row of the §3.3 table. [`ChromeSignals::any_fired`]
+//!   ORs them together.
+//! - **§3.5 "self-dismissal settle rule"** (adversarial finding 1): a
+//!   dismissible chrome element (toast, About, Welcome, paste/broadcast/
+//!   close-guard dialogs, save-layout prompt) can vanish *during its own
+//!   render pass* (the proven toast hazard: it draws itself, then
+//!   `retain`-removes itself as expired, then requests no further repaint
+//!   because the stack is now empty). Comparing this frame's post-render
+//!   state to *last frame's* post-render state shows no delta and misses
+//!   the transition entirely. [`DismissiblePresence`] + [`dismissible_presence_transitioned`]
+//!   implement the fix: presence is sampled *before* any dismissible
+//!   element's `.show(ctx)` call this frame and *after* all of them, and
+//!   the two samples are diffed — catching the transition even when the
+//!   cross-frame (last-frame-vs-this-frame) comparison would not.
+//!
+//! **NOT covered here** (explicitly deferred to their own subtasks, per the
+//! design): §3.1 (egui's own `repaint_delay`) and §3.2 (chrome-affecting
+//! input events, including the region-aware pointer-motion gate) are
+//! `run_frame`-side signals owned by 436.4/436.9. The §5.2 font-atlas-resize
+//! retroactive-FULL fallback is also 436.4/436.6 — it can only be detected
+//! *after* the terminal band tessellates, which does not exist as a
+//! separate pass yet. This module produces app-level signals only; it does
+//! not yet feed into `run_frame` (that wiring is 436.4).
+//!
+//! Like [`super::frame_damage`], every function here is pure — no `self`,
+//! no `egui` context, no window state — so it is directly unit-testable.
+
+use crate::gui::panes::PaneId;
+use crate::gui::tabs::TabId;
+
+/// Number of frames after window creation during which chrome is always
+/// forced `Changed` (#436 §7 warm-up). The font atlas, layout, and
+/// `PanelState` id-maps settle over the first 1-2 frames; giving a small
+/// margin (3) is cheap insurance against a REPLAY being permitted before
+/// steady state.
+pub const WARMUP_FRAMES: u32 = 3;
+
+/// Everything the app measured this frame that bears on whether static
+/// chrome changed (#436 §3.3). Each field maps to a row of the §3.3 table
+/// that the app can compute without any `run_frame`-side state; see the
+/// module doc for what is deliberately NOT here (§3.1/§3.2 egui-side
+/// signals, §5.2 font-atlas resize).
+///
+/// All fields independently force `Changed` when true — see
+/// [`ChromeSignals::any_fired`]. Each is an unrelated, independently-sourced
+/// per-frame observation (not a state machine), which is why this is a flat
+/// bag of bools rather than an enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct ChromeSignals {
+    /// Any menu/dropdown, modal/dialog, or tab-rename editor open
+    /// (`ui_overlay_open` in `app_impl.rs`, itself `any_menu_open ||
+    /// pending_save_layout.is_some() || about_window_open ||
+    /// welcome.is_open() || renaming_tab.is_some() || paste_dialog.is_open()
+    /// || broadcast_dialog.is_open() || close_dialog.is_open()`).
+    pub any_overlay_open: bool,
+    /// Theme, profile, or background-opacity change (`style_cache` miss).
+    pub style_changed: bool,
+    /// The active pane changed (pane switch within a tab, or a tab switch)
+    /// — moves the active-pane border highlight.
+    pub active_pane_changed: bool,
+    /// Tab count, tab-id-list, or active-tab id changed vs. last frame.
+    pub tab_set_changed: bool,
+    /// Any tab's resolved display name changed vs. last frame (rename, OSC
+    /// title, or a `TabTitlePolicy` recombination of the two).
+    pub tab_title_changed: bool,
+    /// The active tab's rendered pane set (split/close) or zoom state
+    /// changed vs. last frame — pane borders move/appear/disappear.
+    pub pane_layout_changed: bool,
+    /// The active tab's broadcast-input flag changed vs. last frame — the
+    /// broadcast label and border tint appear/disappear/retint.
+    pub broadcast_state_changed: bool,
+    /// A window-post-process shader is active or has a pending
+    /// (re)compile (`shader_recomposites` in `app_impl.rs`) — it
+    /// recomposites the whole window every frame, redrawing chrome on top.
+    pub shader_active: bool,
+    /// Any rendered pane has an active bell flash.
+    pub bell_active: bool,
+    /// Any toast is currently on the stack. Unlike the other rows, this
+    /// does not by itself prove a *transition* — it is the "stays forced
+    /// while visible" half; the *transition* half (added/expired) is
+    /// covered separately by [`DismissiblePresence`]/§3.5, mirroring how
+    /// `toast_active` also forces `FrameDamage::Full` every frame it is up
+    /// in `decide_frame_damage` (#435) for the same reason (a toast's
+    /// hover/dismiss hit-test needs live input testing, not stale cache).
+    pub toast_active: bool,
+    /// The window's inner size (physical pixels) changed vs. last frame.
+    pub size_changed: bool,
+    /// `pixels_per_point` (DPI/scale-factor) changed vs. last frame.
+    pub ppp_changed: bool,
+    /// The window gained or lost OS focus this frame — affects the active
+    /// pane's border/cursor style.
+    pub focus_changed: bool,
+    /// Still within the first [`WARMUP_FRAMES`] frames since window
+    /// creation (#436 §7) — force `Changed` unconditionally until steady
+    /// state.
+    pub warming_up: bool,
+}
+
+impl ChromeSignals {
+    /// Whether any individual §3.3 signal fired this frame. A `true` from
+    /// any field forces the frame `Changed`; only when *every* field is
+    /// `false` does this contribute nothing to the decision.
+    const fn any_fired(&self) -> bool {
+        self.any_overlay_open
+            || self.style_changed
+            || self.active_pane_changed
+            || self.tab_set_changed
+            || self.tab_title_changed
+            || self.pane_layout_changed
+            || self.broadcast_state_changed
+            || self.shader_active
+            || self.bell_active
+            || self.toast_active
+            || self.size_changed
+            || self.ppp_changed
+            || self.focus_changed
+            || self.warming_up
+    }
+}
+
+/// Presence of each dismissible chrome element, sampled once per frame.
+///
+/// Field order/identity is stable frame-to-frame (it is a fixed struct, not
+/// a dynamic collection), which is what makes a plain `PartialEq` diff
+/// ([`dismissible_presence_transitioned`]) a correct membership-change test.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct DismissiblePresence {
+    /// The "About Freminal" dialog (`FreminalGui::about_window_open`).
+    pub about: bool,
+    /// The first-run welcome overlay (`FreminalGui::welcome`).
+    pub welcome: bool,
+    /// The smart-paste-guard confirmation dialog (`PerWindowState::paste_dialog`).
+    pub paste_dialog: bool,
+    /// The broadcast-input confirmation dialog (`PerWindowState::broadcast_dialog`).
+    pub broadcast_dialog: bool,
+    /// The close-on-running-command guard dialog (`PerWindowState::close_dialog`).
+    pub close_dialog: bool,
+    /// The floating "Save Layout" name-entry prompt (`FreminalGui::pending_save_layout`).
+    pub save_layout_prompt: bool,
+    /// Whether the shared toast stack is non-empty (`FreminalGui::toasts`).
+    pub any_toast: bool,
+}
+
+/// #436 §3.5 self-dismissal settle rule (adversarial finding 1): a
+/// dismissible element transitioning present<->absent must force THIS frame
+/// AND the next frame FULL, so the cache is never rebuilt from the frame that
+/// still contains a vanishing element. Returns true if `prev != current`
+/// (any element changed presence this frame).
+///
+/// The caller is responsible for calling this twice per frame and OR-ing the
+/// results — once for the before-`.show()`-vs-after-`.show()` comparison
+/// (which is the one that catches the toast intra-frame self-dismissal
+/// hazard) and once for the after-this-frame-vs-after-last-frame comparison
+/// (which catches an element opened/closed by something other than its own
+/// `.show()`, e.g. a menu action). See the finding-1 test below for why the
+/// intra-frame comparison is load-bearing and the cross-frame one alone is
+/// not sufficient.
+pub fn dismissible_presence_transitioned(
+    prev: DismissiblePresence,
+    current: DismissiblePresence,
+) -> bool {
+    prev != current
+}
+
+/// Per-tab/pane snapshot used to detect the §3.3 "tab set changed" / "tab
+/// title changed" / "pane layout changed" / "broadcast state changed" rows
+/// between frames. Captured once per frame from data the app already has;
+/// comparing two snapshots (via [`diff_tab_snapshots`]) yields the four
+/// independent booleans those rows need.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ChromeTabSnapshot {
+    /// Tab ids in display order — captures add/remove/reorder.
+    pub tab_ids: Vec<TabId>,
+    /// The active tab's id — captures a tab switch even when the id list
+    /// and order are otherwise unchanged.
+    pub active_tab_id: Option<TabId>,
+    /// Each tab's resolved display name (under the active `TabTitlePolicy`),
+    /// in the same order as `tab_ids` — captures rename / OSC-title changes.
+    pub tab_titles: Vec<String>,
+    /// Leaf pane ids actually laid out this frame, in layout order — the
+    /// same set/order `pane_layout` produces. Captures split/close.
+    pub pane_ids: Vec<PaneId>,
+    /// The active tab's zoomed pane, if any — captures zoom enter/exit.
+    pub zoomed_pane: Option<PaneId>,
+    /// The active tab's broadcast-input flag.
+    pub broadcast_input: bool,
+}
+
+/// Result of comparing two [`ChromeTabSnapshot`]s: one boolean per §3.3 row
+/// this snapshot covers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+// Four independent §3.3 table rows, each an unrelated per-frame observation
+// (not a state machine) -- same rationale as `ChromeSignals`/`DismissiblePresence`.
+#[allow(clippy::struct_excessive_bools)]
+pub struct ChromeTabSnapshotDiff {
+    pub tab_set_changed: bool,
+    pub tab_title_changed: bool,
+    pub pane_layout_changed: bool,
+    pub broadcast_state_changed: bool,
+}
+
+/// Pure diff of two [`ChromeTabSnapshot`]s into the four §3.3 booleans it
+/// covers. See [`ChromeTabSnapshotDiff`] for the field-to-row mapping.
+pub fn diff_tab_snapshots(
+    prev: &ChromeTabSnapshot,
+    current: &ChromeTabSnapshot,
+) -> ChromeTabSnapshotDiff {
+    ChromeTabSnapshotDiff {
+        tab_set_changed: prev.tab_ids != current.tab_ids
+            || prev.active_tab_id != current.active_tab_id,
+        tab_title_changed: prev.tab_titles != current.tab_titles,
+        pane_layout_changed: prev.pane_ids != current.pane_ids
+            || prev.zoomed_pane != current.zoomed_pane,
+        broadcast_state_changed: prev.broadcast_input != current.broadcast_input,
+    }
+}
+
+/// Decide this frame's [`freminal_windowing::ChromeDamage`] (#436 §3.3 +
+/// §3.5). Returns [`freminal_windowing::ChromeDamage::Changed`] if ANY §3.3
+/// signal fired ([`ChromeSignals::any_fired`]) OR a dismissible element
+/// transitioned this frame OR the previous frame flagged a pending settle
+/// frame; [`freminal_windowing::ChromeDamage::Unchanged`] only when none of
+/// those fired.
+///
+/// `presence_transitioned` is the OR of both [`dismissible_presence_transitioned`]
+/// comparisons the caller is expected to make (intra-frame before/after, and
+/// cross-frame after-vs-last-frame) — see that function's doc.
+///
+/// `settle_frame_pending` is the **other** half of the §3.5 settle rule: a
+/// transition forces BOTH this frame and the NEXT frame `Changed`. The
+/// caller carries this by remembering "a transition happened last frame"
+/// (e.g. a `chrome_settle_pending: bool` field on its per-window state,
+/// simply reassigned to this frame's `presence_transitioned` value at the
+/// end of every frame — no separate reset step is needed since the flag is
+/// always freshly recomputed, never accumulated) and feeding it in here as
+/// `settle_frame_pending` on the *next* frame.
+///
+/// Pure: no `self`/`egui`/window state, so directly unit-testable.
+pub const fn decide_chrome_damage(
+    signals: &ChromeSignals,
+    presence_transitioned: bool,
+    settle_frame_pending: bool,
+) -> freminal_windowing::ChromeDamage {
+    if signals.any_fired() || presence_transitioned || settle_frame_pending {
+        freminal_windowing::ChromeDamage::Changed
+    } else {
+        freminal_windowing::ChromeDamage::Unchanged
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ChromeSignals, ChromeTabSnapshot, DismissiblePresence, decide_chrome_damage,
+        diff_tab_snapshots, dismissible_presence_transitioned,
+    };
+    use crate::gui::panes::{PaneId, PaneIdGenerator};
+    use crate::gui::tabs::TabId;
+    use freminal_windowing::ChromeDamage;
+
+    /// A `PaneId` distinct from [`PaneId::first`], for tests that need two
+    /// different pane identities. `PaneId`'s inner field is private outside
+    /// its module, so a second id must come from a generator.
+    fn second_pane_id() -> PaneId {
+        PaneIdGenerator::new(1).next_id()
+    }
+
+    #[test]
+    fn no_signals_no_transition_no_pending_is_unchanged() {
+        let signals = ChromeSignals::default();
+        assert_eq!(
+            decide_chrome_damage(&signals, false, false),
+            ChromeDamage::Unchanged
+        );
+    }
+
+    /// Table test: every individual `ChromeSignals` field, set alone (all
+    /// others false), forces `Changed`. Exercises every §3.3 row this module
+    /// covers.
+    #[test]
+    fn each_signal_field_alone_forces_changed() {
+        type Setter = fn(&mut ChromeSignals);
+        let setters: [(&str, Setter); 14] = [
+            ("any_overlay_open", |s| s.any_overlay_open = true),
+            ("style_changed", |s| s.style_changed = true),
+            ("active_pane_changed", |s| s.active_pane_changed = true),
+            ("tab_set_changed", |s| s.tab_set_changed = true),
+            ("tab_title_changed", |s| s.tab_title_changed = true),
+            ("pane_layout_changed", |s| s.pane_layout_changed = true),
+            ("broadcast_state_changed", |s| {
+                s.broadcast_state_changed = true;
+            }),
+            ("shader_active", |s| s.shader_active = true),
+            ("bell_active", |s| s.bell_active = true),
+            ("toast_active", |s| s.toast_active = true),
+            ("size_changed", |s| s.size_changed = true),
+            ("ppp_changed", |s| s.ppp_changed = true),
+            ("focus_changed", |s| s.focus_changed = true),
+            ("warming_up", |s| s.warming_up = true),
+        ];
+
+        for (name, set) in setters {
+            let mut signals = ChromeSignals::default();
+            set(&mut signals);
+            assert_eq!(
+                decide_chrome_damage(&signals, false, false),
+                ChromeDamage::Changed,
+                "expected field `{name}` alone to force Changed"
+            );
+        }
+    }
+
+    #[test]
+    fn presence_transitioned_forces_changed_with_no_other_signals() {
+        let signals = ChromeSignals::default();
+        assert_eq!(
+            decide_chrome_damage(&signals, true, false),
+            ChromeDamage::Changed
+        );
+    }
+
+    #[test]
+    fn settle_frame_pending_forces_changed_with_no_other_signals() {
+        // This is the "+ next frame" half of the §3.5 settle rule: even
+        // with nothing else happening this frame, a pending settle from a
+        // transition on the PREVIOUS frame still forces Changed.
+        let signals = ChromeSignals::default();
+        assert_eq!(
+            decide_chrome_damage(&signals, false, true),
+            ChromeDamage::Changed
+        );
+    }
+
+    #[test]
+    fn dismissible_presence_equal_is_not_transitioned() {
+        let a = DismissiblePresence::default();
+        let b = DismissiblePresence::default();
+        assert!(!dismissible_presence_transitioned(a, b));
+    }
+
+    /// Table test: each individual `DismissiblePresence` field, differing
+    /// alone between `prev` and `current`, is detected as a transition.
+    #[test]
+    fn each_dismissible_field_differing_alone_is_transitioned() {
+        let base = DismissiblePresence::default();
+
+        let variants: Vec<(&str, DismissiblePresence)> = vec![
+            (
+                "about",
+                DismissiblePresence {
+                    about: true,
+                    ..base
+                },
+            ),
+            (
+                "welcome",
+                DismissiblePresence {
+                    welcome: true,
+                    ..base
+                },
+            ),
+            (
+                "paste_dialog",
+                DismissiblePresence {
+                    paste_dialog: true,
+                    ..base
+                },
+            ),
+            (
+                "broadcast_dialog",
+                DismissiblePresence {
+                    broadcast_dialog: true,
+                    ..base
+                },
+            ),
+            (
+                "close_dialog",
+                DismissiblePresence {
+                    close_dialog: true,
+                    ..base
+                },
+            ),
+            (
+                "save_layout_prompt",
+                DismissiblePresence {
+                    save_layout_prompt: true,
+                    ..base
+                },
+            ),
+            (
+                "any_toast",
+                DismissiblePresence {
+                    any_toast: true,
+                    ..base
+                },
+            ),
+        ];
+
+        for (name, changed) in variants {
+            assert!(
+                dismissible_presence_transitioned(base, changed),
+                "expected field `{name}` differing alone to be a transition"
+            );
+        }
+    }
+
+    /// Models the app-side §3.5 state machine described in
+    /// `decide_chrome_damage`'s doc: `chrome_settle_pending` is simply
+    /// reassigned to this frame's `presence_transitioned` at the end of
+    /// every frame (no separate "reset" call). Verifies the full sequence:
+    /// a transition on frame N forces N AND N+1 `Changed`, then N+2 (with
+    /// nothing else happening) is `Unchanged`.
+    #[test]
+    fn settle_sequence_forces_two_full_frames_after_a_transition() {
+        let no_signals = ChromeSignals::default();
+        let mut settle_pending = false;
+
+        // Frame N: a presence transition happens (e.g. a dialog closes).
+        let transitioned_n = true;
+        let decision_n = decide_chrome_damage(&no_signals, transitioned_n, settle_pending);
+        assert_eq!(decision_n, ChromeDamage::Changed, "frame N must be Changed");
+        // App-side: carry this frame's transition into the next frame's
+        // pending flag.
+        settle_pending = transitioned_n;
+
+        // Frame N+1: no new transition, but the settle-pending flag from N
+        // alone must force Changed.
+        let transitioned_n1 = false;
+        let decision_n1 = decide_chrome_damage(&no_signals, transitioned_n1, settle_pending);
+        assert_eq!(
+            decision_n1,
+            ChromeDamage::Changed,
+            "frame N+1 must be Changed (settle frame)"
+        );
+        settle_pending = transitioned_n1;
+
+        // Frame N+2: nothing happening at all -> Unchanged.
+        let transitioned_n2 = false;
+        let decision_n2 = decide_chrome_damage(&no_signals, transitioned_n2, settle_pending);
+        assert_eq!(
+            decision_n2,
+            ChromeDamage::Unchanged,
+            "frame N+2 must be Unchanged once the settle frame has passed"
+        );
+    }
+
+    /// **Mandatory finding-1 test.** Reproduces the exact toast hazard
+    /// verbatim from the design: a toast is present when its `.show(ctx)`
+    /// begins on frame N, expires and `retain`-removes itself DURING that
+    /// same call, and — because the stack is now empty — the toast stack
+    /// requests no further repaint. The PREVIOUS frame's post-`.show()`
+    /// state was *already* toast-absent (nothing distinguishes frame N-1's
+    /// end state from frame N's end state), so a naive comparison against
+    /// only last frame's post-mutation state sees NO delta and would wrongly
+    /// permit a REPLAY that keeps painting the (now-ghost) toast forever.
+    ///
+    /// This test asserts that the naive cross-frame comparison indeed misses
+    /// it (documenting the exact bug this subtask exists to prevent) and
+    /// that the mandatory before/after-WITHIN-FRAME comparison catches it —
+    /// i.e. if the before/after-within-frame diff were removed and only the
+    /// cross-frame diff were fed into `decide_chrome_damage`, frame N would
+    /// wrongly compute `Unchanged` instead of `Changed`.
+    #[test]
+    fn finding_1_toast_self_dismissal_ghost_is_caught_by_before_after_diff() {
+        // Frame N: the toast is present right before its `.show(ctx)` call.
+        let before = DismissiblePresence {
+            any_toast: true,
+            ..DismissiblePresence::default()
+        };
+        // ...but it expired and removed itself DURING that same `.show()`
+        // call (toast.rs: draws, `retain`-removes the expired entry, then
+        // only `request_repaint_after`s if the stack is still non-empty).
+        let after = DismissiblePresence {
+            any_toast: false,
+            ..DismissiblePresence::default()
+        };
+        // Last frame's post-`.show()` state was ALSO toast-absent (the toast
+        // was created and fully expired within frame N itself, or simply
+        // frame N-1 ended with no toast visible either way).
+        let prev_frame_after = DismissiblePresence {
+            any_toast: false,
+            ..DismissiblePresence::default()
+        };
+
+        // The BUG this subtask exists to prevent: the naive cross-frame
+        // comparison (this frame's `after` vs last frame's `after`) sees NO
+        // change.
+        let naive_cross_frame_transitioned =
+            dismissible_presence_transitioned(prev_frame_after, after);
+        assert!(
+            !naive_cross_frame_transitioned,
+            "naive cross-frame comparison must (wrongly) show no change here -- \
+             this is exactly the ghost hazard the before/after-within-frame diff exists to catch"
+        );
+
+        // The MANDATORY before/after-within-frame diff DOES catch it.
+        let intra_frame_transitioned = dismissible_presence_transitioned(before, after);
+        assert!(
+            intra_frame_transitioned,
+            "before/after-within-frame diff must detect the toast's self-dismissal"
+        );
+
+        // Feeding the correct (intra-frame) result into the decision forces
+        // THIS frame Changed. If the before/after-within-frame diff were
+        // dropped and only `naive_cross_frame_transitioned` were used here,
+        // this would (wrongly) compute Unchanged -- proving the intra-frame
+        // diff is load-bearing, not redundant.
+        let signals = ChromeSignals::default();
+        let decision_n = decide_chrome_damage(&signals, intra_frame_transitioned, false);
+        assert_eq!(
+            decision_n,
+            ChromeDamage::Changed,
+            "frame N (the toast's self-dismissal frame) must be Changed"
+        );
+
+        // ...and the §3.5 settle rule forces the NEXT frame Changed too,
+        // even though nothing else changed and the naive cross-frame check
+        // would (again) see no difference on that frame either.
+        let settle_pending_next = intra_frame_transitioned;
+        let decision_n_plus_1 = decide_chrome_damage(&signals, false, settle_pending_next);
+        assert_eq!(
+            decision_n_plus_1,
+            ChromeDamage::Changed,
+            "frame N+1 (the settle frame) must also be Changed"
+        );
+    }
+
+    #[test]
+    fn tab_snapshot_diff_all_unchanged_is_all_false() {
+        let snap = ChromeTabSnapshot {
+            tab_ids: vec![TabId::first()],
+            active_tab_id: Some(TabId::first()),
+            tab_titles: vec!["shell".to_owned()],
+            pane_ids: vec![PaneId::first()],
+            zoomed_pane: None,
+            broadcast_input: false,
+        };
+        let diff = diff_tab_snapshots(&snap, &snap.clone());
+        assert!(!diff.tab_set_changed);
+        assert!(!diff.tab_title_changed);
+        assert!(!diff.pane_layout_changed);
+        assert!(!diff.broadcast_state_changed);
+    }
+
+    #[test]
+    fn tab_snapshot_diff_detects_tab_set_change() {
+        let prev = ChromeTabSnapshot {
+            tab_ids: vec![TabId::first()],
+            active_tab_id: Some(TabId::first()),
+            ..ChromeTabSnapshot::default()
+        };
+        let current = ChromeTabSnapshot {
+            tab_ids: vec![TabId::first(), TabId::offset(1)],
+            active_tab_id: Some(TabId::first()),
+            ..ChromeTabSnapshot::default()
+        };
+        let diff = diff_tab_snapshots(&prev, &current);
+        assert!(diff.tab_set_changed, "tab id list grew");
+        assert!(!diff.tab_title_changed);
+        assert!(!diff.pane_layout_changed);
+        assert!(!diff.broadcast_state_changed);
+    }
+
+    #[test]
+    fn tab_snapshot_diff_detects_active_tab_change_with_same_id_list() {
+        let prev = ChromeTabSnapshot {
+            tab_ids: vec![TabId::first(), TabId::offset(1)],
+            active_tab_id: Some(TabId::first()),
+            ..ChromeTabSnapshot::default()
+        };
+        let current = ChromeTabSnapshot {
+            tab_ids: vec![TabId::first(), TabId::offset(1)],
+            active_tab_id: Some(TabId::offset(1)),
+            ..ChromeTabSnapshot::default()
+        };
+        let diff = diff_tab_snapshots(&prev, &current);
+        assert!(diff.tab_set_changed, "active tab id changed");
+    }
+
+    #[test]
+    fn tab_snapshot_diff_detects_tab_title_change() {
+        let prev = ChromeTabSnapshot {
+            tab_titles: vec!["old".to_owned()],
+            ..ChromeTabSnapshot::default()
+        };
+        let current = ChromeTabSnapshot {
+            tab_titles: vec!["new".to_owned()],
+            ..ChromeTabSnapshot::default()
+        };
+        let diff = diff_tab_snapshots(&prev, &current);
+        assert!(diff.tab_title_changed);
+        assert!(!diff.tab_set_changed);
+    }
+
+    #[test]
+    fn tab_snapshot_diff_detects_pane_layout_change_via_pane_ids() {
+        let prev = ChromeTabSnapshot {
+            pane_ids: vec![PaneId::first()],
+            ..ChromeTabSnapshot::default()
+        };
+        let current = ChromeTabSnapshot {
+            pane_ids: vec![PaneId::first(), second_pane_id()],
+            ..ChromeTabSnapshot::default()
+        };
+        let diff = diff_tab_snapshots(&prev, &current);
+        assert!(diff.pane_layout_changed, "a split added a pane");
+        assert!(!diff.tab_set_changed);
+    }
+
+    #[test]
+    fn tab_snapshot_diff_detects_pane_layout_change_via_zoom() {
+        let prev = ChromeTabSnapshot {
+            pane_ids: vec![PaneId::first()],
+            zoomed_pane: None,
+            ..ChromeTabSnapshot::default()
+        };
+        let current = ChromeTabSnapshot {
+            pane_ids: vec![PaneId::first()],
+            zoomed_pane: Some(PaneId::first()),
+            ..ChromeTabSnapshot::default()
+        };
+        let diff = diff_tab_snapshots(&prev, &current);
+        assert!(diff.pane_layout_changed, "zoom entered");
+    }
+
+    #[test]
+    fn tab_snapshot_diff_detects_broadcast_state_change() {
+        let prev = ChromeTabSnapshot {
+            broadcast_input: false,
+            ..ChromeTabSnapshot::default()
+        };
+        let current = ChromeTabSnapshot {
+            broadcast_input: true,
+            ..ChromeTabSnapshot::default()
+        };
+        let diff = diff_tab_snapshots(&prev, &current);
+        assert!(diff.broadcast_state_changed);
+        assert!(!diff.tab_set_changed);
+        assert!(!diff.tab_title_changed);
+        assert!(!diff.pane_layout_changed);
+    }
+}

--- a/freminal/src/gui/frame_damage.rs
+++ b/freminal/src/gui/frame_damage.rs
@@ -1,0 +1,299 @@
+// Copyright (C) 2024-2026 Fred Clausen
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Frame-damage aggregation (#435), extracted for reuse (#436.2b).
+//!
+//! [`decide_frame_damage`] is the pure decision function behind the
+//! `win.pending_frame_damage = 'damage: { ... }` block that used to live
+//! inline in `app_impl.rs::update()`. It is extracted so that both the full
+//! `update()` path and the future REPLAY path (#436) compute the exact same
+//! [`freminal_windowing::FrameDamage`] for the exact same inputs, without
+//! duplicating (and risking drift in) the decision logic.
+//!
+//! The function takes no `self`/`egui` context/window state — only the
+//! handful of booleans and per-pane facts the original block actually read
+//! — so it is directly unit-testable.
+
+use crate::gui::renderer::PaneFrameDamage;
+
+/// What one rendered pane contributed to this frame's damage decision.
+///
+/// Mirrors exactly the facts the original inline block read per pane:
+/// whether a bell flash is animating (forces `Full`) and the pane's
+/// [`PaneFrameDamage`] from the last render.
+///
+/// A pane present in `pane_layout` that could not be resolved in the pane
+/// tree (the `let Some(pane) = ... else { ... }` branch of the original
+/// block) has **no** representation of its own here — instead of adding an
+/// "unresolved" variant, the caller (which is the one doing the tree
+/// lookup) simply does not push an entry for it and instead short-circuits
+/// by treating the whole frame as forced-full. See
+/// [`decide_frame_damage`]'s doc comment for why this preserves the
+/// original "unresolvable pane -> Full" semantics exactly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PaneDamageInput {
+    /// `pane.view_state.bell_since.is_some()` for this pane.
+    pub(crate) bell_active: bool,
+    /// `pane.render_cache.last_frame_cursor_damage` for this pane.
+    pub(crate) cursor_damage: PaneFrameDamage,
+}
+
+/// Decide this frame's [`freminal_windowing::FrameDamage`] — the #435
+/// partial-present decision — from already-computed inputs.
+///
+/// This is a pure function: given the same arguments it always returns the
+/// same result, with no reliance on `egui`, `self`, or any window state.
+/// That is what makes it safe to call from both the full `update()` path
+/// and the future REPLAY path (#436) and get byte-for-byte identical
+/// results to today's inline block.
+///
+/// Semantics (preserved exactly from the original `'damage:` block):
+///
+/// 1. `force_full` (`ui_overlay_open || shader_recomposites ||
+///    active_pane_changed || pointer_moving`, computed by the caller)
+///    short-circuits to [`FrameDamage::Full`].
+/// 2. Otherwise, `toast_active` short-circuits to `Full`.
+/// 3. Otherwise, `per_pane_damage` is walked in order (this must be the
+///    same order as `pane_layout`, i.e. only the panes actually rendered
+///    this frame):
+///    - `bell_active` -> clear any collected rects and stop -> `Full`.
+///    - `cursor_damage == CursorOnly(Some(rect))` -> push `rect`.
+///    - `cursor_damage == CursorOnly(None)` or `Full` -> clear any
+///      collected rects and stop -> `Full`.
+///    - `cursor_damage == Unchanged` -> contributes nothing, continue.
+/// 4. If no rects were collected (either the loop never pushed one, or it
+///    was cleared by a later pane), the result is `Full`; otherwise it is
+///    `Partial(rects)`.
+///
+/// An unresolvable pane in the original block behaved identically to a
+/// `bell_active` pane: clear rects and stop -> `Full`. Since this function
+/// has no pane tree to resolve against, that case is represented by the
+/// **caller** omitting to build a full `per_pane_damage` list and instead
+/// calling this function with `force_full = true` for that frame (there is
+/// no scenario in the real caller where an unresolved pane should do
+/// anything BUT force `Full`, so this is a lossless simplification of the
+/// call site, not a behavior change).
+pub fn decide_frame_damage(
+    force_full: bool,
+    toast_active: bool,
+    per_pane_damage: &[PaneDamageInput],
+) -> freminal_windowing::FrameDamage {
+    if force_full {
+        return freminal_windowing::FrameDamage::Full;
+    }
+    if toast_active {
+        return freminal_windowing::FrameDamage::Full;
+    }
+
+    let mut rects: Vec<freminal_windowing::DamageRect> = Vec::new();
+    for pane in per_pane_damage {
+        if pane.bell_active {
+            rects.clear();
+            break;
+        }
+        match pane.cursor_damage {
+            PaneFrameDamage::Unchanged => {}
+            PaneFrameDamage::CursorOnly(Some(d)) => {
+                rects.push(freminal_windowing::DamageRect {
+                    x: d.x,
+                    y: d.y,
+                    width: d.width,
+                    height: d.height,
+                });
+            }
+            PaneFrameDamage::CursorOnly(None) | PaneFrameDamage::Full => {
+                rects.clear();
+                break;
+            }
+        }
+    }
+
+    if rects.is_empty() {
+        freminal_windowing::FrameDamage::Full
+    } else {
+        freminal_windowing::FrameDamage::Partial(rects)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PaneDamageInput, decide_frame_damage};
+    use crate::gui::renderer::{CursorDamage, PaneFrameDamage};
+    use freminal_windowing::{DamageRect, FrameDamage};
+
+    /// `FrameDamage` does not implement `PartialEq` (see its definition),
+    /// so tests compare it structurally by hand.
+    fn assert_full(damage: &FrameDamage) {
+        assert!(
+            matches!(damage, FrameDamage::Full),
+            "expected FrameDamage::Full, got {damage:?}"
+        );
+    }
+
+    fn assert_partial(damage: &FrameDamage, expected_rects: &[DamageRect]) {
+        match damage {
+            FrameDamage::Partial(rects) => {
+                assert_eq!(rects, expected_rects);
+            }
+            FrameDamage::Full => {
+                panic!("expected FrameDamage::Partial({expected_rects:?}), got Full")
+            }
+        }
+    }
+
+    fn rect(x: i32, y: i32, width: i32, height: i32) -> DamageRect {
+        DamageRect {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    fn unchanged_pane() -> PaneDamageInput {
+        PaneDamageInput {
+            bell_active: false,
+            cursor_damage: PaneFrameDamage::Unchanged,
+        }
+    }
+
+    fn cursor_only_pane(d: CursorDamage) -> PaneDamageInput {
+        PaneDamageInput {
+            bell_active: false,
+            cursor_damage: PaneFrameDamage::CursorOnly(Some(d)),
+        }
+    }
+
+    #[test]
+    fn force_full_wins_regardless_of_other_inputs() {
+        let panes = [cursor_only_pane(CursorDamage {
+            x: 1,
+            y: 2,
+            width: 3,
+            height: 4,
+        })];
+        // toast_active also true, and a valid cursor rect present: force_full
+        // still must win.
+        assert_full(&decide_frame_damage(true, true, &panes));
+        assert_full(&decide_frame_damage(true, false, &panes));
+    }
+
+    #[test]
+    fn toast_active_forces_full_when_not_force_full() {
+        let panes = [cursor_only_pane(CursorDamage {
+            x: 1,
+            y: 2,
+            width: 3,
+            height: 4,
+        })];
+        assert_full(&decide_frame_damage(false, true, &panes));
+    }
+
+    #[test]
+    fn empty_pane_list_is_full() {
+        assert_full(&decide_frame_damage(false, false, &[]));
+    }
+
+    #[test]
+    fn all_panes_unchanged_is_full() {
+        let panes = [unchanged_pane(), unchanged_pane()];
+        assert_full(&decide_frame_damage(false, false, &panes));
+    }
+
+    #[test]
+    fn single_cursor_only_rect_is_partial() {
+        let d = CursorDamage {
+            x: 10,
+            y: 20,
+            width: 8,
+            height: 16,
+        };
+        let panes = [cursor_only_pane(d)];
+        let damage = decide_frame_damage(false, false, &panes);
+        assert_partial(&damage, &[rect(10, 20, 8, 16)]);
+    }
+
+    #[test]
+    fn two_cursor_only_rects_is_partial_pane_switch_case() {
+        let d1 = CursorDamage {
+            x: 0,
+            y: 0,
+            width: 8,
+            height: 16,
+        };
+        let d2 = CursorDamage {
+            x: 100,
+            y: 0,
+            width: 8,
+            height: 16,
+        };
+        let panes = [cursor_only_pane(d1), cursor_only_pane(d2)];
+        let damage = decide_frame_damage(false, false, &panes);
+        assert_partial(&damage, &[rect(0, 0, 8, 16), rect(100, 0, 8, 16)]);
+    }
+
+    #[test]
+    fn bell_active_pane_forces_full_and_clears_prior_rects() {
+        let d = CursorDamage {
+            x: 0,
+            y: 0,
+            width: 8,
+            height: 16,
+        };
+        let panes = [
+            cursor_only_pane(d),
+            PaneDamageInput {
+                bell_active: true,
+                cursor_damage: PaneFrameDamage::Unchanged,
+            },
+        ];
+        assert_full(&decide_frame_damage(false, false, &panes));
+    }
+
+    #[test]
+    fn cursor_only_none_forces_full() {
+        let panes = [PaneDamageInput {
+            bell_active: false,
+            cursor_damage: PaneFrameDamage::CursorOnly(None),
+        }];
+        assert_full(&decide_frame_damage(false, false, &panes));
+    }
+
+    #[test]
+    fn pane_full_forces_full() {
+        let panes = [PaneDamageInput {
+            bell_active: false,
+            cursor_damage: PaneFrameDamage::Full,
+        }];
+        assert_full(&decide_frame_damage(false, false, &panes));
+    }
+
+    #[test]
+    fn unresolvable_pane_is_represented_by_caller_forcing_full() {
+        // The caller cannot build a `PaneDamageInput` for a pane it failed
+        // to resolve in the tree; it instead calls this function with
+        // `force_full = true` for the whole frame. Verify that path yields
+        // `Full` even with an otherwise-empty pane list.
+        assert_full(&decide_frame_damage(true, false, &[]));
+    }
+
+    #[test]
+    fn rects_cleared_when_a_later_pane_is_full() {
+        let d = CursorDamage {
+            x: 0,
+            y: 0,
+            width: 8,
+            height: 16,
+        };
+        let panes = [
+            cursor_only_pane(d),
+            PaneDamageInput {
+                bell_active: false,
+                cursor_damage: PaneFrameDamage::Full,
+            },
+        ];
+        assert_full(&decide_frame_damage(false, false, &panes));
+    }
+}

--- a/freminal/src/gui/frame_damage.rs
+++ b/freminal/src/gui/frame_damage.rs
@@ -117,11 +117,38 @@ pub fn decide_frame_damage(
     }
 }
 
+/// #435/#436 composition (§6): reconcile the #435 partial-present decision
+/// with the #436 chrome-cache decision. They are computed separately but must
+/// agree: if the chrome changed pixels this frame
+/// ([`freminal_windowing::ChromeDamage::Changed`]), the frame must NOT be
+/// presented [`freminal_windowing::FrameDamage::Partial`] — #435's
+/// `buffer_age() == 1` fast path assumes every pixel outside the damage rect
+/// is bit-identical to the previous frame, but a chrome rebuild may have
+/// changed pixels outside a cursor rect, which would then be left stale on
+/// screen. So a `Changed` chrome frame forces `Full`.
+///
+/// On a REPLAY frame `chrome_damage` is `Unchanged` by construction (REPLAY is
+/// only chosen when the previous frame was `Unchanged` and no chrome input
+/// landed this frame), so this is a no-op there and the headline cursor-only
+/// partial-present path (idle blink) is preserved. When `chrome_damage` is
+/// `Changed` this conservatively presents `Full` rather than risk a stale
+/// `Partial`.
+#[must_use]
+pub fn compose_with_chrome_damage(
+    frame_damage: freminal_windowing::FrameDamage,
+    chrome_damage: freminal_windowing::ChromeDamage,
+) -> freminal_windowing::FrameDamage {
+    match chrome_damage {
+        freminal_windowing::ChromeDamage::Changed => freminal_windowing::FrameDamage::Full,
+        freminal_windowing::ChromeDamage::Unchanged => frame_damage,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{PaneDamageInput, decide_frame_damage};
+    use super::{PaneDamageInput, compose_with_chrome_damage, decide_frame_damage};
     use crate::gui::renderer::{CursorDamage, PaneFrameDamage};
-    use freminal_windowing::{DamageRect, FrameDamage};
+    use freminal_windowing::{ChromeDamage, DamageRect, FrameDamage};
 
     /// `FrameDamage` does not implement `PartialEq` (see its definition),
     /// so tests compare it structurally by hand.
@@ -295,5 +322,39 @@ mod tests {
             },
         ];
         assert_full(&decide_frame_damage(false, false, &panes));
+    }
+
+    // ── #435/#436 composition (§6): compose_with_chrome_damage ──────────
+
+    #[test]
+    fn chrome_changed_forces_full_even_when_frame_damage_was_partial() {
+        // The load-bearing case: a Partial (cursor-only) present must be
+        // upgraded to Full when chrome changed pixels this frame, or the
+        // changed chrome outside the cursor rect would be left stale.
+        let partial = FrameDamage::Partial(vec![rect(0, 0, 8, 16)]);
+        let composed = compose_with_chrome_damage(partial, ChromeDamage::Changed);
+        assert_full(&composed);
+    }
+
+    #[test]
+    fn chrome_changed_forces_full_when_frame_damage_was_already_full() {
+        let composed = compose_with_chrome_damage(FrameDamage::Full, ChromeDamage::Changed);
+        assert_full(&composed);
+    }
+
+    #[test]
+    fn chrome_unchanged_preserves_partial() {
+        // The headline REPLAY / idle-blink case: chrome is Unchanged, so the
+        // cursor-only Partial present survives untouched.
+        let rects = [rect(10, 20, 8, 16)];
+        let partial = FrameDamage::Partial(rects.to_vec());
+        let composed = compose_with_chrome_damage(partial, ChromeDamage::Unchanged);
+        assert_partial(&composed, &rects);
+    }
+
+    #[test]
+    fn chrome_unchanged_preserves_full() {
+        let composed = compose_with_chrome_damage(FrameDamage::Full, ChromeDamage::Unchanged);
+        assert_full(&composed);
     }
 }

--- a/freminal/src/gui/layout_ops.rs
+++ b/freminal/src/gui/layout_ops.rs
@@ -733,6 +733,8 @@ impl FreminalGui {
             chrome_frames_rendered: 0,
             pending_terminal_requested_delay: None,
             cached_central_rect: None,
+            chrome_head_rects: None,
+            chrome_border_rects: Vec::new(),
         };
         self.windows.insert(window_id, win);
 

--- a/freminal/src/gui/layout_ops.rs
+++ b/freminal/src/gui/layout_ops.rs
@@ -721,6 +721,7 @@ impl FreminalGui {
             pending_force_close: false,
             pending_raw_keys: Vec::new(),
             pending_frame_damage: freminal_windowing::FrameDamage::Full,
+            pending_terminal_band_shapes: Vec::new(),
             present_is_partial: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             previous_active_pane_key: None,
         };

--- a/freminal/src/gui/layout_ops.rs
+++ b/freminal/src/gui/layout_ops.rs
@@ -11,7 +11,7 @@ use freminal_windowing::{RepaintProxy, WindowId};
 use tracing::{debug, error};
 
 use super::window::PerWindowState;
-use super::{FreminalGui, panes, renderer, rendering, tabs, terminal};
+use super::{FreminalGui, chrome_damage, panes, renderer, rendering, tabs, terminal};
 
 /// Pre-allocated `(repaint_handle, window_post)` pair passed to
 /// `build_window_from_pending_layout` for the first window.  The first
@@ -724,6 +724,13 @@ impl FreminalGui {
             pending_terminal_band_shapes: Vec::new(),
             present_is_partial: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             previous_active_pane_key: None,
+            pending_chrome_damage: freminal_windowing::ChromeDamage::Changed,
+            pending_chrome_signals: chrome_damage::ChromeSignals::default(),
+            chrome_settle_pending: false,
+            prev_dismissible_presence: chrome_damage::DismissiblePresence::default(),
+            prev_chrome_tab_snapshot: chrome_damage::ChromeTabSnapshot::default(),
+            prev_window_focused: false,
+            chrome_frames_rendered: 0,
         };
         self.windows.insert(window_id, win);
 

--- a/freminal/src/gui/layout_ops.rs
+++ b/freminal/src/gui/layout_ops.rs
@@ -731,6 +731,8 @@ impl FreminalGui {
             prev_chrome_tab_snapshot: chrome_damage::ChromeTabSnapshot::default(),
             prev_window_focused: false,
             chrome_frames_rendered: 0,
+            pending_terminal_requested_delay: None,
+            cached_central_rect: None,
         };
         self.windows.insert(window_id, win);
 

--- a/freminal/src/gui/layout_ops.rs
+++ b/freminal/src/gui/layout_ops.rs
@@ -721,7 +721,7 @@ impl FreminalGui {
             pending_force_close: false,
             pending_raw_keys: Vec::new(),
             pending_frame_damage: freminal_windowing::FrameDamage::Full,
-            pending_terminal_band_shapes: Vec::new(),
+            pending_terminal_band_range: 0..0,
             present_is_partial: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             previous_active_pane_key: None,
             pending_chrome_damage: freminal_windowing::ChromeDamage::Changed,

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -42,6 +42,7 @@ pub mod chrome_style;
 mod close_guard;
 mod command_blocks;
 mod command_history;
+mod frame_damage;
 mod hot_reload;
 pub(crate) mod icons;
 mod layout_ops;

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -38,6 +38,7 @@ pub mod view_state;
 mod actions;
 mod app_impl;
 mod broadcast_guard;
+mod chrome_damage;
 pub mod chrome_style;
 mod close_guard;
 mod command_blocks;

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -1199,6 +1199,18 @@ impl PaneRenderCache {
         self.super_state.any()
     }
 
+    /// Whether a URL-hover tooltip is currently displayed for this pane
+    /// (#436.4b). `cached_hovered_url` is `pub(super)` (render-pipeline
+    /// internal); this narrow accessor lets `app_impl.rs`'s chrome-damage
+    /// aggregation know the `Order::Tooltip` URL tooltip is on screen —
+    /// TAIL chrome that must force `ChromeDamage::Changed` so a REPLAY frame
+    /// does not discard it. Mirrors [`Self::super_pressed`]'s pattern rather
+    /// than widening the field's visibility.
+    #[must_use]
+    pub(crate) const fn hover_tooltip_active(&self) -> bool {
+        self.cached_hovered_url.is_some()
+    }
+
     /// Invalidate the cached theme pointer so the next frame forces a full
     /// vertex rebuild with the new palette colors.
     pub const fn invalidate_theme_cache(&mut self) {

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -9,7 +9,11 @@ use egui;
 use freminal_windowing::{RepaintProxy, WindowId};
 
 use super::{
-    PaneBorderDrag, renderer::WindowPostRenderer, tabs::TabId, tabs::TabManager,
+    PaneBorderDrag,
+    chrome_damage::{ChromeSignals, ChromeTabSnapshot, DismissiblePresence},
+    renderer::WindowPostRenderer,
+    tabs::TabId,
+    tabs::TabManager,
     terminal::FreminalTerminalWidget,
 };
 
@@ -258,4 +262,68 @@ pub(super) struct PerWindowState {
     /// `PaintCallback` closures require `'static` captures; only ever touched
     /// on the GUI thread, so `Relaxed` ordering suffices.
     pub(super) present_is_partial: std::sync::Arc<std::sync::atomic::AtomicBool>,
+
+    /// Chrome-damage decision for the most recent `update()` of this window
+    /// (#436.3), drained by `App::take_chrome_damage`.
+    ///
+    /// Set at the end of each `update()` from [`super::chrome_damage::decide_chrome_damage`].
+    /// Defaults to [`freminal_windowing::ChromeDamage::Changed`] — the
+    /// conservative, always-correct behavior for a window that has not yet
+    /// rendered, or any frame whose computation is skipped by an early
+    /// return (mirrors `pending_frame_damage`'s same risk/precedent).
+    pub(super) pending_chrome_damage: freminal_windowing::ChromeDamage,
+
+    /// The individual #436 §3.3 signals computed during the most recent
+    /// `update()` of this window, staged here because most of them are only
+    /// available inside the `CentralPanel` closure while the final decision
+    /// (which also needs the post-toast-render dismissible-presence sample)
+    /// can only be made after that closure returns. Combined with the §3.5
+    /// presence-transition/settle inputs into `pending_chrome_damage` right
+    /// before `update()` returns. Defaults to all-`false` — harmless, since
+    /// it is always overwritten before being read on any frame that reaches
+    /// the point where `pending_chrome_damage` is computed.
+    pub(super) pending_chrome_signals: ChromeSignals,
+
+    /// #436 §3.5 self-dismissal settle rule: `true` when a dismissible
+    /// element (toast, About, Welcome, paste/broadcast/close-guard dialogs,
+    /// save-layout prompt) transitioned presence on the PREVIOUS frame, which
+    /// forces THIS frame `ChromeDamage::Changed` too (the "settle frame").
+    /// Reassigned every frame to that frame's own transition result — see
+    /// `chrome_damage::decide_chrome_damage`'s doc for why this needs no
+    /// separate reset step. `false` before the first frame.
+    pub(super) chrome_settle_pending: bool,
+
+    /// Presence of every dismissible chrome element, sampled once at the end
+    /// of the previous frame (after all `.show()` calls that frame,
+    /// including the toast stack's).
+    ///
+    /// Compared against this frame's own after-`.show()` sample to catch a
+    /// transition NOT caused by that element's own self-dismissal (e.g. a
+    /// menu action closing a dialog) — the cross-frame half of the §3.5
+    /// settle rule. The intra-frame (before-vs-after within a single frame)
+    /// half, which is what catches the toast self-dismissal hazard
+    /// (adversarial finding 1), uses a frame-local `before`/`after` pair
+    /// instead and does not need to be stored here. Defaults to
+    /// all-`false` (nothing dismissible present before the first frame).
+    pub(super) prev_dismissible_presence: DismissiblePresence,
+
+    /// Previous frame's tab/pane snapshot for the §3.3 tab-set / tab-title /
+    /// pane-layout / broadcast-state change-detection rows (#436.3). See
+    /// [`super::chrome_damage::ChromeTabSnapshot`] and
+    /// [`super::chrome_damage::diff_tab_snapshots`]. Defaults to empty,
+    /// which naturally reports every row as "changed" on the first
+    /// comparison — harmless, since the first few frames are also covered
+    /// by the warm-up counter below.
+    pub(super) prev_chrome_tab_snapshot: ChromeTabSnapshot,
+
+    /// Previous frame's `window_focused` value (#436.3 §3.3 "Window focus
+    /// change" row). Compared each frame to the freshly-read value to
+    /// detect focus in/out. `false` before the first frame.
+    pub(super) prev_window_focused: bool,
+
+    /// Frames rendered since this window was created, saturating at
+    /// [`super::chrome_damage::WARMUP_FRAMES`] (#436.3 §7 warm-up). While
+    /// below that count, `ChromeSignals::warming_up` is `true`,
+    /// unconditionally forcing `ChromeDamage::Changed`.
+    pub(super) chrome_frames_rendered: u32,
 }

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -351,4 +351,13 @@ pub(super) struct PerWindowState {
     /// the first FULL frame (a REPLAY can never be chosen then, since
     /// `chrome_cache` is also `None` at that point).
     pub(super) cached_central_rect: Option<egui::Rect>,
+
+    /// #436.8 menu-bar + tab-bar rects (egui logical points), captured on FULL
+    /// frames (REPLAY skips building the panels). `None` until the first FULL
+    /// frame => `is_chrome_interactive_at` returns the conservative `true`.
+    pub(super) chrome_head_rects: Option<Vec<egui::Rect>>,
+    /// #436.8 split-border drag-sensor rects (egui logical points), rebuilt every
+    /// frame; explicitly cleared on frames that build no sensors (single pane /
+    /// zoomed / overlay open).
+    pub(super) chrome_border_rects: Vec<egui::Rect>,
 }

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -216,6 +216,28 @@ pub(super) struct PerWindowState {
     /// [`FrameDamage::Full`]: freminal_windowing::FrameDamage::Full
     pub(super) pending_frame_damage: freminal_windowing::FrameDamage,
 
+    /// Egui shapes for the "terminal band" (the pre-clear FBO callback, the
+    /// per-pane render loop, the post-shader composite callback, pane border
+    /// lines, and the broadcast label) painted during the most recent
+    /// `update()` of this window (#436.2a), drained by
+    /// `App::take_terminal_band_shapes`.
+    ///
+    /// Set at the end of each `update()` by cloning the shape-index range
+    /// `[band_shape_start, band_shape_end)` out of
+    /// `LayerId::background()`'s `PaintList` via `ctx.graphics(..)` — see the
+    /// extraction comment at the `band_shapes` binding in `update()`. The
+    /// band paints into the SAME background layer chrome uses (not a
+    /// dedicated layer: routing it into a second `Order::Background` layer
+    /// trips egui's cross-layer hit-test "hidden" rule and suppresses band
+    /// widget interaction — see the capture-point comments in `update()`).
+    /// This subtask (436.2a) only establishes the extraction seam: the
+    /// shapes are cloned (not removed from the background layer), so they
+    /// still drain into `FullOutput.shapes` and render exactly as before.
+    /// Separate tessellation/painting of the band — which requires
+    /// neutralizing those shapes so they are not double-painted — is 436.4.
+    /// Defaults to empty before the first frame.
+    pub(super) pending_terminal_band_shapes: Vec<egui::epaint::ClippedShape>,
+
     /// The `(active tab, active pane)` shown on the previous frame.
     ///
     /// Compared each frame to detect when the active pane changes — whether by

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -220,27 +220,26 @@ pub(super) struct PerWindowState {
     /// [`FrameDamage::Full`]: freminal_windowing::FrameDamage::Full
     pub(super) pending_frame_damage: freminal_windowing::FrameDamage,
 
-    /// Egui shapes for the "terminal band" (the pre-clear FBO callback, the
-    /// per-pane render loop, the post-shader composite callback, pane border
-    /// lines, and the broadcast label) painted during the most recent
-    /// `update()` of this window (#436.2a), drained by
-    /// `App::take_terminal_band_shapes`.
+    /// Shape-index range for the "terminal band" (the pre-clear FBO
+    /// callback, the per-pane render loop, the post-shader composite
+    /// callback, pane border lines, and the broadcast label) within this
+    /// frame's `full_output.shapes`, drained by
+    /// `App::take_terminal_band_range` (#436.4a; supersedes the #436.2a
+    /// shape-cloning approach previously exposed via the now-removed
+    /// `take_terminal_band_shapes`).
     ///
-    /// Set at the end of each `update()` by cloning the shape-index range
-    /// `[band_shape_start, band_shape_end)` out of
-    /// `LayerId::background()`'s `PaintList` via `ctx.graphics(..)` — see the
-    /// extraction comment at the `band_shapes` binding in `update()`. The
-    /// band paints into the SAME background layer chrome uses (not a
-    /// dedicated layer: routing it into a second `Order::Background` layer
-    /// trips egui's cross-layer hit-test "hidden" rule and suppresses band
-    /// widget interaction — see the capture-point comments in `update()`).
-    /// This subtask (436.2a) only establishes the extraction seam: the
-    /// shapes are cloned (not removed from the background layer), so they
-    /// still drain into `FullOutput.shapes` and render exactly as before.
-    /// Separate tessellation/painting of the band — which requires
-    /// neutralizing those shapes so they are not double-painted — is 436.4.
-    /// Defaults to empty before the first frame.
-    pub(super) pending_terminal_band_shapes: Vec<egui::epaint::ClippedShape>,
+    /// Set at the end of each `update()` to `band_shape_start..band_shape_end`
+    /// — the range appended to `LayerId::background()`'s `PaintList` since
+    /// `band_shape_start` was captured — see the extraction comment at the
+    /// `band_shape_end` binding in `update()`. The band paints
+    /// into the SAME background layer chrome uses (not a dedicated layer:
+    /// routing it into a second `Order::Background` layer trips egui's
+    /// cross-layer hit-test "hidden" rule and suppresses band widget
+    /// interaction — see the capture-point comments in `update()`). Since
+    /// the background layer drains first into `FullOutput.shapes`, this
+    /// range is valid as-is against `full_output.shapes` in `run_frame`.
+    /// Defaults to `0..0` before the first frame.
+    pub(super) pending_terminal_band_range: std::ops::Range<usize>,
 
     /// The `(active tab, active pane)` shown on the previous frame.
     ///

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -325,4 +325,30 @@ pub(super) struct PerWindowState {
     /// below that count, `ChromeSignals::warming_up` is `true`,
     /// unconditionally forcing `ChromeDamage::Changed`.
     pub(super) chrome_frames_rendered: u32,
+
+    /// The delay `update()` itself requested via `ctx.request_repaint_after`
+    /// on the most recent frame (#436.4b §3.1 amendment), drained by
+    /// `App::take_terminal_requested_delay`.
+    ///
+    /// Set at the end of each `update()` from `shortest_repaint_delay` (the
+    /// shortest interval any rendered pane needed — cursor blink, content
+    /// update, or shader animation). Compared against egui's own requested
+    /// repaint delay by `egui_integration::chrome_repaint_settled` to decide
+    /// whether a REPLAY is permitted: a REPLAY requires that nothing OTHER
+    /// than this frame's own request also wants a wake. Defaults to `None`.
+    pub(super) pending_terminal_requested_delay: Option<std::time::Duration>,
+
+    /// The `CentralPanel` content rect (`ui.available_rect_before_wrap()`)
+    /// captured on the most recent FULL frame (#436.4b).
+    ///
+    /// On a REPLAY frame `update()` skips building the menu bar, tab bar,
+    /// and `CentralPanel` (all cached chrome), so there is no fresh
+    /// `available_rect` to read the terminal band's content rect from.
+    /// Instead the band's `Ui` is constructed directly at this cached rect,
+    /// in the same background layer chrome uses — valid because a REPLAY is
+    /// only permitted when chrome (including window size) is proven
+    /// unchanged since the frame that last set this field. `None` before
+    /// the first FULL frame (a REPLAY can never be chosen then, since
+    /// `chrome_cache` is also `None` at that point).
+    pub(super) cached_central_rect: Option<egui::Rect>,
 }

--- a/renovate.json
+++ b/renovate.json
@@ -39,7 +39,10 @@
         "glutin-winit",
         "winit",
         "raw-window-handle"
-      ]
+      ],
+      "description": "The chrome-caching work relies on undocumented internal behaviour of the egui 0.35.0 stack; egui/egui_glow/egui-winit are exact-pinned. Never auto-merge these, and require explicit Dependency-Dashboard approval before a bump PR is even opened, so a human consciously runs the Documents/EGUI_UPGRADE_ASSUMPTIONS.md re-verification checklist first.",
+      "automerge": false,
+      "dependencyDashboardApproval": true
     },
     {
       "groupName": "tracing",


### PR DESCRIPTION
Closes #436.

## What

Caches egui **chrome** primitives (menu bar, tab bar, pane borders, broadcast label, and all Band-D overlays: modals/toasts/tooltips/popups/menus) so that on frames where chrome is provably static — the common idle / cursor-blink / mouse-over-terminal cases — we **skip re-recording + re-tessellating chrome** and reuse the cached tessellated primitives. The terminal band (per-pane GL callbacks + the five content-coupled decorations) is **always freshly rebuilt**, never replayed.

Delivers the #436 mandate: "we do not redraw the chrome unless the chrome changed" — in **all** frame paths, not just the blink fast path.

## Mechanism (the hybrid, per the OQ-2 spike)

`run_frame` decides `ChromeMode::Full` vs `Replay` per frame from three ORed signal families (egui repaint-settled §3.1, region-aware input gate §3.2, app-level `ChromeDamage` §3.3 + self-dismissal settle §3.5). A single `run_ui` still runs every frame (terminal input requires a fresh `InputState`); on REPLAY the app skips constructing the chrome widgets and `run_frame` reuses cached chrome primitives, painting head → fresh band → tail in three `paint_primitives` calls. Font-atlas growth on a REPLAY frame self-heals by re-tessellating the cached chrome *shapes* against the current atlas (§5.2). Composes with #435 damage-aware present (a chrome-pixel change forces `FrameDamage::Full`; the cursor-only partial-present decision is produced on REPLAY frames too).

## Subtasks (14 commits, all reviewed)

436.1 bench · 436.2a band-extraction · 436.2b decide_frame_damage · 436.3 ChromeDamage + settle · 436.4a/b/c (paint split / REPLAY live / atlas self-heal) · 436.5 callback ordering · 436.6 #435-compose + egui exact-pin · 436.7 overlays/multi-window/settings/warm-up · 436.8 region-aware pointer gate · CLEANUP-436-A (pre-existing window-orphan fix) · 436.9 (follow-up tests).

Also: `Documents/EGUI_UPGRADE_ASSUMPTIONS.md` + `.opencode/skills/freminal-egui-upgrade` + Renovate no-auto-merge guard for the egui stack (the approach leans on undocumented egui-stack internals, pinned `=0.35.0`).

## Verification

- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo machete`, `cargo fmt --all -- --check` — all green.
- `cargo xtask check-windows` — clean.
- Bench delta (`main` vs branch, `render_loop_bench`): no bench crosses the 15% threshold (two single-digit-% moves on sub-µs microbenches, within noise). `chrome_frame_record` ≈ 14.95 µs/frame = the per-frame `run_ui`+`tessellate` cost a REPLAY eliminates.
- Adversarial review of the full diff vs §11's 9 invariants: **SHIP-WITH-NOTES**. Invariants 1/3/5/6/7/8/9 upheld; invariant 2's candidate BLOCKER (empty-cache on an aborted `update()` frame) was investigated and confirmed a **false positive** (the `take_chrome_damage` drain-and-reset invariant forces the next frame `Full` before any REPLAY can consume it — verified by induction).

## Deferred to #440 (maintainer-approved)

The three §9 tests requiring a headless-GL / pixel-readback harness that does not exist in-repo — #4 pixel-identity, #5 real-GL texture double-free across atlas growth, #6 wall-clock toast ghost — are tracked in #440. Their decision layers are already exhaustively unit-tested here; #440 adds the real-GL executed evidence for invariants 2 and 4. Building the harness (surfaceless GL context + FBO readback + headless `FreminalGui` seam) is out of scope for #436.

## Not in this PR

The idle-CPU btop cost is a **separate** issue (#439, unbatched PTY fan-out); #436 was empirically confirmed NOT to be that lever. #439's stashed work is deliberately kept off this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved rendering efficiency by reusing unchanged interface elements while updating terminal content as needed.
  * Reduced unnecessary redraws during routine pointer movement and stable UI states.

* **Bug Fixes**
  * Improved visual stability when fonts, window scaling, dialogs, tabs, or overlays change.
  * Preserved correct rendering during partial updates, border interactions, and terminal cursor activity.
  * Added safeguards to maintain consistent UI appearance across egui rendering-stack updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->