### PR TITLE
perf: collapse idle over-repaint in the PTY->snapshot->render pipeline (#439)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "freminal"
-version = "0.12.0-beta.4"
+version = "0.12.0-beta.5"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-buffer"
-version = "0.12.0-beta.4"
+version = "0.12.0-beta.5"
 dependencies = [
  "conv2",
  "criterion",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-common"
-version = "0.12.0-beta.4"
+version = "0.12.0-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-terminal-emulator"
-version = "0.12.0-beta.4"
+version = "0.12.0-beta.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "freminal-windowing"
-version = "0.12.0-beta.4"
+version = "0.12.0-beta.5"
 dependencies = [
  "conv2",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["freminal", "freminal-buffer", "freminal-common", "freminal-terminal-
 default-members = ["freminal", "freminal-buffer", "freminal-common", "freminal-terminal-emulator"]
 
 [workspace.package]
-version = "0.12.0-beta.4"
+version = "0.12.0-beta.5"
 edition = "2024"
 rust-version = "1.95.0"
 description = "A terminal emulator written in Rust"

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     # cargo-bundle is only used inside the dev shell to produce the Linux
     # deb/appimage artifacts locally.  nixpkgs is pinned at 0.9.0, which predates
     # SVG-icon and `appimage` support; we build from upstream master so the dev
-    # shell matches the 0.12.0-beta.4+ the release CI installs via `cargo install`.
+    # shell matches the 0.12.0-beta.5+ the release CI installs via `cargo install`.
     # `nix flake update cargo-bundle-src` picks up new upstream commits.
     cargo-bundle-src = {
       url = "github:burtonageo/cargo-bundle";
@@ -107,7 +107,7 @@
             };
           };
 
-          version = "0.12.0-beta.4";
+          version = "0.12.0-beta.5";
 
           # The build sandbox strips `.git`, so the crate's build.rs `git
           # describe` can only ever yield "unknown".  Feed it a real value via
@@ -177,9 +177,9 @@
                     <key>CFBundleIdentifier</key>
                     <string>io.github.fredclausen.freminal</string>
                     <key>CFBundleVersion</key>
-                    <string>0.12.0-beta.4</string>
+                    <string>0.12.0-beta.5</string>
                     <key>CFBundleShortVersionString</key>
-                    <string>0.12.0-beta.4</string>
+                    <string>0.12.0-beta.5</string>
                     <key>CFBundleExecutable</key>
                     <string>freminal</string>
                     <key>CFBundleIconFile</key>
@@ -342,7 +342,7 @@
 
               # cargo-bundle built from upstream master (see the cargo-bundle-src
               # input).  nixpkgs ships 0.9.0, which cannot bundle SVG icons or
-              # produce appimages; this matches the 0.12.0-beta.4+ the release CI uses.
+              # produce appimages; this matches the 0.12.0-beta.5+ the release CI uses.
               # Mirrors the nixpkgs recipe (squashfsTools wrap for appimage).
               cargoBundleLatest = pkgs.rustPlatform.buildRustPackage {
                 pname = "cargo-bundle";

--- a/freminal-terminal-emulator/src/interface.rs
+++ b/freminal-terminal-emulator/src/interface.rs
@@ -1432,6 +1432,86 @@ mod tests {
     }
 
     #[test]
+    fn build_snapshot_idle_rebuild_reuses_same_visible_chars_arc() {
+        // Issue #439 fix #4 relies EXCLUSIVELY on `Arc::ptr_eq` of
+        // `visible_chars` (not the sticky `content_changed` flag) to decide
+        // whether the GUI must rebuild. That is only sound if an idle
+        // `build_snapshot` (nothing dirty) returns the *same* `Arc`
+        // allocation, not a fresh clone with identical bytes. Assert the
+        // pointer identity directly so the invariant is guarded by a test, not
+        // only by inspection.
+        let (mut emu, _rx) = TerminalEmulator::new_headless(None);
+        emu.handle_incoming_data(b"stable content");
+        let first = emu.build_snapshot();
+        let second = emu.build_snapshot();
+        assert!(
+            !second.content_changed,
+            "an idle rebuild must not report content_changed"
+        );
+        assert!(
+            Arc::ptr_eq(&first.visible_chars, &second.visible_chars),
+            "an idle rebuild must reuse the SAME visible_chars Arc allocation \
+             (Arc::ptr_eq) so the GUI's ptr-identity change detection is sound"
+        );
+    }
+
+    #[test]
+    fn build_snapshot_repeated_primary_alt_bounce_without_writes_reuses_arc() {
+        // Issue #439 fix #4 adversarial-review follow-up: walk
+        // primary -> alt -> primary -> alt (2nd time) with NO writes to the
+        // alt buffer, and assert the returning primary snapshot both reports
+        // `!content_changed` AND reuses the byte-identical `visible_chars`
+        // Arc. This exercises the per-buffer cache-swap stash across a REPEATED
+        // bounce (the existing tests only do a single round trip), which is the
+        // path the reviewer flagged as relied-on-but-untested now that the raw
+        // `content_changed` flag no longer backs up the ptr_eq check on the
+        // GUI side.
+        let (mut emu, _rx) = TerminalEmulator::new_headless(None);
+        emu.handle_incoming_data(b"primary baseline");
+        let _ = emu.build_snapshot();
+        let primary_stable = emu.build_snapshot();
+        assert!(!primary_stable.content_changed, "idle primary is stable");
+        let primary_arc = Arc::clone(&primary_stable.visible_chars);
+
+        // First excursion: enter alt (no writes), render, leave.
+        emu.handle_incoming_data(b"\x1b[?1049h");
+        let _ = emu.build_snapshot();
+        emu.handle_incoming_data(b"\x1b[?1049l");
+        let returned_once = emu.build_snapshot();
+        assert!(
+            !returned_once.is_alternate_screen,
+            "back on primary after first excursion"
+        );
+        assert!(
+            !returned_once.content_changed,
+            "returning to byte-identical primary must not report content_changed"
+        );
+        assert!(
+            Arc::ptr_eq(&returned_once.visible_chars, &primary_arc),
+            "first return must reuse the primary visible_chars Arc"
+        );
+
+        // Second excursion: enter alt AGAIN (still no writes), render, leave.
+        emu.handle_incoming_data(b"\x1b[?1049h");
+        let _ = emu.build_snapshot();
+        emu.handle_incoming_data(b"\x1b[?1049l");
+        let returned_twice = emu.build_snapshot();
+        assert!(
+            !returned_twice.is_alternate_screen,
+            "back on primary after second excursion"
+        );
+        assert!(
+            !returned_twice.content_changed,
+            "second return to byte-identical primary must not report content_changed"
+        );
+        assert!(
+            Arc::ptr_eq(&returned_twice.visible_chars, &primary_arc),
+            "second return must STILL reuse the primary visible_chars Arc \
+             (repeated bounce must not silently reallocate)"
+        );
+    }
+
+    #[test]
     fn build_snapshot_scrolled_primary_to_alt_to_primary_does_not_reuse_scrolled_content() {
         // Issue #405 / CodeRabbit follow-up: a primary snapshot taken while
         // scrolled back must NOT be restored (via the per-buffer cache swap)

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -614,7 +614,7 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                     ),
                 }
                 if response.repaint {
-                    let deadline = Instant::now() + std::time::Duration::from_millis(16);
+                    let deadline = Instant::now() + MIN_REPAINT_INTERVAL;
                     state.repaint_at = Some(
                         state
                             .repaint_at
@@ -906,14 +906,13 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                 };
                 state.repaint_at = None;
 
-                // Honour egui's repaint_delay but clamp to a minimum of 16ms
-                // to prevent unbounded rendering from zero-delay requests
-                // (hover state, tooltip updates).  This ensures layout-settling
-                // frames still fire while keeping idle CPU near zero.
+                // Honour egui's repaint_delay but clamp to the shared
+                // MIN_REPAINT_INTERVAL floor to prevent unbounded rendering
+                // from zero-delay requests (hover state, tooltip updates).
+                // This ensures layout-settling frames still fire while keeping
+                // idle CPU near zero.
                 if frame_output.repaint_delay < std::time::Duration::from_hours(1) {
-                    let min_delay = std::time::Duration::from_millis(16);
-                    let delay = frame_output.repaint_delay.max(min_delay);
-                    let deadline = Instant::now() + delay;
+                    let deadline = Instant::now() + clamp_repaint_delay(frame_output.repaint_delay);
                     state.repaint_at = Some(deadline);
                 }
 
@@ -951,8 +950,10 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
             UserEvent::RequestRepaint(id) => {
                 if let Some(state) = self.windows.get_mut(&id.0) {
                     // Schedule rather than calling request_redraw() directly,
-                    // same throttle as window_event to prevent unbounded rendering.
-                    let min_deadline = Instant::now() + std::time::Duration::from_millis(16);
+                    // throttled to the shared MIN_REPAINT_INTERVAL floor (same
+                    // as window_event / RequestRepaintAfter) to prevent
+                    // unbounded rendering.
+                    let min_deadline = Instant::now() + MIN_REPAINT_INTERVAL;
                     state.repaint_at = Some(
                         state
                             .repaint_at

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -57,6 +57,35 @@ fn logical_coord_to_i32(v: f64) -> i32 {
     })
 }
 
+/// Minimum interval between *delay-scheduled* repaints — the 60fps frame
+/// budget.
+///
+/// Every path that schedules a repaint *after a delay* (both the cross-thread
+/// [`UserEvent::RequestRepaintAfter`] and the same-thread
+/// [`WindowOp::RequestRepaintAfter`], plus egui's own
+/// `frame_output.repaint_delay`) floors that delay to this value so that no
+/// single source can drive the GUI faster than ~60fps while idle. (Discrete
+/// *immediate* repaints — `RequestRepaint`, resize/scale/occlusion redraws —
+/// are one-shot responses to real events, not continuous streams, and are
+/// intentionally not throttled here.)
+///
+/// This closes the issue #439 loophole where the cross-thread
+/// [`UserEvent::RequestRepaintAfter`] path (used by the PTY consumer thread)
+/// accepted an unclamped sub-16ms delay and `min`'d below any already-floored
+/// deadline, letting a bursty PTY output stream (btop, htop, vim, less) drive
+/// ~40+ full frames/sec for a screen that visually changes ~2x/sec.
+const MIN_REPAINT_INTERVAL: std::time::Duration = std::time::Duration::from_millis(16);
+
+/// Floor a requested repaint delay to [`MIN_REPAINT_INTERVAL`].
+///
+/// Pure so it can be unit-tested without a running event loop. A caller may
+/// legitimately request a longer delay (e.g. a 500ms cursor-blink wake or a
+/// 250ms toast-fade); those pass through unchanged. Only sub-16ms requests
+/// are raised to the floor.
+fn clamp_repaint_delay(delay: std::time::Duration) -> std::time::Duration {
+    delay.max(MIN_REPAINT_INTERVAL)
+}
+
 /// Returns `true` for the narrow set of physical keys that egui 0.35 cannot
 /// deliver: print/pause/menu keys, keypad operators and digits, and the
 /// media keys winit's `KeyCode` exposes (Task 114). These are intercepted
@@ -446,7 +475,13 @@ impl<A: App> Handler<A> {
                 }
                 WindowOp::RequestRepaintAfter(id, delay) => {
                     if let Some(state) = self.windows.get_mut(&id.0) {
-                        let deadline = Instant::now() + delay;
+                        // Same 16ms floor as every other repaint-scheduling
+                        // path (issue #439). This same-thread `WindowOp` path
+                        // has no sub-16ms caller today, but flooring it keeps
+                        // the "no scheduling path can drive the GUI past
+                        // ~60fps" invariant true for every caller, present and
+                        // future.
+                        let deadline = Instant::now() + clamp_repaint_delay(delay);
                         state.repaint_at = Some(
                             state
                                 .repaint_at
@@ -927,7 +962,17 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
             }
             UserEvent::RequestRepaintAfter(id, delay) => {
                 if let Some(state) = self.windows.get_mut(&id.0) {
-                    let deadline = Instant::now() + delay;
+                    // Clamp the caller-supplied delay to the same 16ms floor
+                    // the in-frame `frame_output.repaint_delay` path and the
+                    // `RequestRepaint` arm enforce (issue #439). Without this
+                    // floor, a cross-thread caller (the PTY consumer thread's
+                    // `post_event`) could request an 8ms wake that `min`s
+                    // below any 16ms-floored deadline already scheduled,
+                    // defeating the floor entirely and letting a bursty PTY
+                    // output stream drive the GUI past 60fps. Flooring here
+                    // closes the loophole for every caller of this path, not
+                    // just the one we know about today.
+                    let deadline = Instant::now() + clamp_repaint_delay(delay);
                     state.repaint_at = Some(
                         state
                             .repaint_at
@@ -1128,12 +1173,55 @@ pub fn run(config: WindowConfig, app: impl App + 'static) -> Result<(), Error> {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::{
-        ViewportCommandFlags, is_blocked_key, is_unconditional_chrome_input, logical_coord_to_i32,
-        logical_dim_to_u32, physical_to_logical_pos, should_force_chrome_full_for_pointer,
-        update_chrome_drag_latch, viewport_command_flags,
+        MIN_REPAINT_INTERVAL, ViewportCommandFlags, clamp_repaint_delay, is_blocked_key,
+        is_unconditional_chrome_input, logical_coord_to_i32, logical_dim_to_u32,
+        physical_to_logical_pos, should_force_chrome_full_for_pointer, update_chrome_drag_latch,
+        viewport_command_flags,
     };
     use winit::event::{DeviceId, WindowEvent};
     use winit::keyboard::KeyCode;
+
+    #[test]
+    fn clamp_repaint_delay_raises_sub_floor_delays_to_the_floor() {
+        // Issue #439: the PTY consumer thread previously requested an 8ms
+        // repaint delay through the unclamped cross-thread path, bypassing the
+        // 60fps floor and letting bursty output (btop, htop, vim, less) drive
+        // the GUI past 60fps. Any sub-16ms request must now be raised.
+        assert_eq!(
+            clamp_repaint_delay(std::time::Duration::from_millis(8)),
+            MIN_REPAINT_INTERVAL,
+            "the historical 8ms bypass must be floored to 16ms"
+        );
+        assert_eq!(
+            clamp_repaint_delay(std::time::Duration::ZERO),
+            MIN_REPAINT_INTERVAL,
+            "a zero-delay (immediate) request must still respect the floor"
+        );
+        assert_eq!(
+            clamp_repaint_delay(std::time::Duration::from_millis(15)),
+            MIN_REPAINT_INTERVAL,
+            "just-below-floor must be raised"
+        );
+    }
+
+    #[test]
+    fn clamp_repaint_delay_passes_through_at_and_above_the_floor() {
+        // Exactly the floor is unchanged.
+        assert_eq!(
+            clamp_repaint_delay(MIN_REPAINT_INTERVAL),
+            MIN_REPAINT_INTERVAL
+        );
+        // Longer legitimate delays (cursor-blink ~500ms, toast-fade ~250ms)
+        // must pass through untouched — the floor is a minimum, not a cap.
+        for ms in [17u64, 50, 100, 250, 500, 1000] {
+            let d = std::time::Duration::from_millis(ms);
+            assert_eq!(
+                clamp_repaint_delay(d),
+                d,
+                "delay {ms}ms >= floor must pass through unchanged"
+            );
+        }
+    }
 
     #[test]
     fn request_paste_command_sets_only_paste_flag() {

--- a/freminal/Cargo.toml
+++ b/freminal/Cargo.toml
@@ -69,7 +69,7 @@ deb_depends = [
 # `cargo xtask bump-version` keeps this in sync, translating the SemVer
 # pre-release separator to the RPM tilde operator (e.g. "0.9.0~beta.2"), which
 # sorts older than the final release just like the SemVer pre-release does.
-version = "0.12.0~beta.4"
+version = "0.12.0~beta.5"
 assets = [
   { source = "target/release/freminal", dest = "/usr/bin/freminal", mode = "755" },
   # Ship the desktop entry (carrying StartupWMClass=freminal, which matches the

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -70,6 +70,36 @@ const fn settings_owner_close_decision(
     SettingsOwnerCloseDecision::CloseNow
 }
 
+/// Whether a pane's blink-style cursor needs the periodic ~500ms repaint
+/// wake this frame.
+///
+/// A blinking cursor only needs to be re-rendered on a timer while it is
+/// actually visible on screen. The drawing side computes visibility as
+/// `snap.show_cursor && !is_echo_off && is_active_pane`
+/// (`terminal/widget.rs`'s `effective_show_cursor`); the repaint scheduler
+/// MUST gate the blink wake on the same condition, or a full-screen TUI that
+/// hides the cursor via DECTCEM (`\e[?25l`) — btop, htop, vim, less — keeps
+/// the default blink *style* and makes the terminal wake ~2x/sec forever to
+/// redraw an unchanged, cursor-hidden screen (a real idle-CPU drain).
+///
+/// Returns `true` only when the cursor style is a blink variant AND the
+/// cursor is actually visible (DECTCEM-shown, this is the active pane, and
+/// password-echo-off is not hiding it).
+const fn cursor_blink_wants_repaint(
+    style: &freminal_common::cursor::CursorVisualStyle,
+    show_cursor: bool,
+    is_active: bool,
+    is_echo_off: bool,
+) -> bool {
+    let is_blink_style = matches!(
+        style,
+        freminal_common::cursor::CursorVisualStyle::BlockCursorBlink
+            | freminal_common::cursor::CursorVisualStyle::UnderlineCursorBlink
+            | freminal_common::cursor::CursorVisualStyle::VerticalLineCursorBlink,
+    );
+    is_blink_style && show_cursor && is_active && !is_echo_off
+}
+
 impl freminal_windowing::App for FreminalGui {
     /// Called when a window is created.
     ///
@@ -315,6 +345,7 @@ impl freminal_windowing::App for FreminalGui {
                         cached_central_rect: None,
                         chrome_head_rects: None,
                         chrome_border_rects: Vec::new(),
+                        frame_stats: super::window::FrameStats::default(),
                     };
                     self.windows.insert(window_id, win);
 
@@ -2040,6 +2071,34 @@ impl freminal_windowing::App for FreminalGui {
                     pane.view_state.scroll_offset = pane_snap.scroll_offset;
                 }
 
+                // First-observation gate (issue #439 fix #4).
+                //
+                // The PTY thread publishes a new `Arc<TerminalSnapshot>` only
+                // when real output arrives (a few times/sec under a settled
+                // full-screen TUI like btop), but this `update()` runs every
+                // frame (~60fps) and re-reads whatever snapshot is currently
+                // published. `pane_snap.content_changed` is baked into the
+                // snapshot at build time, so on the ~14 frames between real
+                // updates it reads a stale `true`, which used to re-arm a 16ms
+                // content repaint every frame — a self-perpetuating 60fps wake
+                // for pixels that are not changing.
+                //
+                // Compare the current `visible_chars` `Arc` against the one
+                // observed last frame: `is_new_snapshot` is `true` only on the
+                // first frame a genuinely-new snapshot appears. We update the
+                // cache unconditionally (every frame, before the widget draws)
+                // — distinct from `last_rendered_visible`, which the widget
+                // updates only on a full rebuild. Missing a real update is
+                // impossible: every `build_snapshot` in the PTY thread is
+                // paired with its own `request_repaint_after` (min-merged into
+                // the wake schedule), so a new snapshot always gets at least
+                // one wake independent of this gate; the gate only suppresses
+                // the redundant self-scheduled repaints of already-drawn
+                // content.
+                let is_new_snapshot = pane
+                    .render_cache
+                    .observe_visible_snapshot(&pane_snap.visible_chars);
+
                 // OSC 1338 HISTFILE reload trigger (Task 72.15).  When the
                 // shell-integration scripts publish a new HISTFILE path
                 // through `OSC 1338 ; HISTFILE=<path> ST`, the snapshot's
@@ -2288,14 +2347,58 @@ impl freminal_windowing::App for FreminalGui {
                 }
 
                 // Determine repaint delay for this pane.
-                let cursor_is_blinking = matches!(
-                    pane_snap.cursor_visual_style,
-                    freminal_common::cursor::CursorVisualStyle::BlockCursorBlink
-                        | freminal_common::cursor::CursorVisualStyle::UnderlineCursorBlink
-                        | freminal_common::cursor::CursorVisualStyle::VerticalLineCursorBlink,
+                //
+                // A blink-style cursor only needs the periodic ~500ms wake
+                // when the cursor is ACTUALLY on screen — i.e. exactly the
+                // condition the drawing side gates on (`effective_show_cursor`
+                // in `terminal/widget.rs`: `snap.show_cursor && !is_echo_off
+                // && is_active_pane`). Scheduling the wake off the configured
+                // cursor *style* alone (ignoring `show_cursor`) is a real
+                // over-repaint bug: a full-screen TUI that hides the cursor
+                // via DECTCEM (`\e[?25l`) — btop, vim, htop, less, … — keeps
+                // the default blink *style*, so the terminal wakes ~2x/sec to
+                // redraw an unchanged, cursor-hidden screen forever. Gating on
+                // the real cursor visibility lets those idle-at-hidden-cursor
+                // frames drop to zero.
+                let cursor_blink_wants_repaint = cursor_blink_wants_repaint(
+                    &pane_snap.cursor_visual_style,
+                    pane_snap.show_cursor,
+                    is_active,
+                    is_echo_off,
                 );
-                if pane_snap.content_changed || cursor_is_blinking || pane_snap.has_blinking_text {
-                    let delay = if pane_snap.content_changed {
+                // Honour `content_changed` only on the first observation of a
+                // genuinely-new snapshot (issue #439 fix #4). Re-reading the
+                // same published `Arc` on a later frame sees the same
+                // (byte-identical) pixels, so scheduling another content
+                // repaint buys nothing and only perpetuates the 60fps wake.
+                let content_wants_repaint = is_new_snapshot && pane_snap.content_changed;
+                // Diagnostic: count the ~2Hz phantom wakes the `show_cursor`
+                // gate now suppresses — a blink-STYLE cursor on the active
+                // pane, content unchanged, no blinking text, but the cursor
+                // is actually hidden (DECTCEM / echo-off), so the old code
+                // would have scheduled a 500ms wake and the new code does not.
+                // Uses `content_wants_repaint` (the gated signal actually
+                // driving scheduling) rather than the raw sticky flag so the
+                // counter tracks the real scheduling decision.
+                if is_active
+                    && !content_wants_repaint
+                    && !pane_snap.has_blinking_text
+                    && !cursor_blink_wants_repaint
+                    && matches!(
+                        pane_snap.cursor_visual_style,
+                        freminal_common::cursor::CursorVisualStyle::BlockCursorBlink
+                            | freminal_common::cursor::CursorVisualStyle::UnderlineCursorBlink
+                            | freminal_common::cursor::CursorVisualStyle::VerticalLineCursorBlink,
+                    )
+                {
+                    win.frame_stats.blink_wake_suppressed =
+                        win.frame_stats.blink_wake_suppressed.saturating_add(1);
+                }
+                if content_wants_repaint
+                    || cursor_blink_wants_repaint
+                    || pane_snap.has_blinking_text
+                {
+                    let delay = if content_wants_repaint {
                         std::time::Duration::from_millis(16)
                     } else if pane_snap.has_blinking_text {
                         view_state::TEXT_BLINK_TICK_DURATION
@@ -2368,6 +2471,10 @@ impl freminal_windowing::App for FreminalGui {
             // no window input event, exactly the frame a REPLAY would
             // otherwise be chosen.
             let mut foreground_overlay_open = false;
+            // Diagnostic: capture the active pane's per-frame damage class
+            // (reused from the #435 signal) for the frame-attribution stats
+            // flushed below; `None` if the active pane isn't resolved.
+            let mut active_pane_damage: Option<crate::gui::renderer::PaneFrameDamage> = None;
             let mut per_pane_damage: Vec<frame_damage::PaneDamageInput> =
                 Vec::with_capacity(pane_layout.len());
             for (pane_id, _) in &pane_layout {
@@ -2386,6 +2493,9 @@ impl freminal_windowing::App for FreminalGui {
                     || pane.view_state.search_state.is_open
                     || pane.view_state.command_history.is_open
                     || pane.render_cache.hover_tooltip_active();
+                if *pane_id == active_pane_id {
+                    active_pane_damage = Some(pane.render_cache.last_frame_cursor_damage);
+                }
                 per_pane_damage.push(frame_damage::PaneDamageInput {
                     bell_active: pane.view_state.bell_since.is_some(),
                     cursor_damage: pane.render_cache.last_frame_cursor_damage,
@@ -2396,6 +2506,47 @@ impl freminal_windowing::App for FreminalGui {
                 toast_active,
                 &per_pane_damage,
             );
+
+            // Diagnostic frame-attribution stats (reuses the #435 damage
+            // signal). One `update()` == one drawn frame; classify the active
+            // pane's damage so a CPU investigation can see, without a
+            // profiler, how many drawn frames were genuinely-unchanged
+            // (no CPU rebuild), cursor-only patches, or full vertex rebuilds.
+            {
+                let stats = &mut win.frame_stats;
+                stats.frames_drawn = stats.frames_drawn.saturating_add(1);
+                match active_pane_damage {
+                    Some(crate::gui::renderer::PaneFrameDamage::Unchanged) => {
+                        stats.unchanged = stats.unchanged.saturating_add(1);
+                    }
+                    Some(crate::gui::renderer::PaneFrameDamage::CursorOnly(_)) => {
+                        stats.cursor_only = stats.cursor_only.saturating_add(1);
+                    }
+                    Some(crate::gui::renderer::PaneFrameDamage::Full) | None => {
+                        stats.full = stats.full.saturating_add(1);
+                    }
+                }
+                if stats
+                    .frames_drawn
+                    .is_multiple_of(super::window::FrameStats::FLUSH_EVERY)
+                {
+                    // `debug!`, not `info!`: this is an investigative
+                    // diagnostic for chasing idle-CPU / over-repaint issues,
+                    // not end-user-facing telemetry. At `info` it would write
+                    // a line to the user's persistent log every ~2s of active
+                    // use forever; keep it out of the default log stream.
+                    tracing::debug!(
+                        frames_drawn = stats.frames_drawn,
+                        unchanged = stats.unchanged,
+                        cursor_only = stats.cursor_only,
+                        full = stats.full,
+                        blink_wake_suppressed = stats.blink_wake_suppressed,
+                        "frame-attribution stats (#439 diag): drawn frames split \
+                         by active-pane damage class; blink_wake_suppressed = \
+                         ~2Hz phantom wakes avoided by the show_cursor gate"
+                    );
+                }
+            }
 
             // ── Chrome-damage signals (#436.3 §3.3) ───────────────────
             //
@@ -3206,6 +3357,7 @@ impl FreminalGui {
             cached_central_rect: None,
             chrome_head_rects: None,
             chrome_border_rects: Vec::new(),
+            frame_stats: super::window::FrameStats::default(),
         }
     }
 
@@ -3416,7 +3568,74 @@ impl FreminalGui {
 
 #[cfg(test)]
 mod tests {
-    use super::{SettingsOwnerCloseDecision, settings_owner_close_decision};
+    use super::{
+        SettingsOwnerCloseDecision, cursor_blink_wants_repaint, settings_owner_close_decision,
+    };
+    use freminal_common::cursor::CursorVisualStyle;
+
+    #[test]
+    fn blink_cursor_wants_repaint_only_when_actually_visible() {
+        // Visible, active, echo on, blink style -> wants the ~500ms wake.
+        assert!(cursor_blink_wants_repaint(
+            &CursorVisualStyle::BlockCursorBlink,
+            true,
+            true,
+            false
+        ));
+        // DECTCEM-hidden (show_cursor false) -> NO wake. This is the btop /
+        // full-screen-TUI case: the fix. Style is still blink, but the
+        // cursor is hidden, so we must not wake ~2x/sec.
+        assert!(!cursor_blink_wants_repaint(
+            &CursorVisualStyle::BlockCursorBlink,
+            false,
+            true,
+            false
+        ));
+        // Not the active pane -> no wake (only the active pane draws a cursor).
+        assert!(!cursor_blink_wants_repaint(
+            &CursorVisualStyle::BlockCursorBlink,
+            true,
+            false,
+            false
+        ));
+        // Password echo-off hides the cursor -> no wake.
+        assert!(!cursor_blink_wants_repaint(
+            &CursorVisualStyle::BlockCursorBlink,
+            true,
+            true,
+            true
+        ));
+    }
+
+    #[test]
+    fn non_blink_cursor_never_wants_blink_repaint() {
+        // A steady (non-blink) cursor never needs the periodic wake, even
+        // when fully visible.
+        for style in [
+            CursorVisualStyle::BlockCursorSteady,
+            CursorVisualStyle::UnderlineCursorSteady,
+            CursorVisualStyle::VerticalLineCursorSteady,
+        ] {
+            assert!(
+                !cursor_blink_wants_repaint(&style, true, true, false),
+                "steady style {style:?} must not request a blink wake"
+            );
+        }
+    }
+
+    #[test]
+    fn each_blink_style_variant_wants_repaint_when_visible() {
+        for style in [
+            CursorVisualStyle::BlockCursorBlink,
+            CursorVisualStyle::UnderlineCursorBlink,
+            CursorVisualStyle::VerticalLineCursorBlink,
+        ] {
+            assert!(
+                cursor_blink_wants_repaint(&style, true, true, false),
+                "blink style {style:?} must request a wake when visible"
+            );
+        }
+    }
 
     #[test]
     fn not_owner_ignores_other_state() {

--- a/freminal/src/gui/layout_ops.rs
+++ b/freminal/src/gui/layout_ops.rs
@@ -735,6 +735,7 @@ impl FreminalGui {
             cached_central_rect: None,
             chrome_head_rects: None,
             chrome_border_rects: Vec::new(),
+            frame_stats: super::window::FrameStats::default(),
         };
         self.windows.insert(window_id, win);
 

--- a/freminal/src/gui/pty.rs
+++ b/freminal/src/gui/pty.rs
@@ -106,8 +106,22 @@ pub(crate) fn forward_command_events(
     }
 }
 
+/// Upper bound on how many *additional* queued `PtyRead` messages a single
+/// [`drain_pty_reads`] call folds into one batch before yielding back to the
+/// consumer thread's `select!` loop.
+///
+/// The blocking-recv'd message is always processed; this caps only the
+/// non-blocking `try_recv` drain that follows. It exists so a sustained
+/// high-throughput producer that outpaces parsing cannot keep the consumer
+/// inside the drain loop indefinitely and starve `input_rx` / `child_exit`.
+/// At the reader thread's 4096-byte read buffer, 64 chunks is ~256 KiB of
+/// output per batch — comfortably more than any single interactive redraw,
+/// while bounding worst-case input-handling latency to one batch of parses.
+const MAX_PTY_READ_BATCH: usize = 64;
+
 /// Feed a just-received `PtyRead` and every `PtyRead` already queued behind it
-/// into `sink`, in arrival order, in a single batch (issue #439).
+/// (up to [`MAX_PTY_READ_BATCH`]) into `sink`, in arrival order, in a single
+/// batch (issue #439).
 ///
 /// The PTY consumer thread's `select!` loop calls `post_event`
 /// (`build_snapshot` then `arc_swap.store` then a repaint request) exactly once
@@ -118,10 +132,21 @@ pub(crate) fn forward_command_events(
 /// repaint: a ~20-40x over-draw for a screen that visually changes ~2x/sec.
 ///
 /// This helper feeds `first` (the message the blocking `recv` already took)
-/// and then non-blockingly drains the rest of the queue via `try_recv`, so all
-/// currently-available output is folded into the emulator before the single
-/// trailing `post_event`. It mirrors the write-side drain idiom in
-/// `freminal-terminal-emulator/src/io/pty.rs` and the `child_exit` drain arm.
+/// and then non-blockingly drains up to [`MAX_PTY_READ_BATCH`] further queued
+/// messages via `try_recv`, so a burst of currently-available output is folded
+/// into the emulator before the single trailing `post_event`. It mirrors the
+/// write-side drain idiom in `freminal-terminal-emulator/src/io/pty.rs`.
+///
+/// The batch is **capped** rather than draining to exhaustion: under a
+/// sustained high-throughput producer that outpaces parsing (`yes`,
+/// `cat bigfile`, a log flood), an unbounded drain could keep the consumer
+/// thread inside this loop indefinitely, starving the sibling `select!` arms
+/// (`input_rx` keystrokes/resize, `child_exit`). Capping at
+/// [`MAX_PTY_READ_BATCH`] bounds worst-case input latency to one batch of
+/// parses while still coalescing any realistic single visual redraw (btop's is
+/// ~5-6 chunks) into one snapshot. Anything beyond the cap simply stays queued
+/// and is drained by the next `select!` iteration, which also re-services the
+/// other arms first-come-first-served.
 ///
 /// It is architecturally clean: the consumer thread owns the emulator
 /// exclusively, and the terminal handler's `handle_incoming_data` never itself
@@ -131,15 +156,18 @@ pub(crate) fn forward_command_events(
 /// for both correct escape-sequence parsing and byte-accurate recording.
 ///
 /// Extracted as a free function so the "process the first message, then drain
-/// the rest in order, exactly once each" contract is unit-testable without
+/// up to the cap in order, exactly once each" contract is unit-testable without
 /// spinning up a real shell.
 fn drain_pty_reads<F>(first: PtyRead, rx: &Receiver<PtyRead>, mut sink: F)
 where
     F: FnMut(PtyRead),
 {
     sink(first);
-    while let Ok(read) = rx.try_recv() {
-        sink(read);
+    for _ in 0..MAX_PTY_READ_BATCH {
+        match rx.try_recv() {
+            Ok(read) => sink(read),
+            Err(_) => break,
+        }
     }
 }
 
@@ -875,6 +903,44 @@ mod tests {
         let mut count = 0u32;
         drain_pty_reads(first, &rx, |_read| count += 1);
         assert_eq!(count, 1, "a lone message must be processed exactly once");
+    }
+
+    #[test]
+    fn drain_pty_reads_caps_batch_and_leaves_remainder_queued() {
+        // Responsiveness guard: a sustained producer must not keep the consumer
+        // inside the drain forever. `drain_pty_reads` processes `first` plus at
+        // most MAX_PTY_READ_BATCH queued messages, then returns so the caller's
+        // `select!` loop can re-service input_rx / child_exit. Anything beyond
+        // the cap stays queued for the next iteration.
+        let (tx, rx) = crossbeam_channel::unbounded::<PtyRead>();
+        // Queue far more than the cap behind the first message.
+        let queued = MAX_PTY_READ_BATCH * 3;
+        for _ in 0..queued {
+            tx.send(PtyRead {
+                buf: b"y".to_vec(),
+                read_amount: 1,
+            })
+            .unwrap();
+        }
+        let first = PtyRead {
+            buf: b"y".to_vec(),
+            read_amount: 1,
+        };
+        let mut count = 0usize;
+        drain_pty_reads(first, &rx, |_read| count += 1);
+
+        // Exactly first (1) + MAX_PTY_READ_BATCH processed this call.
+        assert_eq!(
+            count,
+            1 + MAX_PTY_READ_BATCH,
+            "must process the first message plus at most MAX_PTY_READ_BATCH queued"
+        );
+        // The rest remain queued for the next select! iteration.
+        assert_eq!(
+            rx.len(),
+            queued - MAX_PTY_READ_BATCH,
+            "over-cap messages must stay queued, not be dropped"
+        );
     }
 
     #[test]

--- a/freminal/src/gui/pty.rs
+++ b/freminal/src/gui/pty.rs
@@ -24,7 +24,7 @@ use freminal_common::buffer_states::window_manipulation::WindowManipulation;
 use freminal_common::pty_write::{FreminalTerminalSize, PtyWrite};
 use freminal_common::send_or_log;
 use freminal_terminal_emulator::interface::TerminalEmulator;
-use freminal_terminal_emulator::io::{InputEvent, WindowCommand};
+use freminal_terminal_emulator::io::{InputEvent, PtyRead, WindowCommand};
 use freminal_terminal_emulator::recording::{EventPayload, RecordingSwap};
 use freminal_terminal_emulator::snapshot::TerminalSnapshot;
 use freminal_terminal_emulator::terminal_handler::TerminalHandler;
@@ -103,6 +103,43 @@ pub(crate) fn forward_command_events(
             CommandFinishedEvent { pane_id, block },
             "Failed to send command-finished event to GUI"
         );
+    }
+}
+
+/// Feed a just-received `PtyRead` and every `PtyRead` already queued behind it
+/// into `sink`, in arrival order, in a single batch (issue #439).
+///
+/// The PTY consumer thread's `select!` loop calls `post_event`
+/// (`build_snapshot` then `arc_swap.store` then a repaint request) exactly once
+/// per loop iteration. Before this batching, a single visual redraw from a
+/// full-screen TUI (btop, htop, vim, less) exceeded the reader thread's
+/// 4096-byte buffer and so arrived as N separate `PtyRead` messages, each
+/// triggering its own iteration and thus its own full vertex rebuild plus
+/// repaint: a ~20-40x over-draw for a screen that visually changes ~2x/sec.
+///
+/// This helper feeds `first` (the message the blocking `recv` already took)
+/// and then non-blockingly drains the rest of the queue via `try_recv`, so all
+/// currently-available output is folded into the emulator before the single
+/// trailing `post_event`. It mirrors the write-side drain idiom in
+/// `freminal-terminal-emulator/src/io/pty.rs` and the `child_exit` drain arm.
+///
+/// It is architecturally clean: the consumer thread owns the emulator
+/// exclusively, and the terminal handler's `handle_incoming_data` never itself
+/// builds a snapshot or requests a repaint — it only mutates emulator state and
+/// sets per-row dirty flags that the single trailing `build_snapshot` consults
+/// once. Ordering is preserved (crossbeam channels are FIFO), which is required
+/// for both correct escape-sequence parsing and byte-accurate recording.
+///
+/// Extracted as a free function so the "process the first message, then drain
+/// the rest in order, exactly once each" contract is unit-testable without
+/// spinning up a real shell.
+fn drain_pty_reads<F>(first: PtyRead, rx: &Receiver<PtyRead>, mut sink: F)
+where
+    F: FnMut(PtyRead),
+{
+    sink(first);
+    while let Ok(read) = rx.try_recv() {
+        sink(read);
     }
 }
 
@@ -523,7 +560,15 @@ fn spawn_pty_consumer_thread(
                     arc_swap.store(Arc::new(snap));
 
                     if let Some((proxy, wid)) = repaint_handle.get() {
-                        proxy.request_repaint_after(*wid, std::time::Duration::from_millis(8));
+                        // 16ms == the 60fps frame budget and the same floor
+                        // enforced everywhere else (issue #439). The previous
+                        // 8ms value bypassed that floor via the unclamped
+                        // `RequestRepaintAfter` proxy path, letting a bursty
+                        // PTY stream drive the GUI toward ~120fps. The event
+                        // loop now also clamps this path to 16ms, so this is
+                        // belt-and-braces: request the correct delay AND rely
+                        // on the floor as a backstop.
+                        proxy.request_repaint_after(*wid, std::time::Duration::from_millis(16));
                     }
                 };
 
@@ -645,14 +690,41 @@ fn spawn_pty_consumer_thread(
                 crossbeam_channel::select! {
                     recv(pty_read_rx) -> msg => {
                         if let Ok(read) = msg {
-                            let data = &read.buf[0..read.read_amount];
-                            if let Some(rec) = recording_swap.load_full() {
-                                rec.emit(EventPayload::PtyOutput {
-                                    pane_id: recording_pane_id,
-                                    data: data.to_vec(),
-                                });
-                            }
-                            emulator.handle_incoming_data(data);
+                            // Batch-drain (issue #439): a single visual redraw
+                            // from a full-screen TUI (btop, htop, vim, less)
+                            // exceeds the 4096-byte reader buffer, so one
+                            // redraw arrives as N `PtyRead` chunks. Feed the
+                            // blocking-recv'd chunk AND every chunk already
+                            // queued behind it into the emulator, then fall
+                            // through to a SINGLE `post_event` (build_snapshot
+                            // + arc_swap.store + repaint) at the bottom of the
+                            // loop. Without this drain, N chunks became N full
+                            // vertex rebuilds + N repaint requests — a ~20-40x
+                            // over-draw for a screen that changes ~2x/sec.
+                            //
+                            // This mirrors the write-side drain idiom in
+                            // `io/pty.rs` (`while let Ok(..) = try_recv()`) and
+                            // the `child_exit` drain arm below. It is
+                            // architecturally clean: this consumer thread owns
+                            // the emulator exclusively, and `handle_incoming_data`
+                            // never itself builds a snapshot or requests a
+                            // repaint — it only mutates emulator state and sets
+                            // per-row dirty flags that the single trailing
+                            // `build_snapshot` consults once.
+                            //
+                            // Recording fidelity is preserved: every chunk is
+                            // still emitted to the recorder individually, in
+                            // arrival order, exactly as before.
+                            drain_pty_reads(read, &pty_read_rx, |read: PtyRead| {
+                                let data = &read.buf[0..read.read_amount];
+                                if let Some(rec) = recording_swap.load_full() {
+                                    rec.emit(EventPayload::PtyOutput {
+                                        pane_id: recording_pane_id,
+                                        data: data.to_vec(),
+                                    });
+                                }
+                                emulator.handle_incoming_data(data);
+                            });
                             idle_deadline = crossbeam_channel::after(IDLE_COMPACTION_INTERVAL);
                         } else {
                             info!("PTY read channel closed; signaling tab death");
@@ -756,6 +828,89 @@ mod tests {
     /// Helper: build a fresh `CommandBlock` with the given fid.
     fn block_with_fid(fid: &str) -> CommandBlock {
         CommandBlock::new_running(0, None, fid.to_owned())
+    }
+
+    #[test]
+    fn drain_pty_reads_processes_first_then_queue_in_order_exactly_once() {
+        // Issue #439: the consumer must fold the blocking-recv'd chunk plus
+        // every already-queued chunk into ONE batch, in FIFO order, each
+        // exactly once, before the single trailing `post_event`. Collect the
+        // read_amounts to prove order + exactly-once without touching a parser.
+        let (tx, rx) = crossbeam_channel::unbounded::<PtyRead>();
+        tx.send(PtyRead {
+            buf: b"CD".to_vec(),
+            read_amount: 2,
+        })
+        .unwrap();
+        tx.send(PtyRead {
+            buf: b"EF".to_vec(),
+            read_amount: 3,
+        })
+        .unwrap();
+
+        let first = PtyRead {
+            buf: b"AB".to_vec(),
+            read_amount: 1,
+        };
+        let mut seen: Vec<usize> = Vec::new();
+        drain_pty_reads(first, &rx, |read| seen.push(read.read_amount));
+
+        assert_eq!(
+            seen,
+            vec![1, 2, 3],
+            "first message must be processed first, then the queue in FIFO order, each once"
+        );
+        assert!(rx.try_recv().is_err(), "the queue must be fully drained");
+    }
+
+    #[test]
+    fn drain_pty_reads_single_message_processes_only_that_one() {
+        // The common steady-state case: nothing queued behind the recv'd
+        // message. Exactly one sink call, queue left empty.
+        let (_tx, rx) = crossbeam_channel::unbounded::<PtyRead>();
+        let first = PtyRead {
+            buf: b"x".to_vec(),
+            read_amount: 1,
+        };
+        let mut count = 0u32;
+        drain_pty_reads(first, &rx, |_read| count += 1);
+        assert_eq!(count, 1, "a lone message must be processed exactly once");
+    }
+
+    #[test]
+    fn drain_pty_reads_feeds_emulator_bytes_in_order() {
+        // End-to-end against a real headless emulator: three chunks whose
+        // concatenation spells "ABCDEF" must be parsed as "ABCDEF" — an
+        // out-of-order or duplicated feed would produce a different string.
+        use freminal_terminal_emulator::interface::TerminalEmulator;
+
+        let (mut emu, _write_rx) = TerminalEmulator::new_headless(None);
+        let (tx, rx) = crossbeam_channel::unbounded::<PtyRead>();
+        tx.send(PtyRead {
+            buf: b"CD".to_vec(),
+            read_amount: 2,
+        })
+        .unwrap();
+        tx.send(PtyRead {
+            buf: b"EF".to_vec(),
+            read_amount: 2,
+        })
+        .unwrap();
+
+        let first = PtyRead {
+            buf: b"AB".to_vec(),
+            read_amount: 2,
+        };
+        drain_pty_reads(first, &rx, |read| {
+            emu.handle_incoming_data(&read.buf[0..read.read_amount]);
+        });
+
+        let text = emu.extract_selection_text(0, 0, 0, 5, false);
+        assert!(
+            text.contains("ABCDEF"),
+            "batched chunks must be parsed in arrival order; got: {text:?}"
+        );
+        assert!(rx.try_recv().is_err(), "the queue must be fully drained");
     }
 
     #[test]

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -1083,6 +1083,28 @@ pub struct PaneRenderCache {
     /// Pointer identity of the `visible_chars` `Arc` used for the last URL
     /// hover lookup.
     pub(super) hover_snap_ptr: usize,
+    /// The `visible_chars` `Arc` this pane observed on the previous frame
+    /// (issue #439 fix #4).
+    ///
+    /// The PTY thread only publishes a new `Arc<TerminalSnapshot>` when real
+    /// output arrives (~a few times/sec under a settled full-screen TUI), but
+    /// the GUI reads the currently-published snapshot on *every* frame
+    /// (~60fps). `TerminalSnapshot::content_changed` is a flag baked into the
+    /// snapshot at build time, so re-reading the *same* published `Arc` sees a
+    /// stale `content_changed == true` on every frame between real updates.
+    ///
+    /// Comparing the current `visible_chars` `Arc` against this field via
+    /// `Arc::ptr_eq` tells us whether *this* frame is the first observation of
+    /// a genuinely-new snapshot. It gates the content-driven 16ms repaint
+    /// scheduling in `app_impl` so an already-drawn snapshot does not
+    /// perpetually re-arm a 60fps wake for pixels that are not changing.
+    ///
+    /// Distinct from [`Self::last_rendered_visible`], which tracks the last
+    /// *full rebuild* (conditionally updated inside the render path); this
+    /// tracks the last *observation* (updated unconditionally every frame,
+    /// before the widget draws). An owned `Arc` (not a bare address) is stored
+    /// to avoid the ABA hazard of a freed allocation reusing an old address.
+    pub(super) last_observed_visible: Option<Arc<Vec<TChar>>>,
     /// Per-pane shaping cache for text layout.
     pub(crate) shaping_cache: crate::gui::shaping::ShapingCache,
     /// Whether the user is currently dragging the scrollbar thumb.
@@ -1174,6 +1196,7 @@ impl PaneRenderCache {
             previous_command_block_hover_rows: None,
             cached_hovered_url: None,
             hover_snap_ptr: 0,
+            last_observed_visible: None,
             shaping_cache: crate::gui::shaping::ShapingCache::new(),
             scrollbar_dragging: false,
             pointer_in_gutter_last_frame: false,
@@ -1209,6 +1232,31 @@ impl PaneRenderCache {
     #[must_use]
     pub(crate) const fn hover_tooltip_active(&self) -> bool {
         self.cached_hovered_url.is_some()
+    }
+
+    /// Record that this pane observed `visible_chars` this frame and report
+    /// whether it is the first observation of a genuinely-new snapshot
+    /// allocation (issue #439 fix #4).
+    ///
+    /// Returns `true` only when `visible_chars` is a different `Arc`
+    /// allocation from the one observed on the previous call — i.e. the PTY
+    /// thread published a new snapshot since last frame. Returns `false` when
+    /// the same published snapshot is being re-read (the ~14 idle frames
+    /// between real updates under a settled full-screen TUI).
+    ///
+    /// Always updates the stored `Arc` (a cheap refcount bump), so it must be
+    /// called exactly once per pane per frame, before the content-driven
+    /// repaint decision. `last_observed_visible` is `pub(super)`
+    /// (render-pipeline internal); this narrow accessor lets `app_impl.rs`'s
+    /// repaint scheduler consult it without widening the field's visibility,
+    /// mirroring [`Self::super_pressed`] / [`Self::hover_tooltip_active`].
+    pub(crate) fn observe_visible_snapshot(&mut self, visible_chars: &Arc<Vec<TChar>>) -> bool {
+        let is_new = self
+            .last_observed_visible
+            .as_ref()
+            .is_none_or(|prev| !Arc::ptr_eq(prev, visible_chars));
+        self.last_observed_visible = Some(Arc::clone(visible_chars));
+        is_new
     }
 
     /// Invalidate the cached theme pointer so the next frame forces a full
@@ -1944,6 +1992,21 @@ impl FreminalTerminalWidget {
             // is a different allocation from the one we last rendered, the
             // content has changed regardless of the `content_changed` flag.
             //
+            // We deliberately do NOT OR in the snapshot's `content_changed`
+            // flag here (issue #439 fix #4). That flag is baked into the
+            // published snapshot at build time, so when the GUI re-reads the
+            // SAME `Arc` on the ~14 frames between real PTY updates it reads a
+            // stale `true` and forces a full vertex rebuild every frame — a
+            // ~60fps rebuild for a screen changing a few times/sec. The
+            // `Arc::ptr_eq` check below already detects every genuine change:
+            // whenever real content changes, `flatten_visible` allocates a NEW
+            // `visible_chars` `Arc` (so ptr_eq fails and we rebuild), and a
+            // cursor-blink re-flatten that produces a byte-identical-but-new
+            // `Arc` also fails ptr_eq and rebuilds. Re-observing the same `Arc`
+            // correctly reports "unchanged". So the raw flag is redundant here
+            // and, worse, sticky — dropping it is what lets an idle screen fall
+            // through to the cheap cursor-only / no-op path.
+            //
             // Also force a full rebuild when the theme palette changes, since
             // foreground/background colors are baked into the vertex buffers.
             let theme_changed = cache
@@ -1962,8 +2025,7 @@ impl FreminalTerminalWidget {
             // the cached background/foreground vertex buffers are stale even
             // if `visible_chars` is byte-identical.
             let folds_changed = fold_epoch != cache.previous_fold_epoch;
-            let content_changed = snap.content_changed
-                || theme_changed
+            let content_changed = theme_changed
                 || dims_changed
                 || folds_changed
                 || cache
@@ -3567,6 +3629,52 @@ mod subtask_1_7_tests {
         assert_eq!(super::truncate_url(url, 5), "abcde");
         // One over — truncates.
         assert_eq!(super::truncate_url(url, 4), "abcd…");
+    }
+
+    #[test]
+    fn observe_visible_snapshot_reports_new_only_on_first_observation() {
+        // Issue #439 fix #4: the repaint scheduler gates the content-driven
+        // 16ms wake on this returning `true` only when a genuinely-new
+        // snapshot allocation is observed. Re-observing the SAME `Arc` (the
+        // idle frames between real PTY updates) must return `false` so the
+        // wake is not re-armed.
+        use freminal_common::buffer_states::tchar::TChar;
+
+        let mut cache = PaneRenderCache::new();
+        let snap_a = Arc::new(vec![TChar::Ascii(b'A'), TChar::Ascii(b'B')]);
+        let snap_b = Arc::new(vec![TChar::Ascii(b'C'), TChar::Ascii(b'D')]);
+
+        // First ever observation of any snapshot is new.
+        assert!(
+            cache.observe_visible_snapshot(&snap_a),
+            "first observation of a snapshot must report new"
+        );
+        // Re-observing the SAME Arc is NOT new (the idle re-read case).
+        assert!(
+            !cache.observe_visible_snapshot(&snap_a),
+            "re-observing the same Arc must report not-new"
+        );
+        assert!(
+            !cache.observe_visible_snapshot(&snap_a),
+            "still not-new on a third re-read of the same Arc"
+        );
+        // A different allocation is new again.
+        assert!(
+            cache.observe_visible_snapshot(&snap_b),
+            "observing a different Arc allocation must report new"
+        );
+        assert!(
+            !cache.observe_visible_snapshot(&snap_b),
+            "re-observing the new Arc must then report not-new"
+        );
+        // A byte-identical but distinct allocation is still "new" (ptr
+        // identity, not value equality) — matching how `flatten_visible`
+        // allocates a fresh Arc whenever it re-flattens dirty rows.
+        let snap_b_clone_bytes = Arc::new(vec![TChar::Ascii(b'C'), TChar::Ascii(b'D')]);
+        assert!(
+            cache.observe_visible_snapshot(&snap_b_clone_bytes),
+            "a distinct allocation with identical bytes is a new observation"
+        );
     }
 }
 

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -360,4 +360,35 @@ pub(super) struct PerWindowState {
     /// frame; explicitly cleared on frames that build no sensors (single pane /
     /// zoomed / overlay open).
     pub(super) chrome_border_rects: Vec<egui::Rect>,
+
+    /// Per-frame render attribution counters (diagnostic), flushed to an
+    /// `info` log line every [`FrameStats::FLUSH_EVERY`] drawn frames. Lets
+    /// a CPU investigation see, without a profiler, how many frames are
+    /// actually drawn and how they split across the #435 per-frame damage
+    /// classes (a genuinely-unchanged redraw costs no CPU rebuild; a `Full`
+    /// frame rebuilds the visible vertex data).
+    pub(super) frame_stats: FrameStats,
+}
+
+/// Diagnostic per-frame render attribution (see [`PerWindowState::frame_stats`]).
+///
+/// Every counted frame is one `update()` call for a window (i.e. one drawn
+/// frame). `unchanged`/`cursor_only`/`full` classify the ACTIVE pane's
+/// `PaneFrameDamage` that frame (the #435 signal), and
+/// `blink_wake_suppressed` counts frames where a blink-style cursor was
+/// hidden (DECTCEM / inactive / echo-off) so the old ~500ms blink wake was
+/// correctly NOT scheduled (validates the `cursor_blink_wants_repaint` fix —
+/// each such frame is a ~2Hz phantom wake that no longer happens).
+#[derive(Debug, Default)]
+pub(super) struct FrameStats {
+    pub(super) frames_drawn: u64,
+    pub(super) unchanged: u64,
+    pub(super) cursor_only: u64,
+    pub(super) full: u64,
+    pub(super) blink_wake_suppressed: u64,
+}
+
+impl FrameStats {
+    /// Emit an `info` summary once every this many drawn frames.
+    pub(super) const FLUSH_EVERY: u64 = 120;
 }

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -361,8 +361,8 @@ pub(super) struct PerWindowState {
     /// zoomed / overlay open).
     pub(super) chrome_border_rects: Vec<egui::Rect>,
 
-    /// Per-frame render attribution counters (diagnostic), flushed to an
-    /// `info` log line every [`FrameStats::FLUSH_EVERY`] drawn frames. Lets
+    /// Per-frame render attribution counters (diagnostic), flushed to a
+    /// `debug` log line every [`FrameStats::FLUSH_EVERY`] drawn frames. Lets
     /// a CPU investigation see, without a profiler, how many frames are
     /// actually drawn and how they split across the #435 per-frame damage
     /// classes (a genuinely-unchanged redraw costs no CPU rebuild; a `Full`
@@ -389,6 +389,6 @@ pub(super) struct FrameStats {
 }
 
 impl FrameStats {
-    /// Emit an `info` summary once every this many drawn frames.
+    /// Emit a `debug` summary once every this many drawn frames.
     pub(super) const FLUSH_EVERY: u64 = 120;
 }


### PR DESCRIPTION
Closes #439.

## Summary

A full-screen TUI that redraws its screen ~2x/sec (btop, htop, vim, less)
drove freminal to **~40-60 full-content vertex rebuilds/sec** — a ~20-40x
over-draw and the dominant residual idle-CPU cost. This PR fixes four
independent contributors and, empirically, collapses the settled
drawn-frame rate to **~2fps (tracking btop's real cadence), 0.0% CPU, flat
flamegraph**.

The four fixes map to the issue's ranked list (1, 2, and the deferred 4;
3 — the 64KiB reader buffer — was unnecessary once batching landed):

### 1. Batch-drain queued `PtyRead` before `post_event` (`gui/pty.rs`)
A single btop redraw exceeds the 4096-byte reader buffer and arrives as N
chunks; each chunk was `1 build_snapshot + 1 arc_swap.store + 1 repaint`.
New `drain_pty_reads` folds the blocking-recv'd chunk plus every queued
chunk into **one** snapshot+repaint, mirroring the existing write-side and
`child_exit` drain idioms. Recording fidelity preserved (per-chunk emit,
in arrival order).

### 2. Stop bypassing the 16ms repaint floor (`freminal-windowing`)
The cross-thread `UserEvent::RequestRepaintAfter` path was unclamped and
`min`-merged below any 16ms-floored deadline, letting the PTY thread's 8ms
request drive >60fps. Added `MIN_REPAINT_INTERVAL` / `clamp_repaint_delay`,
applied to **both** `RequestRepaintAfter` paths; PTY call site raised
8ms→16ms as belt-and-braces.

### 4. Gate the GUI's reaction to sticky `content_changed` behind Arc-identity (the dominant cost)
`content_changed` is baked into each published snapshot, but the GUI
re-reads the **same** `Arc` ~14x between real PTY updates — re-arming a
16ms repaint and reclassifying every frame as `PaneFrameDamage::Full`.
`observe_visible_snapshot` tracks the last-observed `visible_chars` `Arc`
per pane; the content repaint now schedules only on **first observation**
of a new snapshot. The widget's rebuild decision drops the redundant raw
`content_changed` term (the `Arc::ptr_eq` check already detects every real
change, since `flatten_visible` allocates a fresh `Arc` whenever content
changes).

### Recovered diagnostics (belong with this work, were stashed on #436)
- `show_cursor` blink-wake gate: a DECTCEM-hidden cursor no longer
  schedules the ~500ms blink wake (btop hides its cursor).
- `FrameStats` frame-attribution instrumentation (debug-level, flushed
  every 120 drawn frames) — the tool that produced the measurements below.

## Empirical result (btop, settled)

Frame-attribution stats before vs. after: the 120-frame flush interval went
from a pinned ~2s (60fps, every frame `Full`) to **12–59s** between flushes
(~2fps in the deepest idle stretch), with `unchanged`/`cursor_only` resuming
and `full` no longer incrementing per-frame. Observed 0.0% CPU throughout a
2-minute run; the freminal callgraph all but vanishes from the flamegraph.

## Benchmarks

No regression on the affected emulator surfaces (a transient
`build_snapshot_80x24_dirty` "regression" was bench-environment noise —
that production code is unchanged; a 50-sample rerun showed "improved"):

| Benchmark | Change |
| --- | --- |
| `bench_handle_incoming_data/…_4096` | −1.8% (no change) |
| `bench_parse_bursty/…` | ~0% (no change) |
| `bench_build_snapshot/…_clean` | +0.4% (no change) |
| `bench_build_snapshot_with_scrollback/…` | within noise |

## Verification

- `cargo test --all` — green (incl. new tests below)
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check`, `cargo machete` — clean
- `cargo xtask check-windows` (windows-gnu clippy) — clean

New tests: `drain_pty_reads` ordering / exactly-once (+ headless-emulator
feed); `clamp_repaint_delay` floor/passthrough; `observe_visible_snapshot`
first-vs-repeat observation; and idle-rebuild + repeated primary↔alt bounce
asserting `visible_chars` `Arc::ptr_eq` reuse (the invariant fix #4 now
relies on exclusively).

## Notes for reviewers
- The version bump (beta.4→beta.5) is a **separate first commit**.
- Out of scope / follow-up: the `child_exit` shutdown-drain arm does not
  emit to the recorder (pre-existing, unchanged here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release**
  - Updated the application to version 0.12.0-beta.5 across supported packaging formats.
- **Performance**
  - Batch-processes bursts of terminal output for more efficient UI updates.
  - Improves snapshot caching to avoid work when terminal output is unchanged.
  - Standardizes delayed repaint scheduling (minimum frame pacing) for smoother rendering.
- **Bug Fixes**
  - Prevents unnecessary cursor-blink repaint wakeups when the cursor is not actually visible.
  - Fixes false “content changed” signals when switching between primary and alternate screens.
- **Tests**
  - Added coverage for snapshot caching and repaint delay clamping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->