### PR TITLE
feat: 433 -- fully-owned GL toast renderer

### DIFF
--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -3006,14 +3006,14 @@ impl freminal_windowing::App for FreminalGui {
             // below), so this cannot reuse `central_body`'s own locals
             // (`pane_layout`, `available_rect`), which are scoped to that
             // closure.
-            let window_rect = win
+            let content_rect = win
                 .cached_central_rect
                 .unwrap_or_else(|| ctx.input(egui::InputState::content_rect));
             let active_tab = win.tabs.active_tab();
             let active_pane_id = active_tab.active_pane;
             let active_pane_rect = active_tab.zoomed_pane.map_or_else(
                 || {
-                    active_tab.pane_tree.layout(window_rect).ok().and_then(
+                    active_tab.pane_tree.layout(content_rect).ok().and_then(
                         |pane_layout: Vec<(crate::gui::panes::PaneId, egui::Rect)>| {
                             pane_layout
                                 .into_iter()
@@ -3022,10 +3022,10 @@ impl freminal_windowing::App for FreminalGui {
                         },
                     )
                 },
-                |zoomed_id| (zoomed_id == active_pane_id).then_some(window_rect),
+                |zoomed_id| (zoomed_id == active_pane_id).then_some(content_rect),
             );
             let geom = super::toast::ToastGeometry {
-                window_rect,
+                content_rect,
                 active_pane_rect,
             };
             stack.show(

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -313,6 +313,7 @@ impl freminal_windowing::App for FreminalGui {
                         border_drag: None,
                         shader_last_mtime: None,
                         window_post,
+                        toast_render_state: crate::gui::renderer::ToastRenderState::new_shared(),
                         repaint_handle,
                         pending_new_window: false,
                         pending_geometry: None,
@@ -2999,7 +3000,41 @@ impl freminal_windowing::App for FreminalGui {
         if chrome_mode == freminal_windowing::ChromeMode::Full
             && let Ok(mut stack) = self.toasts.try_borrow_mut()
         {
-            stack.show(ctx);
+            // Rebuild the same geometry `central_body` used to populate
+            // `cached_central_rect`/the pane layout — `win` is a local
+            // variable here (removed from `self.windows` above, reinserted
+            // below), so this cannot reuse `central_body`'s own locals
+            // (`pane_layout`, `available_rect`), which are scoped to that
+            // closure.
+            let window_rect = win
+                .cached_central_rect
+                .unwrap_or_else(|| ctx.input(egui::InputState::content_rect));
+            let active_tab = win.tabs.active_tab();
+            let active_pane_id = active_tab.active_pane;
+            let active_pane_rect = active_tab.zoomed_pane.map_or_else(
+                || {
+                    active_tab.pane_tree.layout(window_rect).ok().and_then(
+                        |pane_layout: Vec<(crate::gui::panes::PaneId, egui::Rect)>| {
+                            pane_layout
+                                .into_iter()
+                                .find(|(id, _)| *id == active_pane_id)
+                                .map(|(_, r)| r)
+                        },
+                    )
+                },
+                |zoomed_id| (zoomed_id == active_pane_id).then_some(window_rect),
+            );
+            let geom = super::toast::ToastGeometry {
+                window_rect,
+                active_pane_rect,
+            };
+            stack.show(
+                ctx,
+                geom,
+                &win.toast_render_state,
+                win.terminal_widget.font_manager_mut(),
+                ctx.pixels_per_point(),
+            );
         }
 
         // ── Chrome-damage (#436.3): §3.5 "after" sample + final decision ─────
@@ -3127,7 +3162,8 @@ impl FreminalGui {
     /// Called twice per `update()` for the window being rendered — once as
     /// early as possible (before any dialog's `.show(ctx)` this frame) and
     /// once after all of them (including the shared toast stack's `.show`,
-    /// which runs after `win` is reinserted — see the call site) — so the
+    /// which runs against the still-local `win` before it is reinserted into
+    /// `self.windows` at the end of `update()` — see the call site) — so the
     /// two samples can be diffed to catch a self-dismissal that happens
     /// DURING a `.show()` call this same frame (adversarial finding 1).
     fn sample_dismissible_presence(
@@ -3327,6 +3363,7 @@ impl FreminalGui {
             border_drag: None,
             shader_last_mtime: None,
             window_post,
+            toast_render_state: crate::gui::renderer::ToastRenderState::new_shared(),
             repaint_handle,
             pending_new_window: false,
             pending_geometry: None,

--- a/freminal/src/gui/layout_ops.rs
+++ b/freminal/src/gui/layout_ops.rs
@@ -705,6 +705,7 @@ impl FreminalGui {
             border_drag: None,
             shader_last_mtime: None,
             window_post,
+            toast_render_state: crate::gui::renderer::ToastRenderState::new_shared(),
             repaint_handle,
             pending_new_window: false,
             pending_geometry,

--- a/freminal/src/gui/renderer/gpu.rs
+++ b/freminal/src/gui/renderer/gpu.rs
@@ -63,7 +63,7 @@ pub(super) fn gl_i32(val: usize) -> i32 {
 /// Returns `0` on overflow (texture sizes are always well within `i32` range)
 /// and logs an error so the impossible is visible if it ever occurs.
 #[inline]
-fn gl_i32_u32(val: u32) -> i32 {
+pub(super) fn gl_i32_u32(val: u32) -> i32 {
     i32::value_from(val).unwrap_or_else(|_| {
         error!("gl_i32_u32: u32 {val} overflows i32");
         0

--- a/freminal/src/gui/renderer/gpu.rs
+++ b/freminal/src/gui/renderer/gpu.rs
@@ -48,8 +48,11 @@ use freminal_terminal_emulator::InlineImage;
 /// Convert a `usize` to `i32` for OpenGL counts, strides, or byte offsets.
 /// Returns `0` on overflow (astronomically unlikely for terminal dimensions)
 /// and logs an error so the impossible is visible if it ever occurs.
+///
+/// `pub(super)` so sibling passes under `renderer/` (e.g. [`super::toast_pass`])
+/// can reuse this conversion instead of duplicating it.
 #[inline]
-fn gl_i32(val: usize) -> i32 {
+pub(super) fn gl_i32(val: usize) -> i32 {
     i32::value_from(val).unwrap_or_else(|_| {
         error!("gl_i32: usize {val} overflows i32");
         0
@@ -70,8 +73,11 @@ fn gl_i32_u32(val: u32) -> i32 {
 /// Convert an `i32` to `f32` for GPU viewport uniforms.
 /// Returns `0.0` on precision loss (viewport sizes are always small)
 /// and logs an error so the impossible is visible if it ever occurs.
+///
+/// `pub(super)` so sibling passes under `renderer/` (e.g. [`super::toast_pass`])
+/// can reuse this conversion instead of duplicating it.
 #[inline]
-fn gl_f32_i32(val: i32) -> f32 {
+pub(super) fn gl_f32_i32(val: i32) -> f32 {
     f32::approx_from(val).unwrap_or_else(|_| {
         error!("gl_f32_i32: i32 {val} cannot be approximated as f32");
         0.0
@@ -1526,7 +1532,12 @@ unsafe fn setup_deco_attribs(gl: &glow::Context) {
 /// - Location 3: `vec4  a_uv_rect`      (u0, v0, u1, v1)  — divisor 1
 /// - Location 4: `vec4  a_fg_color`     (r, g, b, a)      — divisor 1
 /// - Location 5: `float a_is_color`     (1.0 or 0.0)      — divisor 1
-unsafe fn setup_fg_inst_attribs(
+///
+/// `pub(super)` so sibling passes under `renderer/` (e.g.
+/// [`super::toast_text_pass`], which draws toast label/icon text through
+/// this same instanced foreground shader) can reuse this attribute binder
+/// instead of duplicating it.
+pub(super) unsafe fn setup_fg_inst_attribs(
     gl: &glow::Context,
     unit_quad_vbo: glow::Buffer,
     instance_vbo: glow::Buffer,
@@ -1586,7 +1597,10 @@ unsafe fn setup_img_attribs(gl: &glow::Context) {
 // ---------------------------------------------------------------------------
 
 /// Compile and link a GLSL program from vertex and fragment source strings.
-fn compile_program(
+///
+/// `pub(super)` so sibling passes under `renderer/` (e.g. [`super::toast_pass`])
+/// can reuse the same compile/link error handling instead of duplicating it.
+pub(super) fn compile_program(
     gl: &glow::Context,
     vert_src: &str,
     frag_src: &str,
@@ -1645,7 +1659,10 @@ unsafe fn compile_shader(
 // ---------------------------------------------------------------------------
 
 /// Upload a `&[f32]` to a VBO using the orphan-then-write pattern.
-fn upload_verts(gl: &glow::Context, vbo: glow::Buffer, verts: &[f32]) {
+///
+/// `pub(super)` so sibling passes under `renderer/` (e.g. [`super::toast_pass`])
+/// can reuse the same orphan-then-write upload instead of duplicating it.
+pub(super) fn upload_verts(gl: &glow::Context, vbo: glow::Buffer, verts: &[f32]) {
     if verts.is_empty() {
         return;
     }

--- a/freminal/src/gui/renderer/mod.rs
+++ b/freminal/src/gui/renderer/mod.rs
@@ -11,18 +11,56 @@
 //!   (decoration, background, foreground, image).
 //! - [`vertex`] — CPU-side vertex/instance builders, `FgRenderOptions`, and helpers.
 //!   Contains the full test suite for vertex generation logic.
+//! - [`toast_pass`] — [`ToastRenderer`], a self-contained SDF rounded-rect
+//!   pill pass for the toast-notification overlay (issue #433). Driven each
+//!   frame from the owned `ToastStack::show` `PaintCallback`; see
+//!   `toast_pass` module docs.
+//! - [`toast_text_pass`] — [`ToastTextRenderer`], a self-contained pass that
+//!   draws toast label/icon text through the shared instanced foreground
+//!   shader (issue #433). Companion to `toast_pass`; see `toast_text_pass`
+//!   module docs.
 
 pub mod errors;
 pub mod gpu;
 pub(super) mod shaders;
+pub mod toast_pass;
+pub mod toast_text_pass;
 pub mod vertex;
 
 pub use gpu::{TerminalRenderer, WindowPostRenderer};
+pub use toast_pass::{ToastQuad, ToastRenderer};
+pub use toast_text_pass::{ToastTextMetrics, ToastTextRenderer, ToastTextRun};
 pub use vertex::{
     BackgroundFrame, CURSOR_QUAD_FLOATS, FgRenderOptions, ImageDrawEntry, MatchHighlight,
     build_background_instances, build_cursor_verts_only, build_foreground_instances,
     build_image_verts,
 };
+
+/// Per-window GL state for the fully-owned toast overlay (issue #433).
+///
+/// The pill pass and the text pass share one window (one GL context).
+/// Created lazily; both sub-renderers `init()` on first draw inside the
+/// toast `PaintCallback` (see `super::toast::ToastStack::show`).
+#[derive(Default)]
+pub struct ToastRenderState {
+    /// Draws each toast's rounded-rect pill background (glow + gradient +
+    /// accent bar).
+    pub pill: ToastRenderer,
+    /// Draws each toast's icon/label/detail text on top of the pills.
+    pub text: ToastTextRenderer,
+}
+
+impl ToastRenderState {
+    /// Construct a fresh, `Arc<Mutex<_>>`-wrapped instance, as stored in
+    /// `PerWindowState::toast_render_state`. A tiny shared constructor
+    /// (rather than duplicating the three-line `Arc::new(Mutex::new(...))`
+    /// at each of the three `PerWindowState` construction sites) so none of
+    /// them tip over the `too_many_lines` limit.
+    #[must_use]
+    pub fn new_shared() -> std::sync::Arc<std::sync::Mutex<Self>> {
+        std::sync::Arc::new(std::sync::Mutex::new(Self::default()))
+    }
+}
 
 use conv2::{ConvUtil, RoundToNearest};
 

--- a/freminal/src/gui/renderer/shaders.rs
+++ b/freminal/src/gui/renderer/shaders.rs
@@ -108,3 +108,33 @@ pub(super) const POST_VERT_SRC: &str = include_str!("./shaders/post.vert");
 /// Used as a fallback when no user shader is configured (or compilation fails).
 /// Simply samples the terminal texture and outputs it directly.
 pub(super) const POST_PASSTHROUGH_FRAG_SRC: &str = include_str!("./shaders/post_passthrough.frag");
+
+// ---------------------------------------------------------------------------
+//  Toast pass (issue #433)
+// ---------------------------------------------------------------------------
+//
+// SDF rounded-rect pill with a soft drop shadow, an outer glow halo, a
+// vertical gradient fill, and an optional left accent bar. Used by the
+// toast-notification overlay. Non-instanced: one expanded quad (6 vertices)
+// per toast, all pill parameters duplicated across the 6 vertices.
+//
+// Vertex layout — `TOAST_VERTEX_FLOATS = 24` floats per vertex, stride
+// `24 * size_of::<f32>()` = 96 bytes:
+//   location 0: `vec2  a_pos`            — expanded-quad corner, physical px
+//   location 1: `vec2  a_pill_center`    — pill rect center, physical px
+//   location 2: `vec2  a_pill_halfsize`  — pill half-extent (w/2, h/2), px
+//   location 3: `float a_corner`         — corner radius, px
+//   location 4: `vec4  a_color_top`      — straight RGBA
+//   location 5: `vec4  a_color_bottom`   — straight RGBA
+//   location 6: `vec4  a_glow`           — rgb + intensity in .a
+//   location 7: `vec4  a_accent`         — straight RGBA, alpha 0 disables
+//   location 8: `float a_opacity`        — overall fade-in/out multiplier
+
+/// Toast pass vertex shader — see module-level doc above for the full
+/// vertex layout.
+pub(super) const TOAST_VERT_SRC: &str = include_str!("./shaders/toast.vert");
+
+/// Toast pass fragment shader — SDF rounded-rect, shadow, glow, gradient,
+/// and accent bar, composited via straight-alpha "over" and output
+/// premultiplied. See `toast.frag` for the full layering breakdown.
+pub(super) const TOAST_FRAG_SRC: &str = include_str!("./shaders/toast.frag");

--- a/freminal/src/gui/renderer/shaders/toast.frag
+++ b/freminal/src/gui/renderer/shaders/toast.frag
@@ -1,0 +1,95 @@
+#version 330 core
+// Toast pass fragment shader (issue #433).
+//
+// Draws one rounded-rect "pill" per primitive using a signed-distance-field
+// (SDF), layered bottom-to-top as: drop shadow -> outer glow -> gradient
+// fill (+ optional left accent bar). All layers are composited with the
+// standard (straight-alpha) "over" operator and the final result is
+// converted to PREMULTIPLIED alpha on output, matching every other pass in
+// this renderer (freminal never touches GL blend state — it inherits
+// egui_glow's ONE / ONE_MINUS_SRC_ALPHA blend func).
+in vec2 v_pos;
+flat in vec2 v_center;
+flat in vec2 v_halfsize;
+flat in float v_corner;
+flat in vec4 v_color_top;
+flat in vec4 v_color_bottom;
+flat in vec4 v_glow;
+flat in vec4 v_accent;
+flat in float v_opacity;
+
+out vec4 frag_color;
+
+// Tuned constants for the glow halo, drop shadow, and accent bar. These are
+// intentionally hardcoded rather than uniforms: every toast pill in the
+// overlay shares the same "chrome" look, only the colors/opacity differ.
+const float GLOW_RADIUS = 18.0;
+const float SHADOW_BLUR = 16.0;
+const vec2 SHADOW_OFFSET = vec2(0.0, 4.0);
+const float SHADOW_ALPHA = 0.35;
+const float ACCENT_WIDTH = 4.0;
+
+// Signed distance to a rounded rect centered at `center` with half-extent
+// `halfsize` and corner radius `corner`. Negative inside, 0 on the edge,
+// positive outside.
+float rounded_rect_sdf(vec2 p, vec2 center, vec2 halfsize, float corner) {
+    vec2 q = abs(p - center) - (halfsize - corner);
+    return length(max(q, 0.0)) - corner;
+}
+
+void main() {
+    float sdf = rounded_rect_sdf(v_pos, v_center, v_halfsize, v_corner);
+
+    // Anti-aliased fill mask: 1 well inside the pill, 0 well outside, with a
+    // ~1px feather (via fwidth) straddling the SDF's zero crossing.
+    float aa = fwidth(sdf);
+    float fill_mask = 1.0 - smoothstep(-aa, aa, sdf);
+
+    // Vertical gradient: t=0 at the pill's top edge -> color_top, t=1 at the
+    // bottom edge -> color_bottom.
+    float top_y = v_center.y - v_halfsize.y;
+    float t = clamp(v_pos.y - top_y, 0.0, 2.0 * v_halfsize.y);
+    t = v_halfsize.y > 0.0 ? t / (2.0 * v_halfsize.y) : 0.0;
+    vec4 gradient = mix(v_color_top, v_color_bottom, t);
+
+    // Left accent bar: a solid-color strip along the pill's left edge,
+    // intersected with `fill_mask` so the corner rounding is respected.
+    // Disabled entirely when a_accent.a == 0.
+    float left_edge = v_center.x - v_halfsize.x;
+    float accent_region = 1.0 - smoothstep(ACCENT_WIDTH - aa, ACCENT_WIDTH + aa, v_pos.x - left_edge);
+    float accent_mask = clamp(accent_region, 0.0, 1.0) * fill_mask * v_accent.a;
+    vec3 fill_rgb = mix(gradient.rgb, v_accent.rgb, accent_mask);
+    float fill_a = gradient.a * fill_mask;
+
+    // Drop shadow: a softened, downward-offset copy of the same SDF, drawn
+    // as a translucent dark layer strictly behind everything else.
+    float shadow_sdf = rounded_rect_sdf(v_pos - SHADOW_OFFSET, v_center, v_halfsize, v_corner);
+    float shadow_mask = 1.0 - smoothstep(-SHADOW_BLUR, SHADOW_BLUR, shadow_sdf);
+    float shadow_a = clamp(shadow_mask, 0.0, 1.0) * SHADOW_ALPHA;
+    vec3 shadow_rgb = vec3(0.0);
+
+    // Outer glow: a soft colored halo outside the pill, fading to 0 over
+    // `GLOW_RADIUS` pixels. `v_glow.a` is the overall glow intensity.
+    float glow_mask = 1.0 - smoothstep(0.0, GLOW_RADIUS, sdf);
+    float glow_a = clamp(glow_mask, 0.0, 1.0) * v_glow.a;
+    vec3 glow_rgb = v_glow.rgb;
+
+    // Composite bottom-to-top with the standard straight-alpha "over"
+    // operator: out_rgb = top*top_a + bottom*(1-top_a); out_a analogous.
+    vec3 out_rgb = shadow_rgb;
+    float out_a = shadow_a;
+
+    out_rgb = glow_rgb * glow_a + out_rgb * (1.0 - glow_a);
+    out_a = glow_a + out_a * (1.0 - glow_a);
+
+    out_rgb = fill_rgb * fill_a + out_rgb * (1.0 - fill_a);
+    out_a = fill_a + out_a * (1.0 - fill_a);
+
+    // Apply the overall fade-in/out multiplier, then emit premultiplied.
+    // `out_rgb`/`out_a` are ALREADY premultiplied (the over-compositing above
+    // emits premultiplied color), so the fade scales BOTH channels by the
+    // same `v_opacity` — scaling `out_rgb` by the faded alpha instead would
+    // double-multiply and darken every translucent pixel (glow, shadow, AA
+    // edges) and muddy the fade. See issue #433 adversarial-review finding 1.
+    frag_color = vec4(out_rgb * v_opacity, out_a * v_opacity);
+}

--- a/freminal/src/gui/renderer/shaders/toast.frag
+++ b/freminal/src/gui/renderer/shaders/toast.frag
@@ -74,8 +74,11 @@ void main() {
     float glow_a = clamp(glow_mask, 0.0, 1.0) * v_glow.a;
     vec3 glow_rgb = v_glow.rgb;
 
-    // Composite bottom-to-top with the standard straight-alpha "over"
-    // operator: out_rgb = top*top_a + bottom*(1-top_a); out_a analogous.
+    // Composite bottom-to-top with the "over" operator, accumulating
+    // PREMULTIPLIED color: out_rgb = top_rgb*top_a + out_rgb*(1-top_a);
+    // out_a = top_a + out_a*(1-top_a). Each layer's color arrives
+    // straight-alpha; the products below premultiply it as it accumulates,
+    // which is what the final premultiplied emit at the bottom relies on.
     vec3 out_rgb = shadow_rgb;
     float out_a = shadow_a;
 

--- a/freminal/src/gui/renderer/shaders/toast.vert
+++ b/freminal/src/gui/renderer/shaders/toast.vert
@@ -1,0 +1,55 @@
+#version 330 core
+// Toast pass vertex shader (issue #433).
+//
+// Vertex layout — one vertex is 24 floats (see TOAST_VERTEX_FLOATS in
+// toast_pass.rs); all pill parameters are constant across a pill's 6
+// vertices (duplicated per-vertex, non-instanced):
+//   location 0: a_pos            vec2  — expanded-quad corner, physical px
+//   location 1: a_pill_center     vec2  — pill rect center, physical px
+//   location 2: a_pill_halfsize   vec2  — pill half-extent (w/2, h/2), px
+//   location 3: a_corner          float — corner radius, px
+//   location 4: a_color_top       vec4  — straight RGBA
+//   location 5: a_color_bottom    vec4  — straight RGBA
+//   location 6: a_glow            vec4  — rgb + intensity in .a
+//   location 7: a_accent          vec4  — straight RGBA, alpha 0 disables
+//   location 8: a_opacity         float — overall fade multiplier
+layout(location = 0) in vec2 a_pos;
+layout(location = 1) in vec2 a_pill_center;
+layout(location = 2) in vec2 a_pill_halfsize;
+layout(location = 3) in float a_corner;
+layout(location = 4) in vec4 a_color_top;
+layout(location = 5) in vec4 a_color_bottom;
+layout(location = 6) in vec4 a_glow;
+layout(location = 7) in vec4 a_accent;
+layout(location = 8) in float a_opacity;
+
+// v_pos varies per-fragment (it is the SDF evaluation point) and must be
+// smoothly interpolated. Every other varying is identical across a pill's
+// six vertices, so `flat` is used to skip needless interpolation.
+out vec2 v_pos;
+flat out vec2 v_center;
+flat out vec2 v_halfsize;
+flat out float v_corner;
+flat out vec4 v_color_top;
+flat out vec4 v_color_bottom;
+flat out vec4 v_glow;
+flat out vec4 v_accent;
+flat out float v_opacity;
+
+uniform vec2 u_viewport_size;
+
+void main() {
+    // Convert from pixel coordinates (top-left origin) to NDC.
+    vec2 ndc = (a_pos / u_viewport_size) * 2.0 - 1.0;
+    gl_Position = vec4(ndc.x, -ndc.y, 0.0, 1.0);
+
+    v_pos = a_pos;
+    v_center = a_pill_center;
+    v_halfsize = a_pill_halfsize;
+    v_corner = a_corner;
+    v_color_top = a_color_top;
+    v_color_bottom = a_color_bottom;
+    v_glow = a_glow;
+    v_accent = a_accent;
+    v_opacity = a_opacity;
+}

--- a/freminal/src/gui/renderer/toast_pass.rs
+++ b/freminal/src/gui/renderer/toast_pass.rs
@@ -1,0 +1,466 @@
+// Copyright (C) 2024-2026 Fred Clausen
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Self-contained OpenGL pass that draws toast "pill" backgrounds (issue #433).
+//!
+//! [`ToastRenderer`] owns its own shader program, VAO, and double-buffered
+//! VBOs — modeled directly on the image pass in [`super::gpu`] (see
+//! `init_image_pass` / `setup_img_attribs` / `upload_img_verts` /
+//! `draw_images`). It is driven by the toast overlay's `PaintCallback` in
+//! [`crate::gui::toast`] (see `ToastStack::show` / `paint_toasts`), which
+//! calls [`ToastRenderer::draw`] on the GL thread after building the pill
+//! quads on the main thread.
+//!
+//! Each toast is drawn as a single quad (2 triangles = 6 vertices), expanded
+//! beyond the crisp pill rect by [`GLOW_MARGIN_PX`] on every side so the
+//! fragment shader has room to render the outer glow and drop shadow. See
+//! `toast.frag` for the SDF-based layering (shadow -> glow -> gradient fill
+//! + accent bar).
+//!
+//! The CPU-side vertex builder ([`build_toast_verts`]) is a pure function,
+//! fully testable without a GL context; GL calls are confined to
+//! [`ToastRenderer::init`], [`ToastRenderer::draw`], and
+//! [`ToastRenderer::destroy`].
+
+use glow::{self, HasContext};
+use tracing::error;
+
+use super::errors::{BufferAllocError, GpuInitError};
+use super::gpu::{compile_program, gl_f32_i32, gl_i32, upload_verts};
+use super::shaders::{TOAST_FRAG_SRC, TOAST_VERT_SRC};
+use super::vertex::VERTS_PER_QUAD;
+
+/// Floats per vertex, summing `a_pos` (2), `a_pill_center` (2),
+/// `a_pill_halfsize` (2), `a_corner` (1), `a_color_top` (4),
+/// `a_color_bottom` (4), `a_glow` (4), `a_accent` (4), and `a_opacity` (1),
+/// for a total of 24. See `toast.vert` for the exact attribute-location
+/// mapping.
+pub(super) const TOAST_VERTEX_FLOATS: usize = 24;
+
+/// Margin, in physical pixels, by which each toast's drawn quad is expanded
+/// beyond its crisp pill rect on every side. Gives the fragment shader room
+/// to render the outer glow (`GLOW_RADIUS` in `toast.frag`) and the
+/// downward-offset drop shadow (`SHADOW_OFFSET` + `SHADOW_BLUR`) without
+/// clipping. Must stay >= the largest of those GLSL constants' reach.
+const GLOW_MARGIN_PX: f32 = 24.0;
+
+// ---------------------------------------------------------------------------
+//  Public CPU-side data
+// ---------------------------------------------------------------------------
+
+/// One toast pill to draw this frame, in physical framebuffer pixels.
+#[derive(Debug, Clone, Copy)]
+pub struct ToastQuad {
+    /// Pill rect (the crisp rounded rectangle), physical pixels, top-left origin.
+    pub x: f32,
+    /// Pill rect top, physical pixels, top-left origin.
+    pub y: f32,
+    /// Pill rect width, physical pixels.
+    pub width: f32,
+    /// Pill rect height, physical pixels.
+    pub height: f32,
+    /// Corner radius in physical pixels.
+    pub corner_radius: f32,
+    /// Top gradient color, straight (non-premultiplied) RGBA, 0..=1.
+    pub color_top: [f32; 4],
+    /// Bottom gradient color, straight RGBA, 0..=1.
+    pub color_bottom: [f32; 4],
+    /// Glow color (straight RGB) + glow intensity in .a (0..=1).
+    pub glow: [f32; 4],
+    /// Left accent-bar color (straight RGBA). Set alpha 0 to disable.
+    pub accent: [f32; 4],
+    /// Overall opacity multiplier for fade-in/out animation (0..=1).
+    pub opacity: f32,
+}
+
+// ---------------------------------------------------------------------------
+//  ToastRenderer
+// ---------------------------------------------------------------------------
+
+/// Holds all GPU resources for the toast-pill pass.
+///
+/// Call [`ToastRenderer::init`] once (inside a `PaintCallback`) to create the
+/// shader program, VAO, and double-buffered VBOs. Then call
+/// [`ToastRenderer::draw`] once per frame with the current toast list.
+pub struct ToastRenderer {
+    /// Whether GPU resources have been created.
+    initialized: bool,
+    /// Compiled + linked toast shader program.
+    program: Option<glow::Program>,
+    /// VAO configured with the 9-attribute toast vertex layout.
+    vao: Option<glow::VertexArray>,
+    /// Double-buffered vertex VBOs (orphan-then-write upload pattern).
+    vbo: [Option<glow::Buffer>; 2],
+    /// Which of the two `vbo` slots to write into next.
+    vbo_index: usize,
+    /// `u_viewport_size` uniform location.
+    u_viewport: Option<glow::UniformLocation>,
+}
+
+impl Default for ToastRenderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ToastRenderer {
+    /// Create a new, uninitialized renderer.
+    ///
+    /// GPU resources are created lazily on the first call to [`Self::init`].
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            initialized: false,
+            program: None,
+            vao: None,
+            vbo: [None, None],
+            vbo_index: 0,
+            u_viewport: None,
+        }
+    }
+
+    /// Return whether GPU resources have been created.
+    #[must_use]
+    pub const fn initialized(&self) -> bool {
+        self.initialized
+    }
+
+    /// Create all GPU resources for the toast pass.
+    ///
+    /// Must be called exactly once, from within a `glow` context (e.g. inside
+    /// a `PaintCallback`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GpuInitError`] if shader compilation/linking fails or if any
+    /// GL object creation fails.
+    pub fn init(&mut self, gl: &glow::Context) -> Result<(), GpuInitError> {
+        let program = compile_program(gl, TOAST_VERT_SRC, TOAST_FRAG_SRC, "toast")?;
+
+        let u_viewport = unsafe { gl.get_uniform_location(program, "u_viewport_size") };
+
+        let vao = unsafe {
+            gl.create_vertex_array()
+                .map_err(|e| BufferAllocError::new("toast VAO", e))?
+        };
+        let vbo0 = unsafe {
+            gl.create_buffer()
+                .map_err(|e| BufferAllocError::new("toast VBO 0", e))?
+        };
+        let vbo1 = unsafe {
+            gl.create_buffer()
+                .map_err(|e| BufferAllocError::new("toast VBO 1", e))?
+        };
+
+        unsafe {
+            gl.bind_vertex_array(Some(vao));
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(vbo0));
+            setup_toast_attribs(gl);
+            gl.bind_vertex_array(None);
+        }
+
+        self.program = Some(program);
+        self.vao = Some(vao);
+        self.vbo = [Some(vbo0), Some(vbo1)];
+        self.u_viewport = u_viewport;
+        self.initialized = true;
+
+        Ok(())
+    }
+
+    /// Draw every toast in `quads` this frame.
+    ///
+    /// Builds the vertex buffer on the CPU via [`build_toast_verts`], uploads
+    /// it into the next double-buffer slot (orphan-then-write), and issues a
+    /// single `glDrawArrays(TRIANGLES, ...)` call covering all quads.
+    ///
+    /// No-op (with a logged error) if [`Self::init`] has not been called yet.
+    /// No-op (silently) if `quads` is empty.
+    pub fn draw(
+        &mut self,
+        gl: &glow::Context,
+        quads: &[ToastQuad],
+        viewport_w: i32,
+        viewport_h: i32,
+    ) {
+        if !self.initialized {
+            error!("ToastRenderer::draw() called before init()");
+            return;
+        }
+        if quads.is_empty() {
+            return;
+        }
+
+        let (Some(prog), Some(vao)) = (self.program, self.vao) else {
+            return;
+        };
+        let buf_idx = self.vbo_index;
+        let Some(vbo) = self.vbo[buf_idx] else {
+            return;
+        };
+
+        let verts = build_toast_verts(quads);
+        upload_verts(gl, vbo, &verts);
+
+        let vp_w = gl_f32_i32(viewport_w);
+        let vp_h = gl_f32_i32(viewport_h);
+        let vertex_count = gl_i32(quads.len() * VERTS_PER_QUAD);
+
+        unsafe {
+            gl.use_program(Some(prog));
+            if let Some(loc) = &self.u_viewport {
+                gl.uniform_2_f32(Some(loc), vp_w, vp_h);
+            }
+            gl.bind_vertex_array(Some(vao));
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(vbo));
+            setup_toast_attribs(gl);
+            gl.draw_arrays(glow::TRIANGLES, 0, vertex_count);
+            gl.bind_vertex_array(None);
+            gl.use_program(None);
+        }
+
+        self.vbo_index = 1 - self.vbo_index;
+    }
+
+    /// Free all GPU resources.
+    ///
+    /// Should be called when the widget/renderer is destroyed. Mirrors
+    /// [`super::gpu::TerminalRenderer::destroy`]'s shape.
+    pub fn destroy(&mut self, gl: &glow::Context) {
+        if !self.initialized {
+            return;
+        }
+
+        unsafe {
+            if let Some(p) = self.program.take() {
+                gl.delete_program(p);
+            }
+            if let Some(v) = self.vao.take() {
+                gl.delete_vertex_array(v);
+            }
+            for slot in &mut self.vbo {
+                if let Some(b) = slot.take() {
+                    gl.delete_buffer(b);
+                }
+            }
+        }
+
+        self.initialized = false;
+    }
+}
+
+/// Configure vertex attributes for the toast shader.
+///
+/// Layout (see `toast.vert` / `TOAST_VERTEX_FLOATS`):
+/// `location 0 = vec2 a_pos, location 1 = vec2 a_pill_center,
+/// location 2 = vec2 a_pill_halfsize, location 3 = float a_corner,
+/// location 4 = vec4 a_color_top, location 5 = vec4 a_color_bottom,
+/// location 6 = vec4 a_glow, location 7 = vec4 a_accent,
+/// location 8 = float a_opacity`.
+/// Stride = `TOAST_VERTEX_FLOATS * size_of::<f32>()` = 96 bytes.
+unsafe fn setup_toast_attribs(gl: &glow::Context) {
+    let stride = gl_i32(TOAST_VERTEX_FLOATS * size_of::<f32>());
+    let f = gl_i32(size_of::<f32>());
+
+    // Byte offsets of each attribute within one vertex, in units of `f`.
+    let off_pos = 0;
+    let off_center = 2 * f;
+    let off_halfsize = 4 * f;
+    let off_corner = 6 * f;
+    let off_color_top = 7 * f;
+    let off_color_bottom = 11 * f;
+    let off_glow = 15 * f;
+    let off_accent = 19 * f;
+    let off_opacity = 23 * f;
+
+    unsafe {
+        gl.enable_vertex_attrib_array(0);
+        gl.vertex_attrib_pointer_f32(0, 2, glow::FLOAT, false, stride, off_pos);
+        gl.enable_vertex_attrib_array(1);
+        gl.vertex_attrib_pointer_f32(1, 2, glow::FLOAT, false, stride, off_center);
+        gl.enable_vertex_attrib_array(2);
+        gl.vertex_attrib_pointer_f32(2, 2, glow::FLOAT, false, stride, off_halfsize);
+        gl.enable_vertex_attrib_array(3);
+        gl.vertex_attrib_pointer_f32(3, 1, glow::FLOAT, false, stride, off_corner);
+        gl.enable_vertex_attrib_array(4);
+        gl.vertex_attrib_pointer_f32(4, 4, glow::FLOAT, false, stride, off_color_top);
+        gl.enable_vertex_attrib_array(5);
+        gl.vertex_attrib_pointer_f32(5, 4, glow::FLOAT, false, stride, off_color_bottom);
+        gl.enable_vertex_attrib_array(6);
+        gl.vertex_attrib_pointer_f32(6, 4, glow::FLOAT, false, stride, off_glow);
+        gl.enable_vertex_attrib_array(7);
+        gl.vertex_attrib_pointer_f32(7, 4, glow::FLOAT, false, stride, off_accent);
+        gl.enable_vertex_attrib_array(8);
+        gl.vertex_attrib_pointer_f32(8, 1, glow::FLOAT, false, stride, off_opacity);
+    }
+}
+
+// ---------------------------------------------------------------------------
+//  Pure CPU vertex builder
+// ---------------------------------------------------------------------------
+
+/// Build the flat `Vec<f32>` vertex buffer for `quads`.
+///
+/// Pure and GL-free so it is fully unit-testable. Emits
+/// `TOAST_VERTEX_FLOATS` floats per vertex, [`VERTS_PER_QUAD`] vertices per
+/// quad (2 triangles), one quad per entry in `quads`.
+fn build_toast_verts(quads: &[ToastQuad]) -> Vec<f32> {
+    let mut out = Vec::with_capacity(quads.len() * VERTS_PER_QUAD * TOAST_VERTEX_FLOATS);
+    for q in quads {
+        push_toast_quad(&mut out, q);
+    }
+    out
+}
+
+/// Append one expanded quad (6 vertices) for `q` to `out`.
+fn push_toast_quad(out: &mut Vec<f32>, q: &ToastQuad) {
+    // Expand the drawn quad beyond the crisp pill rect so the fragment
+    // shader has room to render the outer glow and drop shadow.
+    let x0 = q.x - GLOW_MARGIN_PX;
+    let y0 = q.y - GLOW_MARGIN_PX;
+    let x1 = q.x + q.width + GLOW_MARGIN_PX;
+    let y1 = q.y + q.height + GLOW_MARGIN_PX;
+
+    let center = [q.x + q.width / 2.0, q.y + q.height / 2.0];
+    let halfsize = [q.width / 2.0, q.height / 2.0];
+
+    // Two triangles covering the expanded quad.
+    let positions: [[f32; 2]; VERTS_PER_QUAD] =
+        [[x0, y0], [x1, y0], [x0, y1], [x1, y0], [x1, y1], [x0, y1]];
+
+    for pos in positions {
+        out.extend_from_slice(&pos);
+        out.extend_from_slice(&center);
+        out.extend_from_slice(&halfsize);
+        out.push(q.corner_radius);
+        out.extend_from_slice(&q.color_top);
+        out.extend_from_slice(&q.color_bottom);
+        out.extend_from_slice(&q.glow);
+        out.extend_from_slice(&q.accent);
+        out.push(q.opacity);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::{
+        GLOW_MARGIN_PX, TOAST_VERTEX_FLOATS, ToastQuad, VERTS_PER_QUAD, build_toast_verts,
+    };
+
+    fn sample_quad() -> ToastQuad {
+        ToastQuad {
+            x: 100.0,
+            y: 50.0,
+            width: 200.0,
+            height: 60.0,
+            corner_radius: 10.0,
+            color_top: [0.1, 0.2, 0.3, 0.9],
+            color_bottom: [0.4, 0.5, 0.6, 0.95],
+            glow: [0.9, 0.1, 0.1, 0.5],
+            accent: [0.0, 1.0, 0.0, 1.0],
+            opacity: 0.75,
+        }
+    }
+
+    #[test]
+    fn empty_input_produces_empty_output() {
+        assert!(build_toast_verts(&[]).is_empty());
+    }
+
+    #[test]
+    fn n_quads_produce_expected_float_count() {
+        let quads = vec![sample_quad(), sample_quad(), sample_quad()];
+        let verts = build_toast_verts(&quads);
+        assert_eq!(
+            verts.len(),
+            quads.len() * VERTS_PER_QUAD * TOAST_VERTEX_FLOATS
+        );
+    }
+
+    #[test]
+    fn single_quad_produces_one_quads_worth_of_floats() {
+        let verts = build_toast_verts(&[sample_quad()]);
+        assert_eq!(verts.len(), VERTS_PER_QUAD * TOAST_VERTEX_FLOATS);
+    }
+
+    /// Extract vertex `idx` (`0..VERTS_PER_QUAD`) of the first (and only)
+    /// quad in `verts` as a `TOAST_VERTEX_FLOATS`-length slice.
+    fn vertex_slice(verts: &[f32], idx: usize) -> &[f32] {
+        let start = idx * TOAST_VERTEX_FLOATS;
+        &verts[start..start + TOAST_VERTEX_FLOATS]
+    }
+
+    #[test]
+    fn expanded_quad_extends_beyond_pill_rect_by_glow_margin() {
+        let q = sample_quad();
+        let verts = build_toast_verts(&[q]);
+
+        let mut min_x = f32::MAX;
+        let mut min_y = f32::MAX;
+        let mut max_x = f32::MIN;
+        let mut max_y = f32::MIN;
+        for i in 0..VERTS_PER_QUAD {
+            let v = vertex_slice(&verts, i);
+            let (x, y) = (v[0], v[1]);
+            min_x = min_x.min(x);
+            min_y = min_y.min(y);
+            max_x = max_x.max(x);
+            max_y = max_y.max(y);
+        }
+
+        assert!((min_x - (q.x - GLOW_MARGIN_PX)).abs() < f32::EPSILON);
+        assert!((min_y - (q.y - GLOW_MARGIN_PX)).abs() < f32::EPSILON);
+        assert!((max_x - (q.x + q.width + GLOW_MARGIN_PX)).abs() < f32::EPSILON);
+        assert!((max_y - (q.y + q.height + GLOW_MARGIN_PX)).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn per_vertex_pill_params_replicated_across_all_six_vertices() {
+        let q = sample_quad();
+        let verts = build_toast_verts(&[q]);
+
+        let expected_center = [q.x + q.width / 2.0, q.y + q.height / 2.0];
+        let expected_halfsize = [q.width / 2.0, q.height / 2.0];
+
+        for i in 0..VERTS_PER_QUAD {
+            let v = vertex_slice(&verts, i);
+            // center: floats [2..4)
+            assert_eq!(&v[2..4], &expected_center);
+            // halfsize: floats [4..6)
+            assert_eq!(&v[4..6], &expected_halfsize);
+            // corner: float [6]
+            assert!((v[6] - q.corner_radius).abs() < f32::EPSILON);
+            // color_top: floats [7..11)
+            assert_eq!(&v[7..11], &q.color_top);
+            // color_bottom: floats [11..15)
+            assert_eq!(&v[11..15], &q.color_bottom);
+            // glow: floats [15..19)
+            assert_eq!(&v[15..19], &q.glow);
+            // accent: floats [19..23)
+            assert_eq!(&v[19..23], &q.accent);
+            // opacity: float [23]
+            assert!((v[23] - q.opacity).abs() < f32::EPSILON);
+        }
+    }
+
+    #[test]
+    fn two_quads_do_not_share_vertex_data() {
+        let mut q2 = sample_quad();
+        q2.x = 500.0;
+        q2.opacity = 0.2;
+        let verts = build_toast_verts(&[sample_quad(), q2]);
+
+        assert_eq!(verts.len(), 2 * VERTS_PER_QUAD * TOAST_VERTEX_FLOATS);
+
+        let second_quad_start = VERTS_PER_QUAD * TOAST_VERTEX_FLOATS;
+        let second_quad_verts = &verts[second_quad_start..];
+        let v0 = &second_quad_verts[0..TOAST_VERTEX_FLOATS];
+        // x position of the second quad's first vertex should reflect q2.x,
+        // not the first quad's x.
+        assert!((v0[0] - (q2.x - GLOW_MARGIN_PX)).abs() < f32::EPSILON);
+        assert!((v0[23] - q2.opacity).abs() < f32::EPSILON);
+    }
+}

--- a/freminal/src/gui/renderer/toast_text_pass.rs
+++ b/freminal/src/gui/renderer/toast_text_pass.rs
@@ -66,7 +66,9 @@ use tracing::{error, warn};
 use super::super::atlas::{GlyphAtlas, GlyphKey};
 use super::super::font_manager::{FontManager, GlyphStyle};
 use super::errors::{BufferAllocError, GpuInitError, TextureUploadError};
-use super::gpu::{compile_program, gl_f32_i32, gl_i32, setup_fg_inst_attribs, upload_verts};
+use super::gpu::{
+    compile_program, gl_f32_i32, gl_i32, gl_i32_u32, setup_fg_inst_attribs, upload_verts,
+};
 use super::shaders::{FG_FRAG_SRC, FG_VERT_SRC};
 use super::vertex::{FG_INSTANCE_FLOATS, extract_atlas_rect};
 
@@ -621,20 +623,6 @@ impl ToastTextRenderer {
 // ---------------------------------------------------------------------------
 //  GL upload helper (standalone, not a `TerminalRenderer` method)
 // ---------------------------------------------------------------------------
-
-/// Convert a `u32` atlas dimension to `i32` for GL texture calls.
-///
-/// Mirrors `gpu::gl_i32_u32`, reproduced here because that helper is
-/// private to `gpu.rs`. Returns `0` on overflow (atlas sizes are always well
-/// within `i32` range — the atlas itself refuses to grow past
-/// [`ATLAS_MAX_SIZE_PX`]) and logs an error so the impossible is visible if
-/// it ever occurs.
-fn gl_i32_u32(val: u32) -> i32 {
-    i32::value_from(val).unwrap_or_else(|_| {
-        error!("toast_text_pass: u32 {val} overflows i32");
-        0
-    })
-}
 
 /// Synchronise `atlas`'s CPU-side pixel data to `texture` on the GPU.
 ///

--- a/freminal/src/gui/renderer/toast_text_pass.rs
+++ b/freminal/src/gui/renderer/toast_text_pass.rs
@@ -1,0 +1,935 @@
+// Copyright (C) 2024-2026 Fred Clausen
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Self-contained OpenGL pass that draws toast label/icon TEXT (issue #433).
+//!
+//! Companion to [`super::toast_pass`], which draws the toast "pill"
+//! background. That pass draws a rounded-rect SDF quad; this one draws the
+//! label/detail/icon glyphs *through the same instanced foreground shader*
+//! the terminal grid uses (`fg.vert` / `fg.frag`, see [`super::gpu`]'s
+//! `init_fg_pass` / `draw_foreground`), so pill and text share one absolute
+//! pixel coordinate system — no cell grid involved.
+//!
+//! [`ToastTextRenderer`] owns its own shader program, VAO, unit-quad VBO,
+//! double-buffered instance VBOs, and its own dedicated [`GlyphAtlas`] (kept
+//! separate from the terminal grid's atlas so toast text — which is
+//! typically rasterised at a different pixel size than the terminal's cell
+//! font — never evicts or is evicted by grid glyphs). It is driven by the
+//! toast overlay's `PaintCallback` in [`crate::gui::toast`] (see
+//! `ToastStack::show` / `paint_toasts`): text is shaped and instance data
+//! built on the main thread, then [`ToastTextRenderer::upload_and_draw`] runs
+//! on the GL thread.
+//!
+//! ## Main-thread / GL-thread split
+//!
+//! [`crate::gui::font_manager::FontManager`] is `!Sync` and must only be
+//! touched on the main (GUI) thread — never from inside a `PaintCallback`,
+//! which egui may invoke from a render thread. This module is split
+//! accordingly:
+//!
+//! - [`ToastTextRenderer::build_instances`] — runs on the **main thread**.
+//!   Takes `&mut FontManager`, shapes each [`ToastTextRun`] via
+//!   `rustybuzz`, rasterises any new glyphs into `self.atlas`, and returns a
+//!   flat `Vec<f32>` of `FG_INSTANCE_FLOATS`-per-glyph instance data. Issues
+//!   **no GL calls**.
+//! - [`ToastTextRenderer::upload_and_draw`] — runs from the **GL callback**.
+//!   Takes only `&glow::Context` plus the prebuilt instance buffer: syncs
+//!   the atlas texture, uploads instances, and draws. Touches no
+//!   `FontManager`.
+//!
+//! ## Single-face-per-run assumption
+//!
+//! Each [`ToastTextRun`] is shaped as a single `rustybuzz` run against the
+//! face resolved from its **first character**. This is correct for the
+//! common toast cases (a label string, a detail string, or a single icon
+//! glyph) but does **not** handle a run that mixes, say, a bundled
+//! nerd-font icon codepoint with Latin text — those would all be shaped
+//! against whichever face the first character resolved to, and the other
+//! codepoints could come out as tofu. Callers must split icon glyphs into
+//! their own single-glyph [`ToastTextRun`], exactly as the terminal grid's
+//! run segmentation (see [`crate::gui::shaping`]) splits on face
+//! boundaries — that per-character segmentation is deliberately not
+//! reimplemented here because toast text is short and this simpler
+//! contract is sufficient and easier to test.
+//!
+//! The CPU-side per-glyph float packing ([`pack_glyph_instance`]) is a pure
+//! function, fully testable without a GL context; GL calls are confined to
+//! [`ToastTextRenderer::init`], [`ToastTextRenderer::upload_and_draw`], and
+//! [`ToastTextRenderer::destroy`].
+
+use conv2::{ApproxFrom, RoundToNearest, ValueFrom};
+use glow::{self, HasContext};
+use tracing::{error, warn};
+
+use super::super::atlas::{GlyphAtlas, GlyphKey};
+use super::super::font_manager::{FontManager, GlyphStyle};
+use super::errors::{BufferAllocError, GpuInitError, TextureUploadError};
+use super::gpu::{compile_program, gl_f32_i32, gl_i32, setup_fg_inst_attribs, upload_verts};
+use super::shaders::{FG_FRAG_SRC, FG_VERT_SRC};
+use super::vertex::{FG_INSTANCE_FLOATS, extract_atlas_rect};
+
+// ---------------------------------------------------------------------------
+//  Constants
+// ---------------------------------------------------------------------------
+
+/// Static unit quad in `[0,1]²` space (2 triangles = 6 vertices), matching
+/// the layout [`setup_fg_inst_attribs`] binds to location 0 with divisor 0.
+///
+/// Identical topology (and identical values) to the terminal grid's own
+/// `UNIT_QUAD` in `gpu.rs` — duplicated here rather than reused because that
+/// constant is private to `gpu.rs` and this pass owns its own VBO for it (it
+/// cannot share the terminal grid's `bg_unit_quad_vbo`, which belongs to a
+/// different `TerminalRenderer` instance entirely).
+const UNIT_QUAD: [f32; 12] = [
+    0.0, 0.0, 1.0, 0.0, 0.0, 1.0, // triangle 1
+    1.0, 0.0, 1.0, 1.0, 0.0, 1.0, // triangle 2
+];
+
+/// Initial size (pixels, square) of the dedicated toast-text glyph atlas.
+///
+/// Toast text is tiny compared to a full terminal grid — a handful of short
+/// label/detail strings and icon glyphs, typically one alphabet's worth of
+/// distinct glyph shapes. 256px comfortably holds dozens of glyphs before
+/// the atlas needs to grow.
+const ATLAS_INITIAL_SIZE_PX: u32 = 256;
+
+/// Maximum size (pixels, square) the toast-text atlas is allowed to grow to.
+///
+/// Far more than any realistic toast stack needs (the terminal grid's own
+/// atlas, which must hold every glyph shape in active use across the whole
+/// visible buffer, caps at 4096px by comparison).
+const ATLAS_MAX_SIZE_PX: u32 = 1024;
+
+// ---------------------------------------------------------------------------
+//  Public CPU-side input
+// ---------------------------------------------------------------------------
+
+/// One run of text to draw as part of a toast, positioned in the toast
+/// `PaintCallback`'s viewport-local physical pixel space (origin top-left).
+///
+/// See the module-level docs for the single-face-per-run assumption: split
+/// icon glyphs into their own run rather than mixing them with label text.
+#[derive(Debug, Clone)]
+pub struct ToastTextRun {
+    /// The string to shape and draw (label, detail, or a single-icon string).
+    pub text: String,
+    /// Baseline origin X in physical pixels (left edge of the run).
+    pub origin_x: f32,
+    /// Baseline origin Y in physical pixels (text baseline, not top).
+    pub baseline_y: f32,
+    /// Font size in pixels to rasterize at.
+    pub size_px: f32,
+    /// Straight (non-premultiplied) RGBA 0..=1.
+    pub color: [f32; 4],
+}
+
+/// The pixel footprint a run of text occupies when shaped at a given size.
+///
+/// Measured without rasterising it into any atlas. Returned by
+/// [`ToastTextRenderer::measure`] and consumed by the toast layout model
+/// (`crate::gui::toast::layout_toasts`) to size pills to their content.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ToastTextMetrics {
+    /// Total advance width in physical pixels.
+    pub width: f32,
+    /// Line height (ascent + descent) in physical pixels at this size.
+    pub height: f32,
+    /// Ascent in physical pixels (baseline offset from the top).
+    pub ascent: f32,
+}
+
+impl ToastTextMetrics {
+    /// The zero-size metrics returned for empty text or an unresolvable face.
+    const ZERO: Self = Self {
+        width: 0.0,
+        height: 0.0,
+        ascent: 0.0,
+    };
+}
+
+// ---------------------------------------------------------------------------
+//  ToastTextRenderer
+// ---------------------------------------------------------------------------
+
+/// Holds all GPU resources, plus the dedicated glyph atlas, for the toast
+/// text pass.
+///
+/// Call [`Self::init`] once (inside a `PaintCallback`) to create the shader
+/// program, VAO, and buffers. Then, once per frame: call
+/// [`Self::build_instances`] on the **main thread** with the current toast
+/// text runs, and [`Self::upload_and_draw`] from the **GL callback** with
+/// the returned instance buffer.
+pub struct ToastTextRenderer {
+    /// Whether GPU resources have been created.
+    initialized: bool,
+    /// Compiled + linked foreground shader program (shared source with the
+    /// terminal grid's foreground pass; see `fg.vert` / `fg.frag`).
+    program: Option<glow::Program>,
+    /// VAO configured via [`setup_fg_inst_attribs`].
+    vao: Option<glow::VertexArray>,
+    /// This pass's own static unit-quad VBO (not shared with the terminal
+    /// grid's `TerminalRenderer`, which is a different GL object entirely).
+    unit_quad_vbo: Option<glow::Buffer>,
+    /// Double-buffered instance VBOs (orphan-then-write upload pattern).
+    inst_vbo: [Option<glow::Buffer>; 2],
+    /// Which of the two `inst_vbo` slots to write into next.
+    inst_index: usize,
+    /// This pass's own glyph atlas texture (not shared with the terminal
+    /// grid's atlas texture).
+    atlas_texture: Option<glow::Texture>,
+    /// CPU-side glyph atlas dedicated to toast text.
+    atlas: GlyphAtlas,
+    /// `u_viewport_size` uniform location.
+    u_viewport: Option<glow::UniformLocation>,
+    /// `u_atlas` uniform location.
+    u_atlas: Option<glow::UniformLocation>,
+}
+
+impl Default for ToastTextRenderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ToastTextRenderer {
+    /// Create a new, uninitialized renderer with an empty dedicated atlas.
+    ///
+    /// GPU resources are created lazily on the first call to [`Self::init`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            initialized: false,
+            program: None,
+            vao: None,
+            unit_quad_vbo: None,
+            inst_vbo: [None, None],
+            inst_index: 0,
+            atlas_texture: None,
+            atlas: GlyphAtlas::new(ATLAS_INITIAL_SIZE_PX, ATLAS_MAX_SIZE_PX),
+            u_viewport: None,
+            u_atlas: None,
+        }
+    }
+
+    /// Return whether GPU resources have been created.
+    #[must_use]
+    pub const fn initialized(&self) -> bool {
+        self.initialized
+    }
+
+    /// Create all GPU resources for the toast text pass.
+    ///
+    /// Must be called exactly once, from within a `glow` context (e.g.
+    /// inside a `PaintCallback`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GpuInitError`] if shader compilation/linking fails or if
+    /// any GL object creation fails.
+    pub fn init(&mut self, gl: &glow::Context) -> Result<(), GpuInitError> {
+        let program = compile_program(gl, FG_VERT_SRC, FG_FRAG_SRC, "toast_text")?;
+
+        let u_viewport = unsafe { gl.get_uniform_location(program, "u_viewport_size") };
+        let u_atlas = unsafe { gl.get_uniform_location(program, "u_atlas") };
+
+        let vao = unsafe {
+            gl.create_vertex_array()
+                .map_err(|e| BufferAllocError::new("toast_text VAO", e))?
+        };
+        let unit_quad_vbo = unsafe {
+            gl.create_buffer()
+                .map_err(|e| BufferAllocError::new("toast_text unit-quad VBO", e))?
+        };
+        let inst_vbo0 = unsafe {
+            gl.create_buffer()
+                .map_err(|e| BufferAllocError::new("toast_text instance VBO 0", e))?
+        };
+        let inst_vbo1 = unsafe {
+            gl.create_buffer()
+                .map_err(|e| BufferAllocError::new("toast_text instance VBO 1", e))?
+        };
+
+        // Upload the static unit quad (never changes).
+        let unit_quad_bytes = unsafe {
+            std::slice::from_raw_parts(
+                UNIT_QUAD.as_ptr().cast::<u8>(),
+                std::mem::size_of_val(&UNIT_QUAD),
+            )
+        };
+        unsafe {
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(unit_quad_vbo));
+            gl.buffer_data_u8_slice(glow::ARRAY_BUFFER, unit_quad_bytes, glow::STATIC_DRAW);
+        }
+
+        unsafe {
+            gl.bind_vertex_array(Some(vao));
+            setup_fg_inst_attribs(gl, unit_quad_vbo, inst_vbo0);
+            gl.bind_vertex_array(None);
+        }
+
+        // Create and configure this pass's own atlas texture (mirrors
+        // `TerminalRenderer::init_atlas_texture`, duplicated here because
+        // that method is bound to `TerminalRenderer`'s own texture field).
+        let atlas_texture = unsafe {
+            gl.create_texture()
+                .map_err(|e| TextureUploadError::CreateTexture {
+                    label: "toast_text_atlas",
+                    message: e,
+                })?
+        };
+        unsafe {
+            gl.bind_texture(glow::TEXTURE_2D, Some(atlas_texture));
+            gl.tex_parameter_i32(
+                glow::TEXTURE_2D,
+                glow::TEXTURE_MIN_FILTER,
+                glow::LINEAR.cast_signed(),
+            );
+            gl.tex_parameter_i32(
+                glow::TEXTURE_2D,
+                glow::TEXTURE_MAG_FILTER,
+                glow::LINEAR.cast_signed(),
+            );
+            gl.tex_parameter_i32(
+                glow::TEXTURE_2D,
+                glow::TEXTURE_WRAP_S,
+                glow::CLAMP_TO_EDGE.cast_signed(),
+            );
+            gl.tex_parameter_i32(
+                glow::TEXTURE_2D,
+                glow::TEXTURE_WRAP_T,
+                glow::CLAMP_TO_EDGE.cast_signed(),
+            );
+            gl.bind_texture(glow::TEXTURE_2D, None);
+        }
+
+        self.program = Some(program);
+        self.vao = Some(vao);
+        self.unit_quad_vbo = Some(unit_quad_vbo);
+        self.inst_vbo = [Some(inst_vbo0), Some(inst_vbo1)];
+        self.atlas_texture = Some(atlas_texture);
+        self.u_viewport = u_viewport;
+        self.u_atlas = u_atlas;
+        self.initialized = true;
+
+        Ok(())
+    }
+
+    /// Measure the pixel width and (ascent+descent) height a run of text
+    /// will occupy when shaped at `size_px`, **without** rasterising it into
+    /// the atlas.
+    ///
+    /// Used by the toast layout model to size the pill to its content before
+    /// any glyph is drawn. Shapes `text` the same way [`Self::build_instances`]
+    /// does — resolving the whole run against the face of its first
+    /// character (see the module-level single-face-per-run docs) — but reads
+    /// only [`rustybuzz::GlyphPosition::x_advance`] and the face's scaled
+    /// `swash` metrics, issuing no atlas insertions and no GL calls.
+    ///
+    /// **Must be called on the main thread** — like [`Self::build_instances`],
+    /// it takes `&mut FontManager` (glyph-face resolution populates a cache)
+    /// and must never be touched from a `PaintCallback`.
+    ///
+    /// Returns [`ToastTextMetrics::ZERO`] for empty text or a face that
+    /// cannot be shaped/resolved.
+    #[must_use]
+    pub fn measure(
+        &self,
+        text: &str,
+        size_px: f32,
+        font_manager: &mut FontManager,
+    ) -> ToastTextMetrics {
+        let Some(first_char) = text.chars().next() else {
+            return ToastTextMetrics::ZERO;
+        };
+
+        // Resolve the whole run against the first character's face, exactly
+        // as `emit_run` does.
+        let (face_id, _) = font_manager.resolve_glyph(first_char, GlyphStyle::new(false, false));
+
+        let mut buffer = rustybuzz::UnicodeBuffer::new();
+        buffer.push_str(text);
+        buffer.guess_segment_properties();
+
+        let Some(shaped) = font_manager.shape_cached(face_id, false, &[], buffer) else {
+            warn!("toast_text_pass: face {face_id:?} could not shape measured run {text:?}");
+            return ToastTextMetrics::ZERO;
+        };
+
+        // Font-unit → pixel scale, identical derivation to `emit_run`.
+        let units_per_em_f = font_manager
+            .swash_font_ref(face_id)
+            .map(|font_ref| font_ref.metrics(&[]).units_per_em)
+            .filter(|&upem| upem != 0)
+            .map_or(1.0, f32::from);
+        let font_unit_scale = size_px / units_per_em_f;
+
+        let width: f32 = shaped
+            .glyph_positions()
+            .iter()
+            .map(|pos| gl_f32_i32(pos.x_advance) * font_unit_scale)
+            .sum();
+
+        // Face-level ascent/descent, scaled to `size_px` directly via swash's
+        // own `Metrics::scale` (handles the `units_per_em == 0` fallback
+        // internally, unlike the font-unit scale derived above for advances).
+        let (ascent, descent) =
+            font_manager
+                .swash_font_ref(face_id)
+                .map_or((0.0, 0.0), |font_ref| {
+                    let scaled = font_ref.metrics(&[]).scale(size_px);
+                    (scaled.ascent, scaled.descent.abs())
+                });
+
+        ToastTextMetrics {
+            width,
+            height: ascent + descent,
+            ascent,
+        }
+    }
+
+    /// Shape and rasterise `runs`, returning a flat instance buffer.
+    ///
+    /// **Must be called on the main thread** — it takes `&mut FontManager`,
+    /// which is `!Sync` and must never be touched from a `PaintCallback`.
+    /// Mutates `self.atlas` (rasterising any glyphs not already cached) but
+    /// issues **no GL calls**; the returned buffer is later handed to
+    /// [`Self::upload_and_draw`] from the GL callback.
+    ///
+    /// Runs with empty text, or whose text shapes to no visible glyphs
+    /// (e.g. all-whitespace), contribute no instances.
+    #[must_use]
+    pub fn build_instances(
+        &mut self,
+        runs: &[ToastTextRun],
+        font_manager: &mut FontManager,
+    ) -> Vec<f32> {
+        let mut instances = Vec::new();
+        for run in runs {
+            self.emit_run(&mut instances, run, font_manager);
+        }
+        instances
+    }
+
+    /// Shape one [`ToastTextRun`] and append its visible glyphs' instance
+    /// data to `instances`. See the module-level docs for the
+    /// single-face-per-run assumption.
+    fn emit_run(
+        &mut self,
+        instances: &mut Vec<f32>,
+        run: &ToastTextRun,
+        font_manager: &mut FontManager,
+    ) {
+        let Some(first_char) = run.text.chars().next() else {
+            return;
+        };
+
+        // Resolve the whole run against the first character's face. See the
+        // module-level "single-face-per-run" docs.
+        let (face_id, _) = font_manager.resolve_glyph(first_char, GlyphStyle::new(false, false));
+
+        let mut buffer = rustybuzz::UnicodeBuffer::new();
+        buffer.push_str(&run.text);
+        buffer.guess_segment_properties();
+
+        let Some(shaped) = font_manager.shape_cached(face_id, false, &[], buffer) else {
+            warn!(
+                "toast_text_pass: face {face_id:?} could not shape toast run {:?}",
+                run.text
+            );
+            return;
+        };
+
+        // Rasterise at the run's own requested pixel size — toast text is
+        // proportional (not locked to the terminal cell grid), so this is
+        // independent of `FontManager::rasterization_ppem`.
+        let size_px: u16 =
+            <u16 as ApproxFrom<f32, RoundToNearest>>::approx_from(run.size_px).unwrap_or(u16::MAX);
+
+        // `rustybuzz::Face` positions are in raw font design units (the
+        // face's own `units_per_em`), not pixels — `FontManager::shape_cached`
+        // builds the `rustybuzz::Face` with no ppem/scale applied (see
+        // `FontManager::build_cached_face`). Recover `units_per_em` from the
+        // same swash `FontRef` the atlas rasterises through, mirroring
+        // `compute_cell_metrics`'s identical lookup (and its `1.0` fallback
+        // for the pathological case of a font reporting `units_per_em == 0`,
+        // which should not occur in practice for a valid font).
+        let units_per_em_f = font_manager
+            .swash_font_ref(face_id)
+            .map(|font_ref| font_ref.metrics(&[]).units_per_em)
+            .filter(|&upem| upem != 0)
+            .map_or(1.0, f32::from);
+        let font_unit_scale = run.size_px / units_per_em_f;
+
+        let mut pen_x = run.origin_x;
+
+        for (info, pos) in shaped
+            .glyph_infos()
+            .iter()
+            .zip(shaped.glyph_positions().iter())
+        {
+            // Font-unit offsets/advances scaled into pixels via the same
+            // `font_unit_scale` derived above.
+            let x_offset_px = gl_f32_i32(pos.x_offset) * font_unit_scale;
+            let y_offset_px = gl_f32_i32(pos.y_offset) * font_unit_scale;
+            let x_advance_px = gl_f32_i32(pos.x_advance) * font_unit_scale;
+
+            // `info.glyph_id` is a `u32` guaranteed by rustybuzz to fit in
+            // `u16` (a post-shaping glyph ID, not a pre-shaping codepoint).
+            let glyph_id: u16 = u16::value_from(info.glyph_id).unwrap_or(0);
+            let key = GlyphKey {
+                glyph_id,
+                face_id,
+                size_px,
+            };
+
+            if let Some(entry) = self.atlas.get_or_insert(key, font_manager)
+                && entry.width != 0
+                && entry.height != 0
+            {
+                // Pixel position: pen + font-unit offset + atlas bearing.
+                // `x_offset`/`y_offset` move the pen before drawing without
+                // affecting the advance (see `rustybuzz::GlyphPosition`
+                // docs); `y_offset` is up-positive in font space, so it is
+                // subtracted to convert into this module's top-left-origin
+                // pixel space (matching `baseline_y - bearing_y` below).
+                let x0 = pen_x + x_offset_px + f32::from(entry.bearing_x);
+                let y0 = run.baseline_y - y_offset_px - f32::from(entry.bearing_y);
+                let w = f32::from(entry.width);
+                let h = f32::from(entry.height);
+
+                instances.extend_from_slice(&pack_glyph_instance(
+                    x0,
+                    y0,
+                    w,
+                    h,
+                    entry.uv_rect,
+                    run.color,
+                    entry.is_color,
+                ));
+            }
+
+            pen_x += x_advance_px;
+        }
+    }
+
+    /// Upload `instances` and draw them.
+    ///
+    /// **Must be called from the GL callback** (touches only `&glow::Context`
+    /// plus prebuilt CPU data — no `FontManager` access). Syncs the atlas
+    /// texture to the GPU (uploading any newly-rasterised glyphs from the
+    /// most recent [`Self::build_instances`] call), uploads `instances` into
+    /// the next double-buffer slot (orphan-then-write), and issues a single
+    /// `glDrawArraysInstanced(TRIANGLES, ...)` call — matching exactly how
+    /// the terminal grid's own foreground pass draws (see
+    /// `TerminalRenderer::draw_foreground`).
+    ///
+    /// No-op (with a logged error) if [`Self::init`] has not been called
+    /// yet. No-op (silently) if `instances` is empty.
+    pub fn upload_and_draw(
+        &mut self,
+        gl: &glow::Context,
+        instances: &[f32],
+        viewport_w: i32,
+        viewport_h: i32,
+    ) {
+        if !self.initialized {
+            error!("ToastTextRenderer::upload_and_draw() called before init()");
+            return;
+        }
+        if instances.is_empty() {
+            return;
+        }
+
+        let (Some(prog), Some(vao), Some(unit_vbo), Some(tex)) = (
+            self.program,
+            self.vao,
+            self.unit_quad_vbo,
+            self.atlas_texture,
+        ) else {
+            return;
+        };
+
+        sync_toast_atlas(gl, tex, &mut self.atlas);
+
+        let buf_idx = self.inst_index;
+        let Some(inst_vbo) = self.inst_vbo[buf_idx] else {
+            return;
+        };
+        upload_verts(gl, inst_vbo, instances);
+
+        let instance_count = gl_i32(instances.len() / FG_INSTANCE_FLOATS);
+        let vp_w = gl_f32_i32(viewport_w);
+        let vp_h = gl_f32_i32(viewport_h);
+
+        unsafe {
+            gl.use_program(Some(prog));
+            if let Some(loc) = &self.u_viewport {
+                gl.uniform_2_f32(Some(loc), vp_w, vp_h);
+            }
+            if let Some(loc) = &self.u_atlas {
+                gl.uniform_1_i32(Some(loc), 0); // TEXTURE0
+            }
+            gl.active_texture(glow::TEXTURE0);
+            gl.bind_texture(glow::TEXTURE_2D, Some(tex));
+            gl.bind_vertex_array(Some(vao));
+            // Re-bind both buffers into the VAO for this draw call.
+            setup_fg_inst_attribs(gl, unit_vbo, inst_vbo);
+            gl.draw_arrays_instanced(glow::TRIANGLES, 0, 6, instance_count);
+            gl.bind_vertex_array(None);
+            gl.bind_texture(glow::TEXTURE_2D, None);
+            gl.use_program(None);
+        }
+
+        self.inst_index = 1 - self.inst_index;
+    }
+
+    /// Free all GPU resources.
+    ///
+    /// Should be called when the widget/renderer is destroyed. Mirrors
+    /// [`super::gpu::TerminalRenderer::destroy`]'s shape.
+    pub fn destroy(&mut self, gl: &glow::Context) {
+        if !self.initialized {
+            return;
+        }
+
+        unsafe {
+            if let Some(p) = self.program.take() {
+                gl.delete_program(p);
+            }
+            if let Some(v) = self.vao.take() {
+                gl.delete_vertex_array(v);
+            }
+            if let Some(b) = self.unit_quad_vbo.take() {
+                gl.delete_buffer(b);
+            }
+            for slot in &mut self.inst_vbo {
+                if let Some(b) = slot.take() {
+                    gl.delete_buffer(b);
+                }
+            }
+            if let Some(t) = self.atlas_texture.take() {
+                gl.delete_texture(t);
+            }
+        }
+
+        self.initialized = false;
+    }
+}
+
+// ---------------------------------------------------------------------------
+//  GL upload helper (standalone, not a `TerminalRenderer` method)
+// ---------------------------------------------------------------------------
+
+/// Convert a `u32` atlas dimension to `i32` for GL texture calls.
+///
+/// Mirrors `gpu::gl_i32_u32`, reproduced here because that helper is
+/// private to `gpu.rs`. Returns `0` on overflow (atlas sizes are always well
+/// within `i32` range — the atlas itself refuses to grow past
+/// [`ATLAS_MAX_SIZE_PX`]) and logs an error so the impossible is visible if
+/// it ever occurs.
+fn gl_i32_u32(val: u32) -> i32 {
+    i32::value_from(val).unwrap_or_else(|_| {
+        error!("toast_text_pass: u32 {val} overflows i32");
+        0
+    })
+}
+
+/// Synchronise `atlas`'s CPU-side pixel data to `texture` on the GPU.
+///
+/// A standalone free function mirroring
+/// [`super::gpu::TerminalRenderer::sync_atlas`], reproduced here (rather
+/// than reused) because that method is private to `TerminalRenderer` and
+/// bound to its own `atlas_texture` field — this pass owns a separate
+/// texture and atlas entirely.
+fn sync_toast_atlas(gl: &glow::Context, texture: glow::Texture, atlas: &mut GlyphAtlas) {
+    unsafe {
+        gl.bind_texture(glow::TEXTURE_2D, Some(texture));
+    }
+
+    let size = gl_i32_u32(atlas.size());
+
+    if atlas.needs_full_reupload() {
+        // Full upload — create or replace the entire texture.
+        unsafe {
+            gl.tex_image_2d(
+                glow::TEXTURE_2D,
+                0,
+                glow::RGBA.cast_signed(),
+                size,
+                size,
+                0,
+                glow::RGBA,
+                glow::UNSIGNED_BYTE,
+                glow::PixelUnpackData::Slice(Some(atlas.pixels())),
+            );
+        }
+    } else {
+        // Delta upload — only upload modified regions.
+        for rect in atlas.take_dirty_rects() {
+            let rx = gl_i32_u32(rect.x);
+            let ry = gl_i32_u32(rect.y);
+            let rw = gl_i32_u32(rect.width);
+            let rh = gl_i32_u32(rect.height);
+
+            let sub_pixels = extract_atlas_rect(atlas.pixels(), atlas.size(), &rect);
+
+            unsafe {
+                gl.pixel_store_i32(glow::UNPACK_ALIGNMENT, 1);
+                gl.tex_sub_image_2d(
+                    glow::TEXTURE_2D,
+                    0,
+                    rx,
+                    ry,
+                    rw,
+                    rh,
+                    glow::RGBA,
+                    glow::UNSIGNED_BYTE,
+                    glow::PixelUnpackData::Slice(Some(&sub_pixels)),
+                );
+            }
+        }
+    }
+
+    unsafe {
+        gl.bind_texture(glow::TEXTURE_2D, None);
+    }
+}
+
+// ---------------------------------------------------------------------------
+//  Pure CPU instance packing
+// ---------------------------------------------------------------------------
+
+/// Pack one foreground-shader glyph instance (`FG_INSTANCE_FLOATS` floats),
+/// in the exact attribute order `setup_fg_inst_attribs` binds:
+/// `[glyph_x, glyph_y, glyph_w, glyph_h, u0, v0, u1, v1, r, g, b, a,
+/// is_color]`.
+///
+/// Pure and GL-free so it is fully unit-testable in isolation from atlas
+/// rasterisation and shaping.
+const fn pack_glyph_instance(
+    x0: f32,
+    y0: f32,
+    w: f32,
+    h: f32,
+    uv_rect: [f32; 4],
+    color: [f32; 4],
+    is_color: bool,
+) -> [f32; FG_INSTANCE_FLOATS] {
+    [
+        x0,
+        y0,
+        w,
+        h,
+        uv_rect[0],
+        uv_rect[1],
+        uv_rect[2],
+        uv_rect[3],
+        color[0],
+        color[1],
+        color[2],
+        color[3],
+        if is_color { 1.0 } else { 0.0 },
+    ]
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    #[allow(unused_imports)] // referenced in the `measure` tests below.
+    use super::{
+        FG_INSTANCE_FLOATS, ToastTextMetrics, ToastTextRenderer, ToastTextRun, pack_glyph_instance,
+    };
+    use crate::gui::font_manager::FontManager;
+    use freminal_common::config::Config;
+
+    /// Helper: create a default `FontManager` for tests, exactly as
+    /// `crate::gui::shaping`'s test suite does.
+    fn test_font_manager() -> FontManager {
+        FontManager::new(&Config::default(), 1.0).unwrap()
+    }
+
+    fn sample_run(text: &str) -> ToastTextRun {
+        ToastTextRun {
+            text: text.to_string(),
+            origin_x: 5.0,
+            baseline_y: 20.0,
+            size_px: 16.0,
+            color: [1.0, 1.0, 1.0, 1.0],
+        }
+    }
+
+    // -- Renderer construction --
+
+    #[test]
+    fn new_renderer_starts_uninitialized_with_empty_atlas() {
+        let renderer = ToastTextRenderer::new();
+        assert!(!renderer.initialized());
+        assert_eq!(renderer.atlas.entry_count(), 0);
+    }
+
+    #[test]
+    fn default_matches_new() {
+        let renderer = ToastTextRenderer::default();
+        assert!(!renderer.initialized());
+    }
+
+    // -- pack_glyph_instance: pure float packing --
+
+    #[test]
+    fn pack_glyph_instance_orders_floats_per_fg_instance_layout() {
+        let uv = [0.1, 0.2, 0.3, 0.4];
+        let color = [0.5, 0.6, 0.7, 0.8];
+        let packed = pack_glyph_instance(10.0, 20.0, 30.0, 40.0, uv, color, true);
+
+        assert_eq!(packed.len(), FG_INSTANCE_FLOATS);
+        assert_eq!(&packed[0..4], &[10.0, 20.0, 30.0, 40.0]);
+        assert_eq!(&packed[4..8], &uv);
+        assert_eq!(&packed[8..12], &color);
+        assert!((packed[12] - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn pack_glyph_instance_monochrome_flag_is_zero() {
+        let packed = pack_glyph_instance(0.0, 0.0, 1.0, 1.0, [0.0; 4], [1.0; 4], false);
+        assert!(packed[12].abs() < f32::EPSILON);
+    }
+
+    // -- build_instances: real shaping + atlas, no GL --
+
+    #[test]
+    fn build_instances_empty_run_slice_produces_no_instances() {
+        let mut renderer = ToastTextRenderer::new();
+        let mut fm = test_font_manager();
+        assert!(renderer.build_instances(&[], &mut fm).is_empty());
+    }
+
+    #[test]
+    fn build_instances_empty_text_run_is_skipped() {
+        let mut renderer = ToastTextRenderer::new();
+        let mut fm = test_font_manager();
+        let instances = renderer.build_instances(&[sample_run("")], &mut fm);
+        assert!(instances.is_empty());
+    }
+
+    #[test]
+    fn build_instances_ascii_run_produces_whole_instances() {
+        let mut renderer = ToastTextRenderer::new();
+        let mut fm = test_font_manager();
+        let instances = renderer.build_instances(&[sample_run("Hi")], &mut fm);
+
+        assert_eq!(instances.len() % FG_INSTANCE_FLOATS, 0);
+        assert!(
+            !instances.is_empty(),
+            "'H' and 'i' should both rasterize to visible glyphs"
+        );
+    }
+
+    #[test]
+    fn build_instances_advances_pen_left_to_right() {
+        let mut renderer = ToastTextRenderer::new();
+        let mut fm = test_font_manager();
+        // Two identical glyphs: any nonzero advance places the second
+        // strictly to the right of the first.
+        let instances = renderer.build_instances(&[sample_run("II")], &mut fm);
+
+        let n = instances.len() / FG_INSTANCE_FLOATS;
+        assert_eq!(n, 2, "expected one instance per visible glyph");
+        let x0 = instances[0];
+        let x1 = instances[FG_INSTANCE_FLOATS];
+        assert!(
+            x1 > x0,
+            "second glyph (x={x1}) must be to the right of the first (x={x0})"
+        );
+    }
+
+    #[test]
+    fn build_instances_populates_the_dedicated_atlas() {
+        let mut renderer = ToastTextRenderer::new();
+        let mut fm = test_font_manager();
+        assert_eq!(renderer.atlas.entry_count(), 0);
+
+        let _ = renderer.build_instances(&[sample_run("A")], &mut fm);
+
+        assert!(
+            renderer.atlas.entry_count() > 0,
+            "shaping a visible glyph must rasterise it into this pass's own atlas"
+        );
+    }
+
+    #[test]
+    fn build_instances_multiple_runs_all_contribute() {
+        let mut renderer = ToastTextRenderer::new();
+        let mut fm = test_font_manager();
+        let runs = [sample_run("Hi"), sample_run("Bye")];
+        let instances = renderer.build_instances(&runs, &mut fm);
+
+        assert_eq!(instances.len() % FG_INSTANCE_FLOATS, 0);
+        // At least one instance per run, generously.
+        assert!(instances.len() / FG_INSTANCE_FLOATS >= 2);
+    }
+
+    // -- measure: pure metrics, no atlas insertion --
+
+    #[test]
+    fn measure_empty_text_is_zero() {
+        let renderer = ToastTextRenderer::new();
+        let mut fm = test_font_manager();
+        let m = renderer.measure("", 16.0, &mut fm);
+        assert_eq!(m, ToastTextMetrics::ZERO);
+    }
+
+    #[test]
+    fn measure_longer_string_is_wider() {
+        let renderer = ToastTextRenderer::new();
+        let mut fm = test_font_manager();
+        let short = renderer.measure("Hi", 16.0, &mut fm);
+        let long = renderer.measure("Hello, world!", 16.0, &mut fm);
+        assert!(
+            long.width > short.width,
+            "longer string ({}) must measure wider than shorter string ({})",
+            long.width,
+            short.width
+        );
+    }
+
+    #[test]
+    fn measure_does_not_populate_the_atlas() {
+        let renderer = ToastTextRenderer::new();
+        let mut fm = test_font_manager();
+        assert_eq!(renderer.atlas.entry_count(), 0);
+
+        let m = renderer.measure("Hello", 16.0, &mut fm);
+
+        assert!(
+            m.width > 0.0,
+            "non-empty text should measure a nonzero width"
+        );
+        assert_eq!(
+            renderer.atlas.entry_count(),
+            0,
+            "measure() must not rasterise glyphs into the atlas"
+        );
+    }
+
+    #[test]
+    fn measure_reports_positive_height_and_ascent_for_visible_text() {
+        let renderer = ToastTextRenderer::new();
+        let mut fm = test_font_manager();
+        let m = renderer.measure("A", 16.0, &mut fm);
+        assert!(m.height > 0.0);
+        assert!(m.ascent > 0.0);
+        assert!(m.ascent <= m.height);
+    }
+
+    #[test]
+    fn measure_scales_with_size() {
+        let renderer = ToastTextRenderer::new();
+        let mut fm = test_font_manager();
+        let small = renderer.measure("Hi", 12.0, &mut fm);
+        let large = renderer.measure("Hi", 24.0, &mut fm);
+        assert!(large.width > small.width);
+        assert!(large.height > small.height);
+    }
+}

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -1518,6 +1518,14 @@ impl FreminalTerminalWidget {
         self.font_manager.load_font_bytes_for_family(family)
     }
 
+    /// Mutable access to this window's shared `FontManager`, for main-thread
+    /// shaping/measuring outside the terminal grid (e.g. the toast overlay,
+    /// issue #433). Shaping must never happen inside a `PaintCallback`
+    /// (`FontManager` is `!Sync`); this is called on the GUI thread.
+    pub(crate) const fn font_manager_mut(&mut self) -> &mut FontManager {
+        &mut self.font_manager
+    }
+
     /// If the egui chrome fonts were marked dirty by a no-ctx config change,
     /// re-register them now with the provided context and clear the flag.
     pub fn flush_egui_fonts_if_dirty(&mut self, ctx: &egui::Context, config: &Config) {

--- a/freminal/src/gui/toast.rs
+++ b/freminal/src/gui/toast.rs
@@ -17,12 +17,56 @@
 //!
 //! Toasts auto-expire after a kind-dependent duration unless the user hovers
 //! over them, in which case the timer is paused.  Error toasts expire after
-//! 10 seconds, warnings after 6, and info after 3.  The user can dismiss any
-//! toast immediately by clicking its `x` button.
+//! 15 seconds, warnings after 10, and info after 6.  The user can dismiss any
+//! toast immediately by clicking anywhere on it; the "x" glyph shown at the
+//! pill's right edge is a visual affordance for this, not a separate hit
+//! target.
+//!
+//! Toasts are drawn by a fully-owned OpenGL pass (issue #433), not egui
+//! widgets: [`ToastStack::show`] measures/shapes each toast's text on the
+//! main thread (`renderer::toast_text_pass::ToastTextRenderer`), lays it out
+//! via [`layout_toasts`], and hands the resulting pill quads and text runs
+//! to a single `PaintCallback` that draws pills
+//! (`renderer::toast_pass::ToastRenderer`) then text on top. Hover/dismiss
+//! hit-testing is done in owned code against egui's pointer state, since
+//! there are no interactive egui widgets to generate `Response`s.
 
 use std::time::{Duration, Instant};
 
+use super::font_manager::FontManager;
 use super::icons::ChromeIcon;
+use super::renderer::ToastRenderState;
+
+// ---------------------------------------------------------------------------
+//  Animation constants
+// ---------------------------------------------------------------------------
+//
+// The animation model and layout function below (`Toast::anim`, `ToastAnim`,
+// `layout_toasts`, and their supporting types/constants) are wired into the
+// fully-owned toast `PaintCallback` by [`ToastStack::show`] (issue #433).
+
+/// Duration of the entry (fade + slide + scale in) animation.
+const ANIM_IN: Duration = Duration::from_millis(300);
+
+/// Duration of the exit (fade out) animation, applied to the last slice of a
+/// toast's lifetime before it expires.
+const ANIM_OUT: Duration = Duration::from_millis(400);
+
+/// Horizontal distance, in logical points, a toast slides in from on entry.
+/// For the (current default) right-anchored stack this is a slide-in from
+/// further off to the right; [`Toast::anim`]'s `slide_x` is always toward
+/// positive X (displaced right), and the layout function decides how that
+/// maps onto each anchor.
+const SLIDE_IN_PTS: f32 = 24.0;
+
+/// Scale factor a toast animates in from on entry (1.0 = full size, settled).
+const SCALE_IN: f32 = 0.92;
+
+/// Grace window after the last hover during which a toast is held fully
+/// visible (its removal timer paused). After this grace, a toast that hover
+/// extended past its nominal life fades out over [`ANIM_OUT`]. Keeping this
+/// small makes the toast start fading promptly once the pointer leaves.
+const HOVER_HOLD: Duration = Duration::from_millis(200);
 
 /// Severity of a toast.  Drives color and default duration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -41,9 +85,41 @@ impl ToastKind {
     /// Default lifetime before auto-dismissal, when not hovered.
     const fn default_duration(self) -> Duration {
         match self {
-            Self::Error => Duration::from_secs(10),
-            Self::Warning => Duration::from_secs(6),
-            Self::Info => Duration::from_secs(3),
+            Self::Error => Duration::from_secs(15),
+            Self::Warning => Duration::from_secs(10),
+            Self::Info => Duration::from_secs(6),
+        }
+    }
+
+    /// Accent/glow color for this kind, taken directly from the active
+    /// theme's palette semantic colors (error/warn/link) rather than a
+    /// hard-coded hue. Used both by [`Self::background`] (the egui-rendered
+    /// bubble fill) and by the owned-renderer layout's glow/accent-bar
+    /// colors ([`layout_toasts`]).
+    const fn semantic(self, visuals: &egui::Visuals) -> egui::Color32 {
+        match self {
+            Self::Error => visuals.error_fg_color,
+            Self::Warning => visuals.warn_fg_color,
+            Self::Info => visuals.hyperlink_color,
+        }
+    }
+
+    /// Icon glyph shown alongside this kind's toast in the owned-renderer
+    /// layout ([`layout_toasts`]).
+    ///
+    /// `Error` and `Warning` both use [`ChromeIcon::Warning`] (an exclamation
+    /// triangle) — the existing bundled icon set (see `icons.rs`) has no
+    /// distinct "fatal" glyph, and the two kinds are already visually
+    /// distinguished by their semantic accent color. `Info` reuses
+    /// [`ChromeIcon::Bell`]: there is no dedicated "information" glyph in the
+    /// bundled set either, and an informational toast is conceptually a
+    /// notification, which the bell glyph reads as clearly at toast size.
+    /// Adding a dedicated glyph per kind is out of scope for this subtask —
+    /// `ChromeIcon` variants are not extended here.
+    const fn icon(self) -> ChromeIcon {
+        match self {
+            Self::Error | Self::Warning => ChromeIcon::Warning,
+            Self::Info => ChromeIcon::Bell,
         }
     }
 
@@ -54,11 +130,7 @@ impl ToastKind {
     /// color is darkened toward the panel background and rendered at high
     /// opacity so it reads as a saturated bubble over any background.
     fn background(self, visuals: &egui::Visuals) -> egui::Color32 {
-        let accent = match self {
-            Self::Error => visuals.error_fg_color,
-            Self::Warning => visuals.warn_fg_color,
-            Self::Info => visuals.hyperlink_color,
-        };
+        let accent = self.semantic(visuals);
         // Blend the accent toward the panel background for a deeper bubble, then
         // apply a high (but not full) opacity so it sits over the terminal.
         let base = visuals.panel_fill;
@@ -131,15 +203,690 @@ impl Toast {
     }
 
     /// Returns `true` if the toast should be removed this frame.
+    ///
+    /// A toast is removed once it is both past its nominal lifetime AND past
+    /// the trailing fade-out window. The fade-out window is anchored so it is
+    /// always fully visible: for a non-hovered toast it is the last
+    /// [`ANIM_OUT`] of its nominal life; for a toast whose hover extended it
+    /// past nominal life, it is the [`ANIM_OUT`] following the moment hover
+    /// ended (plus the [`HOVER_HOLD`] grace). Keeping this in lock-step with
+    /// [`Self::anim`] guarantees a toast is never removed while `anim` still
+    /// shows it fading (review finding #2).
     fn is_expired(&self, now: Instant) -> bool {
-        // If currently hovered (within ~100ms), keep the toast alive.
-        if let Some(hover) = self.last_hovered
-            && now.duration_since(hover) < Duration::from_millis(200)
-        {
+        // While actively hovered (within the hold grace), never expire.
+        if self.hovered_recently(now) {
             return false;
         }
-        now.duration_since(self.created) > self.kind.default_duration()
+        let age = now.saturating_duration_since(self.created);
+        let total = self.kind.default_duration();
+        // Not yet past nominal life -> alive.
+        if age <= total {
+            return false;
+        }
+        // Past nominal life. If hover extended it, allow a full ANIM_OUT
+        // fade after the hold grace ends before removing it.
+        self.last_hovered.is_none_or(|hover| {
+            now.saturating_duration_since(hover) >= HOVER_HOLD.saturating_add(ANIM_OUT)
+        })
     }
+
+    /// Whether `now` falls within the active-hover hold grace, during which
+    /// the toast is held fully visible and its timer does not advance toward
+    /// removal. Mirrors the condition [`Self::is_expired`] / [`Self::anim`]
+    /// use to pause auto-dismissal.
+    fn hovered_recently(&self, now: Instant) -> bool {
+        self.last_hovered
+            .is_some_and(|hover| now.saturating_duration_since(hover) < HOVER_HOLD)
+    }
+
+    /// Compute this toast's animation phase at `now`.
+    ///
+    /// Phases, in order:
+    /// 1. **Entry** (`age < ANIM_IN`): eases in from `(opacity=0, slide_x=
+    ///    SLIDE_IN_PTS, scale=SCALE_IN)` to the settled state via an
+    ///    ease-out cubic.
+    /// 2. **Active hover hold** (within [`HOVER_HOLD`] of the last hover):
+    ///    fully settled — the toast is being read, its exit is paused.
+    /// 3. **Post-hover exit** (hovered past its nominal life, hover now
+    ///    ended): fades opacity `1 -> 0` linearly over [`ANIM_OUT`] measured
+    ///    from the end of the [`HOVER_HOLD`] grace. This is the case the old
+    ///    model got wrong — it popped instantly (review finding #2).
+    /// 4. **End-of-life exit** (within the last [`ANIM_OUT`] of nominal life,
+    ///    never hover-extended): fades opacity `1 -> 0` over the remaining
+    ///    time.
+    /// 5. **Hold**: fully settled, `(opacity=1, slide_x=0, scale=1)`.
+    ///
+    /// Phases 2-4 keep `anim` in lock-step with [`Self::is_expired`] so a
+    /// toast is never removed mid-fade nor left visible after fading to zero.
+    /// All outputs are clamped to their documented ranges.
+    fn anim(&self, now: Instant) -> ToastAnim {
+        const SETTLED: ToastAnim = ToastAnim {
+            opacity: 1.0,
+            slide_x: 0.0,
+            scale: 1.0,
+        };
+        // A pure fade-out (no slide/scale) at opacity `q`.
+        let fade = |q: f32| ToastAnim {
+            opacity: q.clamp(0.0, 1.0),
+            slide_x: 0.0,
+            scale: 1.0,
+        };
+
+        let age = now.saturating_duration_since(self.created);
+        let total = self.kind.default_duration();
+
+        // Degenerate timelines (not expected in practice — every
+        // `ToastKind::default_duration()` is nonzero — but guards against
+        // div-by-zero if the animation durations are ever misconfigured).
+        if ANIM_IN.is_zero() || ANIM_OUT.is_zero() || total.is_zero() {
+            return SETTLED;
+        }
+
+        // Phase 1: entry.
+        if age < ANIM_IN {
+            let p = (age.as_secs_f32() / ANIM_IN.as_secs_f32()).clamp(0.0, 1.0);
+            let eased = 1.0 - (1.0 - p).powi(3);
+            return ToastAnim {
+                opacity: eased.clamp(0.0, 1.0),
+                slide_x: (SLIDE_IN_PTS * (1.0 - eased)).clamp(0.0, SLIDE_IN_PTS),
+                scale: SCALE_IN.mul_add(1.0 - eased, eased).clamp(0.0, 1.0),
+            };
+        }
+
+        // Phase 2: actively hovered — held fully visible.
+        if self.hovered_recently(now) {
+            return SETTLED;
+        }
+
+        // Phase 3: post-hover exit. If a hover extended the toast past its
+        // nominal life, fade over ANIM_OUT starting when the HOVER_HOLD grace
+        // ends (mirrors `is_expired`'s removal at HOVER_HOLD + ANIM_OUT after
+        // the last hover).
+        if age > total
+            && let Some(hover) = self.last_hovered
+        {
+            let since_hover = now.saturating_duration_since(hover);
+            let into_fade = since_hover.saturating_sub(HOVER_HOLD);
+            let remaining = ANIM_OUT.saturating_sub(into_fade);
+            return fade(remaining.as_secs_f32() / ANIM_OUT.as_secs_f32());
+        }
+
+        // Phase 4: end-of-life exit (never hover-extended).
+        let remaining = total.saturating_sub(age);
+        if remaining < ANIM_OUT {
+            return fade(remaining.as_secs_f32() / ANIM_OUT.as_secs_f32());
+        }
+
+        // Phase 5: hold.
+        SETTLED
+    }
+}
+
+/// One toast's animation state at a point in time, as computed by
+/// [`Toast::anim`]. All values are already clamped to their documented
+/// ranges.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct ToastAnim {
+    /// Overall opacity multiplier, `0..=1`.
+    pub opacity: f32,
+    /// Horizontal displacement in logical points. `0` when settled; positive
+    /// values displace the toast toward positive X (off-screen, for a
+    /// right-anchored stack).
+    pub slide_x: f32,
+    /// Uniform scale factor, `0..=1` (`1` = full size/settled).
+    pub scale: f32,
+}
+
+// ---------------------------------------------------------------------------
+//  Owned-renderer layout model (issue #433)
+// ---------------------------------------------------------------------------
+//
+// The types and function below turn a list of toasts (plus their measured
+// text and per-toast animation phase) into the GPU-facing draw data for the
+// fully-owned toast renderer (`super::renderer::toast_pass` /
+// `toast_text_pass`): one `ToastQuad` per pill and a handful of
+// `ToastTextRun`s (icon/label/detail) per toast, laid out and animated in
+// the *same* pass so the pill and its text can never drift apart. Hit
+// rectangles for hover/dismiss are also computed here, in logical points
+// (egui's own coordinate space), so [`ToastStack::show`] can hit-test
+// pointer input against them without recomputing geometry.
+//
+// This module is pure and GL-free — no `FontManager`, no `glow::Context` —
+// so it is fully unit-testable with synthesized `ToastTextMetrics`. It is
+// wired into the frame by [`ToastStack::show`], which measures/shapes text
+// on the main thread, calls `layout_toasts`, and hands the resulting
+// `ToastQuad`/`ToastTextRun` data to a single `PaintCallback`.
+
+use super::renderer::{ToastQuad, ToastTextMetrics, ToastTextRun};
+
+/// Inner padding between a pill's edge and its content, logical points.
+const PILL_PAD_X_PTS: f32 = 14.0;
+/// Inner padding between a pill's top/bottom edge and its content, logical points.
+const PILL_PAD_Y_PTS: f32 = 10.0;
+/// Gap between the icon glyph and the label/detail column, logical points.
+const ICON_LABEL_GAP_PTS: f32 = 8.0;
+/// Gap between the label/detail column and the dismiss button, logical points.
+const LABEL_CLOSE_GAP_PTS: f32 = 8.0;
+/// Side length of the (square) dismiss button, logical points.
+const CLOSE_SIZE_PTS: f32 = 18.0;
+/// Vertical gap between successive toasts in the stack, logical points.
+const TOAST_STACK_GAP_PTS: f32 = 8.0;
+/// Gap between the label line and the detail line, logical points.
+const DETAIL_GAP_PTS: f32 = 4.0;
+/// Maximum pill width, logical points. Content wider than this clamps.
+const MAX_PILL_WIDTH_PTS: f32 = 360.0;
+/// Minimum pill height, logical points, regardless of content.
+const MIN_PILL_HEIGHT_PTS: f32 = 40.0;
+/// Floor applied to the theme's `menu_corner_radius`, logical points.
+const MIN_CORNER_RADIUS_PTS: f32 = 8.0;
+/// Inset from the window's right edge to the stack's right edge, logical points.
+const STACK_RIGHT_INSET_PTS: f32 = 12.0;
+/// Inset from the window's top edge to the stack's first toast, logical points.
+const STACK_TOP_INSET_PTS: f32 = 44.0;
+
+/// Where the toast stack is anchored within the window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(super) enum ToastPosition {
+    /// Stacked in the top-right corner of the window — the only placement
+    /// [`ToastStack::show`] currently produces toasts at (`Toast` carries no
+    /// per-toast position yet).
+    #[default]
+    TopRightStack,
+    /// The whole stack centered within the window.
+    #[allow(dead_code)]
+    // Reserved: no caller currently attaches a per-toast position (`Toast`
+    // has no `position` field yet), so only `TopRightStack` is ever
+    // constructed. Kept for a future toast kind that centers itself (e.g. a
+    // blocking-confirmation-style toast).
+    WindowCentered,
+    /// The whole stack centered within the active pane. Falls back to the
+    /// window rect when no active pane rect is known (e.g. no pane focused,
+    /// or a window with no panes yet).
+    #[allow(dead_code)]
+    // Reserved: see `WindowCentered`.
+    PaneCentered,
+}
+
+/// Geometry inputs to [`layout_toasts`], in LOGICAL points (egui's own
+/// coordinate space — the same space `ctx.content_rect()` and pane layout
+/// rects live in).
+#[derive(Debug, Clone, Copy)]
+pub(super) struct ToastGeometry {
+    /// The full window rect.
+    pub window_rect: egui::Rect,
+    /// The currently-active pane's rect, if known. Consulted only by
+    /// [`ToastPosition::PaneCentered`].
+    pub active_pane_rect: Option<egui::Rect>,
+}
+
+/// Per-toast input to [`layout_toasts`]: its measured content plus its
+/// current animation phase.
+///
+/// Carries the exact text (`label_text`/`detail_text`, needed to build the
+/// actual [`ToastTextRun`]s), the physical pixel size each was measured at
+/// (`label_size_px`/`detail_size_px`/`icon_size_px` — needed so the run
+/// handed to [`super::renderer::ToastTextRenderer::build_instances`] later
+/// rasterizes at *exactly* the size [`ToastTextMetrics`] was measured at;
+/// any mismatch would desync the pill's width from the glyphs actually
+/// drawn), and each string's pre-measured [`ToastTextMetrics`] (needed for
+/// layout math). The caller measures text exactly once (via
+/// [`super::renderer::ToastTextRenderer::measure`]) and this function never
+/// re-shapes it.
+#[derive(Debug, Clone)]
+pub(super) struct ToastLayoutInput {
+    /// Stable id, matching [`Toast::id`], used to key the returned outputs
+    /// back to their source toast (e.g. for hit-testing dismiss clicks).
+    pub id: u64,
+    /// The toast's severity — drives color and icon.
+    pub kind: ToastKind,
+    /// The exact `"Kind: title"` label string that was measured.
+    pub label_text: String,
+    /// The physical pixel size `label_text` was measured/rasterized at.
+    pub label_size_px: f32,
+    /// Measured `label_text`, in **physical** pixels (see [`ToastTextMetrics`]).
+    pub label: ToastTextMetrics,
+    /// The exact detail string that was measured. Empty when `has_detail`
+    /// is `false`.
+    pub detail_text: String,
+    /// The physical pixel size `detail_text` was measured/rasterized at.
+    pub detail_size_px: f32,
+    /// Measured `detail_text`, in physical pixels. Zero-valued when
+    /// `has_detail` is `false`.
+    pub detail: ToastTextMetrics,
+    /// Whether this toast has a detail line to render.
+    pub has_detail: bool,
+    /// The physical pixel size the icon glyph was measured/rasterized at.
+    pub icon_size_px: f32,
+    /// Measured icon glyph (a single glyph), in physical pixels.
+    pub icon: ToastTextMetrics,
+    /// The physical pixel size the dismiss ("x") glyph was
+    /// measured/rasterized at.
+    pub close_size_px: f32,
+    /// Measured dismiss ("x") glyph, in physical pixels.
+    pub close: ToastTextMetrics,
+    /// This toast's current animation phase (see [`Toast::anim`]).
+    pub anim: ToastAnim,
+}
+
+/// One laid-out toast, ready to hand to the toast/toast-text GPU passes.
+///
+/// All fields describing GPU draw data (`pill`, `runs`) are in **physical**
+/// pixels, viewport-local to the toast overlay's `PaintCallback` rect
+/// (origin = top-left of the callback's clip rect) — matching [`ToastQuad`]
+/// and [`ToastTextRun`]'s own documented coordinate space. The hit-test
+/// rects are in **logical** points (window space) since that is the space
+/// egui's own pointer/hover queries operate in.
+#[derive(Debug, Clone)]
+pub(super) struct ToastLayoutOutput {
+    /// Matches the source [`ToastLayoutInput::id`].
+    pub id: u64,
+    /// The pill background quad.
+    pub pill: ToastQuad,
+    /// Text runs to draw for this toast: icon, label, and (if present)
+    /// detail, in that order.
+    pub runs: Vec<ToastTextRun>,
+    /// Interactable pill rect, logical points, window space:
+    /// `[min_x, min_y, max_x, max_y]`. The whole pill is the click target —
+    /// a primary click anywhere within this rect dismisses the toast (see
+    /// [`ToastStack::hit_test`]); the drawn "x" glyph (in `runs`) is purely
+    /// a visual affordance, not a separate hit region.
+    pub hit_rect_logical: [f32; 4],
+}
+
+/// The maximum corner radius (in logical points) among the theme's
+/// `menu_corner_radius` four corners, floored at [`MIN_CORNER_RADIUS_PTS`].
+fn corner_radius_pts(visuals: &egui::Visuals) -> f32 {
+    let corner = visuals.menu_corner_radius;
+    let max_corner = corner.nw.max(corner.ne).max(corner.sw).max(corner.se);
+    f32::from(max_corner).max(MIN_CORNER_RADIUS_PTS)
+}
+
+/// Convert a straight-alpha [`egui::Color32`] to straight (non-premultiplied)
+/// `[r, g, b, a]` floats in `0..=1`.
+fn color32_to_rgba(color: egui::Color32) -> [f32; 4] {
+    // `Color32`'s accessors (`r()`/`g()`/`b()`) return components
+    // *premultiplied* by alpha (see the `ecolor::Color32` type docs) — this
+    // pass's `ToastQuad`/`ToastTextRun` colors are documented as *straight*
+    // RGBA, so the alpha must be un-premultiplied via `to_srgba_unmultiplied`
+    // rather than reading the accessors directly.
+    let straight = color.to_srgba_unmultiplied();
+    [
+        f32::from(straight[0]) / 255.0,
+        f32::from(straight[1]) / 255.0,
+        f32::from(straight[2]) / 255.0,
+        f32::from(straight[3]) / 255.0,
+    ]
+}
+
+/// Shift each color channel of `rgba` by `amount` (positive lightens,
+/// negative darkens), clamped to `0..=1`. Alpha is left untouched.
+fn lighten(rgba: [f32; 4], amount: f32) -> [f32; 4] {
+    [
+        (rgba[0] + amount).clamp(0.0, 1.0),
+        (rgba[1] + amount).clamp(0.0, 1.0),
+        (rgba[2] + amount).clamp(0.0, 1.0),
+        rgba[3],
+    ]
+}
+
+/// The settled (pre-animation) pill width/height, in physical pixels, for
+/// one toast's measured content.
+fn settled_pill_size(input: &ToastLayoutInput, ppp: f32) -> (f32, f32) {
+    let pad_x = PILL_PAD_X_PTS * ppp;
+    let pad_y = PILL_PAD_Y_PTS * ppp;
+    let icon_label_gap = ICON_LABEL_GAP_PTS * ppp;
+    let label_close_gap = LABEL_CLOSE_GAP_PTS * ppp;
+    let close_size = CLOSE_SIZE_PTS * ppp;
+    let detail_gap = DETAIL_GAP_PTS * ppp;
+    let max_width = MAX_PILL_WIDTH_PTS * ppp;
+    let min_height = MIN_PILL_HEIGHT_PTS * ppp;
+
+    let text_width = input.label.width.max(input.detail.width);
+    let content_width =
+        input.icon.width + icon_label_gap + text_width + label_close_gap + close_size;
+    let width = pad_x.mul_add(2.0, content_width).min(max_width);
+
+    let mut text_height = input.label.height;
+    if input.has_detail {
+        text_height += detail_gap + input.detail.height;
+    }
+    let height = pad_y.mul_add(2.0, text_height).max(min_height);
+
+    (width, height)
+}
+
+/// Compute the settled (pre-animation) top-left origin, in physical pixels,
+/// of each toast's pill, for the given anchor `position`.
+///
+/// `sizes[i]` is `(width, height)` for `inputs[i]`, as returned by
+/// [`settled_pill_size`]. Returns one `(x, y)` pair per input, in the same
+/// order.
+fn settled_origins(
+    sizes: &[(f32, f32)],
+    position: ToastPosition,
+    geom: ToastGeometry,
+    ppp: f32,
+) -> Vec<(f32, f32)> {
+    let gap = TOAST_STACK_GAP_PTS * ppp;
+
+    // Cumulative vertical offset of each toast's top edge, relative to the
+    // stack's own top (offset 0 for the first toast).
+    let mut offsets = Vec::with_capacity(sizes.len());
+    let mut cumulative = 0.0;
+    for &(_, height) in sizes {
+        offsets.push(cumulative);
+        cumulative += height + gap;
+    }
+    let total_height = if sizes.is_empty() {
+        0.0
+    } else {
+        cumulative - gap
+    };
+
+    let rect_for = |rect: egui::Rect| {
+        (
+            rect.min.x * ppp,
+            rect.min.y * ppp,
+            rect.max.x * ppp,
+            rect.max.y * ppp,
+        )
+    };
+
+    match position {
+        ToastPosition::TopRightStack => {
+            let (_, win_min_y, win_max_x, _) = rect_for(geom.window_rect);
+            let base_y = STACK_TOP_INSET_PTS.mul_add(ppp, win_min_y);
+            let right_edge = STACK_RIGHT_INSET_PTS.mul_add(-ppp, win_max_x);
+            sizes
+                .iter()
+                .zip(&offsets)
+                .map(|(&(width, _), &offset)| (right_edge - width, base_y + offset))
+                .collect()
+        }
+        ToastPosition::WindowCentered => {
+            let (win_min_x, win_min_y, win_max_x, win_max_y) = rect_for(geom.window_rect);
+            let center_x = win_min_x.midpoint(win_max_x);
+            let base_y = win_min_y.midpoint(win_max_y) - total_height / 2.0;
+            sizes
+                .iter()
+                .zip(&offsets)
+                .map(|(&(width, _), &offset)| (center_x - width / 2.0, base_y + offset))
+                .collect()
+        }
+        ToastPosition::PaneCentered => {
+            let pane_rect = geom.active_pane_rect.unwrap_or(geom.window_rect);
+            let (pane_min_x, pane_min_y, pane_max_x, pane_max_y) = rect_for(pane_rect);
+            let center_x = pane_min_x.midpoint(pane_max_x);
+            let base_y = pane_min_y.midpoint(pane_max_y) - total_height / 2.0;
+            sizes
+                .iter()
+                .zip(&offsets)
+                .map(|(&(width, _), &offset)| (center_x - width / 2.0, base_y + offset))
+                .collect()
+        }
+    }
+}
+
+/// Precomputed, `pixels_per_point`-scaled layout constants shared across
+/// every toast in one [`layout_toasts`] call. Bundled into one struct so the
+/// per-toast helper functions stay under the `too_many_arguments` limit.
+struct ToastLayoutMetrics {
+    /// `pixels_per_point`, kept alongside the already-scaled fields below
+    /// since logical-to-physical hit-rect conversion still needs it raw.
+    ppp: f32,
+    /// [`PILL_PAD_X_PTS`], scaled to physical pixels.
+    pad_x: f32,
+    /// [`PILL_PAD_Y_PTS`], scaled to physical pixels.
+    pad_y: f32,
+    /// [`ICON_LABEL_GAP_PTS`], scaled to physical pixels.
+    icon_label_gap: f32,
+    /// [`CLOSE_SIZE_PTS`], scaled to physical pixels.
+    close_size: f32,
+    /// [`DETAIL_GAP_PTS`], scaled to physical pixels.
+    detail_gap: f32,
+    /// The theme's corner radius (see [`corner_radius_pts`]), scaled to
+    /// physical pixels.
+    corner_radius: f32,
+}
+
+/// The pill/glow/text colors for one toast, derived from its kind's
+/// semantic theme color and its current animation opacity.
+struct ToastColors {
+    /// Pill background gradient, top stop.
+    color_top: [f32; 4],
+    /// Pill background gradient, bottom stop.
+    color_bottom: [f32; 4],
+    /// Outer glow color (rgb) + intensity (a).
+    glow: [f32; 4],
+    /// Left accent-bar color.
+    accent: [f32; 4],
+    /// Label/detail text color, contrast-picked against the pill fill.
+    text_color: [f32; 4],
+    /// Icon glyph color (tinted to the kind's semantic color).
+    icon_color: [f32; 4],
+}
+
+/// Derive [`ToastColors`] for `kind` from the active theme, at the given
+/// (already-clamped-elsewhere) animation `opacity`.
+fn toast_colors(kind: ToastKind, visuals: &egui::Visuals, opacity: f32) -> ToastColors {
+    let background = kind.background(visuals);
+    let base_rgba = color32_to_rgba(background);
+    let color_top = lighten(base_rgba, 0.08);
+    let color_bottom = lighten(base_rgba, -0.06);
+    let semantic_rgba = color32_to_rgba(kind.semantic(visuals));
+    let glow = [semantic_rgba[0], semantic_rgba[1], semantic_rgba[2], 0.35];
+    let accent = [semantic_rgba[0], semantic_rgba[1], semantic_rgba[2], 1.0];
+
+    let text_alpha = opacity.clamp(0.0, 1.0);
+    let text_rgb = if ToastKind::prefers_dark_text(background) {
+        [0.08, 0.08, 0.08]
+    } else {
+        [0.96, 0.96, 0.96]
+    };
+    let text_color = [text_rgb[0], text_rgb[1], text_rgb[2], text_alpha];
+    let icon_color = [
+        semantic_rgba[0],
+        semantic_rgba[1],
+        semantic_rgba[2],
+        text_alpha,
+    ];
+
+    ToastColors {
+        color_top,
+        color_bottom,
+        glow,
+        accent,
+        text_color,
+        icon_color,
+    }
+}
+
+/// Build the icon/label/(optional detail)/dismiss [`ToastTextRun`]s for one
+/// toast, anchored to the pill's already-animated top-left corner `(x, y)`
+/// and sized `width` x `height` (physical pixels, post-animation scale —
+/// the same rect the pill quad itself occupies, so the dismiss glyph never
+/// drifts from the pill under the scale-in animation).
+fn build_text_runs(
+    input: &ToastLayoutInput,
+    x: f32,
+    y: f32,
+    width: f32,
+    metrics: &ToastLayoutMetrics,
+    colors: &ToastColors,
+) -> Vec<ToastTextRun> {
+    let icon_origin_x = x + metrics.pad_x;
+    let icon_baseline_y = y + metrics.pad_y + input.icon.ascent;
+    let mut runs = vec![ToastTextRun {
+        text: input.kind.icon().glyph(),
+        origin_x: icon_origin_x,
+        baseline_y: icon_baseline_y,
+        size_px: input.icon_size_px,
+        color: colors.icon_color,
+    }];
+
+    let label_origin_x = icon_origin_x + input.icon.width + metrics.icon_label_gap;
+    let label_baseline_y = y + metrics.pad_y + input.label.ascent;
+    runs.push(ToastTextRun {
+        text: input.label_text.clone(),
+        origin_x: label_origin_x,
+        baseline_y: label_baseline_y,
+        size_px: input.label_size_px,
+        color: colors.text_color,
+    });
+
+    if input.has_detail {
+        let detail_origin_x = x + metrics.pad_x;
+        let detail_baseline_y =
+            y + metrics.pad_y + input.label.height + metrics.detail_gap + input.detail.ascent;
+        runs.push(ToastTextRun {
+            text: input.detail_text.clone(),
+            origin_x: detail_origin_x,
+            baseline_y: detail_baseline_y,
+            size_px: input.detail_size_px,
+            color: colors.text_color,
+        });
+    }
+
+    // Dismiss ("x") glyph — purely a visual affordance (the whole pill is
+    // the click target, see `ToastStack::hit_test`), drawn within the
+    // reserved close-button region at the pill's right edge (physical
+    // pixels, since text runs are physical).
+    let close_right = x + width - metrics.pad_x;
+    let close_left = close_right - metrics.close_size;
+    let close_origin_x =
+        (close_left + (metrics.close_size - input.close.width) / 2.0).max(close_left);
+    // Share the label row's baseline so the "x" aligns with the title text
+    // beside it (top-aligned header row), rather than centering in the full
+    // pill height — which visually drops it too low, more so on a
+    // two-line (detail) toast.
+    let close_baseline_y = y + metrics.pad_y + input.label.ascent;
+    // Dimmed relative to the label/detail text so it reads as a secondary
+    // affordance rather than competing with the message; still respects the
+    // animation's opacity via `colors.text_color`'s alpha.
+    let close_color = [
+        colors.text_color[0],
+        colors.text_color[1],
+        colors.text_color[2],
+        colors.text_color[3] * 0.7,
+    ];
+    runs.push(ToastTextRun {
+        text: ChromeIcon::Close.glyph(),
+        origin_x: close_origin_x,
+        baseline_y: close_baseline_y,
+        size_px: input.close_size_px,
+        color: close_color,
+    });
+
+    runs
+}
+
+/// Lay out one toast: apply its animation to the settled pill rect, derive
+/// its colors, and build its text runs and hit rects.
+fn layout_one_toast(
+    input: &ToastLayoutInput,
+    width: f32,
+    height: f32,
+    settled_x: f32,
+    settled_y: f32,
+    metrics: &ToastLayoutMetrics,
+    visuals: &egui::Visuals,
+) -> ToastLayoutOutput {
+    let anim = input.anim;
+
+    // Scale about the settled rect's center, then apply the horizontal
+    // slide (converted from logical points to physical pixels) on top.
+    let scaled_width = width * anim.scale;
+    let scaled_height = height * anim.scale;
+    let center_x = settled_x + width / 2.0;
+    let center_y = settled_y + height / 2.0;
+    let x = anim
+        .slide_x
+        .mul_add(metrics.ppp, center_x - scaled_width / 2.0);
+    let y = center_y - scaled_height / 2.0;
+
+    let colors = toast_colors(input.kind, visuals, anim.opacity);
+    // Clamp the corner radius to half the pill's smaller dimension: a large
+    // theme `menu_corner_radius` on a short pill could otherwise exceed the
+    // half-extent and distort the SDF into a lozenge (review finding #6).
+    let corner_radius = metrics
+        .corner_radius
+        .min(scaled_width.min(scaled_height) / 2.0)
+        .max(0.0);
+    let pill = ToastQuad {
+        x,
+        y,
+        width: scaled_width,
+        height: scaled_height,
+        corner_radius,
+        color_top: colors.color_top,
+        color_bottom: colors.color_bottom,
+        glow: colors.glow,
+        accent: colors.accent,
+        opacity: anim.opacity.clamp(0.0, 1.0),
+    };
+
+    let runs = build_text_runs(input, x, y, scaled_width, metrics, &colors);
+
+    let hit_rect_logical = [
+        x / metrics.ppp,
+        y / metrics.ppp,
+        (x + scaled_width) / metrics.ppp,
+        (y + scaled_height) / metrics.ppp,
+    ];
+
+    ToastLayoutOutput {
+        id: input.id,
+        pill,
+        runs,
+        hit_rect_logical,
+    }
+}
+
+/// Turn `inputs` into GPU-facing draw data: one [`ToastQuad`] pill and a
+/// handful of [`ToastTextRun`]s per toast, plus logical-point hit rects.
+///
+/// Pure and GL-free (no `FontManager`, no `glow::Context`) — `inputs` already
+/// carries pre-measured [`ToastTextMetrics`] and each toast's animation
+/// phase, so this function only does geometry and color arithmetic.
+pub(super) fn layout_toasts(
+    inputs: &[ToastLayoutInput],
+    position: ToastPosition,
+    geom: ToastGeometry,
+    visuals: &egui::Visuals,
+    pixels_per_point: f32,
+) -> Vec<ToastLayoutOutput> {
+    if inputs.is_empty() {
+        return Vec::new();
+    }
+
+    // Guard against a pathological `pixels_per_point` of 0 from the windowing
+    // layer: `ppp` is used as a divisor when deriving the logical hit rect
+    // (`layout_one_toast`), so a zero would yield `Inf`/`NaN` rects that never
+    // match a pointer. Floor it at a tiny epsilon (review finding #5).
+    let ppp = pixels_per_point.max(f32::EPSILON);
+    let metrics = ToastLayoutMetrics {
+        ppp,
+        pad_x: PILL_PAD_X_PTS * ppp,
+        pad_y: PILL_PAD_Y_PTS * ppp,
+        icon_label_gap: ICON_LABEL_GAP_PTS * ppp,
+        close_size: CLOSE_SIZE_PTS * ppp,
+        detail_gap: DETAIL_GAP_PTS * ppp,
+        corner_radius: corner_radius_pts(visuals) * ppp,
+    };
+
+    let sizes: Vec<(f32, f32)> = inputs.iter().map(|i| settled_pill_size(i, ppp)).collect();
+    let origins = settled_origins(&sizes, position, geom, ppp);
+
+    inputs
+        .iter()
+        .zip(&sizes)
+        .zip(&origins)
+        .map(|((input, &(width, height)), &(settled_x, settled_y))| {
+            layout_one_toast(
+                input, width, height, settled_x, settled_y, &metrics, visuals,
+            )
+        })
+        .collect()
 }
 
 /// Ordered stack of active toasts, rendered top-to-bottom from the most
@@ -189,94 +936,96 @@ impl ToastStack {
         }
     }
 
-    /// Render the stack as an overlay in the top-right corner of the window.
+    /// Font size (physical pixels, pre-`pixels_per_point` scaling) the toast
+    /// label is rasterized at. See [`Self::show`].
+    const LABEL_SIZE_PTS: f32 = 14.0;
+    /// Font size (physical pixels, pre-`pixels_per_point` scaling) the toast
+    /// detail line is rasterized at. See [`Self::show`].
+    const DETAIL_SIZE_PTS: f32 = 12.0;
+
+    /// Render the stack as a fully-owned GL overlay (issue #433): measures
+    /// and shapes every toast's text on the main thread, lays it out via
+    /// [`layout_toasts`], and hands the result to a single `PaintCallback`
+    /// that draws every pill, then every text run, on top of everything
+    /// else in the window.
     ///
-    /// Clears auto-expired toasts and any the user dismissed via the `x` button.
-    pub(super) fn show(&mut self, ctx: &egui::Context) {
+    /// `render_state` is this window's toast GL state (per-window, since GL
+    /// resources belong to one GL context); `font_manager` is this window's
+    /// shared [`FontManager`] (obtained via
+    /// `FreminalTerminalWidget::font_manager_mut`), used only for
+    /// measuring/shaping — never touched from inside the `PaintCallback`.
+    ///
+    /// Clears auto-expired toasts and any the user dismissed by clicking
+    /// anywhere within a toast's pill (its `hit_rect_logical`, computed by
+    /// `layout_toasts`).
+    pub(super) fn show(
+        &mut self,
+        ctx: &egui::Context,
+        geom: ToastGeometry,
+        render_state: &std::sync::Arc<std::sync::Mutex<ToastRenderState>>,
+        font_manager: &mut FontManager,
+        pixels_per_point: f32,
+    ) {
         if self.entries.is_empty() {
             return;
         }
 
         let now = Instant::now();
-        let mut to_remove: Vec<u64> = Vec::new();
+        let ppp = pixels_per_point;
+        let visuals = ctx.global_style().visuals.clone();
 
-        egui::Area::new(egui::Id::new("toast_overlay"))
-            .anchor(egui::Align2::RIGHT_TOP, [-12.0, 44.0])
-            .order(egui::Order::Foreground)
-            .interactable(true)
-            .show(ctx, |ui| {
-                ui.set_max_width(360.0);
-                ui.vertical(|ui| {
-                    // Derive bubble geometry/stroke from the active themed
-                    // visuals (set globally by 112.4): border + profile corner
-                    // radius. Text color is contrast-picked against the bubble
-                    // fill so it stays legible on light and dark themes alike.
-                    let border = ui.visuals().window_stroke.color;
-                    let corner = ui.visuals().menu_corner_radius;
-                    for toast in &mut self.entries {
-                        let bg = toast.kind.background(ui.visuals());
-                        let text_color = if ToastKind::prefers_dark_text(bg) {
-                            egui::Color32::from_gray(20)
-                        } else {
-                            egui::Color32::from_gray(245)
-                        };
-                        let detail_color = if ToastKind::prefers_dark_text(bg) {
-                            egui::Color32::from_gray(60)
-                        } else {
-                            egui::Color32::from_gray(215)
-                        };
-                        let frame = egui::Frame::NONE
-                            .fill(bg)
-                            .stroke(egui::Stroke::new(1.0, border))
-                            .corner_radius(corner)
-                            .inner_margin(egui::Margin::symmetric(10, 8));
-                        let resp = frame.show(ui, |ui| {
-                            ui.horizontal(|ui| {
-                                ui.vertical(|ui| {
-                                    ui.label(
-                                        egui::RichText::new(format!(
-                                            "{}: {}",
-                                            toast.kind.label(),
-                                            toast.title
-                                        ))
-                                        .color(text_color)
-                                        .strong(),
-                                    );
-                                    if let Some(ref detail) = toast.detail {
-                                        ui.label(
-                                            egui::RichText::new(detail).color(detail_color).small(),
-                                        );
-                                    }
-                                });
-                                ui.with_layout(
-                                    egui::Layout::right_to_left(egui::Align::TOP),
-                                    |ui| {
-                                        if ui
-                                            .add(
-                                                egui::Button::new(
-                                                    ChromeIcon::Close
-                                                        .rich_text_colored(text_color)
-                                                        .strong(),
-                                                )
-                                                .frame(false)
-                                                .small(),
-                                            )
-                                            .on_hover_text("Dismiss")
-                                            .clicked()
-                                        {
-                                            to_remove.push(toast.id);
-                                        }
-                                    },
-                                );
-                            });
-                        });
-                        if resp.response.hovered() {
-                            toast.last_hovered = Some(now);
-                        }
-                        ui.add_space(6.0);
-                    }
-                });
-            });
+        let label_size_px = Self::LABEL_SIZE_PTS * ppp;
+        let detail_size_px = Self::DETAIL_SIZE_PTS * ppp;
+        let icon_size_px = label_size_px;
+
+        // Measure + shape every toast's text on the main thread; the lock is
+        // held only for the duration of this call — no GL is touched.
+        let (inputs, any_animating) = {
+            let rs = render_state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            self.measure_inputs(
+                &rs,
+                font_manager,
+                label_size_px,
+                detail_size_px,
+                icon_size_px,
+                now,
+            )
+        };
+
+        // `layout_toasts` emits window-origin-absolute physical-pixel
+        // coordinates (it scales `geom.window_rect` directly, without
+        // subtracting `window_rect.min`) — see its own field docs. The
+        // `PaintCallback` registered by `paint_toasts` below uses
+        // `rect: ctx.content_rect()` (the full window, origin `(0,0)`), so
+        // its GL viewport starts at the window's own origin and these
+        // coordinates need no further translation to land in the right
+        // place.
+        let outputs = layout_toasts(&inputs, ToastPosition::TopRightStack, geom, &visuals, ppp);
+
+        // Owned hover/dismiss hit-testing via a real interactive egui region
+        // per toast (in LOGICAL points, window space). Registering an actual
+        // `Sense::click()` widget — rather than passively reading pointer
+        // state — is what makes egui's input arbitration *consume* a dismiss
+        // click, so the terminal pane beneath the toast never also receives it
+        // (which would otherwise start a selection or leak a mouse-report to
+        // the running program). Clicks outside every toast rect are never
+        // allocated, so they fall through to the terminal untouched. Toasts
+        // are not a typing modal, so this deliberately does NOT touch the
+        // `ui_overlay_open` / `suppress_input` global gate — only the exact
+        // click that lands on a toast is consumed. (Review finding #3.)
+        let to_remove = self.hit_test(ctx, &outputs, now);
+
+        let text_instances = {
+            let mut rs = render_state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let runs: Vec<ToastTextRun> = outputs.iter().flat_map(|o| o.runs.clone()).collect();
+            rs.text.build_instances(&runs, font_manager)
+        };
+        let pills: Vec<ToastQuad> = outputs.iter().map(|o| o.pill).collect();
+        Self::paint_toasts(ctx, render_state, pills, text_instances);
 
         // Remove dismissed toasts.
         if !to_remove.is_empty() {
@@ -285,14 +1034,210 @@ impl ToastStack {
         // Remove expired toasts.
         self.entries.retain(|t| !t.is_expired(now));
 
-        // Request a repaint soon so expiry happens even without input.
+        // Request a repaint soon so expiry/animation happens even without
+        // input: a fast (16ms, ~60fps) cadence while any toast is animating
+        // (entry/exit fade+slide+scale), otherwise a slow (250ms) cadence
+        // just to catch expiry.
         if !self.entries.is_empty() {
-            ctx.request_repaint_after(Duration::from_millis(250));
+            let delay = if any_animating {
+                Duration::from_millis(16)
+            } else {
+                Duration::from_millis(250)
+            };
+            ctx.request_repaint_after(delay);
         }
+    }
+
+    /// Measure and shape every active toast's text, returning the
+    /// [`ToastLayoutInput`]s [`layout_toasts`] needs plus whether any toast
+    /// is currently mid-animation (entry or exit). Split out of
+    /// [`Self::show`] to keep it under the line-count limit.
+    fn measure_inputs(
+        &self,
+        rs: &ToastRenderState,
+        font_manager: &mut FontManager,
+        label_size_px: f32,
+        detail_size_px: f32,
+        icon_size_px: f32,
+        now: Instant,
+    ) -> (Vec<ToastLayoutInput>, bool) {
+        let mut inputs = Vec::with_capacity(self.entries.len());
+        let mut any_animating = false;
+        for toast in &self.entries {
+            let label_text = format!("{}: {}", toast.kind.label(), toast.title);
+            let has_detail = toast.detail.is_some();
+            let detail_text = toast.detail.clone().unwrap_or_default();
+            let icon_text = toast.kind.icon().glyph();
+            let close_text = ChromeIcon::Close.glyph();
+
+            let label = rs.text.measure(&label_text, label_size_px, font_manager);
+            let detail = if has_detail {
+                rs.text.measure(&detail_text, detail_size_px, font_manager)
+            } else {
+                ToastTextMetrics {
+                    width: 0.0,
+                    height: 0.0,
+                    ascent: 0.0,
+                }
+            };
+            let icon = rs.text.measure(&icon_text, icon_size_px, font_manager);
+            // Rasterized at the same size as the kind icon, for visual
+            // consistency between the leading icon and the trailing "x".
+            let close_size_px = icon_size_px;
+            let close = rs.text.measure(&close_text, close_size_px, font_manager);
+
+            let anim = toast.anim(now);
+            if anim.opacity < 1.0 || anim.slide_x.abs() > f32::EPSILON || anim.scale < 1.0 {
+                any_animating = true;
+            }
+
+            inputs.push(ToastLayoutInput {
+                id: toast.id,
+                kind: toast.kind,
+                label_text,
+                label_size_px,
+                label,
+                detail_text,
+                detail_size_px,
+                detail,
+                has_detail,
+                icon_size_px,
+                icon,
+                close_size_px,
+                close,
+                anim,
+            });
+        }
+        (inputs, any_animating)
+    }
+
+    /// Hover/dismiss hit-test: allocate one interactive click-only egui
+    /// region per toast, over its `hit_rect_logical` (logical points).
+    /// Hovering a toast's pill pauses its expiry (`last_hovered`); clicking
+    /// anywhere within a toast's pill dismisses it — the whole pill is the
+    /// click target, the drawn "x" glyph is purely a visual affordance.
+    ///
+    /// The regions live in an interactive `egui::Area` above the terminal so
+    /// egui consumes the click (see the call site's finding-#3 comment). At
+    /// most one toast is dismissed per frame, and regions are hit-tested
+    /// newest-first (newest toasts are drawn on top) so that during the brief
+    /// entry slide — when an arriving toast can transiently overlap its
+    /// neighbour — a click in the overlap dismisses only the topmost one
+    /// (review finding #4). Returns the ids to remove. Split out of
+    /// [`Self::show`] to keep it under the line-count limit.
+    fn hit_test(
+        &mut self,
+        ctx: &egui::Context,
+        outputs: &[ToastLayoutOutput],
+        now: Instant,
+    ) -> Vec<u64> {
+        // Allocate an interactive click region per toast so egui consumes any
+        // click that lands on a toast (keeping it off the terminal). egui's
+        // own arbitration reports the click on whichever region it picked; we
+        // additionally derive the hover target and the (single, topmost)
+        // dismiss target from the pointer position via `topmost_hit`, so the
+        // overlap-precedence rule has one tested source of truth.
+        let mut any_clicked = false;
+        let pointer = egui::Area::new(egui::Id::new("toast_interaction"))
+            .order(egui::Order::Foreground)
+            .interactable(true)
+            .fixed_pos(egui::Pos2::ZERO)
+            .show(ctx, |ui| {
+                for out in outputs {
+                    let [min_x, min_y, max_x, max_y] = out.hit_rect_logical;
+                    let rect = egui::Rect::from_min_max(
+                        egui::pos2(min_x, min_y),
+                        egui::pos2(max_x, max_y),
+                    );
+                    if ui.allocate_rect(rect, egui::Sense::click()).clicked() {
+                        any_clicked = true;
+                    }
+                }
+                ui.input(|i| i.pointer.hover_pos())
+            })
+            .inner;
+
+        let Some(pos) = pointer else {
+            return Vec::new();
+        };
+        let hovered = topmost_hit(outputs, pos);
+        if let Some(id) = hovered
+            && let Some(toast) = self.entries.iter_mut().find(|t| t.id == id)
+        {
+            toast.last_hovered = Some(now);
+        }
+        if any_clicked {
+            hovered.into_iter().collect()
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Register the single `PaintCallback` that draws every toast pill,
+    /// then every toast text run, on top of the rest of the window. Split
+    /// out of [`Self::show`] to keep it under the line-count limit.
+    fn paint_toasts(
+        ctx: &egui::Context,
+        render_state: &std::sync::Arc<std::sync::Mutex<ToastRenderState>>,
+        pills: Vec<ToastQuad>,
+        text_instances: Vec<f32>,
+    ) {
+        let render_state_cb = std::sync::Arc::clone(render_state);
+        let layer_painter = ctx.layer_painter(egui::LayerId::new(
+            egui::Order::Foreground,
+            egui::Id::new("toast_overlay_gl"),
+        ));
+        layer_painter.add(egui::PaintCallback {
+            rect: ctx.content_rect(),
+            callback: std::sync::Arc::new(egui_glow::CallbackFn::new(move |info, painter| {
+                let gl = painter.gl();
+                let vp = info.viewport_in_pixels();
+                let mut rs = render_state_cb
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if !rs.pill.initialized()
+                    && let Err(e) = rs.pill.init(gl)
+                {
+                    tracing::error!("toast pill GL init failed: {e}");
+                    return;
+                }
+                if !rs.text.initialized()
+                    && let Err(e) = rs.text.init(gl)
+                {
+                    tracing::error!("toast text GL init failed: {e}");
+                    return;
+                }
+                rs.pill.draw(gl, &pills, vp.width_px, vp.height_px);
+                rs.text
+                    .upload_and_draw(gl, &text_instances, vp.width_px, vp.height_px);
+            })),
+        });
     }
 }
 
+/// Whether logical-point `pos` falls within `rect` (`[min_x, min_y, max_x,
+/// max_y]`, logical points — see [`ToastLayoutOutput::hit_rect_logical`]).
+fn rect_contains(rect: [f32; 4], pos: egui::Pos2) -> bool {
+    pos.x >= rect[0] && pos.x <= rect[2] && pos.y >= rect[1] && pos.y <= rect[3]
+}
+
+/// The id of the topmost toast whose hit rect contains `pos`, or `None`.
+///
+/// "Topmost" = newest = last in `outputs` (drawn on top), so this iterates in
+/// reverse. Pure and GL-/egui-free so the overlap-precedence rule (review
+/// finding #4) is unit-testable; the interactive [`ToastStack::hit_test`]
+/// egui path relies on the same newest-first ordering when it allocates its
+/// click regions.
+fn topmost_hit(outputs: &[ToastLayoutOutput], pos: egui::Pos2) -> Option<u64> {
+    outputs
+        .iter()
+        .rev()
+        .find(|out| rect_contains(out.hit_rect_logical, pos))
+        .map(|out| out.id)
+}
+
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -417,9 +1362,685 @@ mod tests {
             detail: None,
             id: 0,
             created,
-            // Hover was 5 s ago — well outside the 200 ms keep-alive window.
+            // Hover was 5 s ago — well past HOVER_HOLD + ANIM_OUT.
             last_hovered: Some(stale_hover),
         };
         assert!(toast.is_expired(later));
+    }
+
+    // -----------------------------------------------------------------
+    //  Toast::anim — entry / hold / exit phases
+    // -----------------------------------------------------------------
+
+    fn anim_test_toast(created: Instant, last_hovered: Option<Instant>) -> Toast {
+        Toast {
+            kind: ToastKind::Info,
+            title: "t".to_owned(),
+            detail: None,
+            id: 0,
+            created,
+            last_hovered,
+        }
+    }
+
+    #[test]
+    fn anim_at_creation_is_fully_entry() {
+        let created = Instant::now();
+        let toast = anim_test_toast(created, None);
+        let anim = toast.anim(created);
+        assert!(
+            anim.opacity.abs() < f32::EPSILON,
+            "opacity={}",
+            anim.opacity
+        );
+        assert!(
+            (anim.slide_x - SLIDE_IN_PTS).abs() < f32::EPSILON,
+            "slide_x={}",
+            anim.slide_x
+        );
+        assert!(
+            (anim.scale - SCALE_IN).abs() < f32::EPSILON,
+            "scale={}",
+            anim.scale
+        );
+    }
+
+    #[test]
+    fn anim_mid_entry_is_between_start_and_settled() {
+        let created = Instant::now();
+        let toast = anim_test_toast(created, None);
+        let anim = toast.anim(created + Duration::from_millis(90));
+        assert!(anim.opacity > 0.0 && anim.opacity < 1.0, "{}", anim.opacity);
+        assert!(
+            anim.slide_x > 0.0 && anim.slide_x < SLIDE_IN_PTS,
+            "{}",
+            anim.slide_x
+        );
+        assert!(anim.scale > SCALE_IN && anim.scale < 1.0, "{}", anim.scale);
+    }
+
+    #[test]
+    fn anim_settled_hold_is_fully_visible_and_unslid() {
+        let created = Instant::now();
+        let toast = anim_test_toast(created, None);
+        // Well past entry (ANIM_IN), well before the last ANIM_OUT of the
+        // default duration.
+        let hold_point = ANIM_IN
+            + toast
+                .kind
+                .default_duration()
+                .saturating_sub(ANIM_IN)
+                .saturating_sub(ANIM_OUT)
+                / 2;
+        let anim = toast.anim(created + hold_point);
+        assert!((anim.opacity - 1.0).abs() < f32::EPSILON);
+        assert!(anim.slide_x.abs() < f32::EPSILON);
+        assert!((anim.scale - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn anim_exit_fades_out_over_the_last_slice() {
+        let created = Instant::now();
+        let toast = anim_test_toast(created, None);
+        // 100ms of the lifetime remaining -> inside the ANIM_OUT exit window.
+        let now = created
+            + toast
+                .kind
+                .default_duration()
+                .saturating_sub(Duration::from_millis(100));
+        let anim = toast.anim(now);
+        // remaining (100ms) / ANIM_OUT, both in the same units.
+        let expected_q = 0.100 / ANIM_OUT.as_secs_f32();
+        assert!(
+            (anim.opacity - expected_q).abs() < 0.01,
+            "opacity={} expected~{expected_q}",
+            anim.opacity
+        );
+        assert!(anim.slide_x.abs() < f32::EPSILON, "exit does not re-slide");
+        assert!(
+            (anim.scale - 1.0).abs() < f32::EPSILON,
+            "exit does not re-scale"
+        );
+    }
+
+    #[test]
+    fn anim_hover_suppresses_exit_fade() {
+        let created = Instant::now();
+        // Hovered right up until `now` -> within the HOVER_HOLD grace.
+        let now = created
+            + ToastKind::Info
+                .default_duration()
+                .saturating_sub(Duration::from_millis(50));
+        let toast = anim_test_toast(created, Some(now));
+        let anim = toast.anim(now);
+        assert!(
+            (anim.opacity - 1.0).abs() < f32::EPSILON,
+            "hover must keep the toast fully opaque: {}",
+            anim.opacity
+        );
+    }
+
+    #[test]
+    fn anim_fades_out_after_hover_extends_past_nominal_life() {
+        // Review finding #2: a toast hovered past its nominal duration must
+        // still fade out over ANIM_OUT once the pointer leaves — not pop.
+        let created = Instant::now();
+        // Last hovered well past the 6s Info life (so age > total), and the
+        // hover ended long enough ago to be past HOVER_HOLD but partway into
+        // the ANIM_OUT fade.
+        let total = ToastKind::Info.default_duration();
+        let hover_end = created + total + Duration::from_secs(5);
+        let toast = anim_test_toast(created, Some(hover_end));
+
+        // Just after HOVER_HOLD ends: nearly fully opaque, fading.
+        let early = hover_end + HOVER_HOLD + Duration::from_millis(20);
+        let a_early = toast.anim(early);
+        assert!(
+            a_early.opacity > 0.8 && a_early.opacity < 1.0,
+            "fade just started: {}",
+            a_early.opacity
+        );
+        assert!(!toast.is_expired(early), "must still be alive while fading");
+
+        // Near the end of the fade window: nearly transparent.
+        let fade_span =
+            HOVER_HOLD.saturating_add(ANIM_OUT.saturating_sub(Duration::from_millis(20)));
+        let late = hover_end + fade_span;
+        let a_late = toast.anim(late);
+        assert!(
+            a_late.opacity < 0.2,
+            "fade nearly complete: {}",
+            a_late.opacity
+        );
+
+        // Opacity decreases monotonically as the fade progresses.
+        assert!(
+            a_late.opacity < a_early.opacity,
+            "fade progresses: early={} late={}",
+            a_early.opacity,
+            a_late.opacity
+        );
+
+        // After the full fade window, it is removed.
+        let done = hover_end + HOVER_HOLD + ANIM_OUT + Duration::from_millis(10);
+        assert!(toast.is_expired(done), "removed only after the fade");
+    }
+
+    // -----------------------------------------------------------------
+    //  ToastKind::icon / semantic
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn icon_maps_error_and_warning_to_warning_glyph() {
+        assert_eq!(ToastKind::Error.icon(), ChromeIcon::Warning);
+        assert_eq!(ToastKind::Warning.icon(), ChromeIcon::Warning);
+    }
+
+    #[test]
+    fn icon_maps_info_to_bell_glyph() {
+        assert_eq!(ToastKind::Info.icon(), ChromeIcon::Bell);
+    }
+
+    // -----------------------------------------------------------------
+    //  layout_toasts — pure geometry
+    // -----------------------------------------------------------------
+
+    const SETTLED_ANIM: ToastAnim = ToastAnim {
+        opacity: 1.0,
+        slide_x: 0.0,
+        scale: 1.0,
+    };
+
+    const ENTRY_ANIM: ToastAnim = ToastAnim {
+        opacity: 0.0,
+        slide_x: SLIDE_IN_PTS,
+        scale: SCALE_IN,
+    };
+
+    /// Build a [`ToastLayoutInput`] from simple numbers, so layout tests
+    /// never need real shaping/rasterisation.
+    fn test_input(
+        id: u64,
+        label_width: f32,
+        has_detail: bool,
+        anim: ToastAnim,
+    ) -> ToastLayoutInput {
+        ToastLayoutInput {
+            id,
+            kind: ToastKind::Info,
+            label_text: "Info: hello".to_owned(),
+            label_size_px: 16.0,
+            label: ToastTextMetrics {
+                width: label_width,
+                height: 20.0,
+                ascent: 15.0,
+            },
+            detail_text: if has_detail {
+                "detail line".to_owned()
+            } else {
+                String::new()
+            },
+            detail_size_px: 13.0,
+            detail: ToastTextMetrics {
+                width: 80.0,
+                height: 16.0,
+                ascent: 12.0,
+            },
+            has_detail,
+            icon_size_px: 16.0,
+            icon: ToastTextMetrics {
+                width: 16.0,
+                height: 16.0,
+                ascent: 12.0,
+            },
+            close_size_px: 16.0,
+            close: ToastTextMetrics {
+                width: 16.0,
+                height: 16.0,
+                ascent: 12.0,
+            },
+            anim,
+        }
+    }
+
+    fn test_window_rect() -> egui::Rect {
+        egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(800.0, 600.0))
+    }
+
+    #[test]
+    fn top_right_stack_places_second_toast_below_first() {
+        let inputs = [
+            test_input(0, 100.0, false, SETTLED_ANIM),
+            test_input(1, 100.0, false, SETTLED_ANIM),
+        ];
+        let geom = ToastGeometry {
+            window_rect: test_window_rect(),
+            active_pane_rect: None,
+        };
+        let visuals = egui::Visuals::dark();
+        let out = layout_toasts(&inputs, ToastPosition::TopRightStack, geom, &visuals, 1.0);
+
+        assert_eq!(out.len(), 2);
+        let gap = TOAST_STACK_GAP_PTS; // ppp == 1.0
+        assert!(
+            (out[1].pill.y - out[0].pill.y - (out[0].pill.height + gap)).abs() < 0.01,
+            "second toast must sit `height + gap` below the first: {} vs {}",
+            out[1].pill.y,
+            out[0].pill.y + out[0].pill.height + gap
+        );
+
+        // Both right edges align near the window's right edge.
+        let right0 = out[0].pill.x + out[0].pill.width;
+        let right1 = out[1].pill.x + out[1].pill.width;
+        assert!((right0 - right1).abs() < 0.01);
+        let expected_right = test_window_rect().max.x - STACK_RIGHT_INSET_PTS;
+        assert!((right0 - expected_right).abs() < 0.01);
+    }
+
+    #[test]
+    fn wider_label_produces_wider_pill_up_to_clamp() {
+        let geom = ToastGeometry {
+            window_rect: test_window_rect(),
+            active_pane_rect: None,
+        };
+        let visuals = egui::Visuals::dark();
+
+        let narrow = layout_toasts(
+            &[test_input(0, 50.0, false, SETTLED_ANIM)],
+            ToastPosition::TopRightStack,
+            geom,
+            &visuals,
+            1.0,
+        );
+        let wide = layout_toasts(
+            &[test_input(0, 200.0, false, SETTLED_ANIM)],
+            ToastPosition::TopRightStack,
+            geom,
+            &visuals,
+            1.0,
+        );
+        assert!(wide[0].pill.width > narrow[0].pill.width);
+
+        // An extremely long label must clamp to the max pill width.
+        let huge = layout_toasts(
+            &[test_input(0, 10_000.0, false, SETTLED_ANIM)],
+            ToastPosition::TopRightStack,
+            geom,
+            &visuals,
+            1.0,
+        );
+        assert!((huge[0].pill.width - MAX_PILL_WIDTH_PTS).abs() < 0.01);
+    }
+
+    #[test]
+    fn detail_line_adds_height() {
+        let geom = ToastGeometry {
+            window_rect: test_window_rect(),
+            active_pane_rect: None,
+        };
+        let visuals = egui::Visuals::dark();
+
+        let without = layout_toasts(
+            &[test_input(0, 100.0, false, SETTLED_ANIM)],
+            ToastPosition::TopRightStack,
+            geom,
+            &visuals,
+            1.0,
+        );
+        let with_detail = layout_toasts(
+            &[test_input(0, 100.0, true, SETTLED_ANIM)],
+            ToastPosition::TopRightStack,
+            geom,
+            &visuals,
+            1.0,
+        );
+        assert!(with_detail[0].pill.height > without[0].pill.height);
+        // Detail run must actually be emitted; every toast also gets a
+        // trailing dismiss-glyph run.
+        assert_eq!(
+            with_detail[0].runs.len(),
+            4,
+            "icon + label + detail + close"
+        );
+        assert_eq!(without[0].runs.len(), 3, "icon + label + close only");
+    }
+
+    #[test]
+    fn entry_animation_starts_transparent_and_displaced() {
+        let geom = ToastGeometry {
+            window_rect: test_window_rect(),
+            active_pane_rect: None,
+        };
+        let visuals = egui::Visuals::dark();
+
+        let entry = layout_toasts(
+            &[test_input(0, 100.0, false, ENTRY_ANIM)],
+            ToastPosition::TopRightStack,
+            geom,
+            &visuals,
+            1.0,
+        );
+        let settled = layout_toasts(
+            &[test_input(0, 100.0, false, SETTLED_ANIM)],
+            ToastPosition::TopRightStack,
+            geom,
+            &visuals,
+            1.0,
+        );
+
+        assert!(entry[0].pill.opacity.abs() < f32::EPSILON);
+        assert!(
+            entry[0].pill.x > settled[0].pill.x,
+            "entry pill (x={}) must be displaced right of the settled pill (x={})",
+            entry[0].pill.x,
+            settled[0].pill.x
+        );
+        for run in &entry[0].runs {
+            assert!(
+                run.color[3].abs() < f32::EPSILON,
+                "entry text must be transparent"
+            );
+        }
+        assert!(settled[0].pill.x.is_finite());
+        assert!((settled[0].pill.opacity - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn settled_animation_is_unslid_and_opaque() {
+        let geom = ToastGeometry {
+            window_rect: test_window_rect(),
+            active_pane_rect: None,
+        };
+        let visuals = egui::Visuals::dark();
+        let out = layout_toasts(
+            &[test_input(0, 100.0, false, SETTLED_ANIM)],
+            ToastPosition::TopRightStack,
+            geom,
+            &visuals,
+            1.0,
+        );
+        assert!((out[0].pill.opacity - 1.0).abs() < f32::EPSILON);
+        // The icon/label/detail runs are fully opaque when settled; the
+        // trailing dismiss-glyph run is intentionally dimmed to read as a
+        // secondary affordance (see `build_text_runs`), so it is checked
+        // separately: still visible, but strictly less opaque.
+        let (close_run, primary_runs) = out[0].runs.split_last().expect("at least one run");
+        for run in primary_runs {
+            assert!((run.color[3] - 1.0).abs() < f32::EPSILON);
+        }
+        assert!(
+            close_run.color[3] > 0.0,
+            "close glyph must still be visible"
+        );
+        assert!(
+            close_run.color[3] < 1.0,
+            "close glyph is dimmed relative to primary text"
+        );
+    }
+
+    #[test]
+    fn window_centered_centers_pill_in_window_rect() {
+        let window_rect = test_window_rect();
+        let geom = ToastGeometry {
+            window_rect,
+            active_pane_rect: None,
+        };
+        let visuals = egui::Visuals::dark();
+        let out = layout_toasts(
+            &[test_input(0, 100.0, false, SETTLED_ANIM)],
+            ToastPosition::WindowCentered,
+            geom,
+            &visuals,
+            1.0,
+        );
+        let pill = &out[0].pill;
+        let center_x = pill.x + pill.width / 2.0;
+        let center_y = pill.y + pill.height / 2.0;
+        assert!((center_x - window_rect.center().x).abs() < 0.01);
+        assert!((center_y - window_rect.center().y).abs() < 0.01);
+    }
+
+    #[test]
+    fn pane_centered_uses_active_pane_rect() {
+        let window_rect = test_window_rect();
+        let pane_rect =
+            egui::Rect::from_min_size(egui::pos2(400.0, 300.0), egui::vec2(400.0, 300.0));
+        let geom = ToastGeometry {
+            window_rect,
+            active_pane_rect: Some(pane_rect),
+        };
+        let visuals = egui::Visuals::dark();
+        let out = layout_toasts(
+            &[test_input(0, 100.0, false, SETTLED_ANIM)],
+            ToastPosition::PaneCentered,
+            geom,
+            &visuals,
+            1.0,
+        );
+        let pill = &out[0].pill;
+        let center_x = pill.x + pill.width / 2.0;
+        let center_y = pill.y + pill.height / 2.0;
+        assert!((center_x - pane_rect.center().x).abs() < 0.01);
+        assert!((center_y - pane_rect.center().y).abs() < 0.01);
+        // Sanity: the pane center differs from the window center in this test.
+        assert!((pane_rect.center().x - window_rect.center().x).abs() > 1.0);
+    }
+
+    #[test]
+    fn pane_centered_falls_back_to_window_rect_when_no_active_pane() {
+        let window_rect = test_window_rect();
+        let geom = ToastGeometry {
+            window_rect,
+            active_pane_rect: None,
+        };
+        let visuals = egui::Visuals::dark();
+        let out = layout_toasts(
+            &[test_input(0, 100.0, false, SETTLED_ANIM)],
+            ToastPosition::PaneCentered,
+            geom,
+            &visuals,
+            1.0,
+        );
+        let pill = &out[0].pill;
+        let center_x = pill.x + pill.width / 2.0;
+        let center_y = pill.y + pill.height / 2.0;
+        assert!((center_x - window_rect.center().x).abs() < 0.01);
+        assert!((center_y - window_rect.center().y).abs() < 0.01);
+    }
+
+    #[test]
+    fn hit_rect_logical_divides_out_pixels_per_point() {
+        let ppp = 2.0;
+        let geom = ToastGeometry {
+            window_rect: test_window_rect(),
+            active_pane_rect: None,
+        };
+        let visuals = egui::Visuals::dark();
+        let out = layout_toasts(
+            &[test_input(0, 100.0, false, SETTLED_ANIM)],
+            ToastPosition::TopRightStack,
+            geom,
+            &visuals,
+            ppp,
+        );
+        let pill = &out[0].pill;
+        let hit = out[0].hit_rect_logical;
+        assert!((hit[0] - pill.x / ppp).abs() < 0.01);
+        assert!((hit[1] - pill.y / ppp).abs() < 0.01);
+        assert!((hit[2] - (pill.x + pill.width) / ppp).abs() < 0.01);
+        assert!((hit[3] - (pill.y + pill.height) / ppp).abs() < 0.01);
+    }
+
+    #[test]
+    fn output_id_matches_input_id() {
+        let geom = ToastGeometry {
+            window_rect: test_window_rect(),
+            active_pane_rect: None,
+        };
+        let visuals = egui::Visuals::dark();
+        let inputs = [
+            test_input(42, 100.0, false, SETTLED_ANIM),
+            test_input(7, 100.0, false, SETTLED_ANIM),
+        ];
+        let out = layout_toasts(&inputs, ToastPosition::TopRightStack, geom, &visuals, 1.0);
+        assert_eq!(out[0].id, 42);
+        assert_eq!(out[1].id, 7);
+    }
+
+    #[test]
+    fn close_glyph_run_sits_inside_the_pill_near_the_right_padding() {
+        let geom = ToastGeometry {
+            window_rect: test_window_rect(),
+            active_pane_rect: None,
+        };
+        let visuals = egui::Visuals::dark();
+        let ppp = 1.0;
+        let out = layout_toasts(
+            &[test_input(0, 100.0, false, SETTLED_ANIM)],
+            ToastPosition::TopRightStack,
+            geom,
+            &visuals,
+            ppp,
+        );
+        let pill = &out[0].pill;
+        // icon + label + close, in that order (no detail on this toast).
+        assert_eq!(out[0].runs.len(), 3, "icon + label + close");
+        let close_run = &out[0].runs[2];
+        assert_eq!(
+            close_run.text,
+            ChromeIcon::Close.glyph(),
+            "final run is the dismiss glyph"
+        );
+
+        let pill_left = pill.x;
+        let pill_right = pill.x + pill.width;
+        let pill_top = pill.y;
+        let pill_bottom = pill.y + pill.height;
+
+        // The close glyph sits right of the label origin, within the pill's
+        // horizontal extent, and inset from the pill's right edge (the
+        // padding reserved for the dismiss button).
+        let label_run = &out[0].runs[1];
+        assert!(
+            close_run.origin_x > label_run.origin_x,
+            "close glyph is right of the label"
+        );
+        assert!(close_run.origin_x > pill_left, "close glyph inside pill");
+        assert!(
+            close_run.origin_x < pill_right,
+            "close glyph inset from the pill's right edge"
+        );
+        assert!(close_run.baseline_y >= pill_top);
+        assert!(close_run.baseline_y <= pill_bottom);
+    }
+
+    #[test]
+    fn empty_input_produces_empty_output() {
+        let geom = ToastGeometry {
+            window_rect: test_window_rect(),
+            active_pane_rect: None,
+        };
+        let visuals = egui::Visuals::dark();
+        assert!(layout_toasts(&[], ToastPosition::TopRightStack, geom, &visuals, 1.0).is_empty());
+    }
+
+    // -----------------------------------------------------------------
+    //  ToastStack::hit_test — click-anywhere-on-the-pill dismissal
+    // -----------------------------------------------------------------
+
+    /// Build layout outputs for a single settled error toast (helper for the
+    /// `topmost_hit` geometry tests). The interactive `hit_test` egui path
+    /// itself needs a live egui context and is verified manually; these tests
+    /// cover the pure hit-precedence geometry it relies on.
+    fn single_toast_outputs(id: u64) -> Vec<ToastLayoutOutput> {
+        let geom = ToastGeometry {
+            window_rect: test_window_rect(),
+            active_pane_rect: None,
+        };
+        let visuals = egui::Visuals::dark();
+        layout_toasts(
+            &[test_input(id, 100.0, false, SETTLED_ANIM)],
+            ToastPosition::TopRightStack,
+            geom,
+            &visuals,
+            1.0,
+        )
+    }
+
+    #[test]
+    fn topmost_hit_matches_a_click_anywhere_in_the_pill() {
+        let outputs = single_toast_outputs(7);
+        let pill = &outputs[0].pill;
+        // The pill's center — nowhere near the drawn "x" glyph at the right
+        // edge — must still match (the whole pill is the click target).
+        let center = egui::pos2(pill.x + pill.width / 2.0, pill.y + pill.height / 2.0);
+        assert_eq!(topmost_hit(&outputs, center), Some(7));
+    }
+
+    #[test]
+    fn topmost_hit_misses_a_click_outside_the_pill() {
+        let outputs = single_toast_outputs(7);
+        let pill = &outputs[0].pill;
+        let outside = egui::pos2(pill.x - 50.0, pill.y - 50.0);
+        assert_eq!(topmost_hit(&outputs, outside), None);
+    }
+
+    #[test]
+    fn topmost_hit_prefers_the_newest_toast_on_overlap() {
+        // Two toasts whose hit rects overlap; the newest (last in `outputs`,
+        // drawn on top) must win the overlap (review finding #4).
+        let older = ToastLayoutOutput {
+            id: 1,
+            pill: ToastQuad {
+                x: 0.0,
+                y: 0.0,
+                width: 10.0,
+                height: 10.0,
+                corner_radius: 0.0,
+                color_top: [0.0; 4],
+                color_bottom: [0.0; 4],
+                glow: [0.0; 4],
+                accent: [0.0; 4],
+                opacity: 1.0,
+            },
+            runs: Vec::new(),
+            hit_rect_logical: [0.0, 0.0, 100.0, 100.0],
+        };
+        let mut newer = older.clone();
+        newer.id = 2;
+        newer.hit_rect_logical = [50.0, 50.0, 150.0, 150.0];
+        let outputs = vec![older, newer];
+        // A point inside both rects must resolve to the newer toast (id 2).
+        assert_eq!(topmost_hit(&outputs, egui::pos2(75.0, 75.0)), Some(2));
+        // A point only in the older rect resolves to it.
+        assert_eq!(topmost_hit(&outputs, egui::pos2(10.0, 10.0)), Some(1));
+    }
+
+    // -----------------------------------------------------------------
+    //  Pure color helpers
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn color32_to_rgba_is_straight_normalized() {
+        let c = egui::Color32::from_rgba_unmultiplied(255, 128, 0, 64);
+        let rgba = color32_to_rgba(c);
+        assert!((rgba[0] - 1.0).abs() < f32::EPSILON);
+        assert!((rgba[1] - 128.0 / 255.0).abs() < f32::EPSILON);
+        assert!(rgba[2].abs() < f32::EPSILON);
+        assert!((rgba[3] - 64.0 / 255.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn lighten_shifts_rgb_and_clamps_leaving_alpha_untouched() {
+        let base = [0.5, 0.5, 0.5, 0.9];
+        let lighter = lighten(base, 0.4);
+        assert!((lighter[0] - 0.9).abs() < f32::EPSILON);
+        assert!((lighter[3] - 0.9).abs() < f32::EPSILON);
+
+        let clamped = lighten(base, 10.0);
+        assert!((clamped[0] - 1.0).abs() < f32::EPSILON);
+
+        let darker = lighten(base, -10.0);
+        assert!(darker[0].abs() < f32::EPSILON);
     }
 }

--- a/freminal/src/gui/toast.rs
+++ b/freminal/src/gui/toast.rs
@@ -357,7 +357,7 @@ pub(super) struct ToastAnim {
 // on the main thread, calls `layout_toasts`, and hands the resulting
 // `ToastQuad`/`ToastTextRun` data to a single `PaintCallback`.
 
-use super::renderer::{ToastQuad, ToastTextMetrics, ToastTextRun};
+use super::renderer::{ToastQuad, ToastTextMetrics, ToastTextRenderer, ToastTextRun};
 
 /// Inner padding between a pill's edge and its content, logical points.
 const PILL_PAD_X_PTS: f32 = 14.0;
@@ -412,8 +412,13 @@ pub(super) enum ToastPosition {
 /// rects live in).
 #[derive(Debug, Clone, Copy)]
 pub(super) struct ToastGeometry {
-    /// The full window rect.
-    pub window_rect: egui::Rect,
+    /// The central-panel content rect — the terminal area, i.e. the window
+    /// *minus* the menu/tab chrome (it is `win.cached_central_rect`). This is
+    /// deliberately not the full OS-window rect: toasts anchor within the
+    /// content area so they never overlap chrome, and a future
+    /// [`ToastPosition::WindowCentered`] caller centers within this content
+    /// rect, not the whole window.
+    pub content_rect: egui::Rect,
     /// The currently-active pane's rect, if known. Consulted only by
     /// [`ToastPosition::PaneCentered`].
     pub active_pane_rect: Option<egui::Rect>,
@@ -439,14 +444,19 @@ pub(super) struct ToastLayoutInput {
     pub id: u64,
     /// The toast's severity — drives color and icon.
     pub kind: ToastKind,
-    /// The exact `"Kind: title"` label string that was measured.
+    /// The exact `"Kind: title"` label string that was measured — already
+    /// whitespace-normalized and, if it would otherwise overflow the pill,
+    /// truncated with a trailing ellipsis (see [`fit_text`]). This is *the*
+    /// string handed to the emitted [`ToastTextRun`], so it is guaranteed to
+    /// fit the width [`Self::label`] (below) reports.
     pub label_text: String,
     /// The physical pixel size `label_text` was measured/rasterized at.
     pub label_size_px: f32,
     /// Measured `label_text`, in **physical** pixels (see [`ToastTextMetrics`]).
     pub label: ToastTextMetrics,
-    /// The exact detail string that was measured. Empty when `has_detail`
-    /// is `false`.
+    /// The exact detail string that was measured — already
+    /// whitespace-normalized and fitted the same way as [`Self::label_text`]
+    /// (see [`fit_text`]). Empty when `has_detail` is `false`.
     pub detail_text: String,
     /// The physical pixel size `detail_text` was measured/rasterized at.
     pub detail_size_px: f32,
@@ -529,6 +539,105 @@ fn lighten(rgba: [f32; 4], amount: f32) -> [f32; 4] {
     ]
 }
 
+/// Available width, in physical pixels, for the label/detail text portion
+/// of a toast pill, given a measured `icon_width`.
+///
+/// This mirrors the exact non-text geometry [`settled_pill_size`] subtracts
+/// from [`MAX_PILL_WIDTH_PTS`] to derive its clamped pill width. It is used
+/// by [`ToastStack::measure_inputs`] to fit (truncate + ellipsize, see
+/// [`fit_text`]) the label/detail strings *before* they are measured for
+/// pill sizing, so `settled_pill_size` and the emitted [`ToastTextRun`]s
+/// always agree on how wide the text is — the regression this fixes: the
+/// pill width was clamped, but the un-truncated text was still measured
+/// (and rendered) past that clamp, all the way to the window edge.
+fn text_width_budget(icon_width: f32, ppp: f32) -> f32 {
+    let pad_x = PILL_PAD_X_PTS * ppp;
+    let icon_label_gap = ICON_LABEL_GAP_PTS * ppp;
+    let label_close_gap = LABEL_CLOSE_GAP_PTS * ppp;
+    let close_size = CLOSE_SIZE_PTS * ppp;
+    let max_pill_width = MAX_PILL_WIDTH_PTS * ppp;
+    let non_text_width = pad_x.mul_add(
+        2.0,
+        icon_width + icon_label_gap + label_close_gap + close_size,
+    );
+    max_pill_width - non_text_width
+}
+
+/// Collapse embedded newlines and other whitespace runs (`\n`, `\r`, `\t`,
+/// runs of plain spaces, ...) to a single space, and trim the result.
+///
+/// Toast text runs are shaped as a single line (see the module's
+/// single-face-per-run docs in `renderer::toast_text_pass`), so raw
+/// multi-line input — a shader compile log, a layout/session error
+/// carrying a multi-line path — must never reach a [`ToastTextRun`] with
+/// its newlines intact: they would shape as tofu/invisible glyphs rather
+/// than an actual line break.
+fn normalize_ws(raw: &str) -> String {
+    raw.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Fit `raw` for display as a single-line toast text run within
+/// `max_width` physical pixels: normalize embedded whitespace (see
+/// [`normalize_ws`]), then, if the normalized text still measures wider
+/// than `max_width`, truncate it on a char boundary and append a trailing
+/// ellipsis ("…") — binary-searching the longest char-prefix that still
+/// fits alongside the ellipsis, since width is monotonically
+/// non-decreasing in prefix length.
+///
+/// Returns the (possibly-truncated) string together with its own measured
+/// [`ToastTextMetrics`]. Callers MUST use both the returned string (in the
+/// emitted [`ToastTextRun`]) and the returned metrics (for pill sizing) —
+/// never the original `raw` text — so the pill's width and the text
+/// actually drawn can never disagree.
+///
+/// **Must be called on the main thread** — like [`ToastTextRenderer::measure`]
+/// itself, it takes `&mut FontManager`.
+fn fit_text(
+    renderer: &ToastTextRenderer,
+    raw: &str,
+    size_px: f32,
+    max_width: f32,
+    font_manager: &mut FontManager,
+) -> (String, ToastTextMetrics) {
+    let normalized = normalize_ws(raw);
+    let metrics = renderer.measure(&normalized, size_px, font_manager);
+    if metrics.width <= max_width {
+        return (normalized, metrics);
+    }
+
+    let ellipsis_metrics = renderer.measure("…", size_px, font_manager);
+    if ellipsis_metrics.width > max_width {
+        // Nothing shorter to try — even a bare ellipsis doesn't fit. Return
+        // it anyway (best effort); the caller floors `max_width` at this
+        // same width for the label/detail budget it passes in, so this is
+        // only reachable via a mismatched budget (e.g. a different, larger
+        // font size than the one `max_width` was floored against).
+        return ("…".to_owned(), ellipsis_metrics);
+    }
+
+    let chars: Vec<char> = normalized.chars().collect();
+    // Binary search the longest char-prefix length `p` in `0..=chars.len()`
+    // such that `chars[..p]` plus a trailing ellipsis still fits
+    // `max_width`. `lo` always holds a known-fitting length — `0` fits,
+    // since the bare ellipsis was just confirmed to fit above — and `best`
+    // is kept in lock-step with `lo` so the loop can return it directly.
+    let mut lo = 0_usize;
+    let mut hi = chars.len();
+    let mut best = ("…".to_owned(), ellipsis_metrics);
+    while lo < hi {
+        let mid = lo + (hi - lo).div_ceil(2);
+        let candidate: String = chars[..mid].iter().collect::<String>() + "…";
+        let candidate_metrics = renderer.measure(&candidate, size_px, font_manager);
+        if candidate_metrics.width <= max_width {
+            best = (candidate, candidate_metrics);
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    best
+}
+
 /// The settled (pre-animation) pill width/height, in physical pixels, for
 /// one toast's measured content.
 fn settled_pill_size(input: &ToastLayoutInput, ppp: f32) -> (f32, f32) {
@@ -594,7 +703,7 @@ fn settled_origins(
 
     match position {
         ToastPosition::TopRightStack => {
-            let (_, win_min_y, win_max_x, _) = rect_for(geom.window_rect);
+            let (_, win_min_y, win_max_x, _) = rect_for(geom.content_rect);
             let base_y = STACK_TOP_INSET_PTS.mul_add(ppp, win_min_y);
             let right_edge = STACK_RIGHT_INSET_PTS.mul_add(-ppp, win_max_x);
             sizes
@@ -604,7 +713,7 @@ fn settled_origins(
                 .collect()
         }
         ToastPosition::WindowCentered => {
-            let (win_min_x, win_min_y, win_max_x, win_max_y) = rect_for(geom.window_rect);
+            let (win_min_x, win_min_y, win_max_x, win_max_y) = rect_for(geom.content_rect);
             let center_x = win_min_x.midpoint(win_max_x);
             let base_y = win_min_y.midpoint(win_max_y) - total_height / 2.0;
             sizes
@@ -614,7 +723,7 @@ fn settled_origins(
                 .collect()
         }
         ToastPosition::PaneCentered => {
-            let pane_rect = geom.active_pane_rect.unwrap_or(geom.window_rect);
+            let pane_rect = geom.active_pane_rect.unwrap_or(geom.content_rect);
             let (pane_min_x, pane_min_y, pane_max_x, pane_max_y) = rect_for(pane_rect);
             let center_x = pane_min_x.midpoint(pane_max_x);
             let base_y = pane_min_y.midpoint(pane_max_y) - total_height / 2.0;
@@ -901,6 +1010,23 @@ pub(super) struct ToastStack {
 /// Maximum simultaneous toasts.  Older ones are evicted.
 const MAX_TOASTS: usize = 5;
 
+/// The font sizes (physical pixels) and `pixels_per_point` scale
+/// [`ToastStack::measure_inputs`] needs, bundled into one struct so that
+/// function stays under the `too_many_arguments` limit.
+#[derive(Debug, Clone, Copy)]
+struct ToastMeasureSizes {
+    /// Physical pixel size the label is rasterized at.
+    label_size_px: f32,
+    /// Physical pixel size the detail line is rasterized at.
+    detail_size_px: f32,
+    /// Physical pixel size the icon glyph is rasterized at.
+    icon_size_px: f32,
+    /// `pixels_per_point`, needed to convert the logical-point pill-geometry
+    /// constants into the same physical-pixel space the measured text
+    /// widths live in (see [`text_width_budget`]).
+    ppp: f32,
+}
+
 impl ToastStack {
     /// Push a new error toast onto the stack.
     pub(super) fn error(&mut self, title: impl Into<String>, detail: Option<String>) {
@@ -977,6 +1103,12 @@ impl ToastStack {
         let label_size_px = Self::LABEL_SIZE_PTS * ppp;
         let detail_size_px = Self::DETAIL_SIZE_PTS * ppp;
         let icon_size_px = label_size_px;
+        let sizes = ToastMeasureSizes {
+            label_size_px,
+            detail_size_px,
+            icon_size_px,
+            ppp,
+        };
 
         // Measure + shape every toast's text on the main thread; the lock is
         // held only for the duration of this call — no GL is touched.
@@ -984,19 +1116,12 @@ impl ToastStack {
             let rs = render_state
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            self.measure_inputs(
-                &rs,
-                font_manager,
-                label_size_px,
-                detail_size_px,
-                icon_size_px,
-                now,
-            )
+            self.measure_inputs(&rs, font_manager, sizes, now)
         };
 
         // `layout_toasts` emits window-origin-absolute physical-pixel
-        // coordinates (it scales `geom.window_rect` directly, without
-        // subtracting `window_rect.min`) — see its own field docs. The
+        // coordinates (it scales `geom.content_rect` directly, without
+        // subtracting `content_rect.min`) — see its own field docs. The
         // `PaintCallback` registered by `paint_toasts` below uses
         // `rect: ctx.content_rect()` (the full window, origin `(0,0)`), so
         // its GL viewport starts at the window's own origin and these
@@ -1052,15 +1177,26 @@ impl ToastStack {
     /// [`ToastLayoutInput`]s [`layout_toasts`] needs plus whether any toast
     /// is currently mid-animation (entry or exit). Split out of
     /// [`Self::show`] to keep it under the line-count limit.
+    ///
+    /// The label/detail text is fit to the available pill content width
+    /// (see [`text_width_budget`] / [`fit_text`]) *before* being measured
+    /// here, so the metrics stored on the returned [`ToastLayoutInput`] —
+    /// and therefore both [`settled_pill_size`] and the emitted
+    /// [`ToastTextRun`]s — always describe the exact same (possibly
+    /// truncated + ellipsized) string.
     fn measure_inputs(
         &self,
         rs: &ToastRenderState,
         font_manager: &mut FontManager,
-        label_size_px: f32,
-        detail_size_px: f32,
-        icon_size_px: f32,
+        sizes: ToastMeasureSizes,
         now: Instant,
     ) -> (Vec<ToastLayoutInput>, bool) {
+        let ToastMeasureSizes {
+            label_size_px,
+            detail_size_px,
+            icon_size_px,
+            ppp,
+        } = sizes;
         let mut inputs = Vec::with_capacity(self.entries.len());
         let mut any_animating = false;
         for toast in &self.entries {
@@ -1070,21 +1206,52 @@ impl ToastStack {
             let icon_text = toast.kind.icon().glyph();
             let close_text = ChromeIcon::Close.glyph();
 
-            let label = rs.text.measure(&label_text, label_size_px, font_manager);
-            let detail = if has_detail {
-                rs.text.measure(&detail_text, detail_size_px, font_manager)
-            } else {
-                ToastTextMetrics {
-                    width: 0.0,
-                    height: 0.0,
-                    ascent: 0.0,
-                }
-            };
+            // Icon and close glyph are single fixed glyphs (never
+            // user-controlled text), so they are measured as-is — only
+            // label/detail (arbitrary, possibly very long, possibly
+            // multi-line, user/program-controlled text) go through
+            // `fit_text`. The icon must be measured first: its width feeds
+            // `text_width_budget`.
             let icon = rs.text.measure(&icon_text, icon_size_px, font_manager);
             // Rasterized at the same size as the kind icon, for visual
             // consistency between the leading icon and the trailing "x".
             let close_size_px = icon_size_px;
             let close = rs.text.measure(&close_text, close_size_px, font_manager);
+
+            let raw_budget = text_width_budget(icon.width, ppp);
+            // Floor the budget at the width of a single ellipsis glyph
+            // (measured at the label's, generally larger, font size) so a
+            // pathological input (a tiny window, an oversized icon glyph)
+            // still leaves `fit_text` a positive width to terminate
+            // against, rather than a zero/negative budget.
+            let ellipsis_floor = rs.text.measure("…", label_size_px, font_manager).width;
+            let text_budget = raw_budget.max(ellipsis_floor).max(1.0);
+
+            let (label_text, label) = fit_text(
+                &rs.text,
+                &label_text,
+                label_size_px,
+                text_budget,
+                font_manager,
+            );
+            let (detail_text, detail) = if has_detail {
+                fit_text(
+                    &rs.text,
+                    &detail_text,
+                    detail_size_px,
+                    text_budget,
+                    font_manager,
+                )
+            } else {
+                (
+                    detail_text,
+                    ToastTextMetrics {
+                        width: 0.0,
+                        height: 0.0,
+                        ascent: 0.0,
+                    },
+                )
+            };
 
             let anim = toast.anim(now);
             if anim.opacity < 1.0 || anim.slide_x.abs() > f32::EPSILON || anim.scale < 1.0 {
@@ -1131,32 +1298,37 @@ impl ToastStack {
         outputs: &[ToastLayoutOutput],
         now: Instant,
     ) -> Vec<u64> {
-        // Allocate an interactive click region per toast so egui consumes any
-        // click that lands on a toast (keeping it off the terminal). egui's
-        // own arbitration reports the click on whichever region it picked; we
-        // additionally derive the hover target and the (single, topmost)
+        // Allocate one interactive `Area` PER TOAST, each sized and positioned
+        // exactly to its pill's hit rect, so egui consumes a click that lands
+        // on a toast (keeping it off the terminal). Deliberately NOT a single
+        // window-spanning area anchored at the origin: egui 0.35's cross-layer
+        // hit-test hides a lower-layer widget whose rect is fully contained by
+        // a higher-layer one, so a full-window interactive area would suppress
+        // interaction with the chrome beneath it. Tight per-toast areas only
+        // cover the pills.
+        //
+        // egui's own arbitration reports the click on whichever area it picked;
+        // we additionally derive the hover target and the single, topmost
         // dismiss target from the pointer position via `topmost_hit`, so the
         // overlap-precedence rule has one tested source of truth.
         let mut any_clicked = false;
-        let pointer = egui::Area::new(egui::Id::new("toast_interaction"))
-            .order(egui::Order::Foreground)
-            .interactable(true)
-            .fixed_pos(egui::Pos2::ZERO)
-            .show(ctx, |ui| {
-                for out in outputs {
-                    let [min_x, min_y, max_x, max_y] = out.hit_rect_logical;
-                    let rect = egui::Rect::from_min_max(
-                        egui::pos2(min_x, min_y),
-                        egui::pos2(max_x, max_y),
-                    );
-                    if ui.allocate_rect(rect, egui::Sense::click()).clicked() {
-                        any_clicked = true;
-                    }
-                }
-                ui.input(|i| i.pointer.hover_pos())
-            })
-            .inner;
+        for (i, out) in outputs.iter().enumerate() {
+            let [min_x, min_y, max_x, max_y] = out.hit_rect_logical;
+            let rect = egui::Rect::from_min_max(egui::pos2(min_x, min_y), egui::pos2(max_x, max_y));
+            let clicked = egui::Area::new(egui::Id::new(("toast_interaction", i)))
+                .order(egui::Order::Foreground)
+                .interactable(true)
+                .fixed_pos(rect.min)
+                .show(ctx, |ui| {
+                    ui.allocate_rect(rect, egui::Sense::click()).clicked()
+                })
+                .inner;
+            if clicked {
+                any_clicked = true;
+            }
+        }
 
+        let pointer = ctx.input(|i| i.pointer.hover_pos());
         let Some(pos) = pointer else {
             return Vec::new();
         };
@@ -1542,6 +1714,164 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    //  normalize_ws / fit_text — single-line truncation (regression: the
+    //  pill's width was clamped but the label/detail text was not, so long
+    //  text rendered straight past the pill's right edge; see the `fit_text`
+    //  doc comment).
+    // -----------------------------------------------------------------
+
+    /// A real `FontManager`, exactly as `renderer::toast_text_pass`'s own
+    /// `measure`/`build_instances` test suite constructs one — `fit_text`
+    /// calls `ToastTextRenderer::measure`, which needs real shaping.
+    fn test_font_manager() -> FontManager {
+        FontManager::new(&freminal_common::config::Config::default(), 1.0).unwrap()
+    }
+
+    #[test]
+    fn normalize_ws_collapses_embedded_newlines_and_trims() {
+        // A raw multi-line shader-compile-log-shaped string, the real
+        // trigger for this regression (`push_error_toast("Shader error",
+        // Some(multi_line_glsl_log))`).
+        let raw = "  line one\nline two\r\n\tline three  ";
+        assert_eq!(normalize_ws(raw), "line one line two line three");
+    }
+
+    #[test]
+    fn normalize_ws_leaves_single_line_text_unchanged() {
+        assert_eq!(normalize_ws("Shader error"), "Shader error");
+    }
+
+    #[test]
+    fn fit_text_short_text_is_returned_unchanged() {
+        let renderer = ToastTextRenderer::new();
+        let mut fm = test_font_manager();
+        let (text, metrics) = fit_text(&renderer, "spawn failed", 14.0, 1000.0, &mut fm);
+        assert_eq!(text, "spawn failed");
+        assert!(!text.ends_with('…'));
+        assert!(metrics.width > 0.0);
+    }
+
+    #[test]
+    fn fit_text_long_text_truncates_with_ellipsis_within_budget() {
+        let renderer = ToastTextRenderer::new();
+        let mut fm = test_font_manager();
+        let long = "x".repeat(500);
+        let max_width = 100.0;
+        let (text, metrics) = fit_text(&renderer, &long, 14.0, max_width, &mut fm);
+        assert!(
+            text.ends_with('…'),
+            "truncated text must end in an ellipsis: {text:?}"
+        );
+        assert!(
+            text.chars().count() < long.chars().count(),
+            "truncated text must be shorter than the input"
+        );
+        assert!(
+            metrics.width <= max_width,
+            "truncated text ({}) must measure within the budget ({max_width})",
+            metrics.width
+        );
+    }
+
+    #[test]
+    fn fit_text_respects_char_boundaries_for_multibyte_text() {
+        let renderer = ToastTextRenderer::new();
+        let mut fm = test_font_manager();
+        // "é" is 2 bytes in UTF-8; a byte-index truncation would either
+        // panic or split the codepoint. Building `text` here at all (a
+        // `String`) already proves it is valid UTF-8.
+        let long = "é".repeat(200);
+        let (text, metrics) = fit_text(&renderer, &long, 14.0, 60.0, &mut fm);
+        assert!(text.ends_with('…'));
+        assert!(text.chars().all(|c| c == 'é' || c == '…'));
+        assert!(metrics.width <= 60.0);
+    }
+
+    #[test]
+    fn fit_text_normalizes_embedded_newlines_before_truncating() {
+        let renderer = ToastTextRenderer::new();
+        let mut fm = test_font_manager();
+        let raw = "line one\nline two\nline three";
+        let (text, _metrics) = fit_text(&renderer, raw, 14.0, 10_000.0, &mut fm);
+        assert!(!text.contains('\n'), "no newline should survive: {text:?}");
+        assert_eq!(text, "line one line two line three");
+    }
+
+    #[test]
+    fn fit_text_falls_back_to_bare_ellipsis_when_budget_only_fits_that() {
+        let renderer = ToastTextRenderer::new();
+        let mut fm = test_font_manager();
+        let ellipsis_width = renderer.measure("…", 14.0, &mut fm).width;
+        let (text, metrics) = fit_text(
+            &renderer,
+            "hello world, this is long",
+            14.0,
+            ellipsis_width,
+            &mut fm,
+        );
+        assert_eq!(text, "…");
+        assert!((metrics.width - ellipsis_width).abs() < f32::EPSILON);
+    }
+
+    // -----------------------------------------------------------------
+    //  measure_inputs — end-to-end: truncation keeps the pill within the
+    //  clamp, short toasts are unaffected.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn measure_inputs_leaves_a_short_toast_unchanged() {
+        let mut stack = ToastStack::default();
+        stack.error("short", None);
+        let rs = ToastRenderState::default();
+        let mut fm = test_font_manager();
+        let ppp = 1.0;
+        let sizes = ToastMeasureSizes {
+            label_size_px: ToastStack::LABEL_SIZE_PTS * ppp,
+            detail_size_px: ToastStack::DETAIL_SIZE_PTS * ppp,
+            icon_size_px: ToastStack::LABEL_SIZE_PTS * ppp,
+            ppp,
+        };
+        let (inputs, _any_animating) = stack.measure_inputs(&rs, &mut fm, sizes, Instant::now());
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0].label_text, "Error: short");
+        assert!(!inputs[0].label_text.ends_with('…'));
+    }
+
+    #[test]
+    fn measure_inputs_truncates_long_detail_and_pill_stays_within_max_width() {
+        let mut stack = ToastStack::default();
+        // A raw multi-line GLSL compile log, the real trigger path
+        // (`push_error_toast("Shader error", Some(msg))`) that produced the
+        // overflow this fixes.
+        let long_detail = "ERROR: 0:12: 'foo' : undeclared identifier\n".repeat(20);
+        stack.error("Shader error", Some(long_detail));
+        let rs = ToastRenderState::default();
+        let mut fm = test_font_manager();
+        let ppp = 1.0;
+        let sizes = ToastMeasureSizes {
+            label_size_px: ToastStack::LABEL_SIZE_PTS * ppp,
+            detail_size_px: ToastStack::DETAIL_SIZE_PTS * ppp,
+            icon_size_px: ToastStack::LABEL_SIZE_PTS * ppp,
+            ppp,
+        };
+        let (inputs, _any_animating) = stack.measure_inputs(&rs, &mut fm, sizes, Instant::now());
+        assert_eq!(inputs.len(), 1);
+        let input = &inputs[0];
+        assert!(
+            !input.detail_text.contains('\n'),
+            "no newline should survive into the emitted run: {:?}",
+            input.detail_text
+        );
+        assert!(input.detail_text.ends_with('…'));
+
+        let (width, _height) = settled_pill_size(input, ppp);
+        assert!(
+            width <= MAX_PILL_WIDTH_PTS.mul_add(ppp, 0.01),
+            "pill width ({width}) must stay within the max-width clamp"
+        );
+    }
+
+    // -----------------------------------------------------------------
     //  layout_toasts — pure geometry
     // -----------------------------------------------------------------
 
@@ -1614,7 +1944,7 @@ mod tests {
             test_input(1, 100.0, false, SETTLED_ANIM),
         ];
         let geom = ToastGeometry {
-            window_rect: test_window_rect(),
+            content_rect: test_window_rect(),
             active_pane_rect: None,
         };
         let visuals = egui::Visuals::dark();
@@ -1640,7 +1970,7 @@ mod tests {
     #[test]
     fn wider_label_produces_wider_pill_up_to_clamp() {
         let geom = ToastGeometry {
-            window_rect: test_window_rect(),
+            content_rect: test_window_rect(),
             active_pane_rect: None,
         };
         let visuals = egui::Visuals::dark();
@@ -1675,7 +2005,7 @@ mod tests {
     #[test]
     fn detail_line_adds_height() {
         let geom = ToastGeometry {
-            window_rect: test_window_rect(),
+            content_rect: test_window_rect(),
             active_pane_rect: None,
         };
         let visuals = egui::Visuals::dark();
@@ -1708,7 +2038,7 @@ mod tests {
     #[test]
     fn entry_animation_starts_transparent_and_displaced() {
         let geom = ToastGeometry {
-            window_rect: test_window_rect(),
+            content_rect: test_window_rect(),
             active_pane_rect: None,
         };
         let visuals = egui::Visuals::dark();
@@ -1748,7 +2078,7 @@ mod tests {
     #[test]
     fn settled_animation_is_unslid_and_opaque() {
         let geom = ToastGeometry {
-            window_rect: test_window_rect(),
+            content_rect: test_window_rect(),
             active_pane_rect: None,
         };
         let visuals = egui::Visuals::dark();
@@ -1782,7 +2112,7 @@ mod tests {
     fn window_centered_centers_pill_in_window_rect() {
         let window_rect = test_window_rect();
         let geom = ToastGeometry {
-            window_rect,
+            content_rect: window_rect,
             active_pane_rect: None,
         };
         let visuals = egui::Visuals::dark();
@@ -1806,7 +2136,7 @@ mod tests {
         let pane_rect =
             egui::Rect::from_min_size(egui::pos2(400.0, 300.0), egui::vec2(400.0, 300.0));
         let geom = ToastGeometry {
-            window_rect,
+            content_rect: window_rect,
             active_pane_rect: Some(pane_rect),
         };
         let visuals = egui::Visuals::dark();
@@ -1830,7 +2160,7 @@ mod tests {
     fn pane_centered_falls_back_to_window_rect_when_no_active_pane() {
         let window_rect = test_window_rect();
         let geom = ToastGeometry {
-            window_rect,
+            content_rect: window_rect,
             active_pane_rect: None,
         };
         let visuals = egui::Visuals::dark();
@@ -1852,7 +2182,7 @@ mod tests {
     fn hit_rect_logical_divides_out_pixels_per_point() {
         let ppp = 2.0;
         let geom = ToastGeometry {
-            window_rect: test_window_rect(),
+            content_rect: test_window_rect(),
             active_pane_rect: None,
         };
         let visuals = egui::Visuals::dark();
@@ -1874,7 +2204,7 @@ mod tests {
     #[test]
     fn output_id_matches_input_id() {
         let geom = ToastGeometry {
-            window_rect: test_window_rect(),
+            content_rect: test_window_rect(),
             active_pane_rect: None,
         };
         let visuals = egui::Visuals::dark();
@@ -1890,7 +2220,7 @@ mod tests {
     #[test]
     fn close_glyph_run_sits_inside_the_pill_near_the_right_padding() {
         let geom = ToastGeometry {
-            window_rect: test_window_rect(),
+            content_rect: test_window_rect(),
             active_pane_rect: None,
         };
         let visuals = egui::Visuals::dark();
@@ -1937,7 +2267,7 @@ mod tests {
     #[test]
     fn empty_input_produces_empty_output() {
         let geom = ToastGeometry {
-            window_rect: test_window_rect(),
+            content_rect: test_window_rect(),
             active_pane_rect: None,
         };
         let visuals = egui::Visuals::dark();
@@ -1954,7 +2284,7 @@ mod tests {
     /// cover the pure hit-precedence geometry it relies on.
     fn single_toast_outputs(id: u64) -> Vec<ToastLayoutOutput> {
         let geom = ToastGeometry {
-            window_rect: test_window_rect(),
+            content_rect: test_window_rect(),
             active_pane_rect: None,
         };
         let visuals = egui::Visuals::dark();

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -87,6 +87,13 @@ pub(super) struct PerWindowState {
     /// (in `gui::terminal::widget`) for the full rationale.
     pub(super) window_post: Arc<Mutex<WindowPostRenderer>>,
 
+    /// Per-window GL renderer state for the toast overlay (issue #433).
+    /// `Arc<Mutex<…>>` is GUI-thread interior mutability for the
+    /// `Send + Sync + 'static` `PaintCallback` capture (mirrors `window_post`),
+    /// not cross-thread sync.
+    pub(super) toast_render_state:
+        std::sync::Arc<std::sync::Mutex<crate::gui::renderer::ToastRenderState>>,
+
     /// Shared repaint handle for this window's PTY threads.
     ///
     /// Each window gets its own `Arc<OnceLock<(RepaintProxy, WindowId)>>`


### PR DESCRIPTION
Closes part of #433 (the visual-overhaul slice).

## Summary

Replaces the egui-drawn toast bubbles with a **fully-owned GL renderer** so the
pill background and its text share one coordinate system. This enables proper
animation and eliminates the clipping/alignment issues an egui-text-on-GL-pill
hybrid would have. Scope is deliberately **visual overhaul only** — new toast
types, per-scope positioning, and the notification-routing refactor from #433
are follow-ups (see below).

## Rendering

- **Shader-drawn pill**: SDF rounded-rect + outer glow + vertical gradient +
  drop shadow + left accent bar (`toast.vert` / `toast.frag`, `ToastRenderer`).
- **Owned text**: label, kind icon, and dismiss `x` drawn via the glyph atlas +
  the existing foreground shader (`ToastTextRenderer` with a dedicated toast
  atlas). Shaping/measurement run on the **main thread** (`FontManager` is
  `!Sync`); the single `PaintCallback` only uploads and draws (pills behind
  text).
- **Per-window** `ToastRenderState`.

## Behaviour

- Entry animation (fade + slide + scale, 300ms ease-out) and exit (fade, 400ms).
- Auto-dismiss durations 15 / 10 / 6s (error / warning / info); hover pauses
  expiry, with a correct fade-out even when hover extends a toast past its
  nominal life.
- **Click anywhere** on a toast dismisses it (the `x` is a visual affordance);
  an interactive egui region consumes the click so it never reaches the
  terminal beneath.
- Positioning infrastructure (`TopRightStack` / `PaneCentered` /
  `WindowCentered`) is in place; all current toasts use the top-right stack.

## Review

An adversarial review found 1 BLOCKER (shader double-alpha-multiply muddying the
glow/shadow/fade), 2 MAJOR (hover-past-duration exit-fade skip; dismiss-click
bleeding through to the terminal), and several MINOR/NIT items. **All are fixed**
in this branch, with regression tests for the animation and hit-precedence logic.

## Verification

- \`cargo test --all\`
- \`cargo clippy --all-targets --all-features -- -D warnings\`
- \`cargo machete\`
- \`cargo fmt --all -- --check\`
- \`cargo xtask check-windows\`

all clean.

## Follow-ups (remaining #433 asks, not in this PR)

1. New freminal-derived toast types (copied-to-clipboard, resize w/h, etc.).
2. Per-scope positioning wired up (pane-centered / window-centered), needing the
   `origin: (WindowId, PaneId)` capture.
3. Notification routing/config refactor (kill the synthetic `info` path, split
   OSC 9/777/99/133D routing, add a `Disabled` option).
4. System-notification app icon.
5. New skill documenting the toast-options pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toast notifications now render as GPU-accelerated overlays with themed styling, accents, glow, and icons.
  * Toast text rendering was upgraded for smoother measurement/layout and consistent results across windows.
  * Updated toast positioning to match the active window/pane layout.
  * Default toast durations were adjusted (Error/Warn/Info).
* **Bug Fixes**
  * Fixed toast hover/exit timing so notifications no longer dismiss too early (including the “popped instantly” behavior).
  * Improved toast click and dismissal handling to ensure the correct toast responds when multiple overlap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->