### PR TITLE
Toast visual redesign + notification icon + toast-options skill (Closes #433)

### DIFF
--- a/.opencode/skills/freminal-toast-options/SKILL.md
+++ b/.opencode/skills/freminal-toast-options/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: freminal-toast-options
+description: Use ONLY when working in the freminal repository AND adding, changing, or reasoning about a notification/toast source and how it is routed — a new freminal-derived toast (clipboard, layout, recording, paste-blocked, config-reload, and future UI-feedback toasts), a new OSC-sourced notification (OSC 9/777/99/133D), or a new toast placement. Codifies the two-tier routing model: the restricted Toast/Disabled `FreminalToastRouting` for freminal's own UI toasts (no system leg, no master-switch gate) versus the full `NotificationRouting` (Toast/System/Both/SystemWhenUnfocused/Disabled) for terminal-application-driven notifications, plus the `FreminalToastCategory` → `routing_<cat>` → `route_freminal_toast` → `push_positioned(ToastPlacement)` consumer chain and where the resize overlay deliberately sits outside it.
+---
+
+# Freminal: toast + notification routing options
+
+Freminal has **two distinct notification models**, and choosing the
+wrong one is the most common mistake when adding a new notification
+source. This skill names the two models, the decision rule between
+them, and the exact wiring each requires. It pairs with
+`freminal-config-options` (the generic config-field checklist) and
+`freminal-modal-input-suppression` (toasts are not typing modals).
+
+All file references are to the freminal repo. The routing enums live
+in `freminal-common/src/config.rs`; the router lives in
+`freminal/src/gui/notifications.rs`; placement lives in
+`freminal/src/gui/toast.rs`.
+
+## The two models
+
+| Aspect        | Terminal-app notifications                   | Freminal-derived toasts                    |
+| ------------- | -------------------------------------------- | ------------------------------------------ |
+| Source        | OSC 9 / 777 / 99 / 133D, command-finished    | freminal's own UI events                   |
+| Routing enum  | `NotificationRouting` (5 variants)           | `FreminalToastRouting` (2 variants)        |
+| System leg    | Yes — can raise a desktop notification        | No — toast or nothing, ever                |
+| Master switch | Gated by `notifications.enabled`             | Bypasses `enabled` entirely                |
+| Focus-aware   | Yes (`wants_toast(focused)`)                 | No (`wants_toast()`, no argument)          |
+| Router entry  | `NotificationRouter::route` / `route_osc99`  | `NotificationRouter::route_freminal_toast` |
+| Default anchor| `ToastPlacement::TOP_RIGHT`                  | window- or pane-centered                   |
+
+### Model 1 — terminal-application notifications (full options)
+
+These come from the program running in the terminal (an OSC escape
+sequence) or from a freminal-observed command completion. The user
+gets the full `NotificationRouting` choice:
+
+```rust
+pub enum NotificationRouting {
+    Toast,               // in-app toast only
+    System,              // desktop notification only
+    Both,                // toast + desktop notification
+    SystemWhenUnfocused, // desktop when unfocused, toast when focused
+    Disabled,            // suppressed entirely
+}
+```
+
+`wants_toast(focused)` and `wants_system(focused)` are both
+focus-aware. `route` / `route_osc99` gate on `config.enabled` first,
+then branch on both legs.
+
+### Model 2 — freminal-derived toasts (Toast / Disabled only)
+
+These are freminal's **own** UI feedback (you copied text, a layout
+saved, recording started). They never leave the window as a desktop
+notification, so the only sensible choices are "show a toast" or
+"don't":
+
+```rust
+pub enum FreminalToastRouting {
+    Toast,    // in-app toast (default)
+    Disabled, // suppressed
+}
+```
+
+`wants_toast()` takes no `focused` argument. `route_freminal_toast`
+does **not** check `config.enabled` and has **no** `wants_system` /
+`show_system` leg — these toasts are governed solely by their own
+per-category `routing_<category>` field.
+
+## The decision rule
+
+Ask: **does the program running in the terminal cause this, or does
+freminal's own UI cause it?**
+
+- Program-caused (an escape sequence, a finished command) → Model 1,
+  `NotificationRouting`, wired into `route` / `route_osc99`.
+- Freminal-UI-caused (a keypress, a menu action, a config reload) →
+  Model 2, `FreminalToastRouting`, a new `FreminalToastCategory`
+  variant, wired through `route_freminal_toast`.
+
+If you are tempted to give a freminal-derived toast a `System` option,
+stop: the maintainer's explicit design (issue #433) is that
+freminal's own toasts are toast-or-nothing. Adding a system leg to
+them is a design change, not an implementation detail — surface it.
+
+## The freminal-derived consumer chain (Model 2)
+
+Every freminal-derived toast flows through the same four stages. When
+adding a new one, wire all four:
+
+1. **Category** — add a variant to `FreminalToastCategory`
+   (`config.rs`). The six today are `ClipboardCopy`, `ClipboardRemote`,
+   `Layout`, `Recording`, `PasteBlocked`, `ConfigReload`.
+
+2. **Config field** — add a `routing_<cat>: FreminalToastRouting`
+   field to `NotificationsConfig`, and add its arm to
+   `NotificationsConfig::routing_for_category` (the `match category`
+   dispatch). This is a config option: the full
+   `freminal-config-options` checklist applies (Default,
+   `config_example.toml`, Nix module `mkOption` + known-keys list,
+   Settings UI row, round-trip test). Because `NotificationsConfig` is
+   merged as a whole section in `apply_partial`, adding a field inside
+   it needs no `apply_partial` change — but everything else in the
+   checklist still applies.
+
+3. **Router** — the push site calls
+   `NotificationRouter::route_freminal_toast(category, kind, title,
+   detail, placement, config, toasts)` (usually via the
+   `FreminalGui::route_freminal_toast` `&self` wrapper in `mod.rs`,
+   which handles the `RefCell` borrow). The router checks
+   `config.routing_for_category(category).wants_toast()` and, if true,
+   calls `toasts.push_positioned(kind, title, detail, placement)`.
+
+4. **Placement** — pick a `ToastPlacement` (see below).
+
+## Placement
+
+`ToastPlacement { position: ToastPosition, origin: Option<(WindowId,
+PaneId)> }`. Three consts / constructors:
+
+- `ToastPlacement::TOP_RIGHT` — stacked top-right. Used by the
+  severity pushers (`ToastStack::error` / `info`) and every Model 1
+  (OSC / error / info) toast.
+- `ToastPlacement::WINDOW_CENTERED` — centered in the window. The
+  default for freminal-derived toasts not tied to one pane (recording,
+  layout, config reload, remote clipboard, paste-blocked).
+- `ToastPlacement::pane_centered(window_id, pane_id)` — centered in
+  the originating pane. Used only where the event belongs to a
+  specific pane (today: "Copied to clipboard"). Falls back to
+  window-centered when that pane/window is not the one being rendered.
+
+Rule of thumb: a pane-specific event (something you did *in* a pane)
+is `pane_centered`; a window/app-level event is `WINDOW_CENTERED`;
+program-driven notifications are `TOP_RIGHT`.
+
+There is no `ToastStack::warning` helper — it was deleted in slice 2
+as dead code. Push a warning-severity toast via
+`route_freminal_toast(..., ToastKind::Warning, ...)` /
+`push_positioned(ToastKind::Warning, ...)`, not a bespoke wrapper.
+Do not reintroduce a dead severity wrapper; if a new `ToastPosition`
+or placement is genuinely needed it must have a real caller and a
+test (no `#[allow(dead_code)]`).
+
+## The resize overlay is NOT a toast
+
+The window-resize "cols × rows" readout looks like a toast but is
+deliberately **not** one. It is a passive, hand-painted egui HUD
+(`ResizeOverlayState` in `window.rs`, drawn inline in `app_impl.rs`),
+gated directly by `config.notifications.show_resize_overlay` — it
+never touches `ToastStack`, `route_freminal_toast`, or
+`push_positioned`. It has its own linger/fade timing.
+
+Why it matters: a whole-window size readout that stacked as a toast
+would fight the real toasts for the corner and re-trigger on every
+resize tick. Keeping it a separate centered overlay was the
+issue #433 design. The **only** place the two concepts intersect is
+frame damage: both the resize overlay and any live toast set
+`toast_active` (in `app_impl.rs`) so their self-animating region
+forces a full-frame present. If you add another self-animating
+passive overlay, wire it into that same `toast_active` decision — but
+do not route it as a toast.
+
+## Common mistakes this skill prevents
+
+- Giving a freminal-derived toast a `System`/`Both` routing option
+  (wrong model — surface it as a design change).
+- Gating a freminal-derived toast on `notifications.enabled` (they
+  bypass it by design).
+- Adding a `routing_<cat>` field but forgetting the
+  `routing_for_category` arm (compiles, but the category silently
+  can't be configured).
+- Calling `wants_toast(focused)` on a `FreminalToastRouting` (it takes
+  no argument) or `wants_toast()` on a `NotificationRouting` (it
+  requires `focused`).
+- Routing the resize overlay (or a future passive HUD) as a toast.
+- Reintroducing a `ToastStack::warning`-style dead wrapper.
+
+## When to stop and ask
+
+- A new notification source doesn't cleanly fit either model (e.g. a
+  freminal-UI event that genuinely should also raise a desktop
+  notification). The two-model split is a maintainer design decision —
+  surface the ambiguity rather than bolting a system leg onto Model 2.
+- A new toast needs a placement none of the three consts cover. A new
+  `ToastPosition` variant is a layout change with its own tests and
+  grouping/occlusion implications (see the coincident-group handling
+  in `toast.rs`); confirm the need first.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2478,6 +2478,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
 dependencies = [
  "futures-lite",
+ "image",
+ "lazy_static",
  "log",
  "mac-notification-sys",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,17 @@ libc = "0.2.188"
 log = "0.4.32"
 lz4_flex = "0.14.0"
 nix = "0.31.3"
-notify-rust = "4.18.0"
+# `images_no_default_features` enables the inline `image-data` D-Bus hint
+# (`Notification::image_data` / `Image::from_rgba`) so freminal can attach its
+# app icon to desktop notifications as raw bytes -- working even when freminal
+# is not installed into the system icon theme (dev / cargo-run / AppImage),
+# the way Discord & co. do. `z` is notify-rust's default feature (the zbus
+# backend + serde); it is listed only for documentation -- this entry does
+# NOT set `default-features = false`, so the default set is retained
+# regardless. We decode the PNG ourselves via the workspace `image` crate, so
+# notify-rust's heavier `images` feature (its own codecs + rayon) is
+# deliberately NOT used.
+notify-rust = { version = "4.18.0", features = ["images_no_default_features", "z"] }
 open = "5.4.0"
 predicates = "3.1.4"
 proptest = "1.11.0"

--- a/freminal/src/gui/notifications.rs
+++ b/freminal/src/gui/notifications.rs
@@ -363,50 +363,74 @@ impl NotificationRouter {
         if cfg!(test) {
             return;
         }
-        let summary = req.summary().to_owned();
-        let body = req.body.clone();
-        // `notify-rust`'s `urgency()` setter exists on Linux/BSD and Windows
-        // but NOT on macOS, so capture whether this is a high-urgency
-        // (error-category) notification here and apply the hint only on the
-        // platforms that support it (see the cfg-gated block below).
-        let critical = matches!(req.kind, NotificationKind::Error);
+        let notification = Self::build_system_notification(req);
         let builder = std::thread::Builder::new().name("freminal-notify".to_owned());
         if let Err(e) = builder.spawn(move || {
-            let mut notification = notify_rust::Notification::new();
-            notification
-                .appname("freminal")
-                .summary(&summary)
-                .body(&body);
-
-            // Error-category notifications use Critical urgency so they persist
-            // and pop as a banner; everything else is Normal. Many Linux
-            // notification daemons only raise a banner (rather than silently
-            // filing the notification in the tray) when an urgency hint is set.
-            //
-            // `notify_rust`'s `urgency()` exists on Linux/BSD and Windows but
-            // NOT on macOS (the `Urgency` type is re-exported there but
-            // deprecated and the method is absent), so gate the call on
-            // `not(target_os = "macos")`.
-            #[cfg(not(target_os = "macos"))]
-            {
-                let urgency = if critical {
-                    notify_rust::Urgency::Critical
-                } else {
-                    notify_rust::Urgency::Normal
-                };
-                notification.urgency(urgency);
-            }
-            // Silence the unused-variable warning on macOS, where the urgency
-            // hint is unavailable.
-            #[cfg(target_os = "macos")]
-            let _ = critical;
-
             if let Err(e) = notification.show() {
                 tracing::warn!("failed to show desktop notification: {e}");
             }
         }) {
             tracing::warn!("failed to spawn notification thread: {e}");
         }
+    }
+
+    /// Build the `notify-rust` notification for a freminal-derived / OSC 9 /
+    /// OSC 777 / command-finished desktop notification (the [`show_system`]
+    /// path — *not* the OSC 99 path, which builds its own notification with a
+    /// transmitted icon in [`build_osc99_notification`]).
+    ///
+    /// Attaches the bundled freminal application icon by name
+    /// (`.icon("freminal")`). This is an icon-theme *name* lookup, matching
+    /// `assets/freminal.desktop`'s `Icon=freminal`: when freminal is installed
+    /// its packaging drops `freminal.png` / `freminal.svg` into the system
+    /// hicolor icon theme, so the notification daemon resolves this name to
+    /// the app icon. When freminal is not installed (e.g. an uninstalled dev
+    /// or `AppImage` run with no theme entry) the daemon falls back to
+    /// `appname` resolution — the same behaviour as before this icon was set,
+    /// so the name-based approach never regresses the uninstalled case. The
+    /// OSC 99 path deliberately uses a transmitted-bytes temp file instead
+    /// (see [`build_osc99_notification`]) and must not be routed through here.
+    ///
+    /// Split out as a pure builder (rather than inlined in the spawned thread)
+    /// so the icon/appname/summary/body/urgency wiring is unit-testable
+    /// without invoking the real OS `show()` call (which is skipped under
+    /// `cfg(test)`; see [`show_system`]).
+    ///
+    /// [`show_system`]: Self::show_system
+    /// [`build_osc99_notification`]: Self::build_osc99_notification
+    fn build_system_notification(req: &NotificationRequest) -> notify_rust::Notification {
+        let mut notification = notify_rust::Notification::new();
+        notification
+            .appname("freminal")
+            // The bundled application icon, by icon-theme name (see doc above).
+            // `.icon()` is available on every platform in notify-rust 4.18
+            // (a no-op where unsupported); it is the same name-based
+            // `.icon(name)` call `build_osc99_notification` uses in its
+            // no-transmitted-bytes branch.
+            .icon("freminal")
+            .summary(req.summary())
+            .body(&req.body);
+
+        // Error-category notifications use Critical urgency so they persist
+        // and pop as a banner; everything else is Normal. Many Linux
+        // notification daemons only raise a banner (rather than silently
+        // filing the notification in the tray) when an urgency hint is set.
+        //
+        // `notify_rust`'s `urgency()` exists on Linux/BSD and Windows but
+        // NOT on macOS (the `Urgency` type is re-exported there but
+        // deprecated and the method is absent), so gate the call on
+        // `not(target_os = "macos")`.
+        #[cfg(not(target_os = "macos"))]
+        {
+            let urgency = if matches!(req.kind, NotificationKind::Error) {
+                notify_rust::Urgency::Critical
+            } else {
+                notify_rust::Urgency::Normal
+            };
+            notification.urgency(urgency);
+        }
+
+        notification
     }
 }
 
@@ -1069,6 +1093,110 @@ mod tests {
             body: "done".to_owned(),
         };
         assert_eq!(req.summary(), "Build");
+    }
+
+    /// Slice 3 (#433): the `show_system` path attaches the bundled freminal
+    /// application icon by name so desktop notifications show the app icon.
+    /// The name matches `assets/freminal.desktop`'s `Icon=freminal`.
+    #[test]
+    fn build_system_notification_sets_freminal_icon() {
+        let req = NotificationRequest {
+            kind: NotificationKind::OscText,
+            source: Some(OscNotifySource::Osc9),
+            title: Some("Hello".to_owned()),
+            body: "world".to_owned(),
+        };
+        let notification = NotificationRouter::build_system_notification(&req);
+        assert_eq!(notification.icon, "freminal");
+        assert_eq!(notification.appname, "freminal");
+        assert_eq!(notification.summary, "Hello");
+        assert_eq!(notification.body, "world");
+    }
+
+    /// The builder still applies the per-kind summary fallback when the
+    /// request carries no explicit title.
+    #[test]
+    fn build_system_notification_uses_summary_fallback() {
+        let req = osc_req("body text");
+        let notification = NotificationRouter::build_system_notification(&req);
+        // `OscText` with no title falls back to the kind-derived default.
+        assert_eq!(notification.summary, "Notification");
+        assert_eq!(notification.icon, "freminal");
+    }
+
+    /// Slice 3 invariant guard: the OSC 99 path must NOT be given the
+    /// `"freminal"` app icon — it carries its own transmitted icon (a named
+    /// freedesktop icon, or transmitted bytes via `image_path`). This locks
+    /// the "slice 3 only touches `show_system`, never the OSC 99 path"
+    /// boundary so a future "make it consistent" edit can't silently override
+    /// a program's transmitted OSC 99 icon with the freminal app icon.
+    #[test]
+    fn build_osc99_notification_uses_transmitted_icon_not_freminal() {
+        // Named-icon branch: the transmitted freedesktop icon name is used.
+        let (named, temp) = NotificationRouter::build_osc99_notification(
+            Some("id-1"),
+            Some("Title"),
+            "body",
+            None,
+            &[],
+            None,
+            None,
+            None,
+            &["weather-clear".to_owned()],
+            None,
+        );
+        assert_eq!(
+            named.icon, "weather-clear",
+            "OSC 99 must use the transmitted icon name, never \"freminal\""
+        );
+        assert!(temp.is_none(), "no temp file when no bytes transmitted");
+
+        // Transmitted-bytes branch: `.icon` stays empty (bytes go to
+        // `image_path` via a temp file), and definitely is not "freminal".
+        let (with_bytes, temp) = NotificationRouter::build_osc99_notification(
+            Some("id-2"),
+            Some("Title"),
+            "body",
+            None,
+            &[],
+            None,
+            None,
+            None,
+            &[],
+            Some(vec![1, 2, 3, 4]),
+        );
+        assert_ne!(
+            with_bytes.icon, "freminal",
+            "OSC 99 transmitted-bytes path must not fall back to the freminal app icon"
+        );
+        // Clean up the temp file the bytes branch created.
+        if let Some(path) = temp {
+            NotificationRouter::remove_icon_temp_file(&path);
+        }
+    }
+
+    /// Error-category notifications carry Critical urgency on the platforms
+    /// that support the hint; everything else is Normal. The urgency lives in
+    /// `notify_rust::Notification::hints`, which the crate itself gates
+    /// `#[cfg(all(unix, not(target_os = "macos")))]` — so this test must use
+    /// the *same* cfg as the field. (macOS lacks the `urgency()` setter;
+    /// Windows stores urgency in a private field with no `.hints`.) The
+    /// production `#[cfg(not(target_os = "macos"))]` urgency call in
+    /// `build_system_notification` still runs on Windows — this test just
+    /// can't observe it there without a public accessor.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn build_system_notification_urgency_by_kind() {
+        use notify_rust::{Hint, Urgency};
+
+        let mut req = osc_req("x");
+        req.kind = NotificationKind::Error;
+        let critical = NotificationRouter::build_system_notification(&req);
+        assert!(critical.hints.contains(&Hint::Urgency(Urgency::Critical)));
+
+        req.kind = NotificationKind::OscText;
+        let normal = NotificationRouter::build_system_notification(&req);
+        assert!(normal.hints.contains(&Hint::Urgency(Urgency::Normal)));
     }
 
     #[test]

--- a/freminal/src/gui/notifications.rs
+++ b/freminal/src/gui/notifications.rs
@@ -366,6 +366,20 @@ impl NotificationRouter {
         let notification = Self::build_system_notification(req);
         let builder = std::thread::Builder::new().name("freminal-notify".to_owned());
         if let Err(e) = builder.spawn(move || {
+            // Attach the inline `image-data` icon on the background thread, not
+            // the GUI thread: the first call decodes the embedded PNG (~1 MiB
+            // RGBA), which must never block the frame loop (adversarial review
+            // finding 1). `build_system_notification` stays a pure, icon-less
+            // builder so it remains unit-testable without the decode; the
+            // Linux/BSD-only image attachment lives here. The `mut` rebind is
+            // scoped to this cfg so it isn't an unused-mut on macOS/Windows,
+            // where `image_data` does not exist.
+            #[cfg(all(unix, not(target_os = "macos")))]
+            let mut notification = notification;
+            #[cfg(all(unix, not(target_os = "macos")))]
+            if let Some(image) = freminal_icon_image() {
+                notification.image_data(image.clone());
+            }
             if let Err(e) = notification.show() {
                 tracing::warn!("failed to show desktop notification: {e}");
             }
@@ -379,17 +393,26 @@ impl NotificationRouter {
     /// path — *not* the OSC 99 path, which builds its own notification with a
     /// transmitted icon in [`build_osc99_notification`]).
     ///
-    /// Attaches the bundled freminal application icon by name
-    /// (`.icon("freminal")`). This is an icon-theme *name* lookup, matching
-    /// `assets/freminal.desktop`'s `Icon=freminal`: when freminal is installed
-    /// its packaging drops `freminal.png` / `freminal.svg` into the system
-    /// hicolor icon theme, so the notification daemon resolves this name to
-    /// the app icon. When freminal is not installed (e.g. an uninstalled dev
-    /// or `AppImage` run with no theme entry) the daemon falls back to
-    /// `appname` resolution — the same behaviour as before this icon was set,
-    /// so the name-based approach never regresses the uninstalled case. The
-    /// OSC 99 path deliberately uses a transmitted-bytes temp file instead
-    /// (see [`build_osc99_notification`]) and must not be routed through here.
+    /// Attaches the bundled freminal application icon by icon-theme **name**
+    /// (`.icon("freminal")`), matching `assets/freminal.desktop`'s
+    /// `Icon=freminal`. This is the secondary icon hint: it covers
+    /// macOS/Windows and installed setups whose packaging drops
+    /// `freminal.png` into the hicolor theme.
+    ///
+    /// The *primary*, always-works icon — the embedded app icon as inline
+    /// `image-data` bytes (the mechanism Discord & co. use, which shows even
+    /// when freminal is not installed into the system icon theme) — is
+    /// attached separately, on the background notification thread, in
+    /// [`show_system`], because decoding the embedded PNG (~1 MiB RGBA) must
+    /// not run on the GUI thread. Keeping this builder icon-bytes-free is
+    /// deliberate: it stays a pure, cheap, unit-testable function (no decode,
+    /// no `image-data` platform gating) while the heavy Linux/BSD-only image
+    /// work lives off the frame loop. A daemon that honours `image-data` uses
+    /// that; one that only honours `icon` falls back to this name.
+    ///
+    /// The OSC 99 path deliberately builds its own notification with a
+    /// *transmitted* icon (see [`build_osc99_notification`]) and must not be
+    /// routed through here.
     ///
     /// Split out as a pure builder (rather than inlined in the spawned thread)
     /// so the icon/appname/summary/body/urgency wiring is unit-testable
@@ -402,11 +425,12 @@ impl NotificationRouter {
         let mut notification = notify_rust::Notification::new();
         notification
             .appname("freminal")
-            // The bundled application icon, by icon-theme name (see doc above).
-            // `.icon()` is available on every platform in notify-rust 4.18
-            // (a no-op where unsupported); it is the same name-based
-            // `.icon(name)` call `build_osc99_notification` uses in its
-            // no-transmitted-bytes branch.
+            // Secondary, name-based icon hint (see doc above). `.icon()` is
+            // available on every platform in notify-rust 4.18 (a no-op where
+            // unsupported); it is the same name-based `.icon(name)` call
+            // `build_osc99_notification` uses in its no-transmitted-bytes
+            // branch. The primary inline-bytes icon is attached in
+            // `show_system` on the background thread.
             .icon("freminal")
             .summary(req.summary())
             .body(&req.body);
@@ -432,6 +456,55 @@ impl NotificationRouter {
 
         notification
     }
+}
+
+/// The bundled freminal application icon as a notify-rust [`Image`], decoded
+/// once from the embedded `assets/icon.png` and cached for the process
+/// lifetime.
+///
+/// Returns `None` (and logs a warning once) if the embedded PNG fails to
+/// decode or the pixels don't form a valid RGBA image — a missing
+/// notification icon is non-fatal, so callers simply omit the `image-data`
+/// hint in that case.
+///
+/// Linux/BSD only: notify-rust's [`notify_rust::Image`] /
+/// [`notify_rust::Notification::image_data`] are gated
+/// `#[cfg(all(unix, not(target_os = "macos")))]`.
+///
+/// [`Image`]: notify_rust::Image
+#[cfg(all(unix, not(target_os = "macos")))]
+fn freminal_icon_image() -> Option<&'static notify_rust::Image> {
+    use std::sync::OnceLock;
+
+    static ICON: OnceLock<Option<notify_rust::Image>> = OnceLock::new();
+
+    ICON.get_or_init(|| {
+        use conv2::ValueInto as _;
+
+        // The same embedded PNG used for the OS window icon (see gui::run).
+        const ICON_PNG: &[u8] = include_bytes!("../../../assets/icon.png");
+
+        let rgba = match image::load_from_memory(ICON_PNG) {
+            Ok(img) => img.to_rgba8(),
+            Err(e) => {
+                tracing::warn!("failed to decode embedded notification icon: {e}");
+                return None;
+            }
+        };
+        let (width, height) = rgba.dimensions();
+        let (Ok(width), Ok(height)) = (width.value_into(), height.value_into()) else {
+            tracing::warn!("embedded notification icon dimensions out of range");
+            return None;
+        };
+        match notify_rust::Image::from_rgba(width, height, rgba.into_raw()) {
+            Ok(image) => Some(image),
+            Err(e) => {
+                tracing::warn!("failed to build notification icon image: {e}");
+                None
+            }
+        }
+    })
+    .as_ref()
 }
 
 /// Record of a live OSC 99 notification (for update/close reconciliation).
@@ -1096,8 +1169,9 @@ mod tests {
     }
 
     /// Slice 3 (#433): the `show_system` path attaches the bundled freminal
-    /// application icon by name so desktop notifications show the app icon.
-    /// The name matches `assets/freminal.desktop`'s `Icon=freminal`.
+    /// application icon by name (a secondary hint alongside the inline
+    /// `image-data` bytes on Linux/BSD) so desktop notifications show the app
+    /// icon. The name matches `assets/freminal.desktop`'s `Icon=freminal`.
     #[test]
     fn build_system_notification_sets_freminal_icon() {
         let req = NotificationRequest {
@@ -1111,6 +1185,21 @@ mod tests {
         assert_eq!(notification.appname, "freminal");
         assert_eq!(notification.summary, "Hello");
         assert_eq!(notification.body, "world");
+    }
+
+    /// The embedded `assets/icon.png` must decode into a valid notify-rust
+    /// `Image` so the inline `image-data` icon actually works (this is the
+    /// path that shows the icon even when freminal is not installed into the
+    /// system icon theme). A `None` here means the icon silently vanishes
+    /// from every desktop notification. Linux/BSD only (matches the `cfg` on
+    /// `freminal_icon_image`).
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn embedded_notification_icon_decodes() {
+        assert!(
+            super::freminal_icon_image().is_some(),
+            "embedded assets/icon.png must decode into a valid RGBA notification image"
+        );
     }
 
     /// The builder still applies the per-kind summary fallback when the

--- a/freminal/src/gui/renderer/shaders.rs
+++ b/freminal/src/gui/renderer/shaders.rs
@@ -113,28 +113,31 @@ pub(super) const POST_PASSTHROUGH_FRAG_SRC: &str = include_str!("./shaders/post_
 //  Toast pass (issue #433)
 // ---------------------------------------------------------------------------
 //
-// SDF rounded-rect pill with a soft drop shadow, an outer glow halo, a
-// vertical gradient fill, and an optional left accent bar. Used by the
-// toast-notification overlay. Non-instanced: one expanded quad (6 vertices)
-// per toast, all pill parameters duplicated across the 6 vertices.
+// SDF rounded-rect pill with a soft drop shadow, a solid neutral gradient
+// fill, an optional left accent bar, and a neutral chrome border ring. Used
+// by the toast-notification overlay. Non-instanced: one expanded quad
+// (6 vertices) per toast, all pill parameters duplicated across the 6
+// vertices. (The issue #433 visual redesign removed the former outer glow.)
 //
-// Vertex layout — `TOAST_VERTEX_FLOATS = 24` floats per vertex, stride
-// `24 * size_of::<f32>()` = 96 bytes:
+// Vertex layout — `TOAST_VERTEX_FLOATS = 25` floats per vertex, stride
+// `25 * size_of::<f32>()` = 100 bytes:
 //   location 0: `vec2  a_pos`            — expanded-quad corner, physical px
 //   location 1: `vec2  a_pill_center`    — pill rect center, physical px
 //   location 2: `vec2  a_pill_halfsize`  — pill half-extent (w/2, h/2), px
 //   location 3: `float a_corner`         — corner radius, px
 //   location 4: `vec4  a_color_top`      — straight RGBA
 //   location 5: `vec4  a_color_bottom`   — straight RGBA
-//   location 6: `vec4  a_glow`           — rgb + intensity in .a
-//   location 7: `vec4  a_accent`         — straight RGBA, alpha 0 disables
-//   location 8: `float a_opacity`        — overall fade-in/out multiplier
+//   location 6: `vec4  a_border_color`   — straight RGBA, alpha 0 disables
+//   location 7: `float a_border_width`   — border thickness, px (0 disables)
+//   location 8: `vec4  a_accent`         — straight RGBA, alpha 0 disables
+//   location 9: `float a_opacity`        — overall fade-in/out multiplier
 
 /// Toast pass vertex shader — see module-level doc above for the full
 /// vertex layout.
 pub(super) const TOAST_VERT_SRC: &str = include_str!("./shaders/toast.vert");
 
-/// Toast pass fragment shader — SDF rounded-rect, shadow, glow, gradient,
-/// and accent bar, composited via straight-alpha "over" and output
-/// premultiplied. See `toast.frag` for the full layering breakdown.
+/// Toast pass fragment shader — SDF rounded-rect, soft drop shadow, neutral
+/// gradient fill, left accent bar, and neutral border ring, composited via
+/// straight-alpha "over" and output premultiplied. See `toast.frag` for the
+/// full layering breakdown.
 pub(super) const TOAST_FRAG_SRC: &str = include_str!("./shaders/toast.frag");

--- a/freminal/src/gui/renderer/shaders/toast.frag
+++ b/freminal/src/gui/renderer/shaders/toast.frag
@@ -2,31 +2,40 @@
 // Toast pass fragment shader (issue #433).
 //
 // Draws one rounded-rect "pill" per primitive using a signed-distance-field
-// (SDF), layered bottom-to-top as: drop shadow -> outer glow -> gradient
-// fill (+ optional left accent bar). All layers are composited with the
-// standard (straight-alpha) "over" operator and the final result is
+// (SDF), layered bottom-to-top as: drop shadow -> gradient fill (+ optional
+// left accent bar) -> neutral border ring. All layers are composited with
+// the standard (straight-alpha) "over" operator and the final result is
 // converted to PREMULTIPLIED alpha on output, matching every other pass in
 // this renderer (freminal never touches GL blend state — it inherits
 // egui_glow's ONE / ONE_MINUS_SRC_ALPHA blend func).
+//
+// Issue #433 visual redesign: the outer glow was removed (the maintainer
+// found it too strong and visually disconnecting). Separation from the
+// terminal behind the pill now comes from a crisp neutral border ring
+// (theme window_stroke) plus a softened drop shadow, over a solid, opaque,
+// neutral fill.
 in vec2 v_pos;
 flat in vec2 v_center;
 flat in vec2 v_halfsize;
 flat in float v_corner;
 flat in vec4 v_color_top;
 flat in vec4 v_color_bottom;
-flat in vec4 v_glow;
+flat in vec4 v_border_color;
+flat in float v_border_width;
 flat in vec4 v_accent;
 flat in float v_opacity;
 
 out vec4 frag_color;
 
-// Tuned constants for the glow halo, drop shadow, and accent bar. These are
+// Tuned constants for the drop shadow and accent bar. These are
 // intentionally hardcoded rather than uniforms: every toast pill in the
-// overlay shares the same "chrome" look, only the colors/opacity differ.
-const float GLOW_RADIUS = 18.0;
-const float SHADOW_BLUR = 16.0;
-const vec2 SHADOW_OFFSET = vec2(0.0, 4.0);
-const float SHADOW_ALPHA = 0.35;
+// overlay shares the same "chrome" look, only the colors/opacity/border
+// width differ. The shadow is softer than the pre-redesign value
+// (alpha 0.35 -> 0.22, blur 16 -> 12) so the pill lifts off the terminal
+// subtly rather than casting a heavy halo.
+const float SHADOW_BLUR = 12.0;
+const vec2 SHADOW_OFFSET = vec2(0.0, 3.0);
+const float SHADOW_ALPHA = 0.22;
 const float ACCENT_WIDTH = 4.0;
 
 // Signed distance to a rounded rect centered at `center` with half-extent
@@ -61,6 +70,17 @@ void main() {
     vec3 fill_rgb = mix(gradient.rgb, v_accent.rgb, accent_mask);
     float fill_a = gradient.a * fill_mask;
 
+    // Neutral border ring: the band of pixels just inside the pill edge,
+    // i.e. where the SDF is in [-border_width, 0]. Drawn OVER the fill (and
+    // the accent bar) so it frames the whole pill, including where the
+    // accent bar meets the top/bottom edges. Anti-aliased on both the outer
+    // (sdf ~ 0) and inner (sdf ~ -border_width) edges. Disabled when
+    // border_width == 0 or border_color.a == 0.
+    float outer = 1.0 - smoothstep(-aa, aa, sdf);
+    float inner = 1.0 - smoothstep(-v_border_width - aa, -v_border_width + aa, sdf);
+    float border_mask = clamp(outer - inner, 0.0, 1.0) * v_border_color.a;
+    float border_a = border_mask;
+
     // Drop shadow: a softened, downward-offset copy of the same SDF, drawn
     // as a translucent dark layer strictly behind everything else.
     float shadow_sdf = rounded_rect_sdf(v_pos - SHADOW_OFFSET, v_center, v_halfsize, v_corner);
@@ -68,31 +88,26 @@ void main() {
     float shadow_a = clamp(shadow_mask, 0.0, 1.0) * SHADOW_ALPHA;
     vec3 shadow_rgb = vec3(0.0);
 
-    // Outer glow: a soft colored halo outside the pill, fading to 0 over
-    // `GLOW_RADIUS` pixels. `v_glow.a` is the overall glow intensity.
-    float glow_mask = 1.0 - smoothstep(0.0, GLOW_RADIUS, sdf);
-    float glow_a = clamp(glow_mask, 0.0, 1.0) * v_glow.a;
-    vec3 glow_rgb = v_glow.rgb;
-
     // Composite bottom-to-top with the "over" operator, accumulating
     // PREMULTIPLIED color: out_rgb = top_rgb*top_a + out_rgb*(1-top_a);
     // out_a = top_a + out_a*(1-top_a). Each layer's color arrives
     // straight-alpha; the products below premultiply it as it accumulates,
     // which is what the final premultiplied emit at the bottom relies on.
+    // Order: shadow (back) -> fill+accent -> border (front).
     vec3 out_rgb = shadow_rgb;
     float out_a = shadow_a;
 
-    out_rgb = glow_rgb * glow_a + out_rgb * (1.0 - glow_a);
-    out_a = glow_a + out_a * (1.0 - glow_a);
-
     out_rgb = fill_rgb * fill_a + out_rgb * (1.0 - fill_a);
     out_a = fill_a + out_a * (1.0 - fill_a);
+
+    out_rgb = v_border_color.rgb * border_a + out_rgb * (1.0 - border_a);
+    out_a = border_a + out_a * (1.0 - border_a);
 
     // Apply the overall fade-in/out multiplier, then emit premultiplied.
     // `out_rgb`/`out_a` are ALREADY premultiplied (the over-compositing above
     // emits premultiplied color), so the fade scales BOTH channels by the
     // same `v_opacity` — scaling `out_rgb` by the faded alpha instead would
-    // double-multiply and darken every translucent pixel (glow, shadow, AA
-    // edges) and muddy the fade. See issue #433 adversarial-review finding 1.
+    // double-multiply and darken every translucent pixel (shadow, AA edges)
+    // and muddy the fade. See issue #433 adversarial-review finding 1.
     frag_color = vec4(out_rgb * v_opacity, out_a * v_opacity);
 }

--- a/freminal/src/gui/renderer/shaders/toast.vert
+++ b/freminal/src/gui/renderer/shaders/toast.vert
@@ -1,7 +1,7 @@
 #version 330 core
 // Toast pass vertex shader (issue #433).
 //
-// Vertex layout — one vertex is 24 floats (see TOAST_VERTEX_FLOATS in
+// Vertex layout — one vertex is 25 floats (see TOAST_VERTEX_FLOATS in
 // toast_pass.rs); all pill parameters are constant across a pill's 6
 // vertices (duplicated per-vertex, non-instanced):
 //   location 0: a_pos            vec2  — expanded-quad corner, physical px
@@ -10,18 +10,20 @@
 //   location 3: a_corner          float — corner radius, px
 //   location 4: a_color_top       vec4  — straight RGBA
 //   location 5: a_color_bottom    vec4  — straight RGBA
-//   location 6: a_glow            vec4  — rgb + intensity in .a
-//   location 7: a_accent          vec4  — straight RGBA, alpha 0 disables
-//   location 8: a_opacity         float — overall fade multiplier
+//   location 6: a_border_color    vec4  — straight RGBA, alpha 0 disables
+//   location 7: a_border_width    float — border thickness, px (0 disables)
+//   location 8: a_accent          vec4  — straight RGBA, alpha 0 disables
+//   location 9: a_opacity         float — overall fade multiplier
 layout(location = 0) in vec2 a_pos;
 layout(location = 1) in vec2 a_pill_center;
 layout(location = 2) in vec2 a_pill_halfsize;
 layout(location = 3) in float a_corner;
 layout(location = 4) in vec4 a_color_top;
 layout(location = 5) in vec4 a_color_bottom;
-layout(location = 6) in vec4 a_glow;
-layout(location = 7) in vec4 a_accent;
-layout(location = 8) in float a_opacity;
+layout(location = 6) in vec4 a_border_color;
+layout(location = 7) in float a_border_width;
+layout(location = 8) in vec4 a_accent;
+layout(location = 9) in float a_opacity;
 
 // v_pos varies per-fragment (it is the SDF evaluation point) and must be
 // smoothly interpolated. Every other varying is identical across a pill's
@@ -32,7 +34,8 @@ flat out vec2 v_halfsize;
 flat out float v_corner;
 flat out vec4 v_color_top;
 flat out vec4 v_color_bottom;
-flat out vec4 v_glow;
+flat out vec4 v_border_color;
+flat out float v_border_width;
 flat out vec4 v_accent;
 flat out float v_opacity;
 
@@ -49,7 +52,8 @@ void main() {
     v_corner = a_corner;
     v_color_top = a_color_top;
     v_color_bottom = a_color_bottom;
-    v_glow = a_glow;
+    v_border_color = a_border_color;
+    v_border_width = a_border_width;
     v_accent = a_accent;
     v_opacity = a_opacity;
 }

--- a/freminal/src/gui/renderer/toast_pass.rs
+++ b/freminal/src/gui/renderer/toast_pass.rs
@@ -14,10 +14,10 @@
 //! quads on the main thread.
 //!
 //! Each toast is drawn as a single quad (2 triangles = 6 vertices), expanded
-//! beyond the crisp pill rect by [`GLOW_MARGIN_PX`] on every side so the
-//! fragment shader has room to render the outer glow and drop shadow. See
-//! `toast.frag` for the SDF-based layering (shadow -> glow -> gradient fill
-//! + accent bar).
+//! beyond the crisp pill rect by [`SHADOW_MARGIN_PX`] on every side so the
+//! fragment shader has room to render the drop shadow. See `toast.frag` for
+//! the SDF-based layering (shadow -> gradient fill + accent bar -> neutral
+//! border ring). Issue #433 redesign removed the outer glow.
 //!
 //! The CPU-side vertex builder ([`build_toast_verts`]) is a pure function,
 //! fully testable without a GL context; GL calls are confined to
@@ -34,17 +34,18 @@ use super::vertex::VERTS_PER_QUAD;
 
 /// Floats per vertex, summing `a_pos` (2), `a_pill_center` (2),
 /// `a_pill_halfsize` (2), `a_corner` (1), `a_color_top` (4),
-/// `a_color_bottom` (4), `a_glow` (4), `a_accent` (4), and `a_opacity` (1),
-/// for a total of 24. See `toast.vert` for the exact attribute-location
-/// mapping.
-pub(super) const TOAST_VERTEX_FLOATS: usize = 24;
+/// `a_color_bottom` (4), `a_border_color` (4), `a_border_width` (1),
+/// `a_accent` (4), and `a_opacity` (1), for a total of 25. See `toast.vert`
+/// for the exact attribute-location mapping.
+pub(super) const TOAST_VERTEX_FLOATS: usize = 25;
 
 /// Margin, in physical pixels, by which each toast's drawn quad is expanded
 /// beyond its crisp pill rect on every side. Gives the fragment shader room
-/// to render the outer glow (`GLOW_RADIUS` in `toast.frag`) and the
-/// downward-offset drop shadow (`SHADOW_OFFSET` + `SHADOW_BLUR`) without
-/// clipping. Must stay >= the largest of those GLSL constants' reach.
-const GLOW_MARGIN_PX: f32 = 24.0;
+/// to render the downward-offset drop shadow (`SHADOW_OFFSET` +
+/// `SHADOW_BLUR` in `toast.frag`) without clipping. Issue #433 redesign
+/// removed the outer glow, so this only needs to cover the shadow's reach;
+/// it is kept generous so a future shadow-tuning tweak can't clip.
+const SHADOW_MARGIN_PX: f32 = 24.0;
 
 // ---------------------------------------------------------------------------
 //  Public CPU-side data
@@ -67,8 +68,13 @@ pub struct ToastQuad {
     pub color_top: [f32; 4],
     /// Bottom gradient color, straight RGBA, 0..=1.
     pub color_bottom: [f32; 4],
-    /// Glow color (straight RGB) + glow intensity in .a (0..=1).
-    pub glow: [f32; 4],
+    /// Neutral chrome border color, straight RGBA, 0..=1. Set alpha 0 (or
+    /// `border_width` 0) to disable the border. Issue #433 redesign:
+    /// replaces the removed outer glow with a crisp border for separation.
+    pub border_color: [f32; 4],
+    /// Border thickness in physical pixels (drawn as an inner ring inset from
+    /// the pill edge). 0 disables the border.
+    pub border_width: f32,
     /// Left accent-bar color (straight RGBA). Set alpha 0 to disable.
     pub accent: [f32; 4],
     /// Overall opacity multiplier for fade-in/out animation (0..=1).
@@ -257,9 +263,9 @@ impl ToastRenderer {
 /// `location 0 = vec2 a_pos, location 1 = vec2 a_pill_center,
 /// location 2 = vec2 a_pill_halfsize, location 3 = float a_corner,
 /// location 4 = vec4 a_color_top, location 5 = vec4 a_color_bottom,
-/// location 6 = vec4 a_glow, location 7 = vec4 a_accent,
-/// location 8 = float a_opacity`.
-/// Stride = `TOAST_VERTEX_FLOATS * size_of::<f32>()` = 96 bytes.
+/// location 6 = vec4 a_border_color, location 7 = float a_border_width,
+/// location 8 = vec4 a_accent, location 9 = float a_opacity`.
+/// Stride = `TOAST_VERTEX_FLOATS * size_of::<f32>()` = 100 bytes.
 unsafe fn setup_toast_attribs(gl: &glow::Context) {
     let stride = gl_i32(TOAST_VERTEX_FLOATS * size_of::<f32>());
     let f = gl_i32(size_of::<f32>());
@@ -271,9 +277,10 @@ unsafe fn setup_toast_attribs(gl: &glow::Context) {
     let off_corner = 6 * f;
     let off_color_top = 7 * f;
     let off_color_bottom = 11 * f;
-    let off_glow = 15 * f;
-    let off_accent = 19 * f;
-    let off_opacity = 23 * f;
+    let off_border_color = 15 * f;
+    let off_border_width = 19 * f;
+    let off_accent = 20 * f;
+    let off_opacity = 24 * f;
 
     unsafe {
         gl.enable_vertex_attrib_array(0);
@@ -289,11 +296,13 @@ unsafe fn setup_toast_attribs(gl: &glow::Context) {
         gl.enable_vertex_attrib_array(5);
         gl.vertex_attrib_pointer_f32(5, 4, glow::FLOAT, false, stride, off_color_bottom);
         gl.enable_vertex_attrib_array(6);
-        gl.vertex_attrib_pointer_f32(6, 4, glow::FLOAT, false, stride, off_glow);
+        gl.vertex_attrib_pointer_f32(6, 4, glow::FLOAT, false, stride, off_border_color);
         gl.enable_vertex_attrib_array(7);
-        gl.vertex_attrib_pointer_f32(7, 4, glow::FLOAT, false, stride, off_accent);
+        gl.vertex_attrib_pointer_f32(7, 1, glow::FLOAT, false, stride, off_border_width);
         gl.enable_vertex_attrib_array(8);
-        gl.vertex_attrib_pointer_f32(8, 1, glow::FLOAT, false, stride, off_opacity);
+        gl.vertex_attrib_pointer_f32(8, 4, glow::FLOAT, false, stride, off_accent);
+        gl.enable_vertex_attrib_array(9);
+        gl.vertex_attrib_pointer_f32(9, 1, glow::FLOAT, false, stride, off_opacity);
     }
 }
 
@@ -317,11 +326,12 @@ fn build_toast_verts(quads: &[ToastQuad]) -> Vec<f32> {
 /// Append one expanded quad (6 vertices) for `q` to `out`.
 fn push_toast_quad(out: &mut Vec<f32>, q: &ToastQuad) {
     // Expand the drawn quad beyond the crisp pill rect so the fragment
-    // shader has room to render the outer glow and drop shadow.
-    let x0 = q.x - GLOW_MARGIN_PX;
-    let y0 = q.y - GLOW_MARGIN_PX;
-    let x1 = q.x + q.width + GLOW_MARGIN_PX;
-    let y1 = q.y + q.height + GLOW_MARGIN_PX;
+    // shader has room to render the drop shadow (the glow was removed in the
+    // issue #433 redesign).
+    let x0 = q.x - SHADOW_MARGIN_PX;
+    let y0 = q.y - SHADOW_MARGIN_PX;
+    let x1 = q.x + q.width + SHADOW_MARGIN_PX;
+    let y1 = q.y + q.height + SHADOW_MARGIN_PX;
 
     let center = [q.x + q.width / 2.0, q.y + q.height / 2.0];
     let halfsize = [q.width / 2.0, q.height / 2.0];
@@ -337,7 +347,8 @@ fn push_toast_quad(out: &mut Vec<f32>, q: &ToastQuad) {
         out.push(q.corner_radius);
         out.extend_from_slice(&q.color_top);
         out.extend_from_slice(&q.color_bottom);
-        out.extend_from_slice(&q.glow);
+        out.extend_from_slice(&q.border_color);
+        out.push(q.border_width);
         out.extend_from_slice(&q.accent);
         out.push(q.opacity);
     }
@@ -347,7 +358,7 @@ fn push_toast_quad(out: &mut Vec<f32>, q: &ToastQuad) {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::{
-        GLOW_MARGIN_PX, TOAST_VERTEX_FLOATS, ToastQuad, VERTS_PER_QUAD, build_toast_verts,
+        SHADOW_MARGIN_PX, TOAST_VERTEX_FLOATS, ToastQuad, VERTS_PER_QUAD, build_toast_verts,
     };
 
     fn sample_quad() -> ToastQuad {
@@ -359,7 +370,8 @@ mod tests {
             corner_radius: 10.0,
             color_top: [0.1, 0.2, 0.3, 0.9],
             color_bottom: [0.4, 0.5, 0.6, 0.95],
-            glow: [0.9, 0.1, 0.1, 0.5],
+            border_color: [0.35, 0.36, 0.38, 1.0],
+            border_width: 1.5,
             accent: [0.0, 1.0, 0.0, 1.0],
             opacity: 0.75,
         }
@@ -394,7 +406,7 @@ mod tests {
     }
 
     #[test]
-    fn expanded_quad_extends_beyond_pill_rect_by_glow_margin() {
+    fn expanded_quad_extends_beyond_pill_rect_by_shadow_margin() {
         let q = sample_quad();
         let verts = build_toast_verts(&[q]);
 
@@ -411,10 +423,10 @@ mod tests {
             max_y = max_y.max(y);
         }
 
-        assert!((min_x - (q.x - GLOW_MARGIN_PX)).abs() < f32::EPSILON);
-        assert!((min_y - (q.y - GLOW_MARGIN_PX)).abs() < f32::EPSILON);
-        assert!((max_x - (q.x + q.width + GLOW_MARGIN_PX)).abs() < f32::EPSILON);
-        assert!((max_y - (q.y + q.height + GLOW_MARGIN_PX)).abs() < f32::EPSILON);
+        assert!((min_x - (q.x - SHADOW_MARGIN_PX)).abs() < f32::EPSILON);
+        assert!((min_y - (q.y - SHADOW_MARGIN_PX)).abs() < f32::EPSILON);
+        assert!((max_x - (q.x + q.width + SHADOW_MARGIN_PX)).abs() < f32::EPSILON);
+        assert!((max_y - (q.y + q.height + SHADOW_MARGIN_PX)).abs() < f32::EPSILON);
     }
 
     #[test]
@@ -437,12 +449,14 @@ mod tests {
             assert_eq!(&v[7..11], &q.color_top);
             // color_bottom: floats [11..15)
             assert_eq!(&v[11..15], &q.color_bottom);
-            // glow: floats [15..19)
-            assert_eq!(&v[15..19], &q.glow);
-            // accent: floats [19..23)
-            assert_eq!(&v[19..23], &q.accent);
-            // opacity: float [23]
-            assert!((v[23] - q.opacity).abs() < f32::EPSILON);
+            // border_color: floats [15..19)
+            assert_eq!(&v[15..19], &q.border_color);
+            // border_width: float [19]
+            assert!((v[19] - q.border_width).abs() < f32::EPSILON);
+            // accent: floats [20..24)
+            assert_eq!(&v[20..24], &q.accent);
+            // opacity: float [24]
+            assert!((v[24] - q.opacity).abs() < f32::EPSILON);
         }
     }
 
@@ -460,7 +474,7 @@ mod tests {
         let v0 = &second_quad_verts[0..TOAST_VERTEX_FLOATS];
         // x position of the second quad's first vertex should reflect q2.x,
         // not the first quad's x.
-        assert!((v0[0] - (q2.x - GLOW_MARGIN_PX)).abs() < f32::EPSILON);
-        assert!((v0[23] - q2.opacity).abs() < f32::EPSILON);
+        assert!((v0[0] - (q2.x - SHADOW_MARGIN_PX)).abs() < f32::EPSILON);
+        assert!((v0[24] - q2.opacity).abs() < f32::EPSILON);
     }
 }

--- a/freminal/src/gui/toast.rs
+++ b/freminal/src/gui/toast.rs
@@ -92,11 +92,10 @@ impl ToastKind {
         }
     }
 
-    /// Accent/glow color for this kind, taken directly from the active
+    /// Semantic accent color for this kind, taken directly from the active
     /// theme's palette semantic colors (error/warn/link) rather than a
-    /// hard-coded hue. Used both by [`Self::background`] (the egui-rendered
-    /// bubble fill) and by the owned-renderer layout's glow/accent-bar
-    /// colors ([`layout_toasts`]).
+    /// hard-coded hue. Used by the owned-renderer layout for the left
+    /// accent-bar and icon tint ([`layout_toasts`] / [`toast_colors`]).
     const fn semantic(self, visuals: &egui::Visuals) -> egui::Color32 {
         match self {
             Self::Error => visuals.error_fg_color,
@@ -124,33 +123,24 @@ impl ToastKind {
         }
     }
 
-    /// Background tint for the toast bubble, derived from the active theme.
+    /// Solid background fill for the toast pill, derived from the active
+    /// theme.
     ///
-    /// Each toast kind maps to a palette semantic color (error/warn/link) so
-    /// the bubble follows the theme instead of hard-coded hues. The semantic
-    /// color is darkened toward the panel background and rendered at high
-    /// opacity so it reads as a saturated bubble over any background.
-    fn background(self, visuals: &egui::Visuals) -> egui::Color32 {
-        let accent = self.semantic(visuals);
-        // Blend the accent toward the panel background for a deeper bubble, then
-        // apply a high (but not full) opacity so it sits over the terminal.
-        let base = visuals.panel_fill;
-        let mix = |a: u8, b: u8| -> u8 {
-            use conv2::ConvUtil;
-            // 65% accent, 35% panel background.
-            f32::from(b)
-                .mul_add(0.35, f32::from(a) * 0.65)
-                .round()
-                .clamp(0.0, 255.0)
-                .approx_as::<u8>()
-                .unwrap_or(b)
-        };
-        egui::Color32::from_rgba_unmultiplied(
-            mix(accent.r(), base.r()),
-            mix(accent.g(), base.g()),
-            mix(accent.b(), base.b()),
-            240,
-        )
+    /// Issue #433 visual redesign: the pill fill is the theme's neutral,
+    /// fully-opaque window fill (the same color menus and dialogs use), *not*
+    /// a saturated per-kind tint. The notification kind is expressed by the
+    /// left accent bar and the semantic icon color, not by the whole
+    /// background — so the pill reads as native chrome that sits calmly over
+    /// the terminal rather than a jarring colored bubble. The fill is fully
+    /// opaque (no alpha blending over the terminal) so the message text keeps
+    /// maximum contrast and legibility.
+    ///
+    /// `window_fill` (rather than `panel_fill`) is deliberate: `window_fill`
+    /// is always opaque even when the user has set a translucent
+    /// `background_opacity` (which only affects `panel_fill`), so a toast is
+    /// never see-through.
+    fn background(visuals: &egui::Visuals) -> egui::Color32 {
+        visuals.window_fill.to_opaque()
     }
 
     /// Whether `bg` is light enough that dark text reads better on it.
@@ -822,18 +812,30 @@ struct ToastLayoutMetrics {
     /// The theme's corner radius (see [`corner_radius_pts`]), scaled to
     /// physical pixels.
     corner_radius: f32,
+    /// The neutral chrome border width (from the theme's `window_stroke`,
+    /// Modern 1.0 / Retro 1.5 pt), scaled to physical pixels. Issue #433
+    /// redesign: replaces the removed glow as the pill's separation from the
+    /// terminal, and gives Modern/Retro a subtly different border weight.
+    border_width: f32,
 }
 
-/// The pill/glow/text colors for one toast, derived from its kind's
-/// semantic theme color and its current animation opacity.
+/// The pill/border/text colors for one toast, derived from the active
+/// theme and its current animation opacity.
+///
+/// Issue #433 visual redesign: the pill fill is a neutral, solid theme
+/// color (see [`ToastKind::background`]); the notification kind shows only in
+/// the left accent bar and the icon tint. A neutral chrome border replaces
+/// the old outer glow for separation from the terminal behind it.
 struct ToastColors {
-    /// Pill background gradient, top stop.
+    /// Pill background, top stop (a very subtle vertical gradient is kept for
+    /// depth, but both stops are near the neutral solid fill).
     color_top: [f32; 4],
-    /// Pill background gradient, bottom stop.
+    /// Pill background, bottom stop.
     color_bottom: [f32; 4],
-    /// Outer glow color (rgb) + intensity (a).
-    glow: [f32; 4],
-    /// Left accent-bar color.
+    /// Neutral chrome border color (straight RGBA), from the theme's
+    /// `window_stroke`. Alpha 0 disables the border in the shader.
+    border_color: [f32; 4],
+    /// Left accent-bar color (the notification kind's semantic color).
     accent: [f32; 4],
     /// Label/detail text color, contrast-picked against the pill fill.
     text_color: [f32; 4],
@@ -843,14 +845,26 @@ struct ToastColors {
 
 /// Derive [`ToastColors`] for `kind` from the active theme, at the given
 /// (already-clamped-elsewhere) animation `opacity`.
+///
+/// Issue #433 visual redesign: the fill is the neutral solid theme
+/// background, the border is the neutral `window_stroke` color, and only the
+/// accent bar + icon carry the kind's semantic color.
 fn toast_colors(kind: ToastKind, visuals: &egui::Visuals, opacity: f32) -> ToastColors {
-    let background = kind.background(visuals);
+    let background = ToastKind::background(visuals);
     let base_rgba = color32_to_rgba(background);
-    let color_top = lighten(base_rgba, 0.08);
-    let color_bottom = lighten(base_rgba, -0.06);
+    // A whisper of vertical gradient (±3%) keeps the flat pill from looking
+    // dead without reintroducing the old jarring saturated bubble.
+    let color_top = lighten(base_rgba, 0.03);
+    let color_bottom = lighten(base_rgba, -0.03);
+
     let semantic_rgba = color32_to_rgba(kind.semantic(visuals));
-    let glow = [semantic_rgba[0], semantic_rgba[1], semantic_rgba[2], 0.35];
     let accent = [semantic_rgba[0], semantic_rgba[1], semantic_rgba[2], 1.0];
+
+    // Neutral chrome border for separation from the terminal (replaces the
+    // removed outer glow). The stroke color is already the theme's border
+    // role; its width (Modern 1.0 / Retro 1.5 pt) is applied per-pill by the
+    // layout via `metrics.border_width`.
+    let border_color = color32_to_rgba(visuals.window_stroke.color);
 
     let text_alpha = opacity.clamp(0.0, 1.0);
     let text_rgb = if ToastKind::prefers_dark_text(background) {
@@ -869,7 +883,7 @@ fn toast_colors(kind: ToastKind, visuals: &egui::Visuals, opacity: f32) -> Toast
     ToastColors {
         color_top,
         color_bottom,
-        glow,
+        border_color,
         accent,
         text_color,
         icon_color,
@@ -987,6 +1001,12 @@ fn layout_one_toast(
         .corner_radius
         .min(scaled_width.min(scaled_height) / 2.0)
         .max(0.0);
+    // Clamp the border to half the smaller dimension so a chunky border on a
+    // tiny (mid-scale-in) pill can't cross the pill's center and invert.
+    let border_width = metrics
+        .border_width
+        .min(scaled_width.min(scaled_height) / 2.0)
+        .max(0.0);
     let pill = ToastQuad {
         x,
         y,
@@ -995,7 +1015,8 @@ fn layout_one_toast(
         corner_radius,
         color_top: colors.color_top,
         color_bottom: colors.color_bottom,
-        glow: colors.glow,
+        border_color: colors.border_color,
+        border_width,
         accent: colors.accent,
         opacity: anim.opacity.clamp(0.0, 1.0),
     };
@@ -1047,6 +1068,7 @@ pub(super) fn layout_toasts(
         close_size: CLOSE_SIZE_PTS * ppp,
         detail_gap: DETAIL_GAP_PTS * ppp,
         corner_radius: corner_radius_pts(visuals) * ppp,
+        border_width: visuals.window_stroke.width * ppp,
     };
 
     let sizes: Vec<(f32, f32)> = inputs.iter().map(|i| settled_pill_size(i, ppp)).collect();
@@ -1789,34 +1811,62 @@ mod tests {
     }
 
     #[test]
-    fn background_derives_from_visuals_semantic_colors() {
-        // The bubble fill must be a blend of the kind's palette semantic color
-        // and the panel background — not a hard-coded hue. Use distinct
-        // semantic colors so each kind yields a distinct fill.
+    fn background_is_neutral_opaque_window_fill() {
+        // Issue #433 redesign: the pill fill is the theme's neutral, fully
+        // opaque `window_fill` — the same for every kind (the kind shows in
+        // the accent bar / icon, not the whole background). It must NOT be a
+        // saturated per-kind blend, and it must NOT be translucent even when
+        // `panel_fill` (the terminal-area fill) is translucent.
         let mut v = egui::Visuals::dark();
         v.error_fg_color = egui::Color32::from_rgb(200, 0, 0);
         v.warn_fg_color = egui::Color32::from_rgb(0, 200, 0);
         v.hyperlink_color = egui::Color32::from_rgb(0, 0, 200);
-        v.panel_fill = egui::Color32::from_gray(0);
+        v.window_fill = egui::Color32::from_rgb(30, 32, 36);
+        // A translucent panel fill must not leak into the toast background.
+        v.panel_fill = egui::Color32::from_rgba_unmultiplied(0, 0, 0, 128);
 
-        let err = ToastKind::Error.background(&v);
-        let warn = ToastKind::Warning.background(&v);
-        let info = ToastKind::Info.background(&v);
+        let bg = ToastKind::background(&v);
 
-        // Each is a 65% accent / 35% black blend → dominant channel ~130.
-        assert!(
-            err.r() > err.g() && err.r() > err.b(),
-            "error bubble is red-dominant"
+        assert_eq!(bg.a(), 255, "toast fill must be fully opaque");
+        assert_eq!(
+            (bg.r(), bg.g(), bg.b()),
+            (30, 32, 36),
+            "toast fill is the neutral window_fill, not a per-kind tint"
         );
+    }
+
+    #[test]
+    fn toast_colors_border_from_window_stroke_accent_from_semantic() {
+        // Issue #433 redesign: the border is the neutral window_stroke color;
+        // only the accent bar (and icon) carry the kind's semantic color.
+        let mut v = egui::Visuals::dark();
+        v.error_fg_color = egui::Color32::from_rgb(220, 40, 40);
+        v.window_fill = egui::Color32::from_rgb(30, 32, 36);
+        v.window_stroke = egui::Stroke::new(1.0, egui::Color32::from_rgb(90, 92, 96));
+
+        let colors = toast_colors(ToastKind::Error, &v, 1.0);
+
+        // Border is the neutral stroke color, fully opaque.
+        assert!((colors.border_color[0] - 90.0 / 255.0).abs() < 1e-3);
+        assert!((colors.border_color[1] - 92.0 / 255.0).abs() < 1e-3);
+        assert!((colors.border_color[2] - 96.0 / 255.0).abs() < 1e-3);
+        assert!((colors.border_color[3] - 1.0).abs() < 1e-3);
+
+        // Accent is red-dominant (the Error semantic), fully opaque.
         assert!(
-            warn.g() > warn.r() && warn.g() > warn.b(),
-            "warning bubble is green-dominant"
+            colors.accent[0] > colors.accent[1] && colors.accent[0] > colors.accent[2],
+            "accent bar carries the red Error semantic"
         );
-        assert!(
-            info.b() > info.r() && info.b() > info.g(),
-            "info bubble is blue-dominant"
-        );
-        assert_eq!(err.a(), 240, "bubble opacity is 240");
+        assert!((colors.accent[3] - 1.0).abs() < 1e-3);
+
+        // The fill's two gradient stops straddle the neutral window_fill and
+        // are near-neutral (not saturated red).
+        for stop in [colors.color_top, colors.color_bottom] {
+            assert!(
+                (stop[0] - stop[1]).abs() < 0.1 && (stop[1] - stop[2]).abs() < 0.1,
+                "fill stop is near-neutral gray, not a saturated tint"
+            );
+        }
     }
 
     #[test]
@@ -2379,6 +2429,81 @@ mod tests {
         assert!((right0 - right1).abs() < 0.01);
         let expected_right = test_window_rect().max.x - STACK_RIGHT_INSET_PTS;
         assert!((right0 - expected_right).abs() < 0.01);
+    }
+
+    /// Issue #433 redesign: the neutral border width flows end-to-end from
+    /// `visuals.window_stroke.width` (scaled by ppp) into the final
+    /// [`ToastQuad.border_width`], and the border color comes from
+    /// `window_stroke.color`. This is the plumbing the visual redesign adds;
+    /// `toast_colors` alone (unit-tested elsewhere) doesn't prove it reaches
+    /// the quad through `layout_toasts`.
+    #[test]
+    fn border_width_flows_from_window_stroke_into_quad() {
+        let geom = ToastGeometry {
+            content_rect: test_window_rect(),
+            active_pane_rect: None,
+        };
+        let mut visuals = egui::Visuals::dark();
+        visuals.window_stroke = egui::Stroke::new(1.5, egui::Color32::from_rgb(90, 92, 96));
+
+        let ppp = 2.0;
+        let out = layout_toasts(
+            &[test_input(0, 100.0, false, SETTLED_ANIM)],
+            ToastPosition::TopRightStack,
+            geom,
+            &visuals,
+            ppp,
+        );
+
+        assert_eq!(out.len(), 1);
+        // window_stroke.width (1.5 pt) * ppp (2.0) = 3.0 physical px, and the
+        // settled (scale 1.0) pill is far larger than 2 * 3.0, so the
+        // half-dimension clamp does not bite here.
+        let expected = 1.5 * ppp;
+        assert!(
+            (out[0].pill.border_width - expected).abs() < 0.01,
+            "border_width must be window_stroke.width * ppp, got {}",
+            out[0].pill.border_width
+        );
+        // Border color is the neutral stroke color, fully opaque.
+        assert!((out[0].pill.border_color[0] - 90.0 / 255.0).abs() < 1e-3);
+        assert!((out[0].pill.border_color[3] - 1.0).abs() < 1e-3);
+    }
+
+    /// The border width is clamped to half the pill's smaller (animated)
+    /// dimension so a chunky border on a tiny mid-scale-in pill can't cross
+    /// the pill center and invert. Force the clamp with an absurd stroke
+    /// width and a small-scale entry animation.
+    #[test]
+    fn border_width_clamped_to_half_smaller_dimension() {
+        let geom = ToastGeometry {
+            content_rect: test_window_rect(),
+            active_pane_rect: None,
+        };
+        let mut visuals = egui::Visuals::dark();
+        // Absurdly thick stroke to force the clamp.
+        visuals.window_stroke = egui::Stroke::new(1000.0, egui::Color32::from_rgb(90, 92, 96));
+
+        let out = layout_toasts(
+            &[test_input(0, 100.0, false, ENTRY_ANIM)],
+            ToastPosition::TopRightStack,
+            geom,
+            &visuals,
+            1.0,
+        );
+
+        assert_eq!(out.len(), 1);
+        let pill = out[0].pill;
+        let half_min = pill.width.min(pill.height) / 2.0;
+        assert!(
+            pill.border_width <= half_min + 0.01,
+            "border_width {} must be clamped to <= half the smaller dimension {half_min}",
+            pill.border_width
+        );
+        assert!(
+            pill.border_width >= 0.0,
+            "border_width must be non-negative"
+        );
     }
 
     #[test]
@@ -3054,7 +3179,8 @@ mod tests {
                 corner_radius: 0.0,
                 color_top: [0.0; 4],
                 color_bottom: [0.0; 4],
-                glow: [0.0; 4],
+                border_color: [0.0; 4],
+                border_width: 0.0,
                 accent: [0.0; 4],
                 opacity: 1.0,
             },


### PR DESCRIPTION
Closes #433.

Bundles the remaining #433 work: the toast visual redesign, the
system-notification app icon (slice 3), and the toast-options skill
(slice 4). Slices 1 (PR #450) and 2 (PR #451) already merged.

## 1. Toast visual redesign

The maintainer found the previous toast look jarring / visually
disconnected from the window. Reworked, per maintainer-approved
direction:

- **Glow removed** entirely (was too strong / disconnecting).
- **Solid, opaque, neutral fill** (`window_fill.to_opaque()`) instead
  of a saturated per-kind bubble at alpha 240. Reads as native chrome
  and keeps text at full contrast; the notification kind now shows only
  in the left accent bar + icon tint. `window_fill` (not `panel_fill`)
  so a translucent `background_opacity` never makes a toast see-through.
- **Neutral chrome border ring** (from `window_stroke`: color + width)
  for clean separation from the terminal, replacing the glow.
- **Softer drop shadow** (alpha 0.35→0.22, blur 16→12, y-offset 4→3).
- **Modern vs Retro** differentiation comes for free through the
  existing `egui::Visuals` geometry already derived from `StyleProfile`:
  Modern = `menu_corner_radius` 4 + `stroke_width` 1.0 (rounded, thin
  border); Retro = 0 + 1.5 (square, chunkier border). No signature
  change to `ToastStack::show`, no new config option.

GPU: `ToastQuad.glow` (4 floats) → `border_color` (4) + `border_width`
(1); `TOAST_VERTEX_FLOATS` 24→25; vertex attribs/packing relaid out; the
fragment shader drops the glow layer and adds an SDF border-ring layer,
faded uniformly with the pill. The entry/exit animation and frame-damage
wiring are unchanged.

## 2. System-notification app icon (slice 3 + follow-up fix)

Desktop notifications now show the freminal app icon. First landed as a
name-based `.icon("freminal")` hint, but that resolves to nothing unless
freminal is installed into the system icon theme — so dev / `cargo run`
/ AppImage builds showed no icon (confirmed on a real notification
daemon). Fixed by additionally attaching the bundled `assets/icon.png`
as inline **`image-data` bytes** over D-Bus (the mechanism Discord uses),
which works installed or not. The name hint is kept as a secondary
fallback (macOS/Windows, installed setups).

- Enables notify-rust's light `images_no_default_features` feature (the
  PNG is decoded by the workspace `image` crate, so notify-rust's own
  codecs + rayon are not pulled in).
- The ~1 MiB RGBA decode (cached in a `OnceLock`) runs on the detached
  notification thread, **not** the GUI thread —
  `build_system_notification` stays a pure, unit-testable builder and
  the frame loop is never blocked.
- `image-data`/`Image` are Linux/BSD-only in notify-rust, so the decode
  + attach are `#[cfg(all(unix, not(macos)))]`.
- The OSC 99 (kitty) path is untouched: it carries its own transmitted
  icon and must not be overridden. A guard test locks this invariant.

## 3. `freminal-toast-options` skill (slice 4)

A repo-local opencode skill (`.opencode/skills/freminal-toast-options/`,
loaded via `opencode.json` alongside `freminal-config-options` etc.)
documenting the two-tier routing model: full `NotificationRouting`
(Toast/System/Both/SystemWhenUnfocused/Disabled) for
terminal-application notifications vs. the restricted
`FreminalToastRouting` (Toast/Disabled) for freminal's own UI toasts,
plus the `FreminalToastCategory` → `routing_<cat>` →
`route_freminal_toast` → `push_positioned(ToastPlacement)` consumer
chain, placement selection, and why the resize overlay sits outside it.

## Testing / verification

All green: `cargo test --all`, `cargo clippy --all-targets
--all-features -- -D warnings`, `cargo machete`, `cargo fmt --all --
--check`, and `cargo xtask check-windows`. New tests cover: the icon
builder + per-kind urgency (cfg-matched to notify-rust's `hints`), the
embedded-icon decode, the OSC 99 icon invariant, the neutral-fill /
border-from-`window_stroke` contract, and end-to-end `border_width`
plumbing + clamp.

No toast render benchmark was added: the toast pass is not a benched
hot path (≤5 pills, only when a notification is live), the change only
*reduces* fragment ALU (glow removed) for a fixed +1 vertex float, and
benching it would require exposing a private vertex builder as public
API purely for the bench.

Two mandatory adversarial-review rounds were run (one per change set);
both found real issues that are fixed with regression tests — including
a Windows-only test-cfg compile break and a GUI-thread PNG-decode
regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned toast notifications with a cleaner neutral appearance, softer shadows, crisp borders, and improved visual hierarchy.
  - Desktop notifications now include Freminal’s application icon and appropriate notification urgency.
  - Notification icons and styling are handled consistently across supported platforms.

- **Documentation**
  - Added guidance for choosing and configuring toast notification behavior, placement, and routing.

- **Tests**
  - Expanded coverage for notification icons, urgency, toast rendering, borders, sizing, and layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->