### PR TITLE
fix: stop cursor blink from corrupting selection highlight (#432)

### DIFF
--- a/freminal/benches/render_loop_bench.rs
+++ b/freminal/benches/render_loop_bench.rs
@@ -637,7 +637,7 @@ fn bench_bg_instances(c: &mut Criterion) {
                 let mut instances = Vec::new();
                 let mut deco = Vec::new();
                 b.iter(|| {
-                    build_background_instances(
+                    let _cursor_quad_appended = build_background_instances(
                         &BackgroundFrame {
                             shaped_lines: &lines,
                             cell_width,
@@ -754,7 +754,7 @@ fn bench_bg_instances_partial_dirty(c: &mut Criterion) {
             let mut instances = Vec::new();
             let mut deco = Vec::new();
             b.iter(|| {
-                build_background_instances(
+                let _cursor_quad_appended = build_background_instances(
                     &BackgroundFrame {
                         shaped_lines: &lines,
                         cell_width,
@@ -794,7 +794,7 @@ fn bench_bg_instances_partial_dirty(c: &mut Criterion) {
             let mut instances = Vec::new();
             let mut deco = Vec::new();
             b.iter(|| {
-                build_background_instances(
+                let _cursor_quad_appended = build_background_instances(
                     &BackgroundFrame {
                         shaped_lines: single_row,
                         cell_width,

--- a/freminal/src/gui/renderer/gpu.rs
+++ b/freminal/src/gui/renderer/gpu.rs
@@ -27,8 +27,8 @@ use super::shaders::{
     POST_VERT_SRC,
 };
 use super::vertex::{
-    BG_INSTANCE_FLOATS, CURSOR_QUAD_FLOATS, DECO_VERTEX_FLOATS, FG_INSTANCE_FLOATS,
-    IMG_VERTEX_FLOATS, ImageDrawEntry, VERTS_PER_QUAD, extract_atlas_rect,
+    BG_INSTANCE_FLOATS, DECO_VERTEX_FLOATS, FG_INSTANCE_FLOATS, IMG_VERTEX_FLOATS, ImageDrawEntry,
+    VERTS_PER_QUAD, extract_atlas_rect,
 };
 use freminal_terminal_emulator::InlineImage;
 
@@ -184,6 +184,20 @@ pub struct TerminalRenderer {
 
     // ---- double-buffer index ----
     vbo_index: usize,
+    /// Independent double-buffer index for `deco_vbo` only.
+    ///
+    /// The decoration buffer (underline/strike/search/hover/selection/cursor
+    /// quads) is the one buffer that changes on a "cursor-only" frame (the
+    /// cursor blinks or moves while everything else stays the same). Unlike
+    /// `bg_inst_vbo`/`fg_vbo`/`img_vbo` — which are simply *not* re-uploaded
+    /// on a cursor-only frame and so can safely keep reading from whichever
+    /// slot the last full rebuild wrote — `deco_vbo` genuinely needs a fresh
+    /// upload every such frame. Giving it its own index lets a cursor-only
+    /// frame always orphan-then-write into the slot the GPU is *not*
+    /// currently reading (see [`Self::draw_with_cursor_only_update`]),
+    /// instead of patching live bytes into a buffer a pending draw from the
+    /// previous frame may still be reading (issue #432).
+    deco_vbo_index: usize,
 }
 
 impl Default for TerminalRenderer {
@@ -239,6 +253,7 @@ impl TerminalRenderer {
             img_u_viewport: None,
             img_u_image: None,
             vbo_index: 0,
+            deco_vbo_index: 0,
         }
     }
 
@@ -555,9 +570,18 @@ impl TerminalRenderer {
         self.sync_image_textures(gl, snap_images);
 
         // 2. Upload pre-built vertex data using orphan-then-write.
+        //
+        // `deco_vbo` uses its OWN double-buffer index (`deco_vbo_index`),
+        // independent of `vbo_index` (shared by bg/fg/image), so that the
+        // cursor-only fast path (which re-uploads only `deco_vbo` every
+        // frame the cursor blinks) can always write into the slot that is
+        // NOT the one just drawn from — never patching live bytes into a
+        // buffer a pending GPU read may still be using (see
+        // `draw_with_cursor_only_update`, issue #432).
         let buf_idx = self.vbo_index;
+        let deco_buf_idx = self.deco_vbo_index;
         self.upload_bg_instances(gl, bg_instances, buf_idx);
-        self.upload_deco_verts(gl, deco_verts, buf_idx);
+        self.upload_deco_verts(gl, deco_verts, deco_buf_idx);
         self.upload_fg_instances(gl, fg_instances, buf_idx);
         self.upload_img_verts(gl, image_verts, buf_idx);
 
@@ -579,7 +603,7 @@ impl TerminalRenderer {
             bg_opacity,
             buf_idx,
         );
-        self.draw_decorations(gl, deco_verts.len(), vp_w, vp_h, buf_idx);
+        self.draw_decorations(gl, deco_verts.len(), vp_w, vp_h, deco_buf_idx);
         self.draw_foreground(gl, fg_instances.len(), vp_w, vp_h, buf_idx);
         self.draw_images(gl, image_verts.len(), image_draw_order, vp_w, vp_h, buf_idx);
 
@@ -588,22 +612,37 @@ impl TerminalRenderer {
             gl.bind_framebuffer(glow::FRAMEBUFFER, intermediate_fbo);
         }
 
-        // Advance double-buffer index.
+        // Advance double-buffer indices.
         self.vbo_index = 1 - self.vbo_index;
+        self.deco_vbo_index = 1 - self.deco_vbo_index;
     }
 
     /// Render a cursor-only update.
     ///
     /// When the terminal content has not changed but the cursor blink state
-    /// has toggled (or the cursor moved), this method patches only the cursor
-    /// quad region of the decoration VBO and redraws all passes.  The
-    /// foreground VBO and instanced background VBO are untouched.
+    /// has toggled (or the cursor moved), this method skips the expensive
+    /// CPU-side shaping/rebuild of the background-instance and foreground
+    /// buffers (they are unchanged and simply redrawn from whichever slot
+    /// the last full rebuild wrote), but always fully re-uploads
+    /// `deco_verts` — the decoration buffer holding underline, strikethrough,
+    /// search, hover, selection, and cursor quads.
     ///
-    /// `cursor_vert_byte_offset` is the byte offset into the decoration VBO
-    /// where the cursor quad data begins.  `deco_total_floats` is the total
-    /// float count of the most recently uploaded decoration VBO (needed to
-    /// set the draw vertex count correctly).  `cursor_verts` contains exactly
-    /// `CURSOR_QUAD_FLOATS` floats (or is empty when the cursor is hidden).
+    /// `deco_verts` must be the complete, current decoration vertex data
+    /// (the caller has already patched the cursor quad into its cached copy
+    /// in place). It is uploaded via the same safe orphan-then-write pattern
+    /// [`Self::draw_with_verts`] uses, into `deco_vbo`'s own independent
+    /// double-buffer slot (`deco_vbo_index`) — **never** patched live with
+    /// `glBufferSubData` into the slot that may still be read by a pending
+    /// GPU draw from the previous frame. An earlier version of this method
+    /// did exactly that unsynchronized in-place patch and it was the
+    /// confirmed root cause of issue #432 (selection-highlight quads
+    /// intermittently corrupted while the cursor blinks, anywhere in the
+    /// pane — not only at the cursor's own cell).
+    ///
+    /// The re-upload cost is negligible: `deco_verts` holds only a handful of
+    /// decoration quads (never one per cell or per glyph), unlike the
+    /// background-instance and foreground buffers this fast path exists to
+    /// avoid rebuilding.
     ///
     /// # Safety
     ///
@@ -614,10 +653,8 @@ impl TerminalRenderer {
         &mut self,
         gl: &glow::Context,
         atlas: &mut GlyphAtlas,
-        cursor_vert_byte_offset: usize,
-        deco_total_floats: usize,
+        deco_verts: &[f32],
         bg_inst_total_floats: usize,
-        cursor_verts: &[f32],
         fg_total_floats: usize,
         image_total_floats: usize,
         image_draw_order: &[ImageDrawEntry],
@@ -638,25 +675,20 @@ impl TerminalRenderer {
         // 1. Sync atlas (may have new glyphs from a previous frame).
         self.sync_atlas(gl, atlas);
 
-        // Use the slot that was last fully written by `draw_with_verts`.
-        // After a full frame, `draw_with_verts` advances `vbo_index` to the
-        // *next* slot.  The cursor-only path patches and draws from the
-        // *previous* slot (the one with valid data).
+        // bg/fg/image are unchanged since the last full rebuild: reuse the
+        // slot that was last fully written by `draw_with_verts` (which
+        // advances `vbo_index` to the *next* slot after writing, so the
+        // valid data sits at `1 - vbo_index`).
         let buf_idx = 1 - self.vbo_index;
 
-        // 2. Patch just the cursor region of the deco VBO (no orphan).
-        if cursor_verts.is_empty() {
-            // Cursor is hidden: zero out the cursor quad region so no stale
-            // cursor is painted.  We write CURSOR_QUAD_FLOATS zeros.
-            if let Some(vbo) = self.deco_vbo[buf_idx] {
-                let zeros = vec![0.0f32; CURSOR_QUAD_FLOATS];
-                upload_verts_sub(gl, vbo, cursor_vert_byte_offset, &zeros);
-            }
-        } else if let Some(vbo) = self.deco_vbo[buf_idx] {
-            upload_verts_sub(gl, vbo, cursor_vert_byte_offset, cursor_verts);
-        }
+        // deco_vbo DOES change this frame (the cursor moved/blinked), so it
+        // gets a real orphan-then-write upload — but into its own
+        // independent slot, never the one a pending draw might still be
+        // reading.
+        let deco_buf_idx = self.deco_vbo_index;
+        self.upload_deco_verts(gl, deco_verts, deco_buf_idx);
 
-        // 3. Draw in order: bg image → cell backgrounds → decorations → foreground → images.
+        // 2. Draw in order: bg image → cell backgrounds → decorations → foreground → images.
         let vp_w = gl_f32_i32(viewport_width);
         let vp_h = gl_f32_i32(viewport_height);
 
@@ -671,7 +703,7 @@ impl TerminalRenderer {
             bg_opacity,
             buf_idx,
         );
-        self.draw_decorations(gl, deco_total_floats, vp_w, vp_h, buf_idx);
+        self.draw_decorations(gl, deco_verts.len(), vp_w, vp_h, deco_buf_idx);
         self.draw_foreground(gl, fg_total_floats, vp_w, vp_h, buf_idx);
         self.draw_images(
             gl,
@@ -682,14 +714,16 @@ impl TerminalRenderer {
             buf_idx,
         );
 
-        // 4. Restore egui's framebuffer binding.
+        // 3. Restore egui's framebuffer binding.
         unsafe {
             gl.bind_framebuffer(glow::FRAMEBUFFER, intermediate_fbo);
         }
 
-        // Do NOT advance the double-buffer index: we reused the same buffer
-        // slot this frame (no full orphan).  The next full-frame draw will
-        // advance normally.
+        // Do NOT advance `vbo_index`: bg/fg/image reused the same slot this
+        // frame (no upload happened for them). DO advance `deco_vbo_index`:
+        // we just orphan-wrote a fresh slot for deco and must not reuse it
+        // for the next write without the GPU having had a chance to read it.
+        self.deco_vbo_index = 1 - self.deco_vbo_index;
     }
 
     /// Synchronise the atlas CPU data to the GPU texture.
@@ -1626,30 +1660,6 @@ fn upload_verts(gl: &glow::Context, vbo: glow::Buffer, verts: &[f32]) {
         // Orphan the buffer first to avoid sync stalls.
         gl.buffer_data_size(glow::ARRAY_BUFFER, gl_i32(bytes.len()), glow::STREAM_DRAW);
         gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, bytes);
-        gl.bind_buffer(glow::ARRAY_BUFFER, None);
-    }
-}
-
-/// Upload a sub-range of a VBO **without orphaning** the whole buffer.
-///
-/// Used for cursor-only partial updates: the caller has already orphaned the
-/// buffer (or it is large enough) and just wants to patch a specific byte
-/// range.
-///
-/// `byte_offset` is the byte offset into the existing VBO data.
-fn upload_verts_sub(gl: &glow::Context, vbo: glow::Buffer, byte_offset: usize, verts: &[f32]) {
-    if verts.is_empty() {
-        return;
-    }
-
-    // SAFETY: we reinterpret `&[f32]` as `&[u8]` for the GL call.
-    let bytes = unsafe {
-        std::slice::from_raw_parts(verts.as_ptr().cast::<u8>(), std::mem::size_of_val(verts))
-    };
-
-    unsafe {
-        gl.bind_buffer(glow::ARRAY_BUFFER, Some(vbo));
-        gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, gl_i32(byte_offset), bytes);
         gl.bind_buffer(glow::ARRAY_BUFFER, None);
     }
 }

--- a/freminal/src/gui/renderer/vertex.rs
+++ b/freminal/src/gui/renderer/vertex.rs
@@ -339,14 +339,30 @@ pub struct BackgroundFrame<'a> {
 ///
 /// The cursor quad (if visible) is always appended **last** in `deco_verts`
 /// so that cursor-only partial updates can patch just the tail.
+///
+/// Returns `true` if a cursor quad was actually appended to `deco_verts`,
+/// `false` otherwise. The caller **must** use this return value (not its own
+/// copy of `frame.show_cursor`) to compute where the cursor's tail quad
+/// begins for later cursor-only patches — `frame.show_cursor` alone does not
+/// account for the blink-visibility gate (`cursor_blink_is_visible`) applied
+/// here, and recomputing the append decision independently let the two
+/// silently disagree whenever a full rebuild happened to run during the
+/// cursor's blink-off phase (issue #432): the offset bookkeeping would then
+/// assume a cursor quad was appended when it was not, causing a later
+/// cursor-only frame to blink the cursor back on by overwriting whatever
+/// quad actually occupies that tail position — in practice the bottom-most
+/// row's selection highlight quad, since selection quads are appended in
+/// top-to-bottom row order and the bottom row's is therefore always the last
+/// one pushed before the (absent) cursor quad.
 // All parameters are required geometric and style inputs for GPU instance data generation.
 // Inherently large: iterates all shaped lines, resolving background color for every cell.
 #[allow(clippy::too_many_lines)]
+#[must_use]
 pub fn build_background_instances(
     frame: &BackgroundFrame<'_>,
     instances: &mut Vec<f32>,
     deco: &mut Vec<f32>,
-) {
+) -> bool {
     let shaped_lines = frame.shaped_lines;
     let cell_width = frame.cell_width;
     let cell_height = frame.cell_height;
@@ -601,7 +617,9 @@ pub fn build_background_instances(
     }
 
     // --- Cursor quad (always last in deco so cursor-only patches work) ---
-    if show_cursor && cursor_blink_is_visible(cursor_visual_style, cursor_blink_on) {
+    let cursor_quad_appended =
+        show_cursor && cursor_blink_is_visible(cursor_visual_style, cursor_blink_on);
+    if cursor_quad_appended {
         let (cx, cy) = cursor_pixel_pos;
         let cw = gl_f32_u32(cell_width) * cursor_width_scale;
         let ch = gl_f32_u32(cell_height);
@@ -623,6 +641,8 @@ pub fn build_background_instances(
             }
         }
     }
+
+    cursor_quad_appended
 }
 
 // ---------------------------------------------------------------------------
@@ -1899,7 +1919,7 @@ mod tests {
         );
         let mut instances = Vec::new();
         let mut deco = Vec::new();
-        build_background_instances(
+        let _cursor_quad_appended = build_background_instances(
             &BackgroundFrame {
                 shaped_lines: lines,
                 cell_width,
@@ -1941,7 +1961,7 @@ mod tests {
     ) -> (Vec<f32>, Vec<f32>) {
         let mut instances = Vec::new();
         let mut deco = Vec::new();
-        build_background_instances(
+        let _cursor_quad_appended = build_background_instances(
             &BackgroundFrame {
                 shaped_lines: lines,
                 cell_width: 8,
@@ -2924,6 +2944,87 @@ mod tests {
         );
     }
 
+    /// Regression for issue #432: a full rebuild that happens to run during
+    /// the cursor's blink-*off* phase (a blinking cursor style, not steady)
+    /// must report `cursor_quad_appended == false` and must NOT reserve
+    /// `CURSOR_QUAD_FLOATS` tail floats for a cursor quad that was never
+    /// actually pushed.
+    ///
+    /// Before the fix, callers computed the cursor's tail offset from
+    /// `show_cursor` alone (ignoring blink phase), so this exact scenario —
+    /// `show_cursor: true`, a blinking style, `cursor_blink_on: false` —
+    /// caused the caller to believe a cursor quad occupied the last
+    /// `CURSOR_QUAD_FLOATS` floats of `deco_verts` when in fact NO cursor
+    /// quad was appended at all, and those floats actually belonged to the
+    /// bottom-most (here: only) selection highlight quad. A later cursor-only
+    /// frame, when blink flipped back on, would then overwrite that
+    /// mis-identified region — clobbering the selection quad with the
+    /// cursor's own geometry and color instead of the cursor's absent quad.
+    #[test]
+    fn full_rebuild_during_blink_off_does_not_append_cursor_quad_over_selection() {
+        let line = make_line(3, 8.0, default_colors(), FontDecorationFlags::empty());
+        let mut instances = Vec::new();
+        let mut deco = Vec::new();
+
+        let cursor_quad_appended = build_background_instances(
+            &BackgroundFrame {
+                shaped_lines: std::slice::from_ref(&line),
+                cell_width: 8,
+                cell_height: 16,
+                ascent: 14.0,
+                underline_offset: 13.0,
+                strikeout_offset: 8.0,
+                stroke_size: 1.0,
+                // The cursor is structurally supposed to show...
+                show_cursor: true,
+                // ...but this frame lands on the blink-off half of the cycle...
+                cursor_blink_on: false,
+                cursor_pixel_pos: (0.0, 0.0),
+                cursor_width_scale: 1.0,
+                // ...and the style is a *blinking* one, so blink phase matters
+                // (a steady style would ignore `cursor_blink_on` entirely).
+                cursor_visual_style: &CursorVisualStyle::BlockCursorBlink,
+                // A single-row selection spanning the whole shaped line.
+                selection: Some((0, 0, 2, 0)),
+                selection_is_block: false,
+                match_highlights: &[],
+                command_block_hover_rows: None,
+                term_width_cols: 0,
+                theme: &themes::CATPPUCCIN_MOCHA,
+                cursor_color_override: None,
+                reverse_screen: false,
+            },
+            &mut instances,
+            &mut deco,
+        );
+
+        assert!(
+            !cursor_quad_appended,
+            "blink-off phase with a blinking cursor style must not append a cursor quad"
+        );
+        assert_eq!(
+            deco.len(),
+            CURSOR_QUAD_FLOATS,
+            "deco_verts should contain exactly the one selection quad — no reserved \
+             cursor tail floats — since no cursor quad was actually appended"
+        );
+        // The one quad present must be the selection's color, not the
+        // cursor's — i.e. every float in deco_verts genuinely belongs to the
+        // selection quad, confirming there is no separate reserved cursor
+        // region hiding at the tail.
+        let expected_color = selection_bg_f(&themes::CATPPUCCIN_MOCHA);
+        // Layout: vertex 0 = (x, y, r, g, b, a) — color starts at index 2.
+        let actual_color = [deco[2], deco[3], deco[4], deco[5]];
+        assert!(
+            actual_color
+                .iter()
+                .zip(expected_color.iter())
+                .all(|(a, b)| (a - b).abs() < f32::EPSILON),
+            "the sole quad in deco_verts must be the selection highlight, not a cursor quad: \
+             got {actual_color:?}, expected {expected_color:?}"
+        );
+    }
+
     // -----------------------------------------------------------------------
     //  is_cell_selected tests
     // -----------------------------------------------------------------------
@@ -3221,7 +3322,7 @@ mod tests {
         );
         let mut instances = Vec::new();
         let mut deco = Vec::new();
-        build_background_instances(
+        let cursor_quad_appended = build_background_instances(
             &BackgroundFrame {
                 shaped_lines: &[line],
                 cell_width: cell_width_px,
@@ -3247,6 +3348,7 @@ mod tests {
             &mut instances,
             &mut deco,
         );
+        assert!(!cursor_quad_appended, "show_cursor was false");
 
         // The only deco quad produced (no cursor, no underlines, no
         // selection, no search highlights) is the hover-tint quad.
@@ -3284,7 +3386,7 @@ mod tests {
         );
         let mut instances = Vec::new();
         let mut deco = Vec::new();
-        build_background_instances(
+        let cursor_quad_appended = build_background_instances(
             &BackgroundFrame {
                 shaped_lines: &[line],
                 cell_width: cell_width_px,
@@ -3310,6 +3412,7 @@ mod tests {
             &mut instances,
             &mut deco,
         );
+        assert!(!cursor_quad_appended, "show_cursor was false");
         assert!(
             deco.is_empty(),
             "expected no deco quads when term_width_cols == 0"

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -91,6 +91,58 @@ fn cursor_blink_phase(time: f64, anchor: Option<f64>, tick_seconds: f64) -> bool
     }
 }
 
+/// Patch the cursor's quad into `deco_verts` for a cursor-only frame
+/// (content, selection, and everything else unchanged; only the cursor's
+/// blink state, position, or color changed since the last frame).
+///
+/// `cfo` (`cursor_vert_float_offset`) is the offset recorded by the most
+/// recent full rebuild. It reflects whether that rebuild actually appended a
+/// cursor quad (`cursor_quad_appended` from [`build_background_instances`]),
+/// which depends on blink phase as well as `show_cursor` — so `cfo` can
+/// legitimately equal `deco_verts.len()` (no reserved tail region) when that
+/// rebuild happened to land on the cursor's blink-off half of the cycle.
+///
+/// `cursor_verts` is the freshly-built cursor quad for *this* frame — empty
+/// when the cursor should not be visible right now (hidden, or blink-off),
+/// or exactly `CURSOR_QUAD_FLOATS` floats when it should be.
+///
+/// Three cases:
+/// - A reserved region exists (`cfo + CURSOR_QUAD_FLOATS <= deco_verts.len()`)
+///   and the cursor should be hidden now: zero it out in place.
+/// - A reserved region exists and the cursor should be visible now: overwrite
+///   it in place with the new quad.
+/// - **No** reserved region exists (`cfo == deco_verts.len()`, the blink-off
+///   rebuild case above) and the cursor should be visible now: the quad must
+///   be *appended*, not patched in place — issue #432's follow-up defect,
+///   where skipping this case silently left the cursor invisible until an
+///   unrelated full rebuild happened to run. This is safe precisely because
+///   the GPU upload path always re-uploads `deco_verts` based on its current
+///   (dynamic) length rather than a fixed reserved-tail count. `cfo` itself
+///   never needs updating: it already equals the offset the newly-appended
+///   quad lands at.
+///
+/// Any other combination (an out-of-bounds `cfo` that is neither a valid
+/// reserved region nor exactly the tail) is a defensive no-op — this should
+/// not occur given `cfo` is always produced by the full-rebuild bookkeeping,
+/// but silently doing nothing is safer than a panic or corrupting unrelated
+/// data.
+fn patch_cursor_only_deco_verts(deco_verts: &mut Vec<f32>, cfo: usize, cursor_verts: &[f32]) {
+    if cursor_verts.is_empty() {
+        // Hide cursor: zero out the region, if one is actually reserved.
+        if cfo + CURSOR_QUAD_FLOATS <= deco_verts.len() {
+            for f in &mut deco_verts[cfo..cfo + CURSOR_QUAD_FLOATS] {
+                *f = 0.0;
+            }
+        }
+    } else if cursor_verts.len() == CURSOR_QUAD_FLOATS {
+        if cfo + CURSOR_QUAD_FLOATS <= deco_verts.len() {
+            deco_verts[cfo..cfo + CURSOR_QUAD_FLOATS].copy_from_slice(cursor_verts);
+        } else if cfo == deco_verts.len() {
+            deco_verts.extend_from_slice(cursor_verts);
+        }
+    }
+}
+
 /// Format the fold-placeholder text for a collapsed command block.
 ///
 /// See the render path (`show`) for how this is used.
@@ -2407,22 +2459,10 @@ impl FreminalTerminalWidget {
                 let mut rs = render_state
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
-                // detect the cursor-only mode via a separate flag.
                 // We overwrite the cursor quad data in the CPU copy so that if
                 // a full rebuild happens next frame it starts from correct state.
                 let cfo = rs.cursor_vert_float_offset;
-                if cursor_verts.is_empty() {
-                    // Hide cursor: zero out the region.
-                    if cfo + CURSOR_QUAD_FLOATS <= rs.deco_verts.len() {
-                        for f in &mut rs.deco_verts[cfo..cfo + CURSOR_QUAD_FLOATS] {
-                            *f = 0.0;
-                        }
-                    }
-                } else if cfo + CURSOR_QUAD_FLOATS <= rs.deco_verts.len()
-                    && cursor_verts.len() == CURSOR_QUAD_FLOATS
-                {
-                    rs.deco_verts[cfo..cfo + CURSOR_QUAD_FLOATS].copy_from_slice(&cursor_verts);
-                }
+                patch_cursor_only_deco_verts(&mut rs.deco_verts, cfo, &cursor_verts);
             } else if content_changed
                 || selection_changed
                 || text_blink_changed
@@ -3692,6 +3732,105 @@ mod cursor_blink_phase_tests {
         assert!(!cursor_blink_phase(anchor + 0.5, Some(anchor), TICK));
         // 1.0s after activation -> "on" again.
         assert!(cursor_blink_phase(anchor + 1.0, Some(anchor), TICK));
+    }
+}
+
+#[cfg(test)]
+mod patch_cursor_only_deco_verts_tests {
+    //! Tests for [`patch_cursor_only_deco_verts`], the pure cursor-only
+    //! decoration-buffer patch decision. Covers the two pre-existing cases
+    //! (in-place hide/show) plus the issue #432 follow-up defect: a
+    //! CodeRabbit-flagged regression where `cfo` legitimately pointing past
+    //! the end of `deco_verts` (no reserved tail — the last full rebuild
+    //! landed on the cursor's blink-off phase) combined with a now-visible
+    //! cursor silently dropped the write instead of appending, leaving the
+    //! cursor invisible until an unrelated full rebuild happened to run.
+
+    use super::{CURSOR_QUAD_FLOATS, patch_cursor_only_deco_verts};
+
+    /// A fake "cursor quad" of the correct size, filled with a distinct
+    /// sentinel value so tests can assert on its presence/absence precisely.
+    fn fake_cursor_quad() -> Vec<f32> {
+        vec![9.0; CURSOR_QUAD_FLOATS]
+    }
+
+    #[test]
+    fn hides_cursor_by_zeroing_a_reserved_region() {
+        let mut deco = vec![1.0; CURSOR_QUAD_FLOATS]; // selection quad, say
+        deco.extend(fake_cursor_quad()); // reserved cursor tail
+        let cfo = CURSOR_QUAD_FLOATS;
+
+        patch_cursor_only_deco_verts(&mut deco, cfo, &[]);
+
+        assert_eq!(deco.len(), CURSOR_QUAD_FLOATS * 2, "must not resize");
+        assert!(
+            deco[cfo..].iter().all(|&f| f == 0.0),
+            "reserved cursor region must be zeroed"
+        );
+        assert!(
+            deco[..cfo].iter().all(|&f| (f - 1.0).abs() < f32::EPSILON),
+            "content before the cursor region must be untouched"
+        );
+    }
+
+    #[test]
+    fn overwrites_a_reserved_region_in_place() {
+        let mut deco = vec![1.0; CURSOR_QUAD_FLOATS];
+        deco.extend(vec![0.0; CURSOR_QUAD_FLOATS]); // previously hidden/zeroed
+        let cfo = CURSOR_QUAD_FLOATS;
+        let cursor_verts = fake_cursor_quad();
+
+        patch_cursor_only_deco_verts(&mut deco, cfo, &cursor_verts);
+
+        assert_eq!(deco.len(), CURSOR_QUAD_FLOATS * 2, "must not resize");
+        assert_eq!(
+            deco[cfo..],
+            cursor_verts[..],
+            "reserved cursor region must contain the new cursor quad"
+        );
+        assert!(
+            deco[..cfo].iter().all(|&f| (f - 1.0).abs() < f32::EPSILON),
+            "content before the cursor region must be untouched"
+        );
+    }
+
+    /// Regression for the CodeRabbit-flagged follow-up to issue #432: `cfo`
+    /// pointing exactly at the end of `deco_verts` (no reserved tail, because
+    /// the last full rebuild landed on blink-off) with a now-visible cursor
+    /// must *append* the quad, not silently drop it.
+    #[test]
+    fn appends_cursor_quad_when_no_tail_was_reserved() {
+        let mut deco = vec![1.0; CURSOR_QUAD_FLOATS]; // e.g. one selection quad
+        let cfo = deco.len(); // no reserved region: cfo == len
+        let cursor_verts = fake_cursor_quad();
+
+        patch_cursor_only_deco_verts(&mut deco, cfo, &cursor_verts);
+
+        assert_eq!(
+            deco.len(),
+            CURSOR_QUAD_FLOATS * 2,
+            "the cursor quad must be appended, growing deco_verts"
+        );
+        assert_eq!(
+            deco[cfo..],
+            cursor_verts[..],
+            "the appended region must be the new cursor quad"
+        );
+        assert!(
+            deco[..cfo].iter().all(|&f| (f - 1.0).abs() < f32::EPSILON),
+            "pre-existing content must be untouched"
+        );
+    }
+
+    #[test]
+    fn no_reserved_tail_and_cursor_hidden_is_a_no_op() {
+        let mut deco = vec![1.0; CURSOR_QUAD_FLOATS];
+        let cfo = deco.len();
+        let original = deco.clone();
+
+        patch_cursor_only_deco_verts(&mut deco, cfo, &[]);
+
+        assert_eq!(deco, original, "nothing to hide, nothing to append");
     }
 }
 

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -1968,10 +1968,12 @@ impl FreminalTerminalWidget {
         };
 
         // Cursor-only state captured before the PaintCallback closure (which
-        // requires `Send + Sync + 'static`).  `is_cursor_only` and
-        // `cursor_only_verts` are moved into the closure below.
+        // requires `Send + Sync + 'static`).  `is_cursor_only` is moved into
+        // the closure below. The decoration data itself (including the
+        // patched-in cursor quad) lives in `RenderState::deco_verts` and is
+        // read fresh by the closure — it is not captured here, so it always
+        // reflects whatever was last written to it.
         let mut is_cursor_only = false;
-        let mut cursor_only_verts: Vec<f32> = Vec::new();
         // Damage rect (physical fb pixels, bottom-left origin) for the
         // cursor-only path, used to scissor the GPU redraw to just the changed
         // cell(s) (#435). `None` -> no scissor (draw the full grid).
@@ -2343,7 +2345,6 @@ impl FreminalTerminalWidget {
                     snap.cursor_color_override,
                 );
                 is_cursor_only = true;
-                cursor_only_verts.clone_from(&cursor_verts);
 
                 // Compute the frame-damage rect (#435): the region that
                 // actually changed this frame, so the windowing layer can
@@ -2599,7 +2600,7 @@ impl FreminalTerminalWidget {
                 // disjoint field accesses (MutexGuard's DerefMut is opaque).
                 let rs_ref: &mut RenderState = &mut rs;
 
-                build_background_instances(
+                let cursor_quad_appended = build_background_instances(
                     &BackgroundFrame {
                         shaped_lines: &rendered_shaped_lines,
                         cell_width: cell_w,
@@ -2632,9 +2633,17 @@ impl FreminalTerminalWidget {
                 );
 
                 // Record where the cursor quad starts in the decoration VBO.
-                // The cursor is always appended at the END of deco_verts, and is
-                // exactly CURSOR_QUAD_FLOATS floats (or absent when hidden).
-                let cursor_vert_float_offset = if effective_show_cursor {
+                // The cursor is always appended at the END of deco_verts, and
+                // is exactly CURSOR_QUAD_FLOATS floats (or absent when
+                // hidden). MUST use `cursor_quad_appended` (the authoritative
+                // answer from `build_background_instances`) rather than
+                // re-deriving it from `effective_show_cursor` alone —
+                // `effective_show_cursor` does not account for the blink
+                // phase, so recomputing it here could disagree with what was
+                // actually appended whenever this rebuild happened to land on
+                // the cursor's blink-off phase, corrupting a later
+                // cursor-only patch (issue #432).
+                let cursor_vert_float_offset = if cursor_quad_appended {
                     rs_ref.deco_verts.len().saturating_sub(CURSOR_QUAD_FLOATS)
                 } else {
                     rs_ref.deco_verts.len()
@@ -2755,8 +2764,10 @@ impl FreminalTerminalWidget {
 
         // Hand off the draw call to egui's paint phase via PaintCallback.
         // The closure must be `Send + Sync + 'static`, so only `Arc<Mutex<…>>`
-        // data (not `FontManager`) may be captured here.  `is_cursor_only` and
-        // `cursor_only_verts` are captured by value (bool is Copy; Vec is moved).
+        // data (not `FontManager`) may be captured here.  `is_cursor_only` is
+        // captured by value (bool is Copy). The decoration vertex data itself
+        // is read from `RenderState::deco_verts` inside the closure, not
+        // captured separately.
         let render_state_for_cb = Arc::clone(render_state);
         // Authoritative partial-present flag (#435): the windowing layer sets
         // it just before this callback runs. The cursor-only scissor is gated
@@ -2823,23 +2834,30 @@ impl FreminalTerminalWidget {
                 let restore_fbo = painter.intermediate_fbo();
 
                 if is_cursor_only {
-                    // Cursor-only fast path: patch just the cursor quad on the
-                    // GPU via `glBufferSubData` (no VBO orphan, no full upload).
-                    let deco_len = rs.deco_verts.len();
+                    // Cursor-only fast path: bg/fg/image are unchanged and
+                    // simply redrawn from the last full rebuild's slot.
+                    // `deco_verts` (underline/strike/search/hover/selection/
+                    // cursor quads) DOES change every such frame (the cursor
+                    // moved/blinked), so it is always fully re-uploaded via a
+                    // safe orphan-then-write into its own double-buffer slot
+                    // — never patched live with `glBufferSubData` into a
+                    // buffer a pending GPU read may still be using (#432).
                     let bg_len = rs.bg_instances.len();
                     let fg_len = rs.fg_instances.len();
                     let img_len = rs.image_verts.len();
-                    let cfo_bytes = rs.cursor_vert_float_offset * std::mem::size_of::<f32>();
                     let cw = rs.cell_width_px;
                     let ch = rs.cell_height_px;
                     let opacity = rs.bg_opacity;
                     let bg_image_opacity = rs.bg_image_opacity;
                     let bg_image_mode = rs.bg_image_mode;
                     // Split borrow: renderer + atlas are disjoint from the
-                    // scalar fields and image_draw_order.
+                    // scalar fields, deco_verts, and image_draw_order.
                     let rs_ref: &mut RenderState = &mut rs;
                     let renderer = &mut rs_ref.renderer;
                     let atlas = &mut rs_ref.atlas;
+                    // The full, current decoration data — already patched
+                    // in place with the cursor quad above.
+                    let deco_verts = &rs_ref.deco_verts;
                     // Reuse the draw order retained from the last full
                     // rebuild — the cursor-only path does not recompute
                     // image state, so this is the same list `draw_images`
@@ -2879,10 +2897,8 @@ impl FreminalTerminalWidget {
                     renderer.draw_with_cursor_only_update(
                         gl,
                         atlas,
-                        cfo_bytes,
-                        deco_len,
+                        deco_verts,
                         bg_len,
-                        &cursor_only_verts,
                         fg_len,
                         img_len,
                         draw_order,


### PR DESCRIPTION
## Summary

Fixes #432 — selection highlight intermittently losing its background color on the bottom-most row of the highlighted region, tied to cursor blink.

## Root cause

`build_background_instances` only appends a cursor quad to the decoration vertex buffer (`deco_verts`) when **both** `show_cursor` is true **and** the blink phase currently says visible (`cursor_blink_is_visible`). The cursor's tail-quad byte offset bookkeeping in `widget.rs`, however, was computed from `show_cursor` alone — ignoring blink phase entirely.

Whenever a full rebuild happened to run during the cursor's blink-*off* instant (with a blinking, non-steady cursor style), no cursor quad was actually appended, but the offset was still computed as if one had been — landing exactly on the last real quad already in the buffer. Since selection quads are appended in top-to-bottom row order, the **bottom-most row's selection quad is always the last thing pushed** before where the cursor would go. The next time blink flipped back on, the cursor-only fast path overwrote that region with the cursor's own quad data — clobbering the bottom row's selection highlight with the cursor color instead.

This explains every reported symptom:
- Only the bottom-most row of the selection is ever affected (it's always the last quad pushed).
- Directly tied to blink (disabling blink — steady cursor — makes the two conditions always agree, and the bug disappears).
- Cursor position relative to the selection is irrelevant — it's a buffer-offset bug, not spatial overlap.
- Reliably reproducible via window focus changes, which force extra full rebuilds (each one a fresh roll of the dice on blink phase).

## Fix

`build_background_instances` now returns whether it actually appended a cursor quad, and the caller uses that authoritative answer instead of re-deriving the (incomplete) condition itself. This closes the whole class of bug — the two decisions can no longer silently disagree — rather than just patching this one instance.

While investigating, also hardened the cursor-only GPU fast path: `deco_vbo` now gets its own independent double-buffer index so its per-blink re-upload always orphans into a slot the GPU isn't currently reading, instead of live-patching bytes into a buffer a pending draw may still be using.

## Testing

- Added `full_rebuild_during_blink_off_does_not_append_cursor_quad_over_selection` — reproduces the exact blink-off/selection scenario and asserts the fix's contract directly.
- `cargo test --all` — all tests pass.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `cargo machete` — clean.
- `cargo xtask check-windows` — clean.
- Manually reproduced and confirmed fixed by the reporter, including via the window-focus-change repro technique.

🤖 Generated with [opencode](https://opencode.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cursor-only redraws to correctly respect blink visibility, preventing cursor-tail clobbering and selection highlighting artifacts.
  * Improved consistency of cursor geometry updates across fast cursor rendering and full rebuilds.
* **Performance**
  * Refined renderer buffer management by double-buffering decoration rendering separately, reducing unnecessary cursor buffer patching and improving smoothness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->