### PR TITLE
feat: 433 -- freminal-derived toasts + resize overlay

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -419,6 +419,20 @@ limit = 10000
 
 # routing_command_finished = "system_when_unfocused"
 
+# Routing for freminal's own toast-only notifications. Unlike the OSC
+# routing above, these only ever produce an in-app toast, so the only
+# values are "toast" (default) or "disabled" (suppress that toast).
+# routing_clipboard_copy = "toast"
+# routing_clipboard_remote = "toast"
+# routing_layout = "toast"
+# routing_recording = "toast"
+# routing_paste_blocked = "toast"
+# routing_config_reload = "toast"
+
+# Show a transient overlay with the terminal's new size (cols×rows) while a
+# window or pane is being resized. Default: true.
+# show_resize_overlay = true
+
 # Template for the body of command-finished notifications.  Tokens:
 #   {command}   - the command text (or "Command" if it scrolled away)
 #   {duration}  - human-readable elapsed time (e.g. "3s", "2m15s")

--- a/config_example.toml
+++ b/config_example.toml
@@ -429,8 +429,9 @@ limit = 10000
 # routing_paste_blocked = "toast"
 # routing_config_reload = "toast"
 
-# Show a transient overlay with the terminal's new size (cols×rows) while a
-# window or pane is being resized. Default: true.
+# Show a transient overlay with the terminal's new size (cols×rows) while the
+# OS window is being resized (not on split-border / pane-border drags).
+# Default: true.
 # show_resize_overlay = true
 
 # Template for the body of command-finished notifications.  Tokens:

--- a/freminal-common/src/config.rs
+++ b/freminal-common/src/config.rs
@@ -1088,8 +1088,9 @@ pub struct NotificationsConfig {
     pub routing_clipboard_remote: FreminalToastRouting,
 
     /// When `true`, a transient overlay showing the terminal's new size
-    /// (cols×rows) appears while a window or pane is being resized, and
-    /// fades shortly after. Default: `true`.
+    /// (cols×rows) appears while the OS window is being resized (not on
+    /// split-border / pane-border drags, whose whole-window readout does not
+    /// change), and fades shortly after. Default: `true`.
     pub show_resize_overlay: bool,
 
     /// Routing for the layout saved/loaded toast. Default:

--- a/freminal-common/src/config.rs
+++ b/freminal-common/src/config.rs
@@ -953,8 +953,8 @@ impl NotificationRouting {
 }
 
 /// Routing for freminal's own toast-only notifications (e.g. "Copied to
-/// clipboard", "resize"). These never have a desktop-notification leg, so
-/// the only choices are an in-app toast or nothing.
+/// clipboard", "Layout saved"). These never have a desktop-notification leg,
+/// so the only choices are an in-app toast or nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum FreminalToastRouting {
@@ -974,6 +974,30 @@ impl FreminalToastRouting {
             Self::Disabled => false,
         }
     }
+}
+
+/// The category of a freminal-derived, toast-only notification.
+///
+/// Each category routes independently via its own `routing_*` field on
+/// [`NotificationsConfig`], so a user can silence e.g. layout toasts while
+/// keeping clipboard toasts. These are freminal's own UI events, distinct
+/// from the terminal-application-driven notifications (OSC 9/777/99/133)
+/// modelled by [`NotificationKind`]/[`NotificationRouting`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FreminalToastCategory {
+    /// Local selection copied to the system clipboard (Ctrl+C / menu Copy).
+    ClipboardCopy,
+    /// A terminal application wrote to, or was blocked from reading, the
+    /// system clipboard via OSC 52.
+    ClipboardRemote,
+    /// A layout was saved or loaded.
+    Layout,
+    /// Session recording started or stopped.
+    Recording,
+    /// A paste was blocked by the smart-paste guard.
+    PasteBlocked,
+    /// The configuration was reloaded from disk.
+    ConfigReload,
 }
 
 /// Configuration for the notification system (Task 76).
@@ -1054,6 +1078,36 @@ pub struct NotificationsConfig {
     /// [`NotificationRouting::SystemWhenUnfocused`].
     pub routing_command_finished: NotificationRouting,
 
+    /// Routing for the 'copied to clipboard' toast (local Ctrl+C / menu
+    /// Copy). Default: [`FreminalToastRouting::Toast`].
+    pub routing_clipboard_copy: FreminalToastRouting,
+
+    /// Routing for the OSC 52 remote-clipboard toast (an application wrote
+    /// to, or was blocked from reading, the clipboard). Default:
+    /// [`FreminalToastRouting::Toast`].
+    pub routing_clipboard_remote: FreminalToastRouting,
+
+    /// When `true`, a transient overlay showing the terminal's new size
+    /// (cols×rows) appears while a window or pane is being resized, and
+    /// fades shortly after. Default: `true`.
+    pub show_resize_overlay: bool,
+
+    /// Routing for the layout saved/loaded toast. Default:
+    /// [`FreminalToastRouting::Toast`].
+    pub routing_layout: FreminalToastRouting,
+
+    /// Routing for the recording started/stopped toast. Default:
+    /// [`FreminalToastRouting::Toast`].
+    pub routing_recording: FreminalToastRouting,
+
+    /// Routing for the 'paste blocked' toast (smart-paste guard). Default:
+    /// [`FreminalToastRouting::Toast`].
+    pub routing_paste_blocked: FreminalToastRouting,
+
+    /// Routing for the 'config reloaded' toast. Default:
+    /// [`FreminalToastRouting::Toast`].
+    pub routing_config_reload: FreminalToastRouting,
+
     /// Template for the body of command-finished notifications.
     ///
     /// Supported tokens, substituted at notification time:
@@ -1084,9 +1138,34 @@ impl Default for NotificationsConfig {
             routing_osc_text: NotificationRouting::Toast,
             routing_osc99: NotificationRouting::Both,
             routing_command_finished: NotificationRouting::SystemWhenUnfocused,
+            routing_clipboard_copy: FreminalToastRouting::Toast,
+            routing_clipboard_remote: FreminalToastRouting::Toast,
+            show_resize_overlay: true,
+            routing_layout: FreminalToastRouting::Toast,
+            routing_recording: FreminalToastRouting::Toast,
+            routing_paste_blocked: FreminalToastRouting::Toast,
+            routing_config_reload: FreminalToastRouting::Toast,
             command_finished_template: String::from(
                 "{command} finished in {duration} (exit {exit_code})",
             ),
+        }
+    }
+}
+
+impl NotificationsConfig {
+    /// The routing policy for a given freminal-derived toast category.
+    #[must_use]
+    pub const fn routing_for_category(
+        &self,
+        category: FreminalToastCategory,
+    ) -> FreminalToastRouting {
+        match category {
+            FreminalToastCategory::ClipboardCopy => self.routing_clipboard_copy,
+            FreminalToastCategory::ClipboardRemote => self.routing_clipboard_remote,
+            FreminalToastCategory::Layout => self.routing_layout,
+            FreminalToastCategory::Recording => self.routing_recording,
+            FreminalToastCategory::PasteBlocked => self.routing_paste_blocked,
+            FreminalToastCategory::ConfigReload => self.routing_config_reload,
         }
     }
 }
@@ -2338,6 +2417,22 @@ size = 14.0
     }
 
     #[test]
+    fn freminal_toast_categories_default_to_toast() {
+        let cfg = NotificationsConfig::default();
+        assert_eq!(cfg.routing_clipboard_copy, FreminalToastRouting::Toast);
+        assert_eq!(cfg.routing_clipboard_remote, FreminalToastRouting::Toast);
+        assert_eq!(cfg.routing_layout, FreminalToastRouting::Toast);
+        assert_eq!(cfg.routing_recording, FreminalToastRouting::Toast);
+        assert_eq!(cfg.routing_paste_blocked, FreminalToastRouting::Toast);
+        assert_eq!(cfg.routing_config_reload, FreminalToastRouting::Toast);
+    }
+
+    #[test]
+    fn resize_overlay_defaults_on() {
+        assert!(NotificationsConfig::default().show_resize_overlay);
+    }
+
+    #[test]
     fn notifications_round_trip_through_toml() {
         let mut cfg = Config::default();
         cfg.notifications.enabled = true;
@@ -2482,6 +2577,90 @@ routing_info = \"system\"
         let parsed_disabled: Wrapper =
             toml::from_str(&disabled_toml).expect("re-parse FreminalToastRouting::Disabled");
         assert_eq!(parsed_disabled.routing, FreminalToastRouting::Disabled);
+    }
+
+    #[test]
+    fn freminal_toast_category_routing_round_trips() {
+        let mut cfg = Config::default();
+        cfg.notifications.routing_clipboard_copy = FreminalToastRouting::Disabled;
+        cfg.notifications.routing_clipboard_remote = FreminalToastRouting::Toast;
+        cfg.notifications.routing_layout = FreminalToastRouting::Toast;
+        cfg.notifications.routing_recording = FreminalToastRouting::Toast;
+        cfg.notifications.routing_paste_blocked = FreminalToastRouting::Disabled;
+        cfg.notifications.routing_config_reload = FreminalToastRouting::Toast;
+        cfg.notifications.show_resize_overlay = false;
+
+        let toml = toml::to_string_pretty(&cfg).expect("serialise config");
+        assert!(
+            toml.contains("routing_paste_blocked = \"disabled\""),
+            "Disabled should serialize as the literal string \"disabled\": {toml}"
+        );
+
+        let parsed: Config = toml::from_str(&toml).expect("re-parse");
+
+        assert_eq!(
+            parsed.notifications.routing_clipboard_copy,
+            FreminalToastRouting::Disabled
+        );
+        assert_eq!(
+            parsed.notifications.routing_clipboard_remote,
+            FreminalToastRouting::Toast
+        );
+        assert_eq!(
+            parsed.notifications.routing_layout,
+            FreminalToastRouting::Toast
+        );
+        assert_eq!(
+            parsed.notifications.routing_recording,
+            FreminalToastRouting::Toast
+        );
+        assert_eq!(
+            parsed.notifications.routing_paste_blocked,
+            FreminalToastRouting::Disabled
+        );
+        assert_eq!(
+            parsed.notifications.routing_config_reload,
+            FreminalToastRouting::Toast
+        );
+        assert!(!parsed.notifications.show_resize_overlay);
+    }
+
+    #[test]
+    fn routing_for_category_maps_each_variant() {
+        let cfg = NotificationsConfig {
+            routing_clipboard_copy: FreminalToastRouting::Disabled,
+            routing_clipboard_remote: FreminalToastRouting::Toast,
+            routing_layout: FreminalToastRouting::Toast,
+            routing_recording: FreminalToastRouting::Disabled,
+            routing_paste_blocked: FreminalToastRouting::Toast,
+            routing_config_reload: FreminalToastRouting::Disabled,
+            ..NotificationsConfig::default()
+        };
+
+        assert_eq!(
+            cfg.routing_for_category(FreminalToastCategory::ClipboardCopy),
+            FreminalToastRouting::Disabled
+        );
+        assert_eq!(
+            cfg.routing_for_category(FreminalToastCategory::ClipboardRemote),
+            FreminalToastRouting::Toast
+        );
+        assert_eq!(
+            cfg.routing_for_category(FreminalToastCategory::Layout),
+            FreminalToastRouting::Toast
+        );
+        assert_eq!(
+            cfg.routing_for_category(FreminalToastCategory::Recording),
+            FreminalToastRouting::Disabled
+        );
+        assert_eq!(
+            cfg.routing_for_category(FreminalToastCategory::PasteBlocked),
+            FreminalToastRouting::Toast
+        );
+        assert_eq!(
+            cfg.routing_for_category(FreminalToastCategory::ConfigReload),
+            FreminalToastRouting::Disabled
+        );
     }
 
     #[test]

--- a/freminal/src/gui/actions.rs
+++ b/freminal/src/gui/actions.rs
@@ -721,6 +721,12 @@ impl super::FreminalGui {
                         // Refresh the layout library so the new file appears in the menu.
                         self.discovered_layouts =
                             freminal_common::layout::discover_layouts(&layout_dir);
+                        self.route_freminal_toast(
+                            freminal_common::config::FreminalToastCategory::Layout,
+                            crate::gui::toast::ToastKind::Info,
+                            "Layout saved",
+                            Some(format!("{}", path.display())),
+                        );
                     }
                     Err(e) => {
                         error!("SaveLayout: failed to write {}: {e}", path.display());

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -170,19 +170,7 @@ impl freminal_windowing::App for FreminalGui {
                 );
             }
 
-            // Emit WindowCreate recording event.
-            let rec_wid = self.recording_window_id(window_id);
-            if let Some(h) = self.recording_swap.load_full() {
-                h.emit(
-                    freminal_terminal_emulator::recording::EventPayload::WindowCreate {
-                        window_id: rec_wid,
-                        width_px: inner_size.0,
-                        height_px: inner_size.1,
-                        x: 0,
-                        y: 0,
-                    },
-                );
-            }
+            self.emit_window_create_recording(window_id, inner_size);
         } else {
             // Subsequent window — check if a layout window is waiting, otherwise
             // spawn a default single-pane PTY tab.
@@ -351,19 +339,7 @@ impl freminal_windowing::App for FreminalGui {
                     };
                     self.windows.insert(window_id, win);
 
-                    // Emit WindowCreate recording event.
-                    let rec_wid = self.recording_window_id(window_id);
-                    if let Some(h) = self.recording_swap.load_full() {
-                        h.emit(
-                            freminal_terminal_emulator::recording::EventPayload::WindowCreate {
-                                window_id: rec_wid,
-                                width_px: inner_size.0,
-                                height_px: inner_size.1,
-                                x: 0,
-                                y: 0,
-                            },
-                        );
-                    }
+                    self.emit_window_create_recording(window_id, inner_size);
                 }
                 Err(e) => {
                     error!("Failed to spawn PTY for new window: {e}");
@@ -2536,11 +2512,16 @@ impl freminal_windowing::App for FreminalGui {
             let pointer_moving = ctx.input(|i| i.pointer.is_moving());
             let force_full =
                 ui_overlay_open || shader_recomposites || active_pane_changed || pointer_moving;
-            // A toast being visible animates its own region each frame.
-            let toast_active = self
-                .toasts
-                .try_borrow()
-                .is_ok_and(|stack| !stack.is_empty());
+            // A toast being visible animates its own region each frame. The
+            // resize overlay (issue #433) animates the same way — it fades out
+            // over its linger window on the plain painter — so it must force a
+            // `Full` present too, or a cursor-only `Partial` frame would leave
+            // the fading overlay outside the damage rect stale/ghosted.
+            let toast_active = win.resize_overlay.is_some()
+                || self
+                    .toasts
+                    .try_borrow()
+                    .is_ok_and(|stack| !stack.is_empty());
             // Inspect only the panes actually rendered this frame — the
             // entries in `pane_layout`. Under zoom, only the zoomed pane is
             // rendered; iterating the whole tree would read stale

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -311,6 +311,7 @@ impl freminal_windowing::App for FreminalGui {
                         pending_close_pane: false,
                         pending_focus_direction: None,
                         border_drag: None,
+                        resize_overlay: None,
                         shader_last_mtime: None,
                         window_post,
                         toast_render_state: crate::gui::renderer::ToastRenderState::new_shared(),
@@ -823,6 +824,17 @@ impl freminal_windowing::App for FreminalGui {
             }
         }
         let chrome_size_changed = win.last_known_size != chrome_size_before;
+        // Resize-overlay trigger (issue #433): a GENUINE OS-window resize is a
+        // change between two KNOWN sizes. The first observation of a new
+        // window is `None -> Some(initial)`, which `chrome_size_changed`
+        // (correctly, for chrome damage) treats as a change but which must NOT
+        // pop the resize overlay — otherwise the HUD flashes on every app
+        // launch and every `Ctrl+Shift+N`. Requiring `Some -> Some` with
+        // different values suppresses that launch/spawn false-positive.
+        let window_genuinely_resized = matches!(
+            (chrome_size_before, win.last_known_size),
+            (Some(before), Some(after)) if before != after
+        );
 
         // ── Deferred egui font update from standalone settings window ────────
         win.terminal_widget
@@ -1403,6 +1415,9 @@ impl freminal_windowing::App for FreminalGui {
                 crate::gui::notifications::Osc99Control,
                 crossbeam_channel::Sender<freminal_common::pty_write::PtyWrite>,
             )> = Vec::new();
+            // OSC 52 clipboard events (remote write / blocked read) collected from
+            // every pane this frame, routed to a toast after the loop (issue #433).
+            let mut osc52_events: Vec<rendering::Osc52ToastEvent> = Vec::new();
             for (idx, tab) in win.tabs.iter_mut().enumerate() {
                 let is_active_tab = idx == active_idx;
                 let is_only_pane = match tab.pane_tree.pane_count() {
@@ -1437,6 +1452,7 @@ impl freminal_windowing::App for FreminalGui {
                             &mut osc_notifications,
                             &mut osc99_notifications,
                             &mut osc99_controls,
+                            &mut osc52_events,
                         );
                         if shell_set {
                             tab_shell_set_title = true;
@@ -1463,6 +1479,19 @@ impl freminal_windowing::App for FreminalGui {
                         &mut toasts,
                     );
                 }
+            }
+
+            // Surface OSC 52 remote-clipboard events as toasts (issue #433).
+            // Done after the pane loop so `self.config`/`self.toasts` are
+            // borrowable without conflicting with the `win.tabs` borrow.
+            for event in &osc52_events {
+                let (title, detail) = rendering::osc52_toast_text(event);
+                self.route_freminal_toast(
+                    freminal_common::config::FreminalToastCategory::ClipboardRemote,
+                    crate::gui::toast::ToastKind::Info,
+                    title,
+                    detail,
+                );
             }
 
             // Route OSC 99 stateful notifications collected above (Task
@@ -1661,8 +1690,15 @@ impl freminal_windowing::App for FreminalGui {
                         // buttons (Task 106 bug).
                         Self::send_paste_to_target(&mut win, target, payload);
                     }
-                    super::paste_guard::PasteDialogOutcome::Cancelled
-                    | super::paste_guard::PasteDialogOutcome::Idle => {}
+                    super::paste_guard::PasteDialogOutcome::Cancelled => {
+                        self.route_freminal_toast(
+                            freminal_common::config::FreminalToastCategory::PasteBlocked,
+                            crate::gui::toast::ToastKind::Warning,
+                            "Paste blocked",
+                            None,
+                        );
+                    }
+                    super::paste_guard::PasteDialogOutcome::Idle => {}
                 }
 
                 // Broadcast-input confirm dialog (Task 74.5).  Shown when the user
@@ -1983,6 +2019,15 @@ impl freminal_windowing::App for FreminalGui {
             // the loop (#435).
             let present_is_partial_for_panes = std::sync::Arc::clone(&win.present_is_partial);
 
+            // Resize overlay (issue #433): whether any pane's char grid
+            // changed this frame (the debounced-resize check below). Only a
+            // trigger — the displayed dimensions are recomputed from the
+            // whole window content area after the loop, where `win.tabs` is
+            // no longer borrowed. Captured here rather than written straight
+            // to `win.resize_overlay` because the per-pane loop mutably
+            // borrows `win.tabs`.
+            let mut grid_size_changed = false;
+
             for (pane_id, pane_rect) in &pane_layout {
                 // Shrink the pane rect slightly to leave room for borders.
                 // Each pane edge that is interior (shared with another pane)
@@ -2063,6 +2108,7 @@ impl freminal_windowing::App for FreminalGui {
                         error!("Failed to send resize event for {pane_id}: {e}");
                     } else {
                         pane.view_state.last_sent_size = new_size;
+                        grid_size_changed = true;
                     }
                 }
 
@@ -2185,9 +2231,11 @@ impl freminal_windowing::App for FreminalGui {
                 });
 
                 // Render this pane into a child UI scoped to its content rect.
-                // show() returns (left_clicked, deferred_key_actions).
+                // show() returns (left_clicked, copied_to_clipboard, deferred_key_actions).
                 // left_clicked is true when a primary left-click was pressed inside
-                // this pane's rect — used below for click-to-focus.
+                // this pane's rect — used below for click-to-focus. copied_to_clipboard
+                // is true when a non-empty local selection was copied this frame
+                // (Subtask D3), used below to route a "Copied to clipboard" toast.
                 let show_result =
                     ui.scope_builder(egui::UiBuilder::new().max_rect(content_rect), |pane_ui| {
                         win.terminal_widget.show(
@@ -2215,8 +2263,17 @@ impl freminal_windowing::App for FreminalGui {
                             &present_is_partial_for_panes,
                         )
                     });
-                let (left_clicked, deferred_actions) = show_result.inner;
+                let (left_clicked, copied_to_clipboard, deferred_actions) = show_result.inner;
                 all_deferred_actions.extend(deferred_actions);
+
+                if copied_to_clipboard {
+                    self.route_freminal_toast(
+                        freminal_common::config::FreminalToastCategory::ClipboardCopy,
+                        crate::gui::toast::ToastKind::Info,
+                        "Copied to clipboard",
+                        None,
+                    );
+                }
 
                 // Task 114.7: drain any egui-blocked raw key events queued
                 // this frame (keypad operators/directional, media,
@@ -2409,6 +2466,43 @@ impl freminal_windowing::App for FreminalGui {
                     shortest_repaint_delay =
                         Some(shortest_repaint_delay.map_or(delay, |prev| prev.min(delay)));
                 }
+            }
+
+            // Resize overlay (issue #433): show a transient cols×rows HUD only
+            // on a genuine OS-window resize, not the last_sent_size churn from
+            // new tabs/splits/pane-close/zoom (which reset last_sent_size to
+            // (0, 0)) nor the first geometry observation on window creation.
+            // Split-border drags are excluded: the whole-window readout does
+            // not change when an internal border moves. See `resize_is_genuine`
+            // and `window_genuinely_resized`.
+            //
+            // `grid_size_changed` is only a TRIGGER (did any pane's char
+            // grid change this frame); the displayed dimensions are the
+            // WHOLE terminal content area, not one pane's — the overlay is
+            // window-scoped. Compute cols×rows from `available_rect` (the
+            // central content rect the overlay centers in) using the same
+            // cell size and gutter inset the per-pane sizing uses. For a
+            // single-pane window this is exact; for a split layout it is an
+            // approximate whole-window reading (each pane pays the gutter
+            // individually), which is acceptable for a transient readout.
+            if self.config.notifications.show_resize_overlay
+                && super::window::resize_is_genuine(grid_size_changed, window_genuinely_resized)
+            {
+                let window_content_width = (available_rect.width() - gutter_inset_logical).max(0.0);
+                let window_cols = (window_content_width / logical_char_w)
+                    .floor()
+                    .approx_as::<usize>()
+                    .unwrap_or(0)
+                    .max(1);
+                let window_rows = (available_rect.height() / logical_char_h)
+                    .floor()
+                    .approx_as::<usize>()
+                    .unwrap_or(0)
+                    .max(1);
+                win.resize_overlay = Some(super::window::ResizeOverlayState {
+                    size: (window_cols, window_rows),
+                    last_update: now,
+                });
             }
 
             // ── Frame-damage aggregation (#435) ───────────────────────
@@ -2843,6 +2937,53 @@ impl freminal_windowing::App for FreminalGui {
                     );
                 }
             }
+
+            // Resize overlay HUD (issue #433): a passive, window-centered
+            // "cols × rows" readout, drawn on the plain painter like the
+            // broadcast label above — no input, no `ui_overlay_open`
+            // registration needed. Bind the `Copy` state up front so the
+            // subsequent `win.resize_overlay = None` on timeout (below)
+            // doesn't conflict with the `ui.painter()` borrow used to draw it.
+            let resize_overlay_state = win.resize_overlay;
+            if let Some(overlay) = resize_overlay_state {
+                let elapsed = now.saturating_duration_since(overlay.last_update);
+                if elapsed >= super::window::RESIZE_OVERLAY_LINGER {
+                    win.resize_overlay = None;
+                } else {
+                    let alpha = super::window::resize_overlay_alpha(
+                        elapsed,
+                        super::window::RESIZE_OVERLAY_LINGER,
+                        super::window::RESIZE_OVERLAY_FADE,
+                    );
+                    let text_alpha = (255.0 * alpha)
+                        .round()
+                        .clamp(0.0, 255.0)
+                        .approx_as::<u8>()
+                        .unwrap_or(255);
+                    let bg_alpha = (180.0 * alpha)
+                        .round()
+                        .clamp(0.0, 255.0)
+                        .approx_as::<u8>()
+                        .unwrap_or(180);
+                    let (cols, rows) = overlay.size;
+                    let text_color =
+                        egui::Color32::from_rgba_unmultiplied(255, 255, 255, text_alpha);
+                    let painter = ui.painter();
+                    let galley = painter.layout_no_wrap(
+                        format!("{cols} × {rows}"),
+                        egui::FontId::monospace(28.0),
+                        text_color,
+                    );
+                    let text_rect = egui::Align2::CENTER_CENTER
+                        .anchor_size(available_rect.center(), galley.size())
+                        .expand(12.0);
+                    painter.rect_filled(text_rect, 6.0, egui::Color32::from_black_alpha(bg_alpha));
+                    painter.galley(text_rect.min + egui::vec2(12.0, 12.0), galley, text_color);
+                    // Keep animating/timing-out even without further input.
+                    ctx.request_repaint_after(std::time::Duration::from_millis(16));
+                }
+            }
+
             // ── Terminal band: capture the end of the shape range (#436.4a) ──
             //
             // Read the background layer's current shape count as
@@ -3361,6 +3502,7 @@ impl FreminalGui {
             pending_close_pane: false,
             pending_focus_direction: None,
             border_drag: None,
+            resize_overlay: None,
             shader_last_mtime: None,
             window_post,
             toast_render_state: crate::gui::renderer::ToastRenderState::new_shared(),

--- a/freminal/src/gui/layout_ops.rs
+++ b/freminal/src/gui/layout_ops.rs
@@ -703,6 +703,7 @@ impl FreminalGui {
             pending_close_pane: false,
             pending_focus_direction: None,
             border_drag: None,
+            resize_overlay: None,
             shader_last_mtime: None,
             window_post,
             toast_render_state: crate::gui::renderer::ToastRenderState::new_shared(),
@@ -740,7 +741,19 @@ impl FreminalGui {
         };
         self.windows.insert(window_id, win);
 
-        // Emit WindowCreate recording event.
+        self.emit_window_create_recording(window_id, inner_size);
+
+        Some(commands)
+    }
+
+    /// Emit a `WindowCreate` recording event for a newly built window, if a
+    /// recording is active. Extracted from `build_window_from_pending_layout`
+    /// to keep that function under the line limit.
+    fn emit_window_create_recording(
+        &mut self,
+        window_id: freminal_windowing::WindowId,
+        inner_size: (u32, u32),
+    ) {
         let rec_wid = self.recording_window_id(window_id);
         if let Some(h) = self.recording_swap.load_full() {
             h.emit(
@@ -753,8 +766,6 @@ impl FreminalGui {
                 },
             );
         }
-
-        Some(commands)
     }
 }
 

--- a/freminal/src/gui/layout_ops.rs
+++ b/freminal/src/gui/layout_ops.rs
@@ -748,8 +748,9 @@ impl FreminalGui {
 
     /// Emit a `WindowCreate` recording event for a newly built window, if a
     /// recording is active. Extracted from `build_window_from_pending_layout`
-    /// to keep that function under the line limit.
-    fn emit_window_create_recording(
+    /// (and reused by the two `on_window_created` spawn paths) to centralise
+    /// the event construction and keep those functions under the line limit.
+    pub(super) fn emit_window_create_recording(
         &mut self,
         window_id: freminal_windowing::WindowId,
         inner_size: (u32, u32),

--- a/freminal/src/gui/menu.rs
+++ b/freminal/src/gui/menu.rs
@@ -224,6 +224,12 @@ impl super::FreminalGui {
                     }) {
                         Ok(resolved) => {
                             self.pending_load_layout = Some(resolved);
+                            self.route_freminal_toast(
+                                freminal_common::config::FreminalToastCategory::Layout,
+                                crate::gui::toast::ToastKind::Info,
+                                "Layout loaded",
+                                Some(summary.name.clone()),
+                            );
                         }
                         Err(e) => {
                             tracing::error!("Failed to load layout '{}': {e}", summary.name);

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -579,6 +579,38 @@ impl FreminalGui {
         }
     }
 
+    /// Route a freminal-derived, toast-only notification through its
+    /// per-category routing policy (see
+    /// [`NotificationRouter::route_freminal_toast`]). Best-effort with the
+    /// same borrow semantics as [`Self::push_info_toast`]: if the toast
+    /// stack is already borrowed, the toast is dropped after a warning.
+    ///
+    /// `&self` because the stack lives behind a `RefCell` and `config` is a
+    /// plain field.
+    pub(super) fn route_freminal_toast(
+        &self,
+        category: freminal_common::config::FreminalToastCategory,
+        kind: toast::ToastKind,
+        title: impl Into<String>,
+        detail: Option<String>,
+    ) {
+        match self.toasts.try_borrow_mut() {
+            Ok(mut stack) => {
+                notifications::NotificationRouter::route_freminal_toast(
+                    category,
+                    kind,
+                    title,
+                    detail,
+                    &self.config.notifications,
+                    &mut stack,
+                );
+            }
+            Err(_) => {
+                tracing::warn!("toast stack was already borrowed; dropping freminal toast");
+            }
+        }
+    }
+
     /// Compute the initial PTY terminal size from pixel dimensions and cell size.
     ///
     /// Falls back to [`DEFAULT_WIDTH`]x[`DEFAULT_HEIGHT`] if the cell size is zero

--- a/freminal/src/gui/notifications.rs
+++ b/freminal/src/gui/notifications.rs
@@ -29,12 +29,12 @@ use freminal_common::buffer_states::osc::OscNotifySource;
 use freminal_common::buffer_states::window_manipulation::{
     Notification99Data, NotificationKind, Osc99ControlKind,
 };
-use freminal_common::config::{NotificationRouting, NotificationsConfig};
+use freminal_common::config::{FreminalToastCategory, NotificationRouting, NotificationsConfig};
 use freminal_common::pty_write::PtyWrite;
 use freminal_common::send_or_log;
 
 use super::command_blocks::format_command_duration;
-use super::toast::ToastStack;
+use super::toast::{ToastKind, ToastStack};
 
 /// A fully-formed notification ready to be routed.
 ///
@@ -310,6 +310,35 @@ impl NotificationRouter {
             NotificationKind::OscText | NotificationKind::CommandFinished => {
                 toasts.info(req.summary().to_owned(), detail);
             }
+        }
+    }
+
+    /// Route a freminal-derived, toast-only notification (e.g. "Copied to
+    /// clipboard", "Layout saved") through its per-category routing policy.
+    ///
+    /// Unlike [`Self::route`], there is no desktop-notification leg and no
+    /// `enabled` master-switch gate: these are freminal's own UI feedback
+    /// toasts, governed solely by their `routing_<category>` config field
+    /// ([`FreminalToastRouting`], which is `Toast` or `Disabled`). When the
+    /// category routes to `Disabled`, nothing is pushed.
+    ///
+    /// `kind` selects the toast severity (e.g. [`ToastKind::Warning`] for a
+    /// blocked paste, [`ToastKind::Info`] for a normal confirmation).
+    pub(super) fn route_freminal_toast(
+        category: FreminalToastCategory,
+        kind: ToastKind,
+        title: impl Into<String>,
+        detail: Option<String>,
+        config: &NotificationsConfig,
+        toasts: &mut ToastStack,
+    ) {
+        if !config.routing_for_category(category).wants_toast() {
+            return;
+        }
+        match kind {
+            ToastKind::Error => toasts.error(title, detail),
+            ToastKind::Warning => toasts.warning(title, detail),
+            ToastKind::Info => toasts.info(title, detail),
         }
     }
 
@@ -1011,6 +1040,7 @@ impl NotificationRouter {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use freminal_common::config::FreminalToastRouting;
 
     fn osc_req(body: &str) -> NotificationRequest {
         NotificationRequest {
@@ -1220,6 +1250,81 @@ mod tests {
         let mut toasts = ToastStack::default();
         NotificationRouter::route_test(&NotificationRequest::sample(), &config, true, &mut toasts);
         assert_eq!(toasts.len(), 1);
+    }
+
+    // ── Freminal-derived toast gate (issue #433, subtask C) ──────────────
+
+    #[test]
+    fn freminal_toast_routes_when_enabled() {
+        let config = NotificationsConfig::default();
+        let mut toasts = ToastStack::default();
+        NotificationRouter::route_freminal_toast(
+            FreminalToastCategory::Layout,
+            ToastKind::Info,
+            "Layout saved",
+            None,
+            &config,
+            &mut toasts,
+        );
+        assert_eq!(toasts.len(), 1);
+    }
+
+    #[test]
+    fn freminal_toast_suppressed_when_disabled() {
+        let config = NotificationsConfig {
+            routing_layout: FreminalToastRouting::Disabled,
+            ..NotificationsConfig::default()
+        };
+        let mut toasts = ToastStack::default();
+        NotificationRouter::route_freminal_toast(
+            FreminalToastCategory::Layout,
+            ToastKind::Info,
+            "Layout saved",
+            None,
+            &config,
+            &mut toasts,
+        );
+        assert_eq!(toasts.len(), 0);
+    }
+
+    #[test]
+    fn freminal_toast_ignores_enabled_master_switch() {
+        // Freminal toasts are governed only by their `routing_<category>`
+        // field, not by `NotificationsConfig::enabled` — proving these
+        // bypass the master switch by design.
+        let config = NotificationsConfig {
+            enabled: false,
+            routing_layout: FreminalToastRouting::Toast,
+            ..NotificationsConfig::default()
+        };
+        let mut toasts = ToastStack::default();
+        NotificationRouter::route_freminal_toast(
+            FreminalToastCategory::Layout,
+            ToastKind::Info,
+            "Layout saved",
+            None,
+            &config,
+            &mut toasts,
+        );
+        assert_eq!(toasts.len(), 1);
+    }
+
+    #[test]
+    fn freminal_toast_kind_maps_to_severity() {
+        let config = NotificationsConfig::default();
+        let mut toasts = ToastStack::default();
+        NotificationRouter::route_freminal_toast(
+            FreminalToastCategory::PasteBlocked,
+            ToastKind::Warning,
+            "Paste blocked",
+            None,
+            &config,
+            &mut toasts,
+        );
+        assert_eq!(toasts.len(), 1);
+        // Assert the severity actually maps to Warning (not just that *a*
+        // toast was pushed) — guards `route_freminal_toast`'s kind match.
+        assert_eq!(toasts.last_kind(), Some(ToastKind::Warning));
     }
 
     fn finished_block(exit_code: Option<i32>, dur_secs: u64) -> CommandBlock {

--- a/freminal/src/gui/recording.rs
+++ b/freminal/src/gui/recording.rs
@@ -184,6 +184,12 @@ impl super::FreminalGui {
                 tracing::info!("Started recording to {}", path.display());
                 self.recording_swap.store(Some(Arc::new(handle)));
                 self.recording_join = Some(join);
+                self.route_freminal_toast(
+                    freminal_common::config::FreminalToastCategory::Recording,
+                    crate::gui::toast::ToastKind::Info,
+                    "Recording started",
+                    Some(format!("Saving to {}", path.display())),
+                );
                 self.recording_path = Some(path);
             }
             Err(e) => {
@@ -212,8 +218,20 @@ impl super::FreminalGui {
 
         if let Some(path) = self.recording_path.take() {
             tracing::info!("Stopped recording; file saved to {}", path.display());
+            self.route_freminal_toast(
+                freminal_common::config::FreminalToastCategory::Recording,
+                crate::gui::toast::ToastKind::Info,
+                "Recording stopped",
+                Some(format!("Saved to {}", path.display())),
+            );
         } else {
             tracing::info!("Stopped recording");
+            self.route_freminal_toast(
+                freminal_common::config::FreminalToastCategory::Recording,
+                crate::gui::toast::ToastKind::Info,
+                "Recording stopped",
+                None,
+            );
         }
     }
 }

--- a/freminal/src/gui/rendering.rs
+++ b/freminal/src/gui/rendering.rs
@@ -137,6 +137,47 @@ pub(super) struct WindowManipFlags {
     pub is_only_pane: bool,
 }
 
+/// An OSC 52 clipboard event observed during a frame's window-manipulation
+/// drain, collected so the caller can surface a toast after the per-pane
+/// loop releases its `win.tabs` borrow (the handler itself has no access to
+/// the app-level config/toast stack). See
+/// [`FreminalToastCategory::ClipboardRemote`].
+///
+/// [`FreminalToastCategory::ClipboardRemote`]: freminal_common::config::FreminalToastCategory::ClipboardRemote
+#[derive(Debug, Clone)]
+pub(super) enum Osc52ToastEvent {
+    /// A terminal application wrote text to the system clipboard (OSC 52
+    /// set). Carries the byte length of the written payload for the toast
+    /// detail (never the content itself — do not leak clipboard data into a
+    /// toast).
+    Wrote { bytes: usize },
+    /// A terminal application attempted to READ the system clipboard (OSC 52
+    /// query) but was blocked by `[security] allow_clipboard_read = false`.
+    ReadBlocked,
+}
+
+/// Maps an [`Osc52ToastEvent`] to the `(title, detail)` pair used for the
+/// resulting toast. Pure and free of `egui`/config access so it can be
+/// unit-tested directly; the caller (`app_impl::update()`) supplies the
+/// category gating and the toast stack via `FreminalGui::route_freminal_toast`.
+pub(super) fn osc52_toast_text(event: &Osc52ToastEvent) -> (&'static str, Option<String>) {
+    match event {
+        Osc52ToastEvent::Wrote { bytes } => (
+            "Clipboard updated",
+            Some(format!(
+                "An application copied {bytes} bytes to the clipboard."
+            )),
+        ),
+        Osc52ToastEvent::ReadBlocked => (
+            "Clipboard read blocked",
+            Some(
+                "An application tried to read the clipboard; blocked by your security settings."
+                    .to_owned(),
+            ),
+        ),
+    }
+}
+
 /// Drain and dispatch all pending [`WindowCommand`]s for this frame.
 ///
 /// ## Flow
@@ -201,6 +242,7 @@ pub(super) fn handle_window_manipulation(
     notifications: &mut Vec<NotificationRequest>,
     osc99_notifications: &mut Vec<(Notification99Data, Sender<PtyWrite>)>,
     osc99_controls: &mut Vec<(Osc99Control, Sender<PtyWrite>)>,
+    osc52_events: &mut Vec<Osc52ToastEvent>,
 ) -> bool {
     // Whether the shell set (or restored) a title during this frame.  Used
     // by the caller to clear any user-assigned custom tab name, so
@@ -485,6 +527,9 @@ pub(super) fn handle_window_manipulation(
 
             // OSC 52 clipboard set: copy decoded text to the system clipboard.
             WindowManipulation::SetClipboard(_sel, content) => {
+                osc52_events.push(Osc52ToastEvent::Wrote {
+                    bytes: content.len(),
+                });
                 ui.ctx().copy_text(content);
             }
 
@@ -498,6 +543,7 @@ pub(super) fn handle_window_manipulation(
                     tracing::debug!(
                         "OSC 52 query for selection '{sel}' — blocked by security config"
                     );
+                    osc52_events.push(Osc52ToastEvent::ReadBlocked);
                     String::new()
                 };
                 send_pty_response(pty_write_tx, &format!("\x1b]52;{sel};{payload}\x1b\\"));
@@ -566,4 +612,32 @@ pub(super) fn handle_window_manipulation(
         }
     }
     shell_set_title
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod osc52_toast_text_tests {
+    use super::{Osc52ToastEvent, osc52_toast_text};
+
+    #[test]
+    fn wrote_maps_to_clipboard_updated_with_byte_count() {
+        let (title, detail) = osc52_toast_text(&Osc52ToastEvent::Wrote { bytes: 5 });
+        assert_eq!(title, "Clipboard updated");
+        let detail = detail.expect("write event should carry a detail message");
+        assert!(
+            detail.contains('5'),
+            "detail should mention the byte count: {detail}"
+        );
+        // Privacy: the detail must never contain clipboard content, only the
+        // byte count. This test can't prove a negative for arbitrary content,
+        // but it does assert the message is the fixed template, not raw text.
+        assert_eq!(detail, "An application copied 5 bytes to the clipboard.");
+    }
+
+    #[test]
+    fn read_blocked_maps_to_blocked_title() {
+        let (title, detail) = osc52_toast_text(&Osc52ToastEvent::ReadBlocked);
+        assert_eq!(title, "Clipboard read blocked");
+        assert!(detail.is_some());
+    }
 }

--- a/freminal/src/gui/settings.rs
+++ b/freminal/src/gui/settings.rs
@@ -1798,6 +1798,8 @@ impl SettingsModal {
             &mut self.draft.notifications.routing_command_finished,
         );
 
+        self.show_freminal_toast_routing_section(ui);
+
         ui.add_space(12.0);
         ui.heading("Template");
         ui.label("Command-finished notification body:");
@@ -1833,6 +1835,57 @@ impl SettingsModal {
             ui.visuals().weak_text_color(),
             "Mirrors the toggle in the Bell tab. The bell mode is configured \
              there.",
+        );
+    }
+
+    /// Render the "Freminal toasts" subsection: routing rows for the
+    /// freminal-originated toast categories (clipboard, layout, recording,
+    /// paste guard, config reload), plus the resize-overlay toggle.
+    /// Extracted from [`Self::show_notifications_tab`] to keep that
+    /// function under the `too_many_lines` threshold.
+    fn show_freminal_toast_routing_section(&mut self, ui: &mut Ui) {
+        ui.add_space(12.0);
+        ui.heading("Freminal toasts");
+        ui.colored_label(
+            ui.visuals().weak_text_color(),
+            "In-app toasts for freminal's own events. Each can be shown as a \
+             toast (default) or disabled.",
+        );
+        ui.add_space(4.0);
+        Self::freminal_toast_routing_row(
+            ui,
+            "Copied to clipboard",
+            &mut self.draft.notifications.routing_clipboard_copy,
+        );
+        Self::freminal_toast_routing_row(
+            ui,
+            "Remote clipboard (OSC 52)",
+            &mut self.draft.notifications.routing_clipboard_remote,
+        );
+        Self::freminal_toast_routing_row(
+            ui,
+            "Layout saved / loaded",
+            &mut self.draft.notifications.routing_layout,
+        );
+        Self::freminal_toast_routing_row(
+            ui,
+            "Recording started / stopped",
+            &mut self.draft.notifications.routing_recording,
+        );
+        Self::freminal_toast_routing_row(
+            ui,
+            "Paste blocked",
+            &mut self.draft.notifications.routing_paste_blocked,
+        );
+        Self::freminal_toast_routing_row(
+            ui,
+            "Config reloaded",
+            &mut self.draft.notifications.routing_config_reload,
+        );
+        ui.add_space(4.0);
+        ui.checkbox(
+            &mut self.draft.notifications.show_resize_overlay,
+            "Show resize overlay (cols×rows while resizing)",
         );
     }
 
@@ -1875,6 +1928,34 @@ impl SettingsModal {
                         routing,
                         config::NotificationRouting::Disabled,
                         notification_routing_label(config::NotificationRouting::Disabled),
+                    );
+                });
+        });
+    }
+
+    /// Render one labeled routing combo box for a freminal-derived toast
+    /// category, whose only choices are an in-app toast or nothing
+    /// ([`config::FreminalToastRouting`]). Mirrors
+    /// [`Self::notification_routing_row`] but with the two-variant enum.
+    fn freminal_toast_routing_row(
+        ui: &mut Ui,
+        label: &str,
+        routing: &mut config::FreminalToastRouting,
+    ) {
+        ui.horizontal(|ui| {
+            ui.label(label);
+            ComboBox::from_id_salt(format!("freminal_toast_routing_{label}"))
+                .selected_text(freminal_toast_routing_label(*routing))
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(
+                        routing,
+                        config::FreminalToastRouting::Toast,
+                        freminal_toast_routing_label(config::FreminalToastRouting::Toast),
+                    );
+                    ui.selectable_value(
+                        routing,
+                        config::FreminalToastRouting::Disabled,
+                        freminal_toast_routing_label(config::FreminalToastRouting::Disabled),
                     );
                 });
         });
@@ -2722,6 +2803,13 @@ const fn notification_routing_label(routing: config::NotificationRouting) -> &'s
     }
 }
 
+const fn freminal_toast_routing_label(routing: config::FreminalToastRouting) -> &'static str {
+    match routing {
+        config::FreminalToastRouting::Toast => "Toast",
+        config::FreminalToastRouting::Disabled => "Disabled",
+    }
+}
+
 /// Returns `true` when a startup layout is configured but not present in
 /// the discovered layout list.  Extracted for unit testing since the
 /// `ComboBox` UI itself is hard to exercise in isolation.
@@ -3050,6 +3138,18 @@ mod tests {
         );
         assert_eq!(
             notification_routing_label(config::NotificationRouting::Disabled),
+            "Disabled"
+        );
+    }
+
+    #[test]
+    fn freminal_toast_routing_label_covers_both_variants() {
+        assert_eq!(
+            freminal_toast_routing_label(config::FreminalToastRouting::Toast),
+            "Toast"
+        );
+        assert_eq!(
+            freminal_toast_routing_label(config::FreminalToastRouting::Disabled),
             "Disabled"
         );
     }

--- a/freminal/src/gui/settings_dispatch.rs
+++ b/freminal/src/gui/settings_dispatch.rs
@@ -298,7 +298,12 @@ impl FreminalGui {
             warn!("{warning}");
             self.push_info_toast("Config deprecation", Some(warning.clone()));
         }
-        self.push_info_toast("Config reloaded", Some(format!("From {}", path.display())));
+        self.route_freminal_toast(
+            freminal_common::config::FreminalToastCategory::ConfigReload,
+            crate::gui::toast::ToastKind::Info,
+            "Config reloaded",
+            Some(format!("From {}", path.display())),
+        );
     }
 
     /// Handle a `SettingsAction` from the standalone settings window.

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -674,6 +674,7 @@ fn render_context_menu(
     input_tx: &Sender<InputEvent>,
     clipboard_rx: &Receiver<String>,
     deferred_actions: &mut Vec<freminal_common::keybindings::KeyAction>,
+    copied: &mut bool,
 ) {
     let Some(menu_pos) = view_state.context_menu_pos else {
         return;
@@ -714,6 +715,7 @@ fn render_context_menu(
         input_tx,
         clipboard_rx,
         deferred_actions,
+        copied,
     );
 
     if close {
@@ -866,6 +868,10 @@ fn truncate_url(url: &str, max_len: usize) -> String {
 /// Actions that require full GUI state (e.g. `NewTerminal`) are pushed onto
 /// `deferred_actions` rather than executed directly, because this function
 /// does not have access to `FreminalGui` or `TabManager`.
+// All eight parameters are cohesive context-menu-dispatch state (mirrors the
+// existing `too_many_arguments` allowance on `compute_command_block_hover_rows`
+// above); splitting them into a struct would not meaningfully improve clarity.
+#[allow(clippy::too_many_arguments)]
 fn dispatch_context_menu_action(
     action: Option<ContextMenuAction>,
     ui: &Ui,
@@ -874,6 +880,7 @@ fn dispatch_context_menu_action(
     input_tx: &Sender<InputEvent>,
     clipboard_rx: &Receiver<String>,
     deferred_actions: &mut Vec<freminal_common::keybindings::KeyAction>,
+    copied: &mut bool,
 ) {
     let Some(action) = action else {
         return;
@@ -895,6 +902,7 @@ fn dispatch_context_menu_action(
             {
                 ui.ctx().copy_text(text);
                 view_state.selection.clear();
+                *copied = true;
             }
         }
         ContextMenuAction::Copy => {}
@@ -941,6 +949,7 @@ fn dispatch_context_menu_action(
         }
         ContextMenuAction::CopyUrl(url) => {
             ui.ctx().copy_text(url);
+            *copied = true;
         }
         ContextMenuAction::NewTerminal => {
             deferred_actions.push(freminal_common::keybindings::KeyAction::NewTab);
@@ -964,6 +973,7 @@ fn dispatch_context_menu_action(
                 && !text.is_empty()
             {
                 ui.ctx().copy_text(text);
+                *copied = true;
             }
         }
     }
@@ -1587,6 +1597,10 @@ impl FreminalTerminalWidget {
     /// - `key_broadcast_targets` — input senders of the other panes to mirror
     ///   keyboard input to when broadcast mode is active (Task 74); empty when
     ///   broadcast is off or this is not the active pane.
+    ///
+    /// Returns `(left_mouse_button_pressed, copied_to_clipboard, deferred_actions)`.
+    /// The second `bool`, `copied_to_clipboard`, is `true` iff a non-empty
+    /// local selection was copied to the system clipboard this frame.
     // Inherently large: the main per-frame terminal widget handler — processes input, handles
     // blink/scroll/mouse, and orchestrates layout. Each section is tightly coupled.
     #[allow(clippy::too_many_lines)]
@@ -1617,7 +1631,7 @@ impl FreminalTerminalWidget {
         pending_copy: &mut bool,
         key_broadcast_targets: &[Sender<InputEvent>],
         present_is_partial: &Arc<std::sync::atomic::AtomicBool>,
-    ) -> (bool, Vec<freminal_common::keybindings::KeyAction>) {
+    ) -> (bool, bool, Vec<freminal_common::keybindings::KeyAction>) {
         const BLINK_TICK_SECONDS: f64 = 0.50;
 
         // `sync_pixels_per_point()` has already been called by
@@ -1851,6 +1865,9 @@ impl FreminalTerminalWidget {
         // A gutter click never reaches `write_input_to_terminal` (it is outside
         // `terminal_rect`), so its click-to-focus intent is carried here.
         let mut left_mouse_button_pressed = left_mouse_button_pressed_gutter;
+        // Set to `true` below iff a non-empty local selection is actually
+        // copied to the system clipboard this frame (Subtask D3).
+        let mut copied_to_clipboard = false;
         if suppress_input
             || context_menu_open
             || view_state.search_state.is_open
@@ -1928,6 +1945,7 @@ impl FreminalTerminalWidget {
                 && !text.is_empty()
             {
                 ctx.copy_text(text);
+                copied_to_clipboard = true;
                 // Clear the selection highlight now that the text has been
                 // copied to the clipboard.
                 view_state.selection.clear();
@@ -3381,9 +3399,14 @@ impl FreminalTerminalWidget {
             input_tx,
             clipboard_rx,
             &mut deferred_actions,
+            &mut copied_to_clipboard,
         );
 
-        (left_mouse_button_pressed, deferred_actions)
+        (
+            left_mouse_button_pressed,
+            copied_to_clipboard,
+            deferred_actions,
+        )
     }
 
     /// Apply config changes that can be hot-reloaded at runtime.

--- a/freminal/src/gui/toast.rs
+++ b/freminal/src/gui/toast.rs
@@ -73,9 +73,8 @@ const HOVER_HOLD: Duration = Duration::from_millis(200);
 pub(super) enum ToastKind {
     /// Non-fatal error that the user should see.
     Error,
-    /// Warning that does not prevent continued operation.
-    #[allow(dead_code)]
-    // Reserved for future subtasks (71.3 layout non-fatal, 71.4 shader warnings).
+    /// Warning that does not prevent continued operation. Used by the
+    /// paste-blocked toast (see [`ToastStack::warning`]).
     Warning,
     /// Informational message.
     Info,
@@ -1038,11 +1037,24 @@ impl ToastStack {
         self.push(ToastKind::Info, title.into(), detail);
     }
 
+    /// Push a new warning toast onto the stack.
+    pub(super) fn warning(&mut self, title: impl Into<String>, detail: Option<String>) {
+        self.push(ToastKind::Warning, title.into(), detail);
+    }
+
     /// Number of toasts currently on the stack. Test-only helper used by the
     /// notification router tests to assert toast-leg routing decisions.
     #[cfg(test)]
     pub(super) const fn len(&self) -> usize {
         self.entries.len()
+    }
+
+    /// The kind of the last (most-recently pushed) toast, if any. Test-only
+    /// accessor (also used by the notification-router tests to assert
+    /// freminal-toast severity mapping).
+    #[cfg(test)]
+    pub(super) fn last_kind(&self) -> Option<ToastKind> {
+        self.entries.last().map(|t| t.kind)
     }
 
     /// Whether the stack currently has no toasts. Used by the frame-damage
@@ -1465,6 +1477,18 @@ mod tests {
         assert_eq!(s.entries[0].kind, ToastKind::Error);
         assert_eq!(s.entries[0].title, "spawn failed");
         assert_eq!(s.entries[0].detail.as_deref(), Some("no such file"));
+    }
+
+    // -----------------------------------------------------------------
+    //  ToastStack::warning
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn warning_pushes_warning_kind() {
+        let mut s = ToastStack::default();
+        s.warning("paste blocked", None);
+        assert_eq!(s.len(), 1);
+        assert_eq!(s.last_kind(), Some(ToastKind::Warning));
     }
 
     #[test]

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -23,6 +23,66 @@ use super::{
 /// Position is typically `None` on Wayland.
 pub(super) type PendingGeometry = (Option<[u32; 2]>, Option<[i32; 2]>);
 
+/// Transient state for the resize overlay (issue #433): a passive,
+/// window-centered HUD showing the terminal's new size while the user is
+/// resizing the window or a split, fading out shortly after resizing stops.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct ResizeOverlayState {
+    /// The size to display, in character cells: (cols, rows).
+    pub(super) size: (usize, usize),
+    /// When the most recent resize event was observed. Drives the linger /
+    /// fade-out timeout.
+    pub(super) last_update: std::time::Instant,
+}
+
+/// How long the resize overlay lingers after the last genuine resize event
+/// before disappearing entirely (issue #433).
+pub(super) const RESIZE_OVERLAY_LINGER: std::time::Duration = std::time::Duration::from_millis(900);
+
+/// How long, at the tail end of [`RESIZE_OVERLAY_LINGER`], the overlay fades
+/// out linearly (issue #433).
+pub(super) const RESIZE_OVERLAY_FADE: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// Alpha multiplier (1.0 = fully opaque, 0.0 = invisible) for the resize
+/// overlay, given how long it has been since the last genuine resize event.
+///
+/// Fully opaque until the last `fade` window before `linger` elapses, then
+/// fades linearly to 0, and is 0 at/after `linger`. Pure function so the
+/// timing math is unit-testable without an egui frame (issue #433).
+pub(super) fn resize_overlay_alpha(
+    elapsed: std::time::Duration,
+    linger: std::time::Duration,
+    fade: std::time::Duration,
+) -> f32 {
+    if elapsed >= linger {
+        return 0.0;
+    }
+    let remaining = linger.saturating_sub(elapsed);
+    if remaining >= fade || fade.is_zero() {
+        1.0
+    } else {
+        (remaining.as_secs_f32() / fade.as_secs_f32()).clamp(0.0, 1.0)
+    }
+}
+
+/// Whether an observed char-grid size change is a GENUINE OS-window resize,
+/// rather than the spurious `last_sent_size` churn caused by new
+/// window/tab/split/pane-close/zoom transitions (which reset `last_sent_size`
+/// to `(0, 0)`) (issue #433).
+///
+/// `window_resized` must be true only for a real resize between two KNOWN
+/// window sizes (see `window_genuinely_resized` at the call site) — NOT for
+/// the first `None -> Some` geometry observation of a freshly created window,
+/// which would otherwise flash the overlay on launch / new-window spawn.
+///
+/// Split-border drags are deliberately excluded: the overlay reports the
+/// whole-window `cols × rows`, which does not change when an internal border
+/// moves, so showing a frozen number during a split drag would be
+/// uninformative.
+pub(super) const fn resize_is_genuine(size_changed: bool, window_resized: bool) -> bool {
+    size_changed && window_resized
+}
+
 /// Per-window state for a single OS window.
 ///
 /// Each window (whether it was the first or spawned later via `Ctrl+Shift+N`)
@@ -71,6 +131,10 @@ pub(super) struct PerWindowState {
 
     /// Active pane border drag state (mouse drag-to-resize).
     pub(super) border_drag: Option<PaneBorderDrag>,
+
+    /// Active resize-overlay HUD state, or `None` when no resize is in
+    /// progress / the overlay has timed out (issue #433).
+    pub(super) resize_overlay: Option<ResizeOverlayState>,
 
     /// Last modified time of the shader file, used for hot-reload detection.
     /// `None` when no shader is configured or hot-reload is disabled.
@@ -398,4 +462,74 @@ pub(super) struct FrameStats {
 impl FrameStats {
     /// Emit a `debug` summary once every this many drawn frames.
     pub(super) const FLUSH_EVERY: u64 = 120;
+}
+
+#[cfg(test)]
+mod resize_overlay_tests {
+    use super::{
+        RESIZE_OVERLAY_FADE, RESIZE_OVERLAY_LINGER, resize_is_genuine, resize_overlay_alpha,
+    };
+    use std::time::Duration;
+
+    #[test]
+    fn alpha_is_full_at_zero_elapsed() {
+        assert!(
+            (resize_overlay_alpha(Duration::ZERO, RESIZE_OVERLAY_LINGER, RESIZE_OVERLAY_FADE)
+                - 1.0)
+                .abs()
+                < f32::EPSILON
+        );
+    }
+
+    #[test]
+    fn alpha_is_full_just_before_fade_window_starts() {
+        // linger=900ms, fade=250ms -> fade starts at elapsed=650ms.
+        let elapsed = RESIZE_OVERLAY_LINGER
+            .saturating_sub(RESIZE_OVERLAY_FADE)
+            .checked_sub(Duration::from_millis(1))
+            .unwrap_or(Duration::ZERO);
+        let alpha = resize_overlay_alpha(elapsed, RESIZE_OVERLAY_LINGER, RESIZE_OVERLAY_FADE);
+        assert!((alpha - 1.0).abs() < 0.01, "alpha was {alpha}");
+    }
+
+    #[test]
+    fn alpha_is_half_midway_through_fade() {
+        // elapsed = linger - fade/2 -> remaining = fade/2 -> alpha = 0.5.
+        let elapsed = RESIZE_OVERLAY_LINGER
+            .checked_sub(RESIZE_OVERLAY_FADE / 2)
+            .unwrap_or(Duration::ZERO);
+        let alpha = resize_overlay_alpha(elapsed, RESIZE_OVERLAY_LINGER, RESIZE_OVERLAY_FADE);
+        assert!((alpha - 0.5).abs() < 0.01, "alpha was {alpha}");
+    }
+
+    #[test]
+    fn alpha_is_zero_at_and_after_linger() {
+        let at_linger = resize_overlay_alpha(
+            RESIZE_OVERLAY_LINGER,
+            RESIZE_OVERLAY_LINGER,
+            RESIZE_OVERLAY_FADE,
+        );
+        assert!(at_linger.abs() < f32::EPSILON, "alpha was {at_linger}");
+        let past_linger = resize_overlay_alpha(
+            RESIZE_OVERLAY_LINGER + Duration::from_secs(5),
+            RESIZE_OVERLAY_LINGER,
+            RESIZE_OVERLAY_FADE,
+        );
+        assert!(past_linger.abs() < f32::EPSILON, "alpha was {past_linger}");
+    }
+
+    #[test]
+    fn genuine_requires_size_change_and_window_resize() {
+        // Truth table: size_changed, window_resized -> expected.
+        assert!(!resize_is_genuine(false, false));
+        assert!(!resize_is_genuine(false, true));
+        // The spurious case the adversarial review flagged: char-grid size
+        // changed (e.g. new tab/split reset last_sent_size to (0,0), or the
+        // first `None -> Some` geometry observation on launch) but the OS
+        // window did not genuinely resize between two known sizes.
+        assert!(!resize_is_genuine(true, false));
+        // The only genuine case: a real OS-window resize alongside a char-grid
+        // change.
+        assert!(resize_is_genuine(true, true));
+    }
 }

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -166,6 +166,13 @@ let
           routing_osc_text
           routing_osc99
           routing_command_finished
+          routing_clipboard_copy
+          routing_clipboard_remote
+          show_resize_overlay
+          routing_layout
+          routing_recording
+          routing_paste_blocked
+          routing_config_reload
           ;
       };
 
@@ -945,6 +952,106 @@ in
             Routing for command-finished notifications (see routing_error for
             the value meanings).
             Null uses the default ("system_when_unfocused").
+          '';
+        };
+
+        routing_clipboard_copy = mkOption {
+          type = types.nullOr (
+            types.enum [
+              "toast"
+              "disabled"
+            ]
+          );
+          default = null;
+          description = ''
+            Routing for the "copied to clipboard" toast (local Ctrl+C /
+            menu Copy): "toast" (in-app only) or "disabled" (suppress).
+            Null uses the default ("toast").
+          '';
+        };
+
+        routing_clipboard_remote = mkOption {
+          type = types.nullOr (
+            types.enum [
+              "toast"
+              "disabled"
+            ]
+          );
+          default = null;
+          description = ''
+            Routing for the OSC 52 remote-clipboard toast (an application
+            wrote to, or was blocked from reading, the clipboard): "toast"
+            (in-app only) or "disabled" (suppress).
+            Null uses the default ("toast").
+          '';
+        };
+
+        show_resize_overlay = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = ''
+            Show a transient cols×rows overlay while resizing a window or
+            pane. Null uses the default (true).
+          '';
+        };
+
+        routing_layout = mkOption {
+          type = types.nullOr (
+            types.enum [
+              "toast"
+              "disabled"
+            ]
+          );
+          default = null;
+          description = ''
+            Routing for the layout saved/loaded toast: "toast" (in-app
+            only) or "disabled" (suppress).
+            Null uses the default ("toast").
+          '';
+        };
+
+        routing_recording = mkOption {
+          type = types.nullOr (
+            types.enum [
+              "toast"
+              "disabled"
+            ]
+          );
+          default = null;
+          description = ''
+            Routing for the recording started/stopped toast: "toast"
+            (in-app only) or "disabled" (suppress).
+            Null uses the default ("toast").
+          '';
+        };
+
+        routing_paste_blocked = mkOption {
+          type = types.nullOr (
+            types.enum [
+              "toast"
+              "disabled"
+            ]
+          );
+          default = null;
+          description = ''
+            Routing for the "paste blocked" toast (smart-paste guard):
+            "toast" (in-app only) or "disabled" (suppress).
+            Null uses the default ("toast").
+          '';
+        };
+
+        routing_config_reload = mkOption {
+          type = types.nullOr (
+            types.enum [
+              "toast"
+              "disabled"
+            ]
+          );
+          default = null;
+          description = ''
+            Routing for the "config reloaded" toast: "toast" (in-app only)
+            or "disabled" (suppress).
+            Null uses the default ("toast").
           '';
         };
       };

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -990,8 +990,9 @@ in
           type = types.nullOr types.bool;
           default = null;
           description = ''
-            Show a transient cols×rows overlay while resizing a window or
-            pane. Null uses the default (true).
+            Show a transient cols×rows overlay while resizing the OS window
+            (not on split-border / pane-border drags).
+            Null uses the default (true).
           '';
         };
 


### PR DESCRIPTION
## Summary

Follow-up slice for #433. Adds freminal's **own** toast notifications (distinct from the OSC 9/777/99/133 *application* notifications shipped in #449) plus a dedicated **resize overlay**.

This is the first consumer of the reserved `FreminalToastRouting { Toast, Disabled }` enum introduced in #449.

## What's in it

### Freminal-derived toasts
- `FreminalToastCategory` (6 variants: ClipboardCopy, ClipboardRemote, Layout, Recording, PasteBlocked, ConfigReload). Each routes independently via a per-category `routing_<cat>: FreminalToastRouting` field (default `Toast`), consulted by `NotificationRouter::route_freminal_toast` and the `FreminalGui::route_freminal_toast` `&self` wrapper.
- These are **toast-only** (no desktop leg) and **bypass** the notifications `enabled` master switch by design — they are freminal's own UI feedback.
- New push sites:
  - **Clipboard copy** — local Ctrl+C / Edit menu **and** right-click context menu (Copy / Copy URL / Copy Command Output), via a `copied_to_clipboard` flag threaded through `FreminalTerminalWidget::show()`.
  - **OSC 52 remote clipboard** — write, and policy-blocked read. Privacy: byte count only, never content.
  - **Recording** started/stopped, **layout** saved/loaded, **paste blocked** (Warning severity), **config reloaded** (migrated onto the routing gate so it's individually silenceable).

### Resize overlay (not a toast)
- A passive, **window-centered** overlay (plain painter, like the broadcast label) showing the **whole-window** `cols × rows` while resizing. Gated by `show_resize_overlay` (default true).
- Fires **only on a genuine OS-window resize** (`resize_is_genuine` requires a `Some→Some` window-size change), so it does **not** flash on launch, new window/tab, split, pane close, or zoom, and split-border drags are excluded (the whole-window readout wouldn't change).
- 900ms linger + 250ms fade; timing/gate logic factored into pure, unit-tested functions.

### Config wiring
Per `freminal-config-options`: `NotificationsConfig` fields + `Default`, `config_example.toml`, Nix home-manager module (inherit list + mkOptions), Settings UI (6 Toast/Disabled routing rows + `show_resize_overlay` checkbox), round-trip/default tests. Whole-section merge — no `ConfigPartial` change needed.

## Verification
- `cargo test --all` — green (0 failed)
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo machete` — clean
- `cargo fmt --all -- --check` — clean
- `cargo xtask check-windows` — clean

## Review notes
Two adversarial-review passes were run. The first prompted the maintainer to redesign the resize readout from a (flickering) toast into the dedicated overlay. The second found and fixed a launch/new-window spurious-overlay bug and a frozen-number-during-split-drag bug, plus tightened a tautological test.

## Scope
**Part of #433 — slice 1 of 4.** 
2. Per-scope toast positioning (PaneCentered / WindowCentered origin plumbing)
3. System-notification app icon
4. New skill documenting the toast-options pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable toast notifications for clipboard actions, layout changes, recording, blocked pastes, and configuration reloads.
  * Added a temporary overlay showing terminal dimensions while resizing windows.
  * Added notifications when layouts are saved or loaded and recordings start or stop.
  * Added resize-overlay and notification-routing options to the settings interface and Home Manager configuration.

* **Bug Fixes**
  * Improved feedback for remote clipboard activity and blocked paste operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->