### PR TITLE
perf: FaceId-keyed FontManager caches -> FxHashMap (issue #459 item 1)

### DIFF
--- a/freminal/src/gui/font_manager.rs
+++ b/freminal/src/gui/font_manager.rs
@@ -19,6 +19,7 @@ use conv2::{ConvUtil, ValueFrom};
 use fontdb::Database;
 use freminal_common::buffer_states::fonts::{FontDecorationFlags, FontDecorations, FontWeight};
 use freminal_common::config::Config;
+use rustc_hash::FxHashMap;
 
 // ---------------------------------------------------------------------------
 //  Bundled font data (compiled into the binary via include_bytes!)
@@ -445,7 +446,7 @@ pub struct FontManager {
     /// `glyph_cache`. `None` means the face has no measurable metrics (or is a
     /// primary face). Interior mutability so the renderer can read metrics
     /// through a shared `&FontManager` while still caching.
-    fallback_metrics_cache: RefCell<HashMap<FaceId, Option<FallbackCellMetrics>>>,
+    fallback_metrics_cache: RefCell<FxHashMap<FaceId, Option<FallbackCellMetrics>>>,
 
     /// Per-face cache of parsed `rustybuzz::Face` instances (Task #430).
     /// Populated lazily by [`Self::build_cached_face`] (invoked from
@@ -454,14 +455,14 @@ pub struct FontManager {
     /// size/DPI change (`set_font_size`, `update_pixels_per_point`), even
     /// though the bytes themselves are unaffected by those. `None` means the
     /// face is not loaded or failed to parse as a rustybuzz `Face`.
-    face_cache: RefCell<HashMap<FaceId, Option<CachedFace>>>,
+    face_cache: RefCell<FxHashMap<FaceId, Option<CachedFace>>>,
 
     /// Per-`(face, ligatures, script, direction)` cache of compiled
     /// `rustybuzz::ShapePlan`s (Task #430). Plan compilation is the
     /// second-most expensive part of cold shaping after face parsing;
     /// caching it avoids recompiling an identical plan on every shape call.
     /// Cleared alongside `face_cache`.
-    plan_cache: RefCell<HashMap<PlanKey, Arc<rustybuzz::ShapePlan>>>,
+    plan_cache: RefCell<FxHashMap<PlanKey, Arc<rustybuzz::ShapePlan>>>,
 
     /// Authoritative cell width in integer pixels.
     cell_width: u32,
@@ -578,9 +579,9 @@ impl FontManager {
             system_fallback_cache: HashMap::new(),
             system_faces: Vec::new(),
             glyph_cache: HashMap::new(),
-            fallback_metrics_cache: RefCell::new(HashMap::new()),
-            face_cache: RefCell::new(HashMap::new()),
-            plan_cache: RefCell::new(HashMap::new()),
+            fallback_metrics_cache: RefCell::new(FxHashMap::default()),
+            face_cache: RefCell::new(FxHashMap::default()),
+            plan_cache: RefCell::new(FxHashMap::default()),
             cell_width,
             cell_height,
             ascent,


### PR DESCRIPTION
## Summary

Switches three `FontManager` caches keyed purely or partly by `FaceId` from Rust's default SipHash-based `HashMap` to `FxHashMap`, matching the pattern already established by `atlas.rs`'s glyph cache. This is follow-up item 1 from #459's real-workload profiling investigation.

- `fallback_metrics_cache: RefCell<HashMap<FaceId, Option<FallbackCellMetrics>>>` -> `RefCell<FxHashMap<...>>`
- `face_cache: RefCell<HashMap<FaceId, Option<CachedFace>>>` -> `RefCell<FxHashMap<...>>`
- `plan_cache: RefCell<HashMap<PlanKey, Arc<rustybuzz::ShapePlan>>>` -> `RefCell<FxHashMap<...>>` (`PlanKey = (FaceId, bool, rustybuzz::Script, rustybuzz::Direction)`)

## Why this is safe

`FaceId` is a small `Copy` enum (bare discriminants plus one `System(usize)` variant assigned locally during font discovery) — never derived from untrusted input. `PlanKey`'s other components (`bool`, `Script`, `Direction`) are technically derived from terminal-run text via `guess_segment_properties()`, so they are input-influenced, but their realizable domain is a small, fixed, enumerable set (ISO-15924 script tags + a 5-variant direction enum), so a HashDoS concern doesn't apply in practice.

**Deliberately left unchanged**: `glyph_cache` (`(char, GlyphStyle)` key) and `system_fallback_cache` (`char` key) — both keyed by `char`, which comes directly from PTY output (untrusted input). Switching those raises a HashDoS-resistance trade-off that hasn't been explicitly decided and is out of scope here. (Note: `atlas.rs`'s `procedural_entries` map is already `char`-keyed `FxHashMap`, so the codebase's posture on this isn't actually uniform today — this PR doesn't attempt to reconcile that, only avoids introducing a *new* case beyond what already exists.)

## Validation

- `cargo test --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo machete` — all green.
- `shaping_ligatures` benchmark (before/after via `--save-baseline`): no statistically significant change detected. Expected — that benchmark's call frequency to `face_cache`/`plan_cache` per iteration is much lower than the sustained multi-row-per-frame churn that originally surfaced this cost in real-workload profiling.
- Real-workload before/after flamegraph (`btop` full-screen redraw, same `perf --call-graph dwarf,65528` methodology as #459): `sip::Hasher::write` and `hash_one::<&FaceId>` — two of the hottest leaves in the original capture at ~9.00% + ~2.92% self-time — are absent from the fixed capture with no percent-limit filter; only a 0.04% residual attributable to the deliberately-untouched `glyph_cache` remains. Sample counts are low (~250-400/capture) and the two captures are different windows of `btop`'s own dynamic content, so a precise percentage delta isn't defensible, but the categorical disappearance of a top-2 hot symbol is a credible confirmation.

Adversarially reviewed for completeness (no missed construction sites or ad-hoc maps), correctness of the untouched exclusions, API/iteration-order safety, and style consistency against `atlas.rs` — no blocking findings.

Closes item 1 of #459.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved internal font caching performance.
  * No visible changes to the user interface or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->