### PR TITLE
fix: 431 always-bundled emoji font + 453 pane-divider phantom selection

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -45,8 +45,9 @@ full upstream license texts are bundled under [`res/fonts/`](res/fonts/).
   [`res/fonts/NotoColorEmoji-LICENSE.txt`](res/fonts/NotoColorEmoji-LICENSE.txt)
 - **Files:** `res/NotoColorEmoji.ttf`
 - **Notes:** Bundled so color emoji render without depending on a system-installed
-  emoji font. When a suitable system color-emoji font is present it is preferred;
-  the bundled face is the guaranteed fallback.
+  emoji font. The bundled face is always used for the terminal grid; system emoji
+  fonts are intentionally not consulted, because a system font's aggregate coverage
+  is not a stable guarantee that it maps any particular codepoint (issue #431).
 
 ## Bundled images
 

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -2316,17 +2316,25 @@ impl freminal_windowing::App for FreminalGui {
                     // right-click context menu) also own keyboard input and
                     // suppress normal terminal input; queued raw keys must be
                     // gated the same way so they cannot bypass those overlays.
+                    // A pane-border drag-to-resize is another suppression
+                    // cause (#456 review): the same "no terminal input while
+                    // a border drag is active" invariant that `show()` is
+                    // handed via `border_drag_active` must also apply here,
+                    // or queued raw keys leak keypad/media keys to the PTY
+                    // mid-resize.
                     let pane_input_suppressed = pane.view_state.search_state.is_open
                         || pane.view_state.command_history.is_open
                         || pane.view_state.context_menu_pos.is_some();
-                    if ui_overlay_open || pane_input_suppressed {
+                    if ui_overlay_open || pane_input_suppressed || border_drag_active {
                         // An overlay (rename/paste/close/broadcast dialog,
                         // menu, welcome/about window, save-layout, or a
                         // per-pane search/history/context menu) owns keyboard
                         // input this frame — the same gate that suppresses
-                        // normal terminal input. Drop the queued raw keys
-                        // instead of forwarding them to the PTY, so
-                        // intercepted keys cannot bypass the overlay.
+                        // normal terminal input. A pane-border drag-to-resize
+                        // in progress is the same case: the divider owns
+                        // input this frame. Drop the queued raw keys instead
+                        // of forwarding them to the PTY, so intercepted keys
+                        // cannot bypass the overlay or leak during a resize.
                         win.pending_raw_keys.clear();
                     } else {
                         let super_pressed = pane.render_cache.super_pressed();

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -1883,6 +1883,35 @@ impl freminal_windowing::App for FreminalGui {
 
                     // Clear drag state when drag ends.
                     if response.drag_stopped() {
+                        // On release, focus the pane the pointer ends in (focus
+                        // was frozen during the drag, issue #453). Use the
+                        // release pointer position; fall back to leaving focus
+                        // unchanged if it isn't over any pane.
+                        if let Some(pos) = ui.ctx().pointer_hover_pos()
+                            && let Some(under_id) = panes::pane_at_pos(&pane_layout, pos)
+                        {
+                            let tab = win.tabs.active_tab_mut();
+                            if tab.active_pane != under_id {
+                                let old_active = tab.active_pane;
+                                if let Some(old_pane) = tab.pane_tree.find(old_active)
+                                    && let Err(e) =
+                                        old_pane.input_tx.send(InputEvent::FocusChange(false))
+                                {
+                                    error!(
+                                        "Failed to send FocusChange(false) to pane {old_active}: {e}"
+                                    );
+                                }
+                                tab.active_pane = under_id;
+                                if let Some(new_pane) = tab.pane_tree.find(under_id)
+                                    && let Err(e) =
+                                        new_pane.input_tx.send(InputEvent::FocusChange(true))
+                                {
+                                    error!(
+                                        "Failed to send FocusChange(true) to pane {under_id}: {e}"
+                                    );
+                                }
+                            }
+                        }
                         win.border_drag = None;
                     }
                 }
@@ -1895,6 +1924,26 @@ impl freminal_windowing::App for FreminalGui {
                 // (#436.8).
                 win.chrome_border_rects.clear();
             }
+
+            // Defensive: a border drag can only be in progress while the primary
+            // button is held. If the button is up but `border_drag` is still set,
+            // the drag-sensor loop missed its `drag_stopped()` transition (e.g. an
+            // overlay opened mid-drag and gated the sensor block off). Clear it so a
+            // stuck value can't permanently freeze input via `border_drag_active`
+            // (issue #453 review). This runs every frame, independent of
+            // `ui_overlay_open`/`has_multiple_panes`/`zoomed_pane`, so it can never
+            // be gated off the same way the sensor block above can be.
+            if win.border_drag.is_some() && !ui.ctx().input(|i| i.pointer.primary_down()) {
+                win.border_drag = None;
+            }
+
+            // Whether a pane-border drag-to-resize is currently in progress.
+            // Read into a local now (after the drag-sensor block above has
+            // had a chance to start/stop it this frame) so the per-pane loop
+            // below can pass it to `show()` without holding a borrow of
+            // `win.border_drag` across the mutable borrow of
+            // `win.terminal_widget` (issue #453).
+            let border_drag_active = win.border_drag.is_some();
 
             // ── Terminal band: shape-index range capture (#436.2a, range
             // exposed via `App::take_terminal_band_range` as of #436.4a) ───
@@ -2226,6 +2275,7 @@ impl freminal_windowing::App for FreminalGui {
                             &pane.clipboard_rx,
                             &pane.search_buffer_rx,
                             ui_overlay_open,
+                            border_drag_active,
                             bg_opacity,
                             self.config.ui.background_image_opacity,
                             self.config.ui.background_image_mode,
@@ -2349,7 +2399,12 @@ impl freminal_windowing::App for FreminalGui {
                     .ctx()
                     .pointer_hover_pos()
                     .is_some_and(|pos| content_rect.contains(pos));
+                // Freeze focus while dragging a pane divider so the active pane
+                // doesn't flicker between panes as the pointer moves (issue
+                // #453). On release, focus is set to the pane under the
+                // pointer (see the drag_stopped handler).
                 let should_focus = !is_active
+                    && !border_drag_active
                     && crate::gui::panes::should_focus_inactive_pane(
                         left_clicked,
                         self.config.tabs.focus_follows_mouse,

--- a/freminal/src/gui/font_manager.rs
+++ b/freminal/src/gui/font_manager.rs
@@ -45,13 +45,15 @@ static NOTO_COLOR_EMOJI: &[u8] = include_bytes!("../../../res/NotoColorEmoji.ttf
 /// The Unicode blocks that make up the emoji repertoire, as inclusive
 /// `(start, end)` codepoint ranges.
 ///
-/// A candidate emoji face is scored by counting how many codepoints across
-/// these ranges its `cmap` actually maps ([`LoadedFace::emoji_coverage`]) —
-/// a real coverage measurement over the font's own character map, not a
-/// hand-picked sample. Ranges are the emoji-bearing blocks per the Unicode
-/// Standard (the pictographic/emoji blocks; not every codepoint in these
-/// blocks is an emoji, but the count is a faithful relative measure of how
-/// much of the repertoire a font carries).
+/// Test-only: used by [`LoadedFace::emoji_coverage`] to assert the bundled
+/// Noto Color Emoji face carries broad emoji coverage. Production code no
+/// longer ranks candidate faces by coverage (issue #431) — the bundled face
+/// is always used — so this table only backs regression tests. Ranges are
+/// the emoji-bearing blocks per the Unicode Standard (the pictographic/emoji
+/// blocks; not every codepoint in these blocks is an emoji, but the count is
+/// a faithful relative measure of how much of the repertoire a font
+/// carries).
+#[cfg(test)]
 const EMOJI_BLOCKS: &[(u32, u32)] = &[
     (0x2600, 0x26FF),   // Miscellaneous Symbols
     (0x2700, 0x27BF),   // Dingbats
@@ -73,18 +75,6 @@ const EMOJI_BLOCKS: &[(u32, u32)] = &[
 pub(crate) const fn bundled_regular_font_bytes() -> &'static [u8] {
     CASKAYDIA_REGULAR
 }
-
-/// Emoji font family candidates, tried in order.
-const EMOJI_CANDIDATES: &[&str] = &[
-    "Apple Color Emoji",
-    "Noto Color Emoji",
-    "Segoe UI Emoji",
-    "Twemoji",
-    "Emoji One",
-    "OpenMoji",
-    "Emoji",
-    "Symbola",
-];
 
 // ---------------------------------------------------------------------------
 //  Supporting types
@@ -273,6 +263,12 @@ impl LoadedFace {
     /// palettes or `CBDT`/`CBLC`/`sbix` bitmap strikes) — i.e. is a genuine
     /// color emoji font rather than a text font that happens to map an emoji
     /// codepoint to a monochrome outline.
+    ///
+    /// Test-only: production code no longer gates candidate emoji faces on
+    /// this (the bundled face is always used, issue #431); it remains as a
+    /// regression check that the bundled face really is a color font and
+    /// that a plain text font is not mistaken for one.
+    #[cfg(test)]
     fn has_color_glyphs(&self) -> bool {
         self.as_font_ref().is_some_and(|f| {
             f.color_palettes().next().is_some() || f.color_strikes().next().is_some()
@@ -281,8 +277,12 @@ impl LoadedFace {
 
     /// Count how many codepoints across the [`EMOJI_BLOCKS`] this face's `cmap`
     /// actually maps to a glyph — a real coverage measurement over the font's
-    /// character map. Used to rank candidate emoji faces by how much of the
-    /// emoji repertoire they carry.
+    /// character map.
+    ///
+    /// Test-only: production code no longer ranks candidate emoji faces by
+    /// coverage (issue #431); it remains as a regression check that the
+    /// bundled face carries broad emoji coverage.
+    #[cfg(test)]
     fn emoji_coverage(&self) -> u32 {
         self.as_font_ref().map_or(0, |f| {
             let charmap = f.charmap();
@@ -508,8 +508,8 @@ pub struct FontManager {
 impl FontManager {
     /// Create a new `FontManager` with the given configuration.
     ///
-    /// Loads the primary faces (user font or bundled `CaskaydiaCove`), discovers a
-    /// system emoji font, and computes the authoritative cell size.
+    /// Loads the primary faces (user font or bundled `CaskaydiaCove`), resolves the
+    /// bundled emoji face, and computes the authoritative cell size.
     ///
     /// `pixels_per_point` is the display scale factor from
     /// `egui::Context::pixels_per_point()`. It is used together with the
@@ -557,8 +557,8 @@ impl FontManager {
                 (bundled, None, None)
             };
 
-        // Always resolves to at least the bundled Noto Color Emoji face.
-        let emoji_face = discover_emoji_face(&font_db);
+        // Always resolves to the bundled Noto Color Emoji face (issue #431).
+        let emoji_face = discover_emoji_face();
 
         let font_size_ppem = pt_to_ppem(font_size_pt, pixels_per_point);
         let CellMetrics {
@@ -1461,178 +1461,31 @@ fn suggest_similar_families(query: &str, font_db: &Database) -> Vec<String> {
     suggestions
 }
 
-/// Choose the emoji face: the best capable color-emoji font installed on the
-/// system, falling back to the bundled Noto Color Emoji so emoji always render
-/// (Task #402).
+/// Resolve the emoji face used by the terminal grid.
 ///
-/// System faces are ranked by capability, not merely by name:
-///
-/// 1. A candidate must actually be a **color** font ([`LoadedFace::has_color_glyphs`])
-///    — this is what stops a plain text font that maps an emoji codepoint to a
-///    monochrome outline from being chosen.
-/// 2. Among color faces, a **known-good family name** (in [`EMOJI_CANDIDATES`]
-///    order) is a strong prior, and **emoji codepoint coverage**
-///    ([`LoadedFace::emoji_coverage`]) breaks ties and rescues well-covered
-///    fonts with non-standard names (e.g. `JoyPixels`, a distro-renamed Noto).
-///
-/// This fixes the "user has an emoji font installed but we didn't find it
-/// because it isn't named exactly `Noto Color Emoji`" tofu bug, while keeping
-/// the previously-preferred fonts preferred. If no capable system face is
-/// found, the bundled Noto face is used.
-fn discover_emoji_face(font_db: &Database) -> Option<LoadedFace> {
-    load_emoji_face_from_source(&resolve_emoji_source(font_db))
-}
-
-/// Load the [`LoadedFace`] for a resolved [`EmojiSource`], falling back to the
-/// bundled floor if a system source can no longer be read.
-///
-/// Split out from [`discover_emoji_face`] so it can be exercised without the
-/// process-global [`EMOJI_SOURCE_CACHE`] (which would otherwise couple tests to
-/// execution order and the host's installed fonts).
-fn load_emoji_face_from_source(source: &EmojiSource) -> Option<LoadedFace> {
-    match source {
-        EmojiSource::SystemFile { path, index } => {
-            if let Ok(bytes) = std::fs::read(path)
-                && let Some(loaded) = LoadedFace::from_owned(bytes, *index)
-            {
-                info!("Using system emoji font: {}", path.display());
-                return Some(loaded);
-            }
-            // The cached source vanished (font uninstalled between windows) —
-            // fall through to the bundled floor.
-            warn!(
-                "Cached system emoji font no longer loadable ({}); using bundled",
-                path.display()
-            );
-            load_bundled_emoji_floor()
-        }
-        EmojiSource::Bundled => load_bundled_emoji_floor(),
-    }
+/// The bundled Noto Color Emoji face is **always** used; system emoji fonts
+/// are intentionally **not** consulted. Freminal previously tried to rank
+/// installed system emoji fonts by name and by scanning their `cmap` for
+/// emoji-block coverage, but a font's aggregate coverage count is not a
+/// stable guarantee that it maps any *particular* codepoint the terminal
+/// needs to render — a system font could win the ranking and then still
+/// produce tofu for a codepoint it happens not to carry (issue #431). Always
+/// using the bundled face removes that host-dependent guessing entirely: the
+/// set of codepoints that render correctly is fixed and known at build time,
+/// regardless of what is or isn't installed on the system.
+fn discover_emoji_face() -> Option<LoadedFace> {
+    load_bundled_emoji_floor()
 }
 
 /// Load the bundled Noto Color Emoji floor face.
 fn load_bundled_emoji_floor() -> Option<LoadedFace> {
     let bundled = LoadedFace::from_static(NOTO_COLOR_EMOJI);
     if bundled.is_some() {
-        info!("Using bundled Noto Color Emoji (no suitable system emoji font)");
+        info!("Using bundled Noto Color Emoji");
     } else {
         warn!("Bundled Noto Color Emoji failed to load");
     }
     bundled
-}
-
-/// A resolved emoji-font source: either a concrete system font file, or the
-/// bundled floor. Cheap to clone and store in the process-global cache.
-#[derive(Clone, Debug, PartialEq, Eq)]
-enum EmojiSource {
-    /// A system font file at `path`, face `index`.
-    SystemFile {
-        path: std::path::PathBuf,
-        index: usize,
-    },
-    /// The bundled Noto Color Emoji floor.
-    Bundled,
-}
-
-/// Process-global cache of the resolved emoji source.
-///
-/// Emoji discovery is host-configuration-invariant within a process run, but
-/// `FontManager::new` runs **once per window**. Without this cache, opening a
-/// window on a system with no known-named emoji font would re-run the full
-/// capability scan — reading and parsing *every* installed font file from disk
-/// — every single time. We resolve the source once and reuse it; only the
-/// (single) winning font file is re-read per window.
-static EMOJI_SOURCE_CACHE: std::sync::OnceLock<EmojiSource> = std::sync::OnceLock::new();
-
-/// Resolve (and memoize process-wide) which emoji source to use.
-fn resolve_emoji_source(font_db: &Database) -> EmojiSource {
-    EMOJI_SOURCE_CACHE
-        .get_or_init(|| best_system_emoji_source(font_db).unwrap_or(EmojiSource::Bundled))
-        .clone()
-}
-
-/// Find the best color emoji face installed on the system, or `None`.
-///
-/// Two passes, so the common case stays cheap:
-///
-/// 1. **Fast path** — try the known emoji family names ([`EMOJI_CANDIDATES`])
-///    in priority order, filtering by `fontdb`'s in-memory family metadata
-///    (no disk I/O) before loading a candidate. The first one that is a real
-///    color font wins. This is what runs on virtually every desktop.
-/// 2. **Capability scan** — only if no known-named emoji font is installed do
-///    we fall back to scanning *all* faces, loading each, gating on the color
-///    tables, and ranking by real emoji-block coverage. This rescues fonts
-///    with non-standard names (e.g. `JoyPixels`, a distro-renamed Noto) at the
-///    cost of a fuller scan, which only happens when the fast path found
-///    nothing.
-///
-/// Returns the resolved [`EmojiSource`] (path + index) rather than a loaded
-/// face, so the result can be cheaply cached process-wide (see
-/// [`resolve_emoji_source`]).
-fn best_system_emoji_source(font_db: &Database) -> Option<EmojiSource> {
-    // Fast path: known names, metadata-filtered, stop at the first color face.
-    // Name match is case-insensitive so e.g. "noto color emoji" also matches.
-    for candidate in EMOJI_CANDIDATES {
-        let candidate_lower = candidate.to_lowercase();
-        for face in font_db.faces() {
-            if !face
-                .families
-                .iter()
-                .any(|(fam, _)| fam.to_lowercase().contains(&candidate_lower))
-            {
-                continue;
-            }
-            let fontdb::Source::File(path) = &face.source else {
-                continue;
-            };
-            let Ok(bytes) = std::fs::read(path) else {
-                continue;
-            };
-            let index = usize::value_from(face.index).unwrap_or(0);
-            if let Some(loaded) = LoadedFace::from_owned(bytes, index)
-                && loaded.has_color_glyphs()
-            {
-                return Some(EmojiSource::SystemFile {
-                    path: path.clone(),
-                    index,
-                });
-            }
-        }
-    }
-
-    // Capability scan: no known emoji font installed — rank every color face by
-    // real coverage.
-    let mut best: Option<(u32, EmojiSource)> = None;
-    for face in font_db.faces() {
-        let fontdb::Source::File(path) = &face.source else {
-            continue;
-        };
-        let Ok(bytes) = std::fs::read(path) else {
-            continue;
-        };
-        let index = usize::value_from(face.index).unwrap_or(0);
-        let Some(loaded) = LoadedFace::from_owned(bytes, index) else {
-            continue;
-        };
-        if !loaded.has_color_glyphs() {
-            continue;
-        }
-        let coverage = loaded.emoji_coverage();
-        if coverage > 0
-            && best
-                .as_ref()
-                .is_none_or(|(best_cov, _)| coverage > *best_cov)
-        {
-            best = Some((
-                coverage,
-                EmojiSource::SystemFile {
-                    path: path.clone(),
-                    index,
-                },
-            ));
-        }
-    }
-    best.map(|(_, source)| source)
 }
 
 /// Search `fontdb` for any font containing the given codepoint.
@@ -2088,7 +1941,7 @@ mod tests {
         );
     }
 
-    // --- Task 402: bundled Noto Color Emoji + capability-based ranking ---
+    // --- Task 402 / issue #431: bundled Noto Color Emoji, always used ---
 
     #[test]
     fn bundled_noto_is_a_color_emoji_face() {
@@ -2129,22 +1982,35 @@ mod tests {
     }
 
     #[test]
-    fn emoji_face_falls_back_to_bundled_noto() {
-        // An empty font database has no system emoji font, so source resolution
-        // must yield the bundled floor. Exercised via the uncached path
-        // (`best_system_emoji_source` + `load_emoji_face_from_source`) so this
-        // test does not depend on / mutate the process-global source cache.
-        let empty_db = Database::new();
-        let source = best_system_emoji_source(&empty_db).unwrap_or(EmojiSource::Bundled);
-        assert_eq!(
-            source,
-            EmojiSource::Bundled,
-            "an empty db must resolve to the bundled floor"
-        );
-        let face = load_emoji_face_from_source(&source).expect("bundled floor must load");
+    fn emoji_face_is_always_bundled_noto() {
+        // `discover_emoji_face` takes no font database — it must always
+        // resolve to the bundled color face, independent of what is (or
+        // isn't) installed on the host (issue #431).
+        let face = discover_emoji_face().expect("bundled Noto Color Emoji must load");
         assert!(
             face.has_color_glyphs(),
-            "the bundled fallback must be a color emoji face"
+            "the emoji face must always be the bundled color emoji face"
+        );
+    }
+
+    #[test]
+    fn discover_emoji_face_returns_bundled_color_face() {
+        // Regression guard for issue #431: the snowflake emoji (U+2744) must
+        // resolve to a real glyph in the always-used bundled face, not tofu
+        // from a ranked-but-incomplete system font.
+        let face = discover_emoji_face().expect("bundled Noto Color Emoji must load");
+        assert!(
+            face.has_glyph('\u{2744}'),
+            "bundled Noto Color Emoji must map U+2744 (snowflake) to a glyph"
+        );
+        assert_ne!(
+            face.map_char('\u{2744}'),
+            0,
+            "U+2744 must not map to .notdef in the bundled face"
+        );
+        assert!(
+            face.has_color_glyphs(),
+            "the bundled emoji face must carry color glyph tables"
         );
     }
 

--- a/freminal/src/gui/fonts.rs
+++ b/freminal/src/gui/fonts.rs
@@ -342,6 +342,7 @@ fn add_fallback_to_terminal_families(defs: &mut FontDefinitions, name: &str) {
 
 mod emoji_fonts {
     use super::{FontData, FontDefinitions};
+    use conv2::ValueFrom;
     use fontdb::{Database, Source};
 
     const CANDIDATES: &[&str] = &[
@@ -360,11 +361,19 @@ mod emoji_fonts {
     /// This is the **egui chrome** path (menu bar, settings), NOT the terminal
     /// grid. It deliberately does NOT reuse the terminal-side emoji face (the
     /// bundled Noto Color Emoji, always used since issue #431): egui's
-    /// grayscale atlas cannot render color (COLR/CBDT) glyphs, so for chrome a
-    /// monochrome-renderable emoji/symbol face (e.g. `Symbola`) is actually the
-    /// *useful* choice, and a color-only font would render as tofu. The
-    /// name-priority list here is correct for that goal; the two paths
-    /// intentionally differ.
+    /// grayscale atlas cannot render color (COLR/CPAL, CBDT/CBLC, sbix) glyphs
+    /// — it locks glyph ownership by cmap and renders a color-only glyph as
+    /// blank — so for chrome a monochrome-renderable emoji/symbol face (e.g.
+    /// `Symbola`) is actually the *useful* choice, while a color-only font
+    /// would render blank. `find_candidate` enforces this: it actively SKIPS
+    /// any face carrying color glyph tables, regardless of where it sits in
+    /// the name-priority list below, so only a face egui can actually
+    /// rasterize is ever returned. The name list is therefore a priority
+    /// order among monochrome-capable candidates; the color-only entries
+    /// (Apple/Noto/Segoe UI Emoji, etc.) are harmless no-ops on this path —
+    /// kept for documentation of intent and in case a monochrome variant of
+    /// one is ever installed under the same family name — and the two paths
+    /// (chrome vs. terminal grid) intentionally differ.
     pub fn add_emoji_fallback(defs: &mut FontDefinitions) {
         let mut db = Database::new();
         db.load_system_fonts();
@@ -380,6 +389,22 @@ mod emoji_fonts {
         }
 
         warn!("Emoji fallback: no suitable emoji font found");
+    }
+
+    /// Whether the face at `index` within `bytes` carries color glyph tables
+    /// (`COLR`/`CPAL` vector palettes or `CBDT`/`CBLC`/`sbix` bitmap strikes).
+    ///
+    /// egui's chrome text atlas is grayscale-only and cannot rasterize these
+    /// glyphs, so a face for which this returns `true` must be skipped by
+    /// `find_candidate` rather than handed to egui. A face that swash cannot
+    /// parse at all is treated as unusable — this returns `true` for it too,
+    /// so `find_candidate` skips it (fail closed).
+    fn is_color_font(bytes: &[u8], index: u32) -> bool {
+        let index = usize::value_from(index).unwrap_or(0);
+        let Some(font_ref) = swash::FontRef::from_index(bytes, index) else {
+            return true;
+        };
+        font_ref.color_palettes().next().is_some() || font_ref.color_strikes().next().is_some()
     }
 
     fn find_candidate(db: &Database, target: &str) -> Option<(String, Vec<u8>)> {
@@ -398,12 +423,48 @@ mod emoji_fonts {
                 && path.exists()
                 && let Ok(bytes) = std::fs::read(path)
             {
+                // egui's chrome atlas can't render color glyphs (COLR/CPAL,
+                // CBDT/CBLC, sbix) — skip a color-only face and keep looking,
+                // even though its name matched, so a color emoji font
+                // installed alongside (or instead of) a monochrome one
+                // doesn't win by name priority and render blank.
+                if is_color_font(&bytes, face.index) {
+                    continue;
+                }
+
                 let key = format!("emoji-{}", target.replace(' ', "_"));
                 return Some((key, bytes));
             }
         }
 
         None
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::is_color_font;
+
+        static NOTO_COLOR_EMOJI: &[u8] = include_bytes!("../../../res/NotoColorEmoji.ttf");
+        static CASKAYDIA_REGULAR: &[u8] =
+            include_bytes!("../../../res/CaskaydiaCoveNerdFont-Regular.ttf");
+
+        #[test]
+        fn color_emoji_font_is_detected_as_color() {
+            assert!(
+                is_color_font(NOTO_COLOR_EMOJI, 0),
+                "bundled Noto Color Emoji carries color glyph tables and must \
+                 be detected as a color font"
+            );
+        }
+
+        #[test]
+        fn monochrome_font_is_not_detected_as_color() {
+            assert!(
+                !is_color_font(CASKAYDIA_REGULAR, 0),
+                "CaskaydiaCove Nerd Font is a monochrome text font and must \
+                 not be misdetected as a color font"
+            );
+        }
     }
 }
 

--- a/freminal/src/gui/fonts.rs
+++ b/freminal/src/gui/fonts.rs
@@ -358,13 +358,13 @@ mod emoji_fonts {
     /// Add a system emoji font as a chrome-text fallback.
     ///
     /// This is the **egui chrome** path (menu bar, settings), NOT the terminal
-    /// grid. It deliberately does NOT reuse the terminal-side capability
-    /// ranking (`font_manager::best_system_emoji_source`, which gates on
-    /// `has_color_glyphs`): egui's grayscale atlas cannot render color
-    /// (COLR/CBDT) glyphs, so for chrome a monochrome-renderable emoji/symbol
-    /// face (e.g. `Symbola`) is actually the *useful* choice, and a color-only
-    /// font would render as tofu. The name-priority list here is correct for
-    /// that goal; the two paths intentionally differ.
+    /// grid. It deliberately does NOT reuse the terminal-side emoji face (the
+    /// bundled Noto Color Emoji, always used since issue #431): egui's
+    /// grayscale atlas cannot render color (COLR/CBDT) glyphs, so for chrome a
+    /// monochrome-renderable emoji/symbol face (e.g. `Symbola`) is actually the
+    /// *useful* choice, and a color-only font would render as tofu. The
+    /// name-priority list here is correct for that goal; the two paths
+    /// intentionally differ.
     pub fn add_emoji_fallback(defs: &mut FontDefinitions) {
         let mut db = Database::new();
         db.load_system_fonts();

--- a/freminal/src/gui/panes/mod.rs
+++ b/freminal/src/gui/panes/mod.rs
@@ -1550,6 +1550,24 @@ pub const fn should_focus_inactive_pane(
     left_clicked || (focus_follows_mouse && pointer_over_content)
 }
 
+/// Find which pane (if any) a point lands in, given the current pane
+/// layout (issue #453).
+///
+/// Used on pane-border drag release to determine which pane should receive
+/// focus, since focus-follows-mouse is frozen for the duration of the drag
+/// (see `should_focus_inactive_pane` callers in `app_impl.rs`). `layout` is
+/// the `Vec<(PaneId, Rect)>` produced by `PaneNode::layout`; the first
+/// entry whose rect contains `pos` wins. Returns `None` when `pos` is not
+/// over any pane in `layout` (e.g. the drag ended outside the terminal
+/// band).
+#[must_use]
+pub fn pane_at_pos(layout: &[(PaneId, Rect)], pos: egui::Pos2) -> Option<PaneId> {
+    layout
+        .iter()
+        .find(|(_, rect)| rect.contains(pos))
+        .map(|(id, _)| *id)
+}
+
 // ── Tests ────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -1580,6 +1598,56 @@ mod tests {
         // A non-active pane with no click and no pointer-over does not focus.
         assert!(!should_focus_inactive_pane(false, true, false));
         assert!(!should_focus_inactive_pane(false, false, false));
+    }
+
+    // ── pane_at_pos tests (issue #453) ───────────────────────────────
+
+    #[test]
+    fn pane_at_pos_finds_containing_pane() {
+        let pane_a = PaneId(0);
+        let pane_b = PaneId(1);
+        let layout = vec![
+            (
+                pane_a,
+                Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(100.0, 100.0)),
+            ),
+            (
+                pane_b,
+                Rect::from_min_max(egui::pos2(100.0, 0.0), egui::pos2(200.0, 100.0)),
+            ),
+        ];
+
+        assert_eq!(
+            pane_at_pos(&layout, egui::pos2(50.0, 50.0)),
+            Some(pane_a),
+            "point inside pane A's rect must resolve to pane A"
+        );
+        assert_eq!(
+            pane_at_pos(&layout, egui::pos2(150.0, 50.0)),
+            Some(pane_b),
+            "point inside pane B's rect must resolve to pane B"
+        );
+    }
+
+    #[test]
+    fn pane_at_pos_outside_all_panes_returns_none() {
+        let pane_a = PaneId(0);
+        let layout = vec![(
+            pane_a,
+            Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(100.0, 100.0)),
+        )];
+
+        assert_eq!(
+            pane_at_pos(&layout, egui::pos2(500.0, 500.0)),
+            None,
+            "point outside every pane rect must resolve to None"
+        );
+    }
+
+    #[test]
+    fn pane_at_pos_empty_layout_returns_none() {
+        let layout: Vec<(PaneId, Rect)> = Vec::new();
+        assert_eq!(pane_at_pos(&layout, egui::pos2(0.0, 0.0)), None);
     }
 
     // ── PaneId tests ─────────────────────────────────────────────────

--- a/freminal/src/gui/terminal/input.rs
+++ b/freminal/src/gui/terminal/input.rs
@@ -378,9 +378,18 @@ pub const fn raw_mods_to_key_modifiers(
 ///
 /// The caller is responsible for NOT calling this while an overlay owns
 /// keyboard input (global `ui_overlay_open`, or a per-pane search /
-/// command-history / context-menu overlay) — in that case it clears the
-/// queue instead of draining, so intercepted keys cannot bypass the overlay
-/// and reach the PTY. See the drain call site in `app_impl.rs`.
+/// command-history / context-menu overlay), or while a pane-border
+/// drag-to-resize is in progress (`border_drag_active`) — in any of these
+/// cases it clears the queue instead of draining, so intercepted keys
+/// cannot bypass the overlay/resize and reach the PTY. See the drain call
+/// site in `app_impl.rs`.
+///
+/// Unlike the pointer-input suppression in `widget.rs`, the border-drag
+/// gate here needs no one-frame release tail: a raw key is only ever queued
+/// because it was physically pressed, and ending a drag does not synthesize
+/// a key event (whereas a drag-release *does* synthesize a spurious pointer
+/// click, which is why that path carries a tail). Gating on the
+/// current-frame `border_drag_active` is therefore sufficient.
 ///
 /// ## Broadcast (Task 74)
 ///

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -1174,6 +1174,14 @@ pub struct PaneRenderCache {
     /// Whether a UI overlay (modal dialog or dropdown menu) was open on the
     /// previous frame.
     pub(super) overlay_was_open_last_frame: bool,
+    /// Whether a pane-border drag-to-resize was active on the previous
+    /// frame. Mirrors `overlay_was_open_last_frame`'s one-frame release tail
+    /// but tracks a distinct cause: the release-click that ends a divider
+    /// drag must not leak through to the terminal on the same frame
+    /// `border_drag_active` goes false (issue #453 review). Kept separate
+    /// from `overlay_was_open_last_frame` so each latch tracks only its own
+    /// cause.
+    pub(super) border_drag_was_active_last_frame: bool,
     /// Number of search matches from the most recently rendered frame.
     pub(super) previous_search_match_count: usize,
     /// Current match index from the most recently rendered frame.
@@ -1297,6 +1305,7 @@ impl PaneRenderCache {
             previous_text_blink_slow_visible: true,
             previous_text_blink_fast_visible: true,
             overlay_was_open_last_frame: false,
+            border_drag_was_active_last_frame: false,
             previous_search_match_count: 0,
             previous_search_current_match: 0,
             previous_hover_cell: None,
@@ -1589,6 +1598,12 @@ impl FreminalTerminalWidget {
     /// - `clipboard_rx` — receives clipboard content from the PTY write-back.
     /// - `search_buffer_rx` — receives full-buffer search content from the PTY thread.
     /// - `ui_overlay_open` — suppresses terminal input while a modal or menu dropdown is visible.
+    /// - `border_drag_active` — suppresses terminal input and clears any
+    ///   phantom selection while a pane-border drag-to-resize is in
+    ///   progress. The invisible drag-sensor rect geometrically overlaps
+    ///   the adjacent pane's `terminal_rect`, so without this the same
+    ///   press+drag would also start/extend a real text selection there
+    ///   (issue #453).
     /// - `bg_opacity` — background panel opacity (`0.0`–`1.0`) from config.
     /// - `bg_image_opacity` — background image opacity (`0.0`–`1.0`) from config.
     /// - `bg_image_mode` — background image fit mode from config.
@@ -1607,6 +1622,11 @@ impl FreminalTerminalWidget {
     // All parameters are required: each pane needs its own render state, cache, channels, and
     // view state; there is no sensible grouping that reduces the count without hiding the intent.
     #[allow(clippy::too_many_arguments)]
+    // Each bool gates an independent, unrelated suppression/state concern
+    // (overlay-open, border-drag-active, echo-off, active-pane); bundling
+    // them into an enum would not express any real combined state and
+    // would only obscure the call site.
+    #[allow(clippy::fn_params_excessive_bools)]
     pub fn show(
         &mut self,
         ui: &mut Ui,
@@ -1618,6 +1638,7 @@ impl FreminalTerminalWidget {
         clipboard_rx: &Receiver<String>,
         search_buffer_rx: &Receiver<(usize, Vec<TChar>)>,
         ui_overlay_open: bool,
+        border_drag_active: bool,
         bg_opacity: f32,
         bg_image_opacity: f32,
         bg_image_mode: freminal_common::config::BackgroundImageMode,
@@ -1648,11 +1669,16 @@ impl FreminalTerminalWidget {
         let logical_cell_w = cell_w_f / ppp;
         let logical_cell_h = row_h_f / ppp;
 
-        // Suppress input for one extra frame after a modal closes.
-        // This prevents the dismiss-click (Cancel / X / click-away) from
-        // leaking through to the terminal as a pointer event.
-        let suppress_input = ui_overlay_open || cache.overlay_was_open_last_frame;
+        // Suppress input for one extra frame after a modal closes, or after
+        // a pane-border drag-to-resize ends. This prevents the dismiss-click
+        // (Cancel / X / click-away) or the drag-release-click from leaking
+        // through to the terminal as a pointer event (issue #453 review).
+        let suppress_input = ui_overlay_open
+            || border_drag_active
+            || cache.overlay_was_open_last_frame
+            || cache.border_drag_was_active_last_frame;
         cache.overlay_was_open_last_frame = ui_overlay_open;
+        cache.border_drag_was_active_last_frame = border_drag_active;
 
         // Claim the full available space.
         let available = ui.available_size();
@@ -1877,18 +1903,28 @@ impl FreminalTerminalWidget {
             cache.previous_key = None;
             cache.previous_mouse_state = None;
             cache.previous_scroll_amount = 0.0;
-            // Task 116.3 (defect 3): route through `finalize_interrupted_drag`
-            // instead of bluntly clearing `is_selecting`. An in-progress drag
-            // interrupted here (modal/menu/search/command-history opening,
-            // scrollbar-drag starting, or a split-pane-boundary release that
-            // never reaches this pane's `write_input_to_terminal` call) would
-            // otherwise strand `anchor`/`end` with `is_selecting = false`,
-            // making the next primary press see a stale `has_selection()`
-            // and clear instead of starting a new drag. Finalizing collapses
-            // a not-yet-dragged point selection (clears everything) or keeps
-            // a real range as a completed selection, matching what a normal
-            // mouse-release would have done.
-            view_state.selection.finalize_interrupted_drag();
+            if border_drag_active {
+                // A pane-border drag geometrically overlaps the adjacent
+                // pane's `terminal_rect`; the same press+drag would
+                // otherwise start and extend a phantom text selection
+                // here (issue #453). Fully clear it rather than
+                // finalize-and-keep, since the gesture was a resize, not
+                // a selection.
+                view_state.selection.clear();
+            } else {
+                // Task 116.3 (defect 3): route through `finalize_interrupted_drag`
+                // instead of bluntly clearing `is_selecting`. An in-progress drag
+                // interrupted here (modal/menu/search/command-history opening,
+                // scrollbar-drag starting, or a split-pane-boundary release that
+                // never reaches this pane's `write_input_to_terminal` call) would
+                // otherwise strand `anchor`/`end` with `is_selecting = false`,
+                // making the next primary press see a stale `has_selection()`
+                // and clear instead of starting a new drag. Finalizing collapses
+                // a not-yet-dragged point selection (clears everything) or keeps
+                // a real range as a completed selection, matching what a normal
+                // mouse-release would have done.
+                view_state.selection.finalize_interrupted_drag();
+            }
         } else {
             let repeat_characters = snap.repeat_keys;
             let ctx = ui.ctx().clone();
@@ -4327,6 +4363,140 @@ mod overlay_suppress_input_tests {
         let overlay_is_open = false;
         let suppress = overlay_is_open || overlay_was_open_last_frame;
         assert!(!suppress, "fresh widget should not suppress input");
+    }
+
+    /// Issue #453: a pane-border drag-to-resize must suppress terminal
+    /// input the same way a modal/menu overlay does. The `suppress_input`
+    /// flag is computed as:
+    ///   `ui_overlay_open || border_drag_active || self.overlay_was_open_last_frame`
+    /// Verify that `border_drag_active` alone (no overlay open, no
+    /// one-frame latch active) is sufficient to suppress input.
+    #[test]
+    fn border_drag_active_suppresses_input() {
+        let ui_overlay_open = false;
+        let overlay_was_open_last_frame = false;
+
+        let border_drag_active = true;
+        let suppress = ui_overlay_open || border_drag_active || overlay_was_open_last_frame;
+        assert!(
+            suppress,
+            "border_drag_active alone must suppress input, matching the \
+             ui_overlay_open || border_drag_active || overlay_was_open_last_frame \
+             computation in FreminalTerminalWidget::show"
+        );
+
+        let border_drag_active = false;
+        let suppress = ui_overlay_open || border_drag_active || overlay_was_open_last_frame;
+        assert!(
+            !suppress,
+            "with everything else false, no border drag must NOT suppress input"
+        );
+    }
+
+    /// Issue #453 root cause: a pane-border drag sensor sits geometrically
+    /// inside the adjacent pane's `terminal_rect`, so the same press+drag
+    /// also starts/extends a phantom text selection in that pane.
+    ///
+    /// This locks in that the border-drag suppression branch fully CLEARS
+    /// the phantom selection (`SelectionState::clear`) rather than
+    /// finalizing-and-keeping it (`SelectionState::finalize_interrupted_drag`,
+    /// used for every OTHER suppression cause). Finalizing would keep a
+    /// real anchor != end range as a "completed" selection — which is
+    /// exactly the bug: the phantom selection painted during a divider
+    /// drag would survive the drag ending instead of disappearing.
+    #[test]
+    fn border_drag_clears_phantom_selection() {
+        use crate::gui::view_state::{CellCoord, SelectionState};
+
+        // Build a phantom in-progress selection exactly as described in
+        // the root-cause diagnostic: one endpoint pinned at the mouse-down
+        // anchor, the other tracking the drag, `is_selecting = true`.
+        let make_phantom = || SelectionState {
+            anchor: Some(CellCoord { col: 2, row: 3 }),
+            end: Some(CellCoord { col: 9, row: 3 }),
+            is_selecting: true,
+            ..SelectionState::default()
+        };
+
+        // Contrast case: on every OTHER suppression cause, the existing
+        // `finalize_interrupted_drag()` KEEPS a real range as a completed
+        // selection (only `is_selecting` is cleared).
+        let mut finalized = make_phantom();
+        finalized.finalize_interrupted_drag();
+        assert!(
+            finalized.has_selection(),
+            "finalize_interrupted_drag must KEEP a real anchor != end range"
+        );
+        assert!(!finalized.is_selecting, "drag flag must be cleared");
+        assert_eq!(finalized.anchor, Some(CellCoord { col: 2, row: 3 }));
+        assert_eq!(finalized.end, Some(CellCoord { col: 9, row: 3 }));
+
+        // Fix under test: when the suppression cause is a border drag, the
+        // widget must call `clear()` instead, fully discarding the phantom
+        // rather than keeping it as a "completed" selection.
+        let mut cleared = make_phantom();
+        cleared.clear();
+        assert!(
+            !cleared.has_selection(),
+            "border-drag suppression must fully clear the phantom selection"
+        );
+        assert!(!cleared.is_selecting);
+        assert_eq!(cleared.anchor, None);
+        assert_eq!(cleared.end, None);
+    }
+
+    /// Issue #453 review: the release-click that ends a pane-border drag
+    /// must not leak through to the terminal on the same frame
+    /// `border_drag_active` goes false, mirroring the existing overlay
+    /// one-frame release tail. `suppress_input` is computed as:
+    ///   `ui_overlay_open || border_drag_active
+    ///       || overlay_was_open_last_frame || border_drag_was_active_last_frame`
+    /// and `border_drag_was_active_last_frame` is then set to
+    /// `border_drag_active`, kept as its own latch separate from
+    /// `overlay_was_open_last_frame`.
+    #[test]
+    fn border_drag_one_frame_release_tail() {
+        let mut overlay_was_open_last_frame = false;
+        let mut border_drag_was_active_last_frame = false;
+
+        let mut frame = |ui_overlay_open: bool, border_drag_active: bool| -> bool {
+            let suppress = ui_overlay_open
+                || border_drag_active
+                || overlay_was_open_last_frame
+                || border_drag_was_active_last_frame;
+            overlay_was_open_last_frame = ui_overlay_open;
+            border_drag_was_active_last_frame = border_drag_active;
+            suppress
+        };
+
+        // Frame 1: no overlay, no drag → input NOT suppressed.
+        assert!(!frame(false, false), "frame 1: idle → no suppression");
+
+        // Frame 2: drag starts → input suppressed.
+        assert!(frame(false, true), "frame 2: drag active → suppressed");
+
+        // Frame 3: drag still in progress → input suppressed.
+        assert!(
+            frame(false, true),
+            "frame 3: drag still active → suppressed"
+        );
+
+        // Frame 4: drag ends (release click lands this frame) → input
+        // STILL suppressed because `border_drag_was_active_last_frame` is
+        // true, exactly mirroring the overlay dismiss-click tail.
+        assert!(
+            frame(false, false),
+            "frame 4: drag-release frame → still suppressed"
+        );
+
+        // Frame 5: drag ended last frame, no overlay → input allowed again.
+        assert!(
+            !frame(false, false),
+            "frame 5: fully settled → input allowed"
+        );
+
+        // Frame 6: verify stable — stays unsuppressed.
+        assert!(!frame(false, false), "frame 6: stable → input allowed");
     }
 }
 


### PR DESCRIPTION
Two related-in-scope-only bug fixes, one atomic commit each.

## Closes #431 — always use the bundled emoji font (`e5bafe12`)

Freminal ranked system-installed emoji fonts (by name priority, then by
scanning each font's `cmap` for emoji-block coverage) and only fell back
to the bundled Noto Color Emoji when nothing capable was found. But a
system font's aggregate coverage is not a stable guarantee that it maps
any *particular* codepoint: a font could win the ranking and still render
tofu for a codepoint it happens not to carry. Observed concretely with a
starship prompt's NixOS snowflake glyph (U+2744) — and two
"Noto Color Emoji"-named builds on one machine were measured to differ by
9 codepoints under the identical family name.

Now the terminal grid **always** uses the bundled `res/NotoColorEmoji.ttf`:
the set of codepoints that render is fixed and known at build time,
independent of the host. Removes the dead ranking machinery
(`EMOJI_CANDIDATES`, `best_system_emoji_source`, `resolve_emoji_source`,
`EMOJI_SOURCE_CACHE`, `EmojiSource`, `load_emoji_face_from_source`);
`has_color_glyphs` / `emoji_coverage` / `EMOJI_BLOCKS` survive only as
`#[cfg(test)]` regression helpers. The egui **chrome** path (`fonts.rs`)
is deliberately untouched (its grayscale atlas can't render colour glyphs
so it keeps its own monochrome fallback list). Regression test asserts
the bundled face maps U+2744 to a real colour glyph.

## Closes #453 — pane-divider drag painted a phantom selection (`95a9182b`)

Dragging a mux pane divider flashed inverted (selection-coloured) pixels
on a row of the adjacent pane. Root-caused via frame-by-frame diagnostic
logging (after a bisect proved noisy and an initial GPU-path theory was
disproved): the invisible border-drag sensor sits inside the adjacent
pane's `terminal_rect`, so the same press+drag that resizes the split
also starts and extends a real text selection there.

Fix threads a `border_drag_active` flag into the terminal widget, folds it
into input suppression, and fully clears the phantom selection during a
drag. Plus, from review + user request:

- **Focus freeze/restore**: focus-follows-mouse is frozen during a divider
  drag (no active-pane flicker between panes); on release, the pane under
  the pointer becomes active.
- **Stuck-state defense**: `win.border_drag` is force-cleared any frame the
  primary button isn't held, so an overlay opening mid-drag can't strand it
  `Some` and freeze all input.
- **One-frame release tail** so the drag-release click can't leak into the
  terminal (matters for mouse-tracking PTY apps).

## Verification

- `cargo test --all` — all pass (new tests for emoji bundling, `pane_at_pos`
  hit-test, border-drag suppression/clear, one-frame release tail)
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo machete` — clean
- `cargo xtask check-windows` — clean
- Both fixes manually verified against a live build by the maintainer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pane divider resizing to prevent focus flicker and ensure keyboard focus follows the pane under the pointer when dragging ends.
  * Prevented input from getting stuck during divider drag edge cases.
  * Improved selection behavior during resizing (including clearing phantom selections and blocking stray keystrokes).

* **Improvements**
  * Emoji rendering is now consistently driven by the bundled Noto Color Emoji font for more predictable cross-system output.
  * Cursor-to-pane detection was refined to correctly identify the pane under the pointer (or none when outside the layout).

* **Documentation**
  * Updated attribution/usage notes for the bundled emoji font.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->