### PR TITLE
fix: visual bell flash gets stuck on background/inactive panes

### DIFF
--- a/freminal-terminal-emulator/src/state/internal.rs
+++ b/freminal-terminal-emulator/src/state/internal.rs
@@ -186,7 +186,9 @@ impl TerminalState {
 
     /// Send the focus-change escape sequence to the PTY if focus reporting is enabled.
     ///
-    /// This no longer touches `window_focused`; the GUI owns that field on `ViewState`.
+    /// This is purely a PTY-facing side effect; the GUI tracks the window's
+    /// actual focus state itself (queried live from egui) rather than through
+    /// any state owned by the terminal handler.
     pub fn send_focus_event(&mut self, focused: bool) {
         if self.modes.focus_reporting == XtMseWin::Disabled {
             return;

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -928,11 +928,11 @@ impl freminal_windowing::App for FreminalGui {
         // routed after the loop, where `self.config` / the toast stack are
         // borrowable without conflicting with `win.tabs`.
         let active_tab_idx = win.tabs.active_index();
-        let cmd_window_focused = win
-            .tabs
-            .active_tab()
-            .active_pane()
-            .is_some_and(|p| p.view_state.window_focused);
+        // Read live from egui rather than a per-pane cached flag: the latter
+        // is only ever updated while a given pane happens to be the active
+        // one, so it goes permanently stale for every other pane (regression
+        // that left the visual bell overlay stuck; see `paint_bell_flash`).
+        let cmd_window_focused = ctx.input(|i| i.focused);
         let mut command_notifications: Vec<crate::gui::notifications::NotificationRequest> =
             Vec::new();
         let tab_title_policy = self.config.tab_title.policy;
@@ -1374,11 +1374,11 @@ impl freminal_windowing::App for FreminalGui {
             // window geometry.
             let active_idx = win.tabs.active_index();
             let active_pane_id_for_drain = win.tabs.active_tab().active_pane;
-            let window_focused = win
-                .tabs
-                .active_tab()
-                .active_pane()
-                .is_some_and(|p| p.view_state.window_focused);
+            // Read live from egui rather than a per-pane cached flag: the
+            // latter is only ever updated while a given pane happens to be
+            // the active one, so it goes permanently stale for every other
+            // pane (regression that left the visual bell overlay stuck).
+            let window_focused = ui.input(|i| i.focused);
             // #436.3 §3.3 "Window focus change" chrome signal.
             let chrome_focus_changed = window_focused != win.prev_window_focused;
             win.prev_window_focused = window_focused;

--- a/freminal/src/gui/terminal/input.rs
+++ b/freminal/src/gui/terminal/input.rs
@@ -2039,7 +2039,6 @@ pub(super) fn write_input_to_terminal(
                 continue;
             }
             Event::WindowFocused(focused) => {
-                view_state.window_focused = *focused;
                 // Forward focus change to the PTY consumer thread so it can
                 // send the focus-reporting escape sequence if enabled.
                 send_or_log!(

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -482,6 +482,50 @@ const BELL_FLASH_MAX_ALPHA: u8 = 60;
 /// window is unfocused and a bell has fired (0–255).
 const BELL_PERSISTENT_ALPHA: u8 = 30;
 
+/// Outcome of evaluating whether a visual bell overlay should still be
+/// shown, computed by the pure [`bell_flash_outcome`] decision function.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BellFlashOutcome {
+    /// Window is unfocused: paint a persistent, non-fading overlay at the
+    /// given alpha and keep `bell_since` set. Self-heals (re-evaluated as
+    /// `Fading`/`Cleared`) the moment the window is next found focused.
+    Persistent { alpha: u8 },
+    /// Window is focused and the flash duration has not yet elapsed: paint
+    /// a fading overlay at the given alpha and keep `bell_since` set so the
+    /// fade continues next frame.
+    Fading { alpha: u8 },
+    /// Window is focused and the flash duration has elapsed: clear
+    /// `bell_since`, nothing more to paint.
+    Cleared,
+}
+
+/// Pure decision logic for [`paint_bell_flash`], factored out so it is
+/// unit-testable without a live `egui::Ui`/`Context`.
+///
+/// `window_focused` must be the OS window's *current* focus state — see the
+/// caller-discipline note on [`paint_bell_flash`] for why this must never be
+/// a per-pane cached flag.
+fn bell_flash_outcome(window_focused: bool, elapsed: Duration) -> BellFlashOutcome {
+    if !window_focused {
+        return BellFlashOutcome::Persistent {
+            alpha: BELL_PERSISTENT_ALPHA,
+        };
+    }
+
+    // Focused: if the flash duration has elapsed the bell either fired
+    // while unfocused (the user just alt-tabbed back) or the fade-out
+    // already completed — either way, clear immediately.
+    if elapsed >= BELL_FLASH_DURATION {
+        return BellFlashOutcome::Cleared;
+    }
+
+    // Linear fade from BELL_FLASH_MAX_ALPHA → 0 over the flash duration.
+    let progress = elapsed.as_secs_f32() / BELL_FLASH_DURATION.as_secs_f32();
+    let alpha_f = f32::from(BELL_FLASH_MAX_ALPHA) * (1.0 - progress);
+    let alpha: u8 = alpha_f.approx_as::<u8>().unwrap_or(0);
+    BellFlashOutcome::Fading { alpha }
+}
+
 /// Paint a semi-transparent white overlay for the visual bell.
 ///
 /// **Focused window:** a brief flash that fades from [`BELL_FLASH_MAX_ALPHA`]
@@ -492,41 +536,42 @@ const BELL_PERSISTENT_ALPHA: u8 = 30;
 /// [`BELL_PERSISTENT_ALPHA`] that remains until the window regains focus.
 /// When focus returns the flash duration will have long since elapsed, so
 /// `bell_since` is cleared on the first focused frame (no fade).
+///
+/// Focus is read live from `ui.ctx().input(|i| i.focused)` every frame
+/// rather than from any per-pane cached flag. This function runs for every
+/// rendered pane (active or not, in the active tab or a background one), so
+/// the focus check must reflect the OS window's *current* focus state
+/// unconditionally -- a value that is only updated while a given pane
+/// happens to be the active one would go stale for every other pane and
+/// get permanently stuck on the "unfocused, non-fading, no-repaint" branch
+/// below (regression fixed here: a bell firing in a background/inactive
+/// pane, or a newly created split/tab that never itself received a real
+/// focus transition, would flash once and then never clear).
 fn paint_bell_flash(ui: &Ui, terminal_rect: Rect, view_state: &mut ViewState) {
     let Some(since) = view_state.bell_since else {
         return;
     };
 
-    if !view_state.window_focused {
-        // Unfocused: show a persistent, non-fading overlay.  No repaint
-        // request — the overlay is static and doesn't need continuous
-        // redraws while the window is in the background.
-        let alpha = BELL_PERSISTENT_ALPHA;
-        let overlay_color = Color32::from_rgba_premultiplied(alpha, alpha, alpha, alpha);
-        ui.painter().rect_filled(terminal_rect, 0.0, overlay_color);
-        return;
+    let window_focused = ui.ctx().input(|i| i.focused);
+    match bell_flash_outcome(window_focused, since.elapsed()) {
+        BellFlashOutcome::Persistent { alpha } => {
+            // No repaint request — the overlay is static and doesn't need
+            // continuous redraws while the window is in the background.
+            let overlay_color = Color32::from_rgba_premultiplied(alpha, alpha, alpha, alpha);
+            ui.painter().rect_filled(terminal_rect, 0.0, overlay_color);
+        }
+        BellFlashOutcome::Fading { alpha } => {
+            let overlay_color = Color32::from_rgba_premultiplied(alpha, alpha, alpha, alpha);
+            ui.painter().rect_filled(terminal_rect, 0.0, overlay_color);
+
+            // Request a repaint so the fade-out continues next frame (~60 fps cap).
+            ui.ctx()
+                .request_repaint_after(std::time::Duration::from_millis(16));
+        }
+        BellFlashOutcome::Cleared => {
+            view_state.bell_since = None;
+        }
     }
-
-    // Focused: if the flash duration has elapsed the bell either fired
-    // while unfocused (the user just alt-tabbed back) or the fade-out
-    // already completed — either way, clear immediately.
-    let elapsed = since.elapsed();
-    if elapsed >= BELL_FLASH_DURATION {
-        view_state.bell_since = None;
-        return;
-    }
-
-    // Linear fade from BELL_FLASH_MAX_ALPHA → 0 over the flash duration.
-    let progress = elapsed.as_secs_f32() / BELL_FLASH_DURATION.as_secs_f32();
-    let alpha_f = f32::from(BELL_FLASH_MAX_ALPHA) * (1.0 - progress);
-    let alpha: u8 = alpha_f.approx_as::<u8>().unwrap_or(0);
-
-    let overlay_color = Color32::from_rgba_premultiplied(alpha, alpha, alpha, alpha);
-    ui.painter().rect_filled(terminal_rect, 0.0, overlay_color);
-
-    // Request a repaint so the fade-out animation continues next frame (~60 fps cap).
-    ui.ctx()
-        .request_repaint_after(std::time::Duration::from_millis(16));
 }
 
 /// Context menu action produced by the right-click popup.
@@ -3498,6 +3543,89 @@ fn handle_file_drop(ui: &Ui, terminal_rect: Rect, input_tx: &Sender<InputEvent>)
             "Drop files here",
             egui::FontId::proportional(20.0),
             Color32::WHITE,
+        );
+    }
+}
+
+#[cfg(test)]
+mod bell_flash_tests {
+    //! Tests for [`bell_flash_outcome`], the pure decision function behind
+    //! [`paint_bell_flash`]. Covers the fade/clear/persistent boundaries and
+    //! guards the regression where a bell overlay got stuck forever: the
+    //! overlay must clear once focused and the flash duration has elapsed,
+    //! *regardless* of how the caller learned `window_focused` — the fix
+    //! removed the only source of staleness (a per-pane cached flag) by
+    //! deleting `ViewState::window_focused` entirely and requiring callers
+    //! to pass a live-queried value instead.
+
+    use super::{
+        BELL_FLASH_DURATION, BELL_FLASH_MAX_ALPHA, BELL_PERSISTENT_ALPHA, BellFlashOutcome,
+        bell_flash_outcome,
+    };
+    use std::time::Duration;
+
+    #[test]
+    fn focused_fresh_bell_fades_from_max_alpha() {
+        let outcome = bell_flash_outcome(true, Duration::from_millis(0));
+        assert_eq!(
+            outcome,
+            BellFlashOutcome::Fading {
+                alpha: BELL_FLASH_MAX_ALPHA
+            }
+        );
+    }
+
+    #[test]
+    fn focused_partway_through_fade_has_reduced_alpha() {
+        let half = BELL_FLASH_DURATION / 2;
+        let BellFlashOutcome::Fading { alpha } = bell_flash_outcome(true, half) else {
+            panic!("expected Fading at the halfway point");
+        };
+        assert!(
+            alpha > 0 && alpha < BELL_FLASH_MAX_ALPHA,
+            "alpha {alpha} should be strictly between 0 and max at the halfway point"
+        );
+    }
+
+    #[test]
+    fn focused_exactly_at_duration_clears() {
+        // Regression guard: this is the boundary that must actually clear.
+        // A stuck bell would show as this never returning `Cleared`.
+        assert_eq!(
+            bell_flash_outcome(true, BELL_FLASH_DURATION),
+            BellFlashOutcome::Cleared
+        );
+    }
+
+    #[test]
+    fn focused_past_duration_clears() {
+        assert_eq!(
+            bell_flash_outcome(true, BELL_FLASH_DURATION + Duration::from_secs(1)),
+            BellFlashOutcome::Cleared
+        );
+        // Also true for a bell that has been "stuck" for a long time (e.g.
+        // the pre-fix scenario of an entire session) — once the caller
+        // passes the correct live `window_focused = true`, it clears
+        // immediately rather than requiring a fresh focus *transition*.
+        assert_eq!(
+            bell_flash_outcome(true, Duration::from_hours(1)),
+            BellFlashOutcome::Cleared
+        );
+    }
+
+    #[test]
+    fn unfocused_is_persistent_regardless_of_elapsed() {
+        assert_eq!(
+            bell_flash_outcome(false, Duration::from_millis(0)),
+            BellFlashOutcome::Persistent {
+                alpha: BELL_PERSISTENT_ALPHA
+            }
+        );
+        assert_eq!(
+            bell_flash_outcome(false, Duration::from_hours(1)),
+            BellFlashOutcome::Persistent {
+                alpha: BELL_PERSISTENT_ALPHA
+            }
         );
     }
 }

--- a/freminal/src/gui/view_state.rs
+++ b/freminal/src/gui/view_state.rs
@@ -422,9 +422,6 @@ pub struct ViewState {
     /// The last mouse position reported to the terminal, if any.
     pub mouse_position: Option<egui::Pos2>,
 
-    /// Whether the terminal window currently has keyboard focus.
-    pub window_focused: bool,
-
     /// The last `(width, height)` in character cells that was sent to the PTY
     /// as a resize.  Used to debounce resize events so we only send a new
     /// `InputEvent::Resize` when the size actually changes.
@@ -642,7 +639,6 @@ impl Default for ViewState {
         Self {
             scroll_offset: 0,
             mouse_position: None,
-            window_focused: false,
             last_sent_size: (0, 0),
             previous_key: None,
             previous_scroll_amount: 0.0,


### PR DESCRIPTION
## Summary

The visual bell overlay (flash-then-fade on BEL) could get permanently
stuck instead of clearing — reported as a regression against recent
render-loop work, but the actual root cause is older and unrelated to
that work (see Root cause below).

`ViewState::window_focused` was a per-pane cached flag, only ever
updated while that specific pane happened to be the *active* pane
during a genuine OS `WindowFocused` event
(`write_input_to_terminal` gates every event behind `is_active_pane`
before the `WindowFocused` arm runs). Newly created panes (new tabs,
splits) default to `window_focused: false` and are immediately made
active without any OS focus transition occurring (the window was
already focused), so the flag never gets re-seeded. Any bell firing in
such a pane falls into `paint_bell_flash`'s "unfocused, persistent,
non-fading, no-repaint" branch and stays stuck indefinitely — an
outcome that depends entirely on a given pane's incidental
focus-event history, which is why it felt intermittent rather than
always reproducing.

## Root cause timeline

- `c8bec087` (2026-04-07) introduced the buggy `!window_focused`
  persistent-overlay branch.
- `c6370b52` / Task 58 (2026-04-11, split panes) made the bug far
  easier to hit — every split or new tab is an exposed pane.
- The render-loop/chrome-caching work merged most recently
  (`ce99c47c` / `a6732e2f`, #439) was traced end-to-end and confirmed
  **not** responsible — the repaint-scheduling chain for the focused
  fade path is sound and unaffected by that work.

## Fix

Read the OS window's live focus state directly from egui
(`ctx.input(|i| i.focused)` / `ui.input(|i| i.focused)`) everywhere a
render-time "is the window focused" decision is made, instead of a
per-pane cached flag:

- the bell flash overlay (`paint_bell_flash`)
- the shared `window_focused` used for taskbar-attention and OSC
  9/777/99 notification routing
- the #436.3 chrome focus-change signal

egui already tracks this accurately every frame per-window via
egui-winit's `WindowEvent::Focused` handling, so no per-pane state is
needed at all. `ViewState::window_focused` is removed entirely (it had
no remaining readers after this change), which closes off the
staleness bug at the type level rather than papering over it.

Also extracts the bell overlay's fade/clear/persistent decision into a
pure `bell_flash_outcome()` function (mirroring the existing
`held_keys_after_focus_change` pattern) so the fade-duration and
focus-boundary logic is unit-testable without a live `egui::Ui`.

## Testing

- 5 new unit tests on `bell_flash_outcome` covering the fade
  start/midpoint, the exact and past-duration clear boundaries, and
  the persistent-while-unfocused branch.
- `cargo test --all` — all green.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo machete` — clean.
- `cargo xtask check-windows` — clean.
- Manually reproduced and verified fixed: split a pane
  (Ctrl+Shift+\\/Ctrl+Shift+-), fire a bell (`printf '\a'`) in the new
  pane — before this fix the overlay stuck forever; after, it flashes
  and clears within ~150ms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window-focus detection for command notifications and focus-dependent terminal behavior.
  * Ensured focus changes continue reaching the terminal while preventing stale focus state from affecting the interface.
  * Refined visual bell behavior: flashes now persist appropriately when unfocused, fade smoothly when focused, and clear at the correct time.
  * Preserved mouse-tracking and keyboard-state cleanup when the window loses focus.

* **Tests**
  * Added coverage for visual bell timing and focus-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->