### PR TITLE
perf: fix inert chrome cache + suppress redundant pointer frames (issue #459)

### DIFF
--- a/Documents/DECOUPLING_FRAMEWORK.md
+++ b/Documents/DECOUPLING_FRAMEWORK.md
@@ -21,9 +21,11 @@ returns `repaint: true` unconditionally for nearly every window event, and
 upstream has declined to change this for three years.
 
 **That thesis is correct about egui's design and wrong about the consequences
-being unavoidable.** Phase 0 found three defects — two ours, one a workable
-override — that together took idle frame cost down 13.4% and pointer-motion
-frame rate from ~61fps to ~2fps. See §2A.
+being unavoidable.** Phase 0 produced three findings — one bug of our own in
+the chrome-cache gate, one confirmation that egui's repaint behaviour is
+exactly as described, and one workaround that suppresses it from outside egui —
+which together took idle frame cost down 13.4% and pointer-motion frame rate
+from ~61fps to ~2fps. See §2A.
 
 What survives as an argument for the rewrite is **not performance**. It is:
 
@@ -261,6 +263,16 @@ works.
   every build; `frame-profiling` gates only the diagnostics. If any of the
   above proves troublesome in the field, the only remedy today is a revert.
   Consider a config toggle before this is relied upon.
+- **Two heap allocations per `CursorMoved`, on the path built to be cheap.**
+  `pane_tree.layout(central_rect)` and `iter_panes()` each allocate a `Vec`
+  inside `pointer_motion_needs_repaint`, which runs at the mouse's full report
+  rate — measured at 425-478 events/s. At ~1000 small allocations/s that is
+  plausibly on the same order as the ~0.077% of a core the suppression leaves
+  behind, i.e. it could be a material fraction of what remains. **Measure
+  before fixing**: add a counter or profile the predicate specifically, then
+  decide between a `layout_into(&mut buf)` variant and a scratch buffer on
+  `PerWindowState`. Do not build the buffers speculatively — every hypothesis
+  in Phase 0 that was acted on without measurement turned out to be wrong.
 
 ### The unifying next step: cell-granular suppression
 

--- a/Documents/DECOUPLING_FRAMEWORK.md
+++ b/Documents/DECOUPLING_FRAMEWORK.md
@@ -213,11 +213,101 @@ frame was suppressed pointer motion breaks the loop: **61fps → 2.05fps**,
 matching the ~2Hz blink rate exactly (which is what shows the window is live,
 not stalled). ~2% of a core → ~0.08%.
 
-**PROVISIONAL.** That run was confounded — the tester accidentally
-clicked/dragged and left the window partway — and could not be re-run. The
-suppressed-event rate (478/s versus 425/s unsuppressed) argues the confound is
-small, but **a clean before/after is required before this number is cited as
-validated.**
+The original bench run was confounded (the tester accidentally clicked/dragged
+and left the window partway). **It was subsequently corroborated by an
+independent A/B on different hardware** — a laptop, different observer, no
+accidental input — which is stronger evidence than a clean re-run of the same
+test would have been:
+
+| Workload   | Before        | After                  |
+| ---------- | ------------- | ---------------------- |
+| idle       | 0.0-0.3% CPU  | flat 0.0%              |
+| mouse move | up to 0.6%    | occasional 0.1% spikes |
+
+Same machine, wezterm for comparison: 0.0% at both idle and mouse move.
+**Caveat on that comparison: wezterm is not blinking a cursor at 2 Hz.**
+Freminal's floor is ~2 fps of blink frames by construction, so the honest
+apples-to-apples test is freminal with `cursor.blink = false` — untested, and
+likely to close most of the remaining gap.
+
+Verdict: the mechanism is real and the magnitude is corroborated. Remaining
+work on this axis is closing the gaps below, not re-litigating whether it
+works.
+
+### Finding 3's known gaps
+
+- **`has_urls` and `scroll_offset > 0` are pane-wide.** Any pane containing a
+  hyperlink, or scrolled back at all, reverts to full-rate scheduling for
+  motion anywhere in it. Conservative direction (costs benefit, not
+  correctness). **This is the biggest remaining win** — see "cell-granular
+  suppression" below.
+- **`animation_in_flight` tests presence, not motion.** It is
+  `resize_overlay.is_some() || !toasts.is_empty()`, but a toast only requests
+  16 ms while actually fading (entry/exit); during its steady hold it requests
+  250 ms, and the resize HUD is fully opaque for 650 ms of its 900 ms life. So
+  any visible toast or HUD disables suppression for its whole ~1-3 s life, not
+  just its animating portion. Superset of correct, so safe, but wasteful. The
+  fix is to surface `toast.rs`'s existing `any_animating` local as a real
+  signal.
+- **The gutter strip's safety rests on `pixels_per_point >= 1.0`.** The bound
+  uses `width_px` directly as a logical width, which over-estimates only while
+  `ppp >= 1.0`. On a display reporting fractional scale below 1.0 the
+  guarantee **inverts** to a possible under-estimate, i.e. a stale gutter
+  hover tint until the next frame. Low likelihood, cosmetic, bounded. Exact
+  fix: cache `pixels_per_point` on `PerWindowState` during `update()` and
+  compute `width_px / ppp`. Deliberately not done — it needs per-frame
+  caching machinery this spike did not justify.
+- **The spike is default-on with no kill switch.** It changes scheduling for
+  every build; `frame-profiling` gates only the diagnostics. If any of the
+  above proves troublesome in the field, the only remedy today is a revert.
+  Consider a config toggle before this is relied upon.
+
+### The unifying next step: cell-granular suppression
+
+The `has_urls` and selection-drag coarseness have the **same** root cause and
+the same fix. Nearly all of the terminal's interactive state changes at **cell**
+granularity, not pixel granularity: URL hover, gutter hover, selection extent,
+and mouse-tracking reports are all per-cell. Pointer motion within a single
+cell therefore cannot change any of them.
+
+So: cache the pane's terminal-rect origin and logical cell size during
+`update()`, track the pointer's **cell** rather than its position, and suppress
+any `CursorMoved` that does not cross a cell boundary. That single mechanism:
+
+- removes the `has_urls` pane-wide veto (only wake when the hovered cell
+  changes, so a pane full of hyperlinks still suppresses),
+- lets **selection drags suppress too** (the selection's end cell is what
+  matters, so a drag only needs a frame when it crosses into a new cell),
+- subsumes the gutter test (the gutter is per-row),
+- and is correct for mouse-tracking mode (reports are per-cell).
+
+The scrollbar must stay excluded — thumb dragging is genuinely pixel-granular.
+
+This is the highest-value follow-up on the scheduling axis and is strictly
+freminal-owned logic with no egui dependence.
+
+### Beyond scheduling: per-frame cost
+
+With scheduling largely handled, the remaining cost is per-frame work, and
+issue #459's unactioned candidate list is the roadmap. Highest-value first, per
+the maintainer:
+
+1. **Font/text pipeline** — unicode width, rustybuzz shaping (#459 item 4's
+   ASCII/simple-text fast path), and `build_foreground_instances`. Judged the
+   most logical next target.
+2. **Non-incremental vertex-instance build** (#459 item 3) — both
+   `build_background_instances` and `build_foreground_instances` clear and walk
+   every visible row unconditionally; there is no per-row incremental vertex
+   path. `instanced_bg_partial_dirty` / `instanced_fg_partial_dirty` already
+   quantify the recoverable headroom.
+3. GPU buffer-orphaning for `deco_verts` (#459 item 5), compute-shader clear
+   scope (item 6), `wayland_client_handle` call frequency (item 7).
+
+Note the idle work generalises: the same per-frame savings apply on the active
+path (new PTY data, scrolling), so this is not idle-only tuning.
+
+Already done and not to be redone: `FaceId` caches to `FxHashMap` (#459 item 1,
+PR #460) — the largest single CPU win before this session's work.
 
 ### Where that leaves the decision
 

--- a/Documents/DECOUPLING_FRAMEWORK.md
+++ b/Documents/DECOUPLING_FRAMEWORK.md
@@ -1,38 +1,41 @@
 # Decoupling Framework — Owning the Frame Schedule
 
-> **Status: RATIFIED DIRECTION + IMPLEMENTATION PLAN.** The "should we do
-> this?" question is closed. The maintainer has ruled: freminal will stop
-> using egui for the main terminal window and own its own frame schedule and
-> chrome drawing. This document is the working plan an agent executes from.
-> It supersedes the earlier framing/iteration version of this file.
+> **Status: DIRECTION REOPENED — leaning AGAINST the rewrite.** An earlier
+> revision of this file declared the rewrite ratified. **Phase 0 overtook that
+> ruling.** Measurement found three cheap fixes inside egui that between them
+> recovered most of the benefit the rewrite was meant to deliver, so the
+> maintainer's position is now *leaning no* — explicitly undecided, not closed.
 >
-> This is **not** yet a `PLAN_VERSION_*.md` and the tasks below are **not**
-> yet in `MASTER_PLAN.md`. Version assignment happens once Phase 1 lands and
-> the roadmap is re-sequenced (deliberately deferred — see "Roadmap" below).
+> Read §2A before acting on anything below. Phases 1-5 are retained as the
+> plan-of-record **if** the rewrite is chosen, and Phase 1 is worth doing
+> regardless, but do **not** treat the rewrite as agreed.
+>
+> This is **not** a `PLAN_VERSION_*.md` and these tasks are **not** in
+> `MASTER_PLAN.md`.
 
 ## 0. TL;DR
 
-egui cannot give freminal a demand-driven render model. Its contract is "an
-input event runs a frame", `egui-winit` returns `repaint: true` unconditionally
-for nearly every window event, and upstream has declined to change this for
-three years. Every workaround freminal has built to fight this pins correctness
-to undocumented egui internals.
+The original thesis was: egui cannot give freminal a demand-driven render
+model, because its contract is "an input event runs a frame", `egui-winit`
+returns `repaint: true` unconditionally for nearly every window event, and
+upstream has declined to change this for three years.
 
-Measurement (see §2) found something worse than expected: the largest such
-workaround — the `#436` chrome cache — **never engages at all**. So freminal
-carries 13 undocumented-internal assumptions, an exact `=0.35.0` pin, a
-Renovate no-auto-merge rule and a dedicated upgrade skill in exchange for an
-optimisation that measurably does nothing.
+**That thesis is correct about egui's design and wrong about the consequences
+being unavoidable.** Phase 0 found three defects — two ours, one a workable
+override — that together took idle frame cost down 13.4% and pointer-motion
+frame rate from ~61fps to ~2fps. See §2A.
 
-The plan: extract the orchestration layer, build a small purpose-built UI layer
-on top of the **existing** winit + glutin + custom-GL stack, cut the main
-window over, and delete the entire damage/scheduling workaround category.
-Auxiliary OS windows (settings) keep egui, possibly forever.
+What survives as an argument for the rewrite is **not performance**. It is:
 
-**The performance win is modest and that is accepted.** The justification is
-architectural: deleting a category of undocumented-internals debt and owning
-the frame schedule. Anyone reading this later should not expect the numbers in
-§2 to justify a rewrite on CPU grounds alone — they do not.
+1. Reliance on undocumented egui internals (13 catalogued assumptions, two
+   flagged untested by their own authors).
+2. Edge cases that keep surfacing in the damage-tracking machinery.
+3. How ugly that machinery becomes as those edge cases accumulate.
+
+Those are real and unresolved, but they are a maintainability judgement, not a
+measurement. **Nobody should read this document as evidence that the numbers
+justify a rewrite. They do not, and after Phase 0 they justify it less than
+when this file was first written.**
 
 ## 1. How we got here (evidence trail)
 
@@ -56,9 +59,9 @@ found a **new** egui-internal dependency:
 
 - **Event-queue accumulation.** Calling `on_window_event` without running a
   frame accumulates `egui::Event`s (drained only at `take_egui_input`), so a
-  later frame double-forwards. _Note: this obstacle turned out to be
+  later frame double-forwards. *Note: this obstacle turned out to be
   overstated — `State::egui_input_mut()` is public, so the queue can be
-  drained manually. It does not rescue the overall position._
+  drained manually. It does not rescue the overall position.*
 - **`interact_pos` vs `latest_pos` one-frame lag** on window exit (PR #461).
 - **`on_keyboard_input`'s `is_cmd` / `is_printable_char` gating** determines
   whether egui emits `Event::Text`; a fast path must mirror it exactly.
@@ -79,8 +82,8 @@ re-derives a piece of egui's private frame/input model.
 `WindowEvent` variant except three (`ActivationTokenDone`, `AxisMotion`,
 `DoubleTapGesture`). There is no gating on pointer position or hit-test.
 
-- Issue #3017 (2023), emilk: _"there is no way to turn if off at the moment,
-  but feel free to open a PR."_
+- Issue #3017 (2023), emilk: *"there is no way to turn if off at the moment,
+  but feel free to open a PR."*
 - Restated in #5387 (2024, proposal never implemented — `raw_input_hook` still
   returns `()`), #7371 (2025), #8326 (2026). Never fixed.
 - **0.35.0 is the latest release.** No upgrade path helps.
@@ -155,14 +158,98 @@ Two findings here: **21% of frames presented with nothing changed at all**
 
 - They **do not** justify removing egui on CPU grounds. egui is 21% of an idle
   frame; `swap` alone is 52% and no UI toolkit change touches it.
-- They **do** justify it on maintenance grounds: the workaround subsystem is
-  large, risky, pinned to private egui behaviour, and delivers nothing.
 - Partial present works and **must survive** any rewrite.
-- Still unmeasured: **mouse-move**, **typing** and **btop** workloads. Mouse-move
-  is the important gap — it is the frequency axis where egui's unconditional
-  `repaint: true` actually bites. Requires a human at the machine.
 
-## 3. Target end state
+## 2A. Phase 0 results — why the direction reopened
+
+Three findings, in the order they landed. All are on
+`task-121/repaint-gate-fixes`.
+
+### Finding 1 — `ChromeMode::Replay` had never once engaged (FIXED)
+
+Measured 0 Replay frames out of 360 at idle. Root cause: every frame is driven
+by `WindowEvent::RedrawRequested`; `egui-winit` returns `repaint: true` for it
+(it sits in a grouped arm commented *"Things that may require repaint"*); the
+chrome-input gate consumed that as evidence of input; and the same event's
+handler then read the flag back via `std::mem::take` ~110 lines later in the
+same call. **The event that drove the frame disqualified the frame.**
+
+A one-line carve-out fixed it. Steady-state Replay went 0% → 100%:
+
+| Metric               | Before | After   | Change |
+| -------------------- | ------ | ------- | ------ |
+| chrome construction  | 69 us  | 10 us   | -86%   |
+| freminal's own       | 96 us  | 42 us   | -56%   |
+| total per idle frame | 434 us | 376 us  | -13.4% |
+| partial present      | 115/120 | 120/120 | —     |
+
+**This destroyed the strongest maintenance argument in this document.** The
+claim was "we carry 13 undocumented assumptions for an optimisation that never
+fires". It fires now, and it delivers.
+
+### Finding 2 — the frequency axis is real (QUANTIFIED)
+
+Pointer motion over static terminal content: **58-61fps versus 1.95fps idle**
+(~2% of a core), with **95% of frames changing zero pixels**. The
+repaint-cause harness named the culprit exactly — `egui-0.35.0/src/context.rs`
+`begin_pass` → `InputState::wants_repaint_after()`, which returns
+`Duration::ZERO` whenever `!self.events.is_empty()`. Any input event, and egui
+demands an immediate repaint of itself. Not gated on hit-testing, not on
+whether a pixel changed.
+
+Zero freminal call sites appeared in the causes, which excluded the gutter,
+scrollbar and cursor-trail hypotheses by measurement rather than argument.
+
+### Finding 3 — it can be suppressed from outside egui (SPIKE, PROVISIONAL)
+
+Suppressing the input side alone achieves **nothing**: suppressed events still
+must go to `on_window_event` (egui's pointer state has to stay fresh), so they
+queue in `RawInput.events`, so egui re-arms a 16ms frame from *inside* the
+frame. Measured: 99.99% of pointer events suppressed, frame rate unchanged at
+61fps. egui owns the schedule from both ends.
+
+Overriding `frame_output.repaint_delay` when the only thing since the last
+frame was suppressed pointer motion breaks the loop: **61fps → 2.05fps**,
+matching the ~2Hz blink rate exactly (which is what shows the window is live,
+not stalled). ~2% of a core → ~0.08%.
+
+**PROVISIONAL.** That run was confounded — the tester accidentally
+clicked/dragged and left the window partway — and could not be re-run. The
+suppressed-event rate (478/s versus 425/s unsuppressed) argues the confound is
+small, but **a clean before/after is required before this number is cited as
+validated.**
+
+### Where that leaves the decision
+
+The performance case is spent. Idle was already 0.073% of a core; mouse-move
+went from ~2% to ~0.08%. Nothing in the measured data justifies a multi-version
+rewrite on CPU grounds.
+
+What remains, and what the decision now rests on entirely:
+
+- **Undocumented-internals reliance.** Finding 3's override is freminal
+  overriding egui's judgement. It keys off *our* classification rather than
+  egui source-line matching, so it should survive version bumps better than
+  the 13 existing assumptions — but it is one more thing that has to be
+  re-verified on every bump.
+- **Edge cases.** The suppression predicate already needed four rounds:
+  pane-wide gutter (too coarse, fixed), `has_urls` and `scroll_offset`
+  (still coarse, accepted), and animation-in-flight (toasts / resize-HUD,
+  structurally invisible to a positional predicate, folded in explicitly).
+  Every future always-animating chrome element needs the same treatment.
+- **Ugliness.** Judge `pointer_motion_needs_repaint` and
+  `effective_repaint_delay` on the branch and decide whether that is a shape
+  worth maintaining indefinitely.
+
+**Maintainer position as of the end of Phase 0: leaning against the rewrite,
+explicitly undecided.**
+
+### Still unmeasured
+
+**Typing** and **btop** (hidden-cursor / `DECTCEM`) workloads, plus the clean
+re-run of Finding 3. All need a human at the machine.
+
+## 3. Target end state (only if the rewrite is chosen)
 
 ```text
 freminal (binary: GUI)
@@ -326,20 +413,33 @@ Wayland + IBus works.
 Each phase must leave `cargo test --all` green and the app usable. No
 big-bang cutover.
 
-### Phase 0 — finish measuring
+### Phase 0 — measure (mostly DONE, see §2A)
 
-- **0.1** Fix the two `ctx.request_repaint_after` call sites in
-  `terminal/widget.rs` (cursor-trail animation, animated-image tick) that
-  bypass `shortest_repaint_delay` and therefore defeat `chrome_repaint_settled`.
-  These are the prime suspect for the 0.0% `Replay` duty cycle. Re-run the idle
-  capture and record whether the duty cycle moves.
-- **0.2** Capture mouse-move, typing and btop workloads (needs a human).
-  Mouse-move is the frequency axis and the most important remaining unknown.
-- **0.3** Cross-validate with `perf record --call-graph dwarf,65528 --no-inline`
-  per the #459 methodology.
-- **0.4** Rule on whether `#436` is salvageable or dies with egui.
-- **0.5** Write the `DESIGN_DECISIONS.md` entry, recording the direction **and**
-  the inconvenient numbers from §2.
+- **0.1** ~~Fix the two `ctx.request_repaint_after` call sites in
+  `terminal/widget.rs`~~ — **DONE differently.** The hypothesis was wrong:
+  those two sites surface as `not_settled`, which stops firing after warm-up.
+  Instrumenting the gate instead identified `RedrawRequested` as the real and
+  total blocker (Finding 1). The two call sites remain unfixed and are now
+  known to be benign at idle. **Lesson: this hypothesis cost nothing only
+  because it was instrumented rather than acted on.**
+- **0.2** Capture mouse-move — **DONE** (Finding 2). **Typing and btop still
+  outstanding**; both need a human at the machine.
+- **0.3** Cross-validate with `perf record --call-graph dwarf,65528
+  --no-inline` per the #459 methodology — **NOT DONE.** The in-app harness
+  proved sufficient to root-cause all three findings, so this was never
+  needed; keep it in reserve if a finding is ever disputed.
+- **0.4** Rule on whether `#436` is salvageable — **DONE: yes, it works.**
+  It was inert due to a one-line bug, now fixed. This inverts the earlier
+  conclusion; see Finding 1.
+- **0.5** Write the `DESIGN_DECISIONS.md` entry — **OUTSTANDING.** Must record
+  the direction *and* the inconvenient numbers, including that Phase 0
+  weakened the case for the rewrite rather than strengthening it.
+- **0.6** **NEW, required before the spike is trusted:** clean, unconfounded
+  before/after run of Finding 3.
+- **0.7** **NEW:** decide whether the spike's animation-in-flight term is
+  sufficient or needs a general "something is animating" signal, and whether
+  the `has_urls` / `scroll_offset` pane-wide approximations are acceptable
+  permanently or need per-span geometry.
 
 ### Phase 1 — orchestration extraction (no behaviour change)
 
@@ -398,9 +498,14 @@ freminal binary. Keeps winit + glutin.
 - **3.3** Port HOT chrome: tab bar, scrollbar, gutter, bell, resize HUD, lock
   icon, context menu, search, command-history, tab rename. Toasts already done.
 - **3.4** Ship with `hide_menu_bar` forced on.
-- **3.5** Delete the `#435`/`#436` three-axis machinery and assumptions A5–A13.
-  **Preserve the partial-present path** — it demonstrably works (115 of 120
-  idle frames).
+- **3.5** Retire the `#435`/`#436` three-axis machinery and assumptions A5–A13.
+  **Two things must be REPLACED, not merely deleted** — both are now measured
+  to work and removing them without an equivalent is a regression:
+  - **Partial present** — 120/120 idle frames present as `Partial`.
+  - **Chrome caching** — since the Finding 1 fix, `Replay` engages on 100% of
+    steady-state idle frames and saves 69 us → 10 us of chrome construction
+    per frame (-86%). An earlier revision of this document said "delete"; that
+    was written when the subsystem was inert and is wrong now.
 - **3.6** Keep egui alive for auxiliary windows only.
 
 ### Phase 4 — menu bar
@@ -467,6 +572,16 @@ should be closed when the roadmap is next touched.
 - PR #464 — the two landed fixes; the `post_event` classifier is a clean
   example of orchestration logic wanting a home.
 - Commit `0620cc60` — the frame-profiling harness and the §2 numbers.
+- Commit `436a54f1` — gate-blocker + per-signal instrumentation; how Finding 1
+  was isolated rather than guessed.
+- Commit `7d483998` — **the `RedrawRequested` fix (Finding 1).** Worth reading
+  even if the rewrite is abandoned; it is the single highest-value change of
+  the whole investigation.
+- Commit `ab88d0f5` — repaint-cause instrumentation; how Finding 2 named egui's
+  `context.rs` as the culprit and excluded freminal's own call sites.
+- Commit `19780e16` — **the suppression spike (Finding 3).** Read
+  `pointer_motion_needs_repaint` and `effective_repaint_delay` here to judge
+  the "how ugly does this get" question directly.
 - `Documents/EGUI_UPGRADE_ASSUMPTIONS.md` — assumptions A1–A13; A6 and A13 are
   flagged by their own authors as untested.
 - `.opencode/skills/freminal-architecture` — invariants in §10.

--- a/Documents/EGUI_UPGRADE_ASSUMPTIONS.md
+++ b/Documents/EGUI_UPGRADE_ASSUMPTIONS.md
@@ -270,10 +270,14 @@ event.
 
 **Carve-out (found post-#436, fixed after #436 landed): `RedrawRequested` must
 be excluded from the `response.repaint` half of this gate.** `egui-winit`
-0.35.0 groups `WindowEvent::RedrawRequested` into the same "things that may
-require repaint" match arm as `ScaleFactorChanged` and returns
-`EventResponse { repaint: true, .. }` for it _unconditionally_
-(`egui-winit-0.35.0/src/lib.rs:492-500`). But `RedrawRequested` is also the
+0.35.0 returns `EventResponse { repaint: true, .. }` for
+`WindowEvent::RedrawRequested` _unconditionally_, via a grouped match arm
+commented "Things that may require repaint:" that also covers
+`CursorEntered`/`Destroyed`/`Occluded`/`Resized`/`Moved`/`TouchpadPressure`/
+`CloseRequested` (`egui-winit-0.35.0/src/lib.rs:489-500`). Note this is a
+_different_ arm from `ScaleFactorChanged`'s, which is its own separate arm
+(`~310-324`) that happens to return `repaint: true` too — the two are not
+grouped together, they merely share the outcome this gate relies on. But `RedrawRequested` is also the
 event that drives every single frame, and `window_event`'s `RedrawRequested`
 arm reads this gate back (via `std::mem::take(&mut
 state.chrome_input_pending)`) in the same call that just set it. Before the
@@ -296,10 +300,14 @@ it would need the same carve-out or the bug returns under a new name.
   `RedrawRequested` carve-out), and the general event arm's call to it in
   place of the old inline `|| response.repaint` OR.
 - **Upstream (0.35.0):** `egui-winit/src/lib.rs` —
-  `WindowEvent::ScaleFactorChanged { .. }` and `WindowEvent::RedrawRequested`
-  both fall into the same "things that may require repaint" arm returning
-  `EventResponse { repaint: true, .. }` (`~311-324` and `~492-500`
-  respectively).
+  `WindowEvent::ScaleFactorChanged { .. }` (`~310-324`) and
+  `WindowEvent::RedrawRequested` (`~489-500`, in the grouped "Things that may
+  require repaint:" arm) each return `EventResponse { repaint: true, .. }`
+  unconditionally, from **separate** match arms. On a bump, re-verify both
+  that `ScaleFactorChanged` still flags a repaint (the gate's completeness
+  depends on it) and that `RedrawRequested` still does (the carve-out exists
+  because it does, and would become unnecessary — though harmless — if it
+  ever stopped).
 - **Symptom if broken:**
   - If the `ScaleFactorChanged` half regresses: a DPI / scale-factor change is
     not forced FULL — the chrome renders at the wrong scale on a REPLAY frame

--- a/Documents/EGUI_UPGRADE_ASSUMPTIONS.md
+++ b/Documents/EGUI_UPGRADE_ASSUMPTIONS.md
@@ -268,15 +268,50 @@ part on `egui-winit` returning `EventResponse { repaint: true }` for events like
 branch even though `is_unconditional_chrome_input` does not enumerate every such
 event.
 
+**Carve-out (found post-#436, fixed after #436 landed): `RedrawRequested` must
+be excluded from the `response.repaint` half of this gate.** `egui-winit`
+0.35.0 groups `WindowEvent::RedrawRequested` into the same "things that may
+require repaint" match arm as `ScaleFactorChanged` and returns
+`EventResponse { repaint: true, .. }` for it _unconditionally_
+(`egui-winit-0.35.0/src/lib.rs:492-500`). But `RedrawRequested` is also the
+event that drives every single frame, and `window_event`'s `RedrawRequested`
+arm reads this gate back (via `std::mem::take(&mut
+state.chrome_input_pending)`) in the same call that just set it. Before the
+fix this made `chrome_input_pending` `true` on every frame with no exception,
+which made `ChromeMode::Replay` permanently unreachable (measured: 0/360
+Replay frames at idle) — the entire chrome-cache subsystem was inert since
+issue #436 landed. The gate condition is therefore not simply
+`is_unconditional_chrome_input(event) || response.repaint`; it is
+`should_set_chrome_input_pending(event, response.repaint)`, which forces
+`false` for `RedrawRequested` regardless of `repaint`. **A future egui bump
+must re-verify that `RedrawRequested` is still in this same grouped arm (and
+that no other event which fires unconditionally every frame has joined it)**
+— if egui-winit ever stops reporting `repaint: true` unconditionally for
+`RedrawRequested`, this carve-out becomes a no-op rather than wrong, but if a
+_different_ every-frame event starts reporting unconditional `repaint: true`,
+it would need the same carve-out or the bug returns under a new name.
+
 - **Our code:** `freminal-windowing/src/event_loop.rs` —
-  `is_unconditional_chrome_input` plus the `|| response.repaint` OR at the
-  general event arm.
+  `is_unconditional_chrome_input`, `should_set_chrome_input_pending` (the
+  `RedrawRequested` carve-out), and the general event arm's call to it in
+  place of the old inline `|| response.repaint` OR.
 - **Upstream (0.35.0):** `egui-winit/src/lib.rs` —
-  `WindowEvent::ScaleFactorChanged { .. }` arm returning `EventResponse {
-  repaint: true, .. }` (`~311-324`).
-- **Symptom if broken:** a DPI / scale-factor change is not forced FULL — the
-  chrome renders at the wrong scale on a REPLAY frame until an unrelated FULL
-  frame fixes it.
+  `WindowEvent::ScaleFactorChanged { .. }` and `WindowEvent::RedrawRequested`
+  both fall into the same "things that may require repaint" arm returning
+  `EventResponse { repaint: true, .. }` (`~311-324` and `~492-500`
+  respectively).
+- **Symptom if broken:**
+  - If the `ScaleFactorChanged` half regresses: a DPI / scale-factor change is
+    not forced FULL — the chrome renders at the wrong scale on a REPLAY frame
+    until an unrelated FULL frame fixes it.
+  - If the `RedrawRequested` carve-out is removed or "simplified away": no
+    visible pixel symptom, but `ChromeMode::Replay` silently stops firing at
+    idle — the chrome-cache subsystem goes inert again with no compile error
+    and no failing pixel test (only the frame-profiling instrumentation's
+    Replay/Full duty-cycle counters would show it, and only if someone looks).
+    Regression tests: `should_set_chrome_input_pending_excludes_redraw_requested_regardless_of_repaint`
+    and `should_set_chrome_input_pending_still_honors_repaint_for_non_enumerated_events`
+    in `event_loop.rs`'s test module pin both halves of this behaviour.
 
 ### A13 — egui `pixels_per_point` equals winit `scale_factor` (zoom is off)
 

--- a/Documents/EGUI_UPGRADE_ASSUMPTIONS.md
+++ b/Documents/EGUI_UPGRADE_ASSUMPTIONS.md
@@ -287,13 +287,17 @@ Replay frames at idle) — the entire chrome-cache subsystem was inert since
 issue #436 landed. The gate condition is therefore not simply
 `is_unconditional_chrome_input(event) || response.repaint`; it is
 `should_set_chrome_input_pending(event, response.repaint)`, which forces
-`false` for `RedrawRequested` regardless of `repaint`. **A future egui bump
-must re-verify that `RedrawRequested` is still in this same grouped arm (and
-that no other event which fires unconditionally every frame has joined it)**
-— if egui-winit ever stops reporting `repaint: true` unconditionally for
-`RedrawRequested`, this carve-out becomes a no-op rather than wrong, but if a
-_different_ every-frame event starts reporting unconditional `repaint: true`,
-it would need the same carve-out or the bug returns under a new name.
+`false` for `RedrawRequested` regardless of `repaint`.
+
+**What a future egui bump must re-verify is the _behaviour_, not the source
+layout:** does `on_window_event` still report `repaint: true` for
+`RedrawRequested` (so the carve-out is still needed), and does any _other_
+event that fires unconditionally every frame now report it too (so it would
+need the same carve-out)? How upstream happens to group its match arms is an
+implementation detail that can change freely without affecting this invariant
+— don't check the grouping, check the returned `repaint` value. If egui-winit
+ever stops reporting `repaint: true` for `RedrawRequested`, the carve-out
+becomes a harmless no-op rather than wrong.
 
 - **Our code:** `freminal-windowing/src/event_loop.rs` —
   `is_unconditional_chrome_input`, `should_set_chrome_input_pending` (the
@@ -313,13 +317,17 @@ it would need the same carve-out or the bug returns under a new name.
     not forced FULL — the chrome renders at the wrong scale on a REPLAY frame
     until an unrelated FULL frame fixes it.
   - If the `RedrawRequested` carve-out is removed or "simplified away": no
-    visible pixel symptom, but `ChromeMode::Replay` silently stops firing at
-    idle — the chrome-cache subsystem goes inert again with no compile error
-    and no failing pixel test (only the frame-profiling instrumentation's
-    Replay/Full duty-cycle counters would show it, and only if someone looks).
-    Regression tests: `should_set_chrome_input_pending_excludes_redraw_requested_regardless_of_repaint`
-    and `should_set_chrome_input_pending_still_honors_repaint_for_non_enumerated_events`
-    in `event_loop.rs`'s test module pin both halves of this behaviour.
+    visible pixel symptom, and `ChromeMode::Replay` silently stops firing at
+    idle — the chrome-cache subsystem goes inert again, as it was for the whole
+    life of #436 before this was found. **This is caught by a unit test, not
+    only by observation:**
+    `should_set_chrome_input_pending_excludes_redraw_requested_regardless_of_repaint`
+    in `event_loop.rs`'s test module fails immediately if the carve-out is
+    dropped, and
+    `should_set_chrome_input_pending_still_honors_repaint_for_non_enumerated_events`
+    fails if it is over-broadened. The frame-profiling Replay/Full duty-cycle
+    counters are supplementary confirmation in a live session, not the primary
+    detection mechanism.
 
 ### A13 — egui `pixels_per_point` equals winit `scale_factor` (zoom is off)
 

--- a/freminal-windowing/src/egui_integration.rs
+++ b/freminal-windowing/src/egui_integration.rs
@@ -182,6 +182,62 @@ struct FrameProfile {
     swap_total: std::time::Duration,
     /// Largest single-frame swap duration observed.
     swap_max: std::time::Duration,
+
+    // ── Gate-blocker counters (feature-gated): issue #459/#461 follow-up ──
+    //
+    // `decide_chrome_mode` permits REPLAY only when ALL FOUR of
+    // `ChromeGatePredicates`'s fields hold (see that struct and
+    // `evaluate_chrome_gate`, the single source of truth both
+    // `decide_chrome_mode` and this instrumentation call). Every counter
+    // below is incremented independently -- a frame that fails more than one
+    // predicate increments more than one counter -- so overlap between
+    // blockers is visible rather than only ever seeing "the first" reason.
+    /// Frames where `ChromeGatePredicates::cache_matches` was `false`: no
+    /// chrome cache exists yet, or this frame's framebuffer size/`ppp`
+    /// didn't match what the cache was tessellated at.
+    gate_blocked_cache_mismatch: u64,
+    /// Frames where `ChromeGatePredicates::repaint_settled` was `false`:
+    /// [`chrome_repaint_settled`] found something wanted a wake sooner than
+    /// this frame's own request permits. See the `settle_*` fields below
+    /// for the VALUES behind this failure, not just the count.
+    gate_blocked_not_settled: u64,
+    /// Frames where `ChromeGatePredicates::damage_unchanged` was `false`:
+    /// the PREVIOUS frame's `ChromeDamage` was `Changed`, so this frame
+    /// cannot REPLAY regardless of anything else.
+    gate_blocked_damage_changed: u64,
+    /// Frames where `ChromeGatePredicates::no_chrome_input` was `false`:
+    /// `chrome_input_this_frame` was `true` (a window input event this
+    /// frame could plausibly have affected chrome).
+    gate_blocked_chrome_input: u64,
+
+    // ── Settle-gate value diagnostics (feature-gated), reset every flush
+    // window (`reset_settle_window`) rather than cumulative-since-creation
+    // like every other field above. A lifetime min/max would not be useful
+    // here: the lifetime min collapses to whatever the very first settle
+    // failure happened to be (often frame 0-ish transients) and the
+    // lifetime max trivially saturates at `Duration::MAX` the first time
+    // egui or the app ever reports "no repaint needed" on a losing frame --
+    // neither tells you what is happening in THIS flush window, which is
+    // the question ("did the app ask for 500ms and egui want 500ms too, or
+    // did something ask for 16ms behind our back").
+    /// Smallest `prev_repaint_delay` observed on a frame where the settle
+    /// predicate failed, this flush window. `None` until the first such
+    /// frame in this window.
+    settle_repaint_delay_min: Option<std::time::Duration>,
+    /// Largest `prev_repaint_delay` observed on a frame where the settle
+    /// predicate failed, this flush window.
+    settle_repaint_delay_max: Option<std::time::Duration>,
+    /// Smallest `prev_terminal_requested_delay` (when `Some`) observed on a
+    /// frame where the settle predicate failed, this flush window.
+    settle_terminal_requested_delay_min: Option<std::time::Duration>,
+    /// Largest `prev_terminal_requested_delay` (when `Some`) observed on a
+    /// frame where the settle predicate failed, this flush window.
+    settle_terminal_requested_delay_max: Option<std::time::Duration>,
+    /// Count of settle-predicate failures this flush window where
+    /// `prev_terminal_requested_delay` was `None` (nothing app-side had
+    /// requested a delay at all this frame, counted separately from "the
+    /// app requested something, but egui wanted sooner").
+    settle_terminal_requested_delay_none_count: u64,
 }
 
 #[cfg(feature = "frame-profiling")]
@@ -226,6 +282,86 @@ impl FrameProfile {
         let count_f: f64 = conv2::ConvUtil::approx_as(count).unwrap_or(1.0);
         total.div_f64(count_f.max(1.0))
     }
+
+    /// Record one settle-gate failure's values into this flush window's
+    /// min/max/none-count tracking. Called only when
+    /// `ChromeGatePredicates::repaint_settled` is `false` for the frame
+    /// (see the call site in `run_frame`) -- these fields answer "what were
+    /// the actual delays on the frames that failed", not just "how many
+    /// failed".
+    fn record_settle_failure(
+        &mut self,
+        repaint_delay: std::time::Duration,
+        terminal_requested_delay: Option<std::time::Duration>,
+    ) {
+        let (min, max) = min_max_duration(
+            (self.settle_repaint_delay_min, self.settle_repaint_delay_max),
+            repaint_delay,
+        );
+        self.settle_repaint_delay_min = min;
+        self.settle_repaint_delay_max = max;
+
+        match terminal_requested_delay {
+            Some(d) => {
+                let (min, max) = min_max_duration(
+                    (
+                        self.settle_terminal_requested_delay_min,
+                        self.settle_terminal_requested_delay_max,
+                    ),
+                    d,
+                );
+                self.settle_terminal_requested_delay_min = min;
+                self.settle_terminal_requested_delay_max = max;
+            }
+            None => {
+                self.settle_terminal_requested_delay_none_count = self
+                    .settle_terminal_requested_delay_none_count
+                    .saturating_add(1);
+            }
+        }
+    }
+
+    /// Clear the settle-gate value diagnostics at the end of a flush window
+    /// -- see the field docs on `settle_repaint_delay_min` etc. for why
+    /// these are windowed rather than cumulative-since-creation.
+    const fn reset_settle_window(&mut self) {
+        self.settle_repaint_delay_min = None;
+        self.settle_repaint_delay_max = None;
+        self.settle_terminal_requested_delay_min = None;
+        self.settle_terminal_requested_delay_max = None;
+        self.settle_terminal_requested_delay_none_count = 0;
+    }
+
+    /// Format an optional `Duration` for a `tracing` field: `"none"` when
+    /// no sample was recorded this window, the literal string `"MAX"` when
+    /// the sample IS `Duration::MAX` (egui's "no repaint needed" sentinel --
+    /// printing it as a microsecond count would show an absurd
+    /// ~584,942,417,355-year figure), or the microsecond count otherwise.
+    /// Pure, so directly unit-testable.
+    fn format_duration_field(d: Option<std::time::Duration>) -> String {
+        match d {
+            None => "none".to_string(),
+            Some(d) if d == std::time::Duration::MAX => "MAX".to_string(),
+            Some(d) => format!("{}us", d.as_micros()),
+        }
+    }
+}
+
+/// Update a running `(min, max)` pair with one new `Duration` sample.
+/// `current` starts `(None, None)` before the first sample. Pure, so
+/// directly unit-testable; shared by [`FrameProfile::record_settle_failure`]
+/// for both the `prev_repaint_delay` and `prev_terminal_requested_delay`
+/// tracking (avoiding writing the same min/max-or-first-sample logic twice).
+#[cfg(feature = "frame-profiling")]
+fn min_max_duration(
+    current: (Option<std::time::Duration>, Option<std::time::Duration>),
+    sample: std::time::Duration,
+) -> (Option<std::time::Duration>, Option<std::time::Duration>) {
+    let (min, max) = current;
+    (
+        Some(min.map_or(sample, |m| m.min(sample))),
+        Some(max.map_or(sample, |m| m.max(sample))),
+    )
 }
 
 /// #436 §3.1 (amended): a REPLAY is permitted only if nothing OTHER than
@@ -275,29 +411,93 @@ fn atlas_grew(textures_delta: &egui::TexturesDelta) -> bool {
         .any(|(id, delta)| *id == egui::TextureId::default() && delta.is_whole())
 }
 
-/// #436.4b: decide this frame's [`crate::ChromeMode`].
+/// The four independent REPLAY gate predicates from [`decide_chrome_mode`]'s
+/// doc, bundled so `decide_chrome_mode` and the (feature-gated) gate-blocker
+/// instrumentation in `run_frame` evaluate them via the SAME function
+/// ([`evaluate_chrome_gate`]) rather than two hand-maintained copies of the
+/// same boolean logic drifting apart. See `evaluate_chrome_gate`'s doc for
+/// what each field means.
+// struct_excessive_bools: these are four independent, unrelated gate
+// observations (mirrors the existing allow on `ChromeSignals`/
+// `DismissiblePresence` in `freminal::gui::chrome_damage`) -- not a state
+// machine, and each field is consumed both individually (the gate-blocker
+// counters) and via `all_pass` (the actual decision), so collapsing them
+// into an enum would make the individual-predicate consumer harder, not
+// easier.
+#[allow(clippy::struct_excessive_bools)]
+struct ChromeGatePredicates {
+    cache_matches: bool,
+    repaint_settled: bool,
+    damage_unchanged: bool,
+    no_chrome_input: bool,
+}
+
+impl ChromeGatePredicates {
+    /// A REPLAY is permitted only when every predicate holds.
+    const fn all_pass(&self) -> bool {
+        self.cache_matches && self.repaint_settled && self.damage_unchanged && self.no_chrome_input
+    }
+}
+
+/// #436.4b: evaluate the four independent REPLAY gate predicates. This is
+/// the single source of truth [`decide_chrome_mode`] consumes to make its
+/// decision, and (feature-gated only) the frame-profiling gate-blocker
+/// counters in `run_frame` call this SAME function a second time with the
+/// SAME arguments to see WHICH predicate(s) failed -- see the `run_frame`
+/// call site. If this function's logic ever changes, both consumers change
+/// with it; there is no second copy of the boolean expressions to forget.
 ///
-/// A REPLAY is permitted only when ALL of the following hold:
-///   - `cache_valid` — a chrome cache exists from a prior FULL frame.
-///   - `cache_size`/`cache_ppp` match `cur_size`/`cur_ppp` — the cached
-///     primitives were tessellated at this frame's framebuffer size and
-///     scale factor (a mismatch, e.g. a resize or DPI change, invalidates
-///     the whole cache rather than attempting a partial re-tessellation).
-///   - [`chrome_repaint_settled`] — nothing egui-internal wants a wake
-///     sooner than the app's own scheduling this frame (§3.1 amendment).
-///   - `prev_chrome_damage` is [`crate::ChromeDamage::Unchanged`] — the
-///     PREVIOUS frame proved static chrome did not change (§3.3/§3.5).
-///   - `!chrome_input_this_frame` — no window input event this frame could
-///     plausibly have affected chrome (§3.2, conservative: any qualifying
-///     input forces `Full`, refined region-aware in #436.8).
+///   - `cache_matches` — a chrome cache exists from a prior FULL frame
+///     (`cache_valid`), AND `cache_size`/`cache_ppp` match
+///     `cur_size`/`cur_ppp` — the cached primitives were tessellated at
+///     this frame's framebuffer size and scale factor (a mismatch, e.g. a
+///     resize or DPI change, invalidates the whole cache rather than
+///     attempting a partial re-tessellation).
+///   - `repaint_settled` — [`chrome_repaint_settled`]: nothing egui-internal
+///     wants a wake sooner than the app's own scheduling this frame (§3.1
+///     amendment).
+///   - `damage_unchanged` — `prev_chrome_damage` is
+///     [`crate::ChromeDamage::Unchanged`] — the PREVIOUS frame proved
+///     static chrome did not change (§3.3/§3.5).
+///   - `no_chrome_input` — `!chrome_input_this_frame`: no window input
+///     event this frame could plausibly have affected chrome (§3.2,
+///     conservative: any qualifying input forces `Full`, refined
+///     region-aware in #436.8).
 ///
-/// Any failure forces `ChromeMode::Full` — the always-correct, conservative
-/// default. Pure (no `self`/`egui` state), so directly unit-testable.
+/// Pure (no `self`/`egui` state), so directly unit-testable.
 // Nine independent, unrelated gate inputs (cache validity/size/ppp, this
 // frame's size/ppp, the two settle-rule delays, prior chrome damage, and the
 // input gate) -- bundling them into a struct would just relocate the same
 // fields without adding clarity, and this function exists specifically so
 // tests can drive each one independently.
+#[allow(clippy::too_many_arguments)]
+fn evaluate_chrome_gate(
+    cache_valid: bool,
+    cache_size: [u32; 2],
+    cache_ppp: f32,
+    cur_size: [u32; 2],
+    cur_ppp: f32,
+    prev_repaint_delay: std::time::Duration,
+    prev_terminal_requested_delay: Option<std::time::Duration>,
+    prev_chrome_damage: crate::ChromeDamage,
+    chrome_input_this_frame: bool,
+) -> ChromeGatePredicates {
+    ChromeGatePredicates {
+        cache_matches: cache_valid
+            && cache_size == cur_size
+            && (cache_ppp - cur_ppp).abs() < f32::EPSILON,
+        repaint_settled: chrome_repaint_settled(prev_repaint_delay, prev_terminal_requested_delay),
+        damage_unchanged: prev_chrome_damage == crate::ChromeDamage::Unchanged,
+        no_chrome_input: !chrome_input_this_frame,
+    }
+}
+
+/// #436.4b: decide this frame's [`crate::ChromeMode`].
+///
+/// A REPLAY is permitted only when ALL of [`evaluate_chrome_gate`]'s four
+/// predicates hold. Any failure forces `ChromeMode::Full` — the
+/// always-correct, conservative default. Pure (no `self`/`egui` state), so
+/// directly unit-testable.
 #[allow(clippy::too_many_arguments)]
 fn decide_chrome_mode(
     cache_valid: bool,
@@ -310,15 +510,19 @@ fn decide_chrome_mode(
     prev_chrome_damage: crate::ChromeDamage,
     chrome_input_this_frame: bool,
 ) -> crate::ChromeMode {
-    let cache_matches =
-        cache_valid && cache_size == cur_size && (cache_ppp - cur_ppp).abs() < f32::EPSILON;
+    let gate = evaluate_chrome_gate(
+        cache_valid,
+        cache_size,
+        cache_ppp,
+        cur_size,
+        cur_ppp,
+        prev_repaint_delay,
+        prev_terminal_requested_delay,
+        prev_chrome_damage,
+        chrome_input_this_frame,
+    );
 
-    let replay_allowed = cache_matches
-        && chrome_repaint_settled(prev_repaint_delay, prev_terminal_requested_delay)
-        && prev_chrome_damage == crate::ChromeDamage::Unchanged
-        && !chrome_input_this_frame;
-
-    if replay_allowed {
+    if gate.all_pass() {
         crate::ChromeMode::Replay
     } else {
         crate::ChromeMode::Full
@@ -473,6 +677,59 @@ impl EguiState {
             crate::ChromeMode::Replay => {
                 self.frame_profile.chrome_mode_replay =
                     self.frame_profile.chrome_mode_replay.saturating_add(1);
+            }
+        }
+
+        // Gate-blocker instrumentation (feature-gated only): re-evaluate the
+        // SAME four predicates `decide_chrome_mode` just consumed, via the
+        // SAME `evaluate_chrome_gate` function and the SAME arguments, so
+        // this can never drift from what actually gated the decision above
+        // (see `evaluate_chrome_gate`'s doc). Every failing predicate
+        // increments its own counter -- not just the first -- so overlap
+        // between blockers (e.g. cache mismatch AND not-settled on the same
+        // frame) is visible rather than only ever attributing to one cause.
+        #[cfg(feature = "frame-profiling")]
+        {
+            let gate = evaluate_chrome_gate(
+                cache_valid,
+                cache_size,
+                cache_ppp,
+                size_arr,
+                ppp_before_run_ui,
+                self.prev_repaint_delay,
+                self.prev_terminal_requested_delay,
+                self.prev_chrome_damage,
+                chrome_input_this_frame,
+            );
+            if !gate.cache_matches {
+                self.frame_profile.gate_blocked_cache_mismatch = self
+                    .frame_profile
+                    .gate_blocked_cache_mismatch
+                    .saturating_add(1);
+            }
+            if !gate.repaint_settled {
+                self.frame_profile.gate_blocked_not_settled = self
+                    .frame_profile
+                    .gate_blocked_not_settled
+                    .saturating_add(1);
+                // Settle-gate value diagnostics: only recorded when this
+                // predicate specifically failed -- see `record_settle_failure`.
+                self.frame_profile.record_settle_failure(
+                    self.prev_repaint_delay,
+                    self.prev_terminal_requested_delay,
+                );
+            }
+            if !gate.damage_unchanged {
+                self.frame_profile.gate_blocked_damage_changed = self
+                    .frame_profile
+                    .gate_blocked_damage_changed
+                    .saturating_add(1);
+            }
+            if !gate.no_chrome_input {
+                self.frame_profile.gate_blocked_chrome_input = self
+                    .frame_profile
+                    .gate_blocked_chrome_input
+                    .saturating_add(1);
             }
         }
 
@@ -843,12 +1100,57 @@ impl EguiState {
                     swap_max_us = p.swap_max.as_micros(),
                     swap_mean_us =
                         FrameProfile::mean_duration(p.swap_total, p.frame_counter).as_micros(),
+                    // Gate-blocker counters: which of the four REPLAY gate
+                    // predicates (see `evaluate_chrome_gate`) blocked a Full
+                    // decision this window, cumulative since window
+                    // creation. More than one may be nonzero for the same
+                    // set of frames -- that overlap is itself a finding.
+                    gate_blocked_cache_mismatch = p.gate_blocked_cache_mismatch,
+                    gate_blocked_not_settled = p.gate_blocked_not_settled,
+                    gate_blocked_damage_changed = p.gate_blocked_damage_changed,
+                    gate_blocked_chrome_input = p.gate_blocked_chrome_input,
+                    // Settle-gate value diagnostics: only populated on
+                    // frames where `gate_blocked_not_settled` fired this
+                    // flush window (see `record_settle_failure`); "none"
+                    // means the settle gate never failed this window, "MAX"
+                    // means a failing frame's `prev_repaint_delay` was
+                    // itself `Duration::MAX` (egui wanted no repaint yet the
+                    // gate still failed -- only possible via the
+                    // `prev_terminal_requested_delay` arm, since `MAX >=
+                    // app_delay` is only false when `app_delay` is also
+                    // `MAX`, which cannot itself fail the gate -- so seeing
+                    // this would itself be a notable finding).
+                    settle_repaint_delay_min_us =
+                        %FrameProfile::format_duration_field(p.settle_repaint_delay_min),
+                    settle_repaint_delay_max_us =
+                        %FrameProfile::format_duration_field(p.settle_repaint_delay_max),
+                    settle_terminal_requested_delay_min_us = %FrameProfile::format_duration_field(
+                        p.settle_terminal_requested_delay_min
+                    ),
+                    settle_terminal_requested_delay_max_us = %FrameProfile::format_duration_field(
+                        p.settle_terminal_requested_delay_max
+                    ),
+                    settle_terminal_requested_delay_none_count =
+                        p.settle_terminal_requested_delay_none_count,
                     "windowing frame-profiling stats (task 121 harness): ChromeMode \
-                     duty cycle and the windowing-owned phase_total/run_ui/tessellate/\
+                     duty cycle, the windowing-owned phase_total/run_ui/tessellate/\
                      paint/swap wall-clock split over frame_counter drawn frames for \
-                     this window_id; phase_total minus (run_ui + tessellate + paint + \
-                     swap) is the unmeasured residual -- see FrameProfile::phase_total_total"
+                     this window_id (phase_total minus (run_ui + tessellate + paint + \
+                     swap) is the unmeasured residual -- see \
+                     FrameProfile::phase_total_total), which of the four REPLAY gate \
+                     predicates blocked Full->Replay this window (gate_blocked_*, \
+                     cumulative, non-exclusive), and -- when the settle gate \
+                     specifically failed -- the min/max prev_repaint_delay and \
+                     prev_terminal_requested_delay values behind that failure this \
+                     flush window (settle_*)"
                 );
+
+                // Settle-gate value diagnostics are windowed, not
+                // cumulative-since-creation (see the field docs) -- clear
+                // them now that this window's line has been logged. The
+                // `gate_blocked_*` counters above are NOT reset; they stay
+                // cumulative like every other `FrameProfile` counter.
+                self.frame_profile.reset_settle_window();
             }
         }
 
@@ -943,11 +1245,59 @@ mod frame_profiling_tests {
         let mean = FrameProfile::mean_duration(Duration::from_micros(42), 1);
         assert_eq!(mean, Duration::from_micros(42));
     }
+
+    // ── `min_max_duration` ──────────────────────────────────────────────
+
+    #[test]
+    fn min_max_duration_first_sample_sets_both() {
+        let (min, max) = super::min_max_duration((None, None), Duration::from_millis(16));
+        assert_eq!(min, Some(Duration::from_millis(16)));
+        assert_eq!(max, Some(Duration::from_millis(16)));
+    }
+
+    #[test]
+    fn min_max_duration_tracks_a_smaller_second_sample() {
+        let first = super::min_max_duration((None, None), Duration::from_millis(16));
+        let second = super::min_max_duration(first, Duration::from_millis(4));
+        assert_eq!(second.0, Some(Duration::from_millis(4)));
+        assert_eq!(second.1, Some(Duration::from_millis(16)));
+    }
+
+    #[test]
+    fn min_max_duration_tracks_a_larger_second_sample() {
+        let first = super::min_max_duration((None, None), Duration::from_millis(16));
+        let second = super::min_max_duration(first, Duration::from_millis(500));
+        assert_eq!(second.0, Some(Duration::from_millis(16)));
+        assert_eq!(second.1, Some(Duration::from_millis(500)));
+    }
+
+    // ── `FrameProfile::format_duration_field` ────────────────────────────
+
+    #[test]
+    fn format_duration_field_none_is_literal_none() {
+        assert_eq!(FrameProfile::format_duration_field(None), "none");
+    }
+
+    #[test]
+    fn format_duration_field_max_is_literal_max_not_an_absurd_number() {
+        assert_eq!(
+            FrameProfile::format_duration_field(Some(Duration::MAX)),
+            "MAX"
+        );
+    }
+
+    #[test]
+    fn format_duration_field_formats_a_real_duration_as_micros() {
+        assert_eq!(
+            FrameProfile::format_duration_field(Some(Duration::from_millis(16))),
+            "16000us"
+        );
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{atlas_grew, chrome_repaint_settled, decide_chrome_mode};
+    use super::{atlas_grew, chrome_repaint_settled, decide_chrome_mode, evaluate_chrome_gate};
     use egui::ImageData;
     use egui::epaint::{ImageDelta, Primitive};
     use egui::{Color32, ColorImage, Rect, TextureId, TextureOptions, TexturesDelta, pos2, vec2};
@@ -1052,11 +1402,118 @@ mod tests {
                 self.chrome_input_this_frame,
             )
         }
+
+        /// The four raw gate predicates -- used by the tests below to prove
+        /// `evaluate_chrome_gate` (the gate-blocker instrumentation's data
+        /// source) fails exactly the expected predicate(s), independent of
+        /// `decide_chrome_mode`'s Full/Replay collapse.
+        fn gate(&self) -> super::ChromeGatePredicates {
+            evaluate_chrome_gate(
+                self.cache_valid,
+                self.cache_size,
+                self.cache_ppp,
+                self.cur_size,
+                self.cur_ppp,
+                self.prev_repaint_delay,
+                self.prev_terminal_requested_delay,
+                self.prev_chrome_damage,
+                self.chrome_input_this_frame,
+            )
+        }
     }
 
     #[test]
     fn all_clear_decides_replay() {
         assert_eq!(Inputs::all_clear().decide(), crate::ChromeMode::Replay);
+    }
+
+    // ── `evaluate_chrome_gate` (gate-blocker instrumentation's data source) ──
+    // These mirror the `decide_chrome_mode` per-predicate tests below, but
+    // assert on the individual `ChromeGatePredicates` fields rather than the
+    // collapsed `ChromeMode`, proving the instrumentation can distinguish
+    // WHICH predicate(s) failed -- including more than one at once.
+
+    #[test]
+    fn gate_all_clear_passes_every_predicate() {
+        let gate = Inputs::all_clear().gate();
+        assert!(gate.cache_matches);
+        assert!(gate.repaint_settled);
+        assert!(gate.damage_unchanged);
+        assert!(gate.no_chrome_input);
+        assert!(gate.all_pass());
+    }
+
+    #[test]
+    fn gate_invalid_cache_fails_only_cache_matches() {
+        let gate = Inputs {
+            cache_valid: false,
+            ..Inputs::all_clear()
+        }
+        .gate();
+        assert!(!gate.cache_matches);
+        assert!(gate.repaint_settled);
+        assert!(gate.damage_unchanged);
+        assert!(gate.no_chrome_input);
+    }
+
+    #[test]
+    fn gate_not_settled_fails_only_repaint_settled() {
+        let gate = Inputs {
+            prev_repaint_delay: Duration::from_millis(16),
+            prev_terminal_requested_delay: Some(Duration::from_millis(500)),
+            ..Inputs::all_clear()
+        }
+        .gate();
+        assert!(gate.cache_matches);
+        assert!(!gate.repaint_settled);
+        assert!(gate.damage_unchanged);
+        assert!(gate.no_chrome_input);
+    }
+
+    #[test]
+    fn gate_chrome_damage_changed_fails_only_damage_unchanged() {
+        let gate = Inputs {
+            prev_chrome_damage: crate::ChromeDamage::Changed,
+            ..Inputs::all_clear()
+        }
+        .gate();
+        assert!(gate.cache_matches);
+        assert!(gate.repaint_settled);
+        assert!(!gate.damage_unchanged);
+        assert!(gate.no_chrome_input);
+    }
+
+    #[test]
+    fn gate_chrome_input_fails_only_no_chrome_input() {
+        let gate = Inputs {
+            chrome_input_this_frame: true,
+            ..Inputs::all_clear()
+        }
+        .gate();
+        assert!(gate.cache_matches);
+        assert!(gate.repaint_settled);
+        assert!(gate.damage_unchanged);
+        assert!(!gate.no_chrome_input);
+    }
+
+    /// Proves overlap is visible: a frame that fails BOTH the cache-match
+    /// AND the chrome-input predicates simultaneously reports both as
+    /// failed, not just one -- this is exactly what lets the (feature-gated)
+    /// `run_frame` instrumentation increment more than one gate-blocker
+    /// counter on the same frame.
+    #[test]
+    fn gate_multiple_simultaneous_failures_are_all_visible() {
+        let gate = Inputs {
+            cache_valid: false,
+            chrome_input_this_frame: true,
+            ..Inputs::all_clear()
+        }
+        .gate();
+        assert!(!gate.cache_matches);
+        assert!(gate.repaint_settled);
+        assert!(gate.damage_unchanged);
+        assert!(!gate.no_chrome_input);
+        assert!(!gate.all_pass());
     }
 
     #[test]

--- a/freminal-windowing/src/egui_integration.rs
+++ b/freminal-windowing/src/egui_integration.rs
@@ -588,6 +588,19 @@ impl ChromeGatePredicates {
     const fn all_pass(&self) -> bool {
         self.cache_matches && self.repaint_settled && self.damage_unchanged && self.no_chrome_input
     }
+
+    /// The `ChromeMode` these predicates imply.
+    ///
+    /// Lets a caller that already evaluated the gate (e.g. to also count which
+    /// predicates failed) derive the mode without re-evaluating, so the
+    /// nine-argument list appears exactly once per frame.
+    const fn chrome_mode(&self) -> crate::ChromeMode {
+        if self.all_pass() {
+            crate::ChromeMode::Replay
+        } else {
+            crate::ChromeMode::Full
+        }
+    }
 }
 
 /// #436.4b: evaluate the four independent REPLAY gate predicates. This is
@@ -640,43 +653,6 @@ fn evaluate_chrome_gate(
         repaint_settled: chrome_repaint_settled(prev_repaint_delay, prev_terminal_requested_delay),
         damage_unchanged: prev_chrome_damage == crate::ChromeDamage::Unchanged,
         no_chrome_input: !chrome_input_this_frame,
-    }
-}
-
-/// #436.4b: decide this frame's [`crate::ChromeMode`].
-///
-/// A REPLAY is permitted only when ALL of [`evaluate_chrome_gate`]'s four
-/// predicates hold. Any failure forces `ChromeMode::Full` — the
-/// always-correct, conservative default. Pure (no `self`/`egui` state), so
-/// directly unit-testable.
-#[allow(clippy::too_many_arguments)]
-fn decide_chrome_mode(
-    cache_valid: bool,
-    cache_size: [u32; 2],
-    cache_ppp: f32,
-    cur_size: [u32; 2],
-    cur_ppp: f32,
-    prev_repaint_delay: std::time::Duration,
-    prev_terminal_requested_delay: Option<std::time::Duration>,
-    prev_chrome_damage: crate::ChromeDamage,
-    chrome_input_this_frame: bool,
-) -> crate::ChromeMode {
-    let gate = evaluate_chrome_gate(
-        cache_valid,
-        cache_size,
-        cache_ppp,
-        cur_size,
-        cur_ppp,
-        prev_repaint_delay,
-        prev_terminal_requested_delay,
-        prev_chrome_damage,
-        chrome_input_this_frame,
-    );
-
-    if gate.all_pass() {
-        crate::ChromeMode::Replay
-    } else {
-        crate::ChromeMode::Full
     }
 }
 
@@ -835,7 +811,13 @@ impl EguiState {
             .chrome_cache
             .as_ref()
             .map_or((false, [0, 0], 0.0), |cache| (true, cache.size, cache.ppp));
-        let chrome_mode = decide_chrome_mode(
+        // Evaluated ONCE per frame; the mode is derived from the same
+        // `ChromeGatePredicates` the feature-gated blocker counters below
+        // consume. Previously this argument list appeared twice (once here via
+        // `decide_chrome_mode`, once in the instrumentation), which was the
+        // real drift risk -- the predicates were already shared, the arguments
+        // were not.
+        let gate = evaluate_chrome_gate(
             cache_valid,
             cache_size,
             cache_ppp,
@@ -846,6 +828,7 @@ impl EguiState {
             self.prev_chrome_damage,
             chrome_input_this_frame,
         );
+        let chrome_mode = gate.chrome_mode();
 
         // Task 121 frame-profiling harness: count which `ChromeMode` was
         // just decided. Cross-checkable against `freminal`'s own
@@ -875,17 +858,6 @@ impl EguiState {
         // frame) is visible rather than only ever attributing to one cause.
         #[cfg(feature = "frame-profiling")]
         {
-            let gate = evaluate_chrome_gate(
-                cache_valid,
-                cache_size,
-                cache_ppp,
-                size_arr,
-                ppp_before_run_ui,
-                self.prev_repaint_delay,
-                self.prev_terminal_requested_delay,
-                self.prev_chrome_damage,
-                chrome_input_this_frame,
-            );
             if !gate.cache_matches {
                 self.frame_profile.gate_blocked_cache_mismatch = self
                     .frame_profile
@@ -1687,7 +1659,7 @@ mod frame_profiling_tests {
 
 #[cfg(test)]
 mod tests {
-    use super::{atlas_grew, chrome_repaint_settled, decide_chrome_mode, evaluate_chrome_gate};
+    use super::{atlas_grew, chrome_repaint_settled, evaluate_chrome_gate};
     use egui::ImageData;
     use egui::epaint::{ImageDelta, Primitive};
     use egui::{Color32, ColorImage, Rect, TextureId, TextureOptions, TexturesDelta, pos2, vec2};
@@ -1780,7 +1752,7 @@ mod tests {
         }
 
         fn decide(&self) -> crate::ChromeMode {
-            decide_chrome_mode(
+            evaluate_chrome_gate(
                 self.cache_valid,
                 self.cache_size,
                 self.cache_ppp,
@@ -1791,12 +1763,13 @@ mod tests {
                 self.prev_chrome_damage,
                 self.chrome_input_this_frame,
             )
+            .chrome_mode()
         }
 
         /// The four raw gate predicates -- used by the tests below to prove
         /// `evaluate_chrome_gate` (the gate-blocker instrumentation's data
         /// source) fails exactly the expected predicate(s), independent of
-        /// `decide_chrome_mode`'s Full/Replay collapse.
+        /// `ChromeGatePredicates::chrome_mode`'s Full/Replay collapse.
         fn gate(&self) -> super::ChromeGatePredicates {
             evaluate_chrome_gate(
                 self.cache_valid,
@@ -1970,7 +1943,7 @@ mod tests {
     #[test]
     fn blinking_cursor_idle_frame_decides_replay() {
         assert_eq!(
-            decide_chrome_mode(
+            evaluate_chrome_gate(
                 true,
                 [800, 600],
                 1.0,
@@ -1980,7 +1953,8 @@ mod tests {
                 Some(Duration::from_millis(500)),
                 crate::ChromeDamage::Unchanged,
                 false,
-            ),
+            )
+            .chrome_mode(),
             crate::ChromeMode::Replay
         );
     }

--- a/freminal-windowing/src/egui_integration.rs
+++ b/freminal-windowing/src/egui_integration.rs
@@ -19,6 +19,14 @@ pub struct FrameOutput {
     pub commands: Vec<egui::ViewportCommand>,
     /// Requested repaint delay (`Duration::MAX` = no repaint needed).
     pub repaint_delay: std::time::Duration,
+    /// The delay the *app* itself asked for this frame (`App::take_terminal_requested_delay`),
+    /// independent of whatever egui decided it wanted.
+    ///
+    /// SPIKE (Task 121): the event loop uses this to override `repaint_delay`
+    /// when egui asked for an immediate repaint *solely* because of pointer
+    /// events the app already classified as needing no frame. See the
+    /// override at the `RedrawRequested` arm in `event_loop.rs`.
+    pub app_requested_delay: Option<std::time::Duration>,
 }
 
 /// Cached tessellated chrome (head + tail) primitives from the most recent
@@ -238,6 +246,54 @@ struct FrameProfile {
     /// requested a delay at all this frame, counted separately from "the
     /// app requested something, but egui wanted sooner").
     settle_terminal_requested_delay_none_count: u64,
+
+    // ── Repaint-cause aggregation (feature-gated), reset every flush
+    // window like the settle-gate diagnostics above (`reset_repaint_cause_window`)
+    // rather than cumulative-since-creation -- the question this answers
+    // ("what is asking for an immediate repaint on THIS kind of frame,
+    // right now") only makes sense as "in the last `FLUSH_EVERY` frames",
+    // the same reasoning as the settle-value fields.
+    /// Occurrence count per `ctx.repaint_causes()` cause, keyed on the
+    /// formatted `"{trimmed_file}:{line} {reason}"` string (see
+    /// [`trim_cause_file_path`]) — e.g. distinguishing an egui-internal
+    /// cause (`index.crates.io-.../egui-0.35.0/src/context.rs:1234 ...`)
+    /// from a freminal call site
+    /// (`freminal/src/gui/terminal/widget.rs:1936 ...`) is the whole
+    /// point of this map. `BTreeMap`, not `HashMap`: deterministic
+    /// (alphabetical) iteration order for the flush log, and
+    /// `freminal-windowing` has no hash-map dependency to gain for this.
+    ///
+    /// **These are the PREVIOUS pass's causes, not this frame's own** — see
+    /// [`egui::Context::repaint_causes`]'s doc and the call site in
+    /// `run_frame` for why: `Context::begin_pass` (called from inside
+    /// `run_ui`) swaps the just-finished pass's `causes` into `prev_causes`
+    /// at the START of the pass that follows it, so `repaint_causes()`
+    /// always lags by exactly one `run_frame` call. That is fine for
+    /// aggregate counting over a 120-frame window (the lag is invisible in
+    /// the aggregate); it would matter for attributing causes to a SPECIFIC
+    /// single frame, which this harness does not attempt.
+    repaint_cause_counts: std::collections::BTreeMap<String, u64>,
+
+    // ── Task 121 pointer-motion repaint-gate spike (issue: pointer motion
+    // over static terminal content measured at 58fps vs. 1.95fps idle, 95%
+    // of those frames changing zero pixels) ──────────────────────────────
+    //
+    // Cumulative since window creation, like every other plain counter on
+    // this struct. Incremented from `event_loop.rs`'s `CursorMoved` arm
+    // (the only place the scheduling decision is made) via the
+    // `record_pointer_frame_scheduled`/`record_pointer_frame_suppressed`
+    // accessors below, NOT here — these fields stay private to `FrameProfile`
+    // (see those accessors' docs for why a method, not a public field).
+    /// `CursorMoved` events that scheduled a repaint (either the app's
+    /// [`crate::App::pointer_motion_needs_repaint`] said so, the chrome-drag
+    /// latch was set, or this was the one-frame edge-detect transition after
+    /// a needed -> not-needed change).
+    pointer_frames_scheduled: u64,
+    /// `CursorMoved` events suppressed by the Task 121 gate — i.e. events
+    /// that would have scheduled a repaint before this spike (egui-winit
+    /// reports `repaint: true` unconditionally for `CursorMoved`) but did
+    /// not need to, per the app's own state.
+    pointer_frames_suppressed: u64,
 }
 
 #[cfg(feature = "frame-profiling")]
@@ -332,6 +388,30 @@ impl FrameProfile {
         self.settle_terminal_requested_delay_none_count = 0;
     }
 
+    /// Record one `ctx.repaint_causes()` entry into `repaint_cause_counts`.
+    /// Called once per returned cause (a frame that pushed the same cause
+    /// twice -- e.g. two `request_repaint()` calls at the same call site in
+    /// one pass -- increments the count twice, matching what
+    /// `egui::Context` actually recorded: `causes.push(cause)` is
+    /// unconditional, with no dedup, at `context.rs:153`).
+    fn record_repaint_cause(&mut self, cause: &egui::RepaintCause) {
+        let key = format!(
+            "{}:{} {}",
+            trim_cause_file_path(cause.file),
+            cause.line,
+            cause.reason
+        );
+        let counter = self.repaint_cause_counts.entry(key).or_insert(0);
+        *counter = counter.saturating_add(1);
+    }
+
+    /// Clear the repaint-cause aggregation map at the end of a flush window
+    /// -- see the field doc on `repaint_cause_counts` for why this is
+    /// windowed rather than cumulative-since-creation.
+    fn reset_repaint_cause_window(&mut self) {
+        self.repaint_cause_counts.clear();
+    }
+
     /// Format an optional `Duration` for a `tracing` field: `"none"` when
     /// no sample was recorded this window, the literal string `"MAX"` when
     /// the sample IS `Duration::MAX` (egui's "no repaint needed" sentinel --
@@ -362,6 +442,77 @@ fn min_max_duration(
         Some(min.map_or(sample, |m| m.min(sample))),
         Some(max.map_or(sample, |m| m.max(sample))),
     )
+}
+
+/// Trim a [`egui::RepaintCause::file`] path down to its last
+/// `KEEP_COMPONENTS` `/`-or-`\`-separated segments.
+///
+/// Egui-internal causes carry the registry cache's long, absolute-ish path
+/// (e.g. `.../registry/src/index.crates.io-.../egui-0.35.0/src/context.rs`);
+/// keeping the last four segments retains the registry-hash and
+/// crate-name+version directory components (e.g.
+/// `index.crates.io-1949cf8c6b5b557f/egui-0.35.0/src/context.rs`), which is
+/// exactly what distinguishes an egui-internal cause from a freminal call
+/// site (`freminal/src/gui/terminal/widget.rs`) -- the entire point of this
+/// instrumentation. Paths with `KEEP_COMPONENTS` segments or fewer
+/// (freminal's own workspace-relative `file!()` paths typically are) pass
+/// through unchanged. Pure, so directly unit-testable.
+#[cfg(feature = "frame-profiling")]
+fn trim_cause_file_path(file: &str) -> String {
+    const KEEP_COMPONENTS: usize = 4;
+    let parts: Vec<&str> = file.split(['/', '\\']).collect();
+    if parts.len() <= KEEP_COMPONENTS {
+        file.to_string()
+    } else {
+        parts[parts.len() - KEEP_COMPONENTS..].join("/")
+    }
+}
+
+/// Sum of all occurrence counts in a repaint-cause aggregation map -- the
+/// total number of `ctx.repaint_causes()` entries recorded this flush
+/// window, for comparison against the window's `frame_counter` (e.g. 120
+/// frames producing 480 causes means ~4 requests/frame). Pure, so directly
+/// unit-testable.
+#[cfg(feature = "frame-profiling")]
+fn total_repaint_cause_count(counts: &std::collections::BTreeMap<String, u64>) -> u64 {
+    counts
+        .values()
+        .fold(0u64, |acc, count| acc.saturating_add(*count))
+}
+
+/// The top `n` entries of a repaint-cause aggregation map, ordered by
+/// occurrence count descending. `BTreeMap::iter` yields keys in ascending
+/// (alphabetical) order; a *stable* sort by count descending therefore
+/// leaves ties ordered by key ascending, deterministically -- no
+/// `HashMap`-style iteration-order nondeterminism to fight. Pure, so
+/// directly unit-testable.
+#[cfg(feature = "frame-profiling")]
+fn top_repaint_causes(
+    counts: &std::collections::BTreeMap<String, u64>,
+    n: usize,
+) -> Vec<(String, u64)> {
+    let mut entries: Vec<(String, u64)> = counts.iter().map(|(k, v)| (k.clone(), *v)).collect();
+    entries.sort_by_key(|(_, count)| std::cmp::Reverse(*count));
+    entries.truncate(n);
+    entries
+}
+
+/// Format a top-N repaint-cause list (see [`top_repaint_causes`]) as a
+/// single readable `tracing` field: `"{count}x {cause}"` entries joined by
+/// `"; "`, or the literal `"none"` when empty (matching the
+/// `format_duration_field`/`format_nonzero_signal_counts` "none when empty"
+/// idiom already used by this harness and its `freminal`-side counterpart).
+/// Pure, so directly unit-testable.
+#[cfg(feature = "frame-profiling")]
+fn format_repaint_causes(entries: &[(String, u64)]) -> String {
+    if entries.is_empty() {
+        return "none".to_string();
+    }
+    entries
+        .iter()
+        .map(|(cause, count)| format!("{count}x {cause}"))
+        .collect::<Vec<_>>()
+        .join("; ")
 }
 
 /// #436 §3.1 (amended): a REPLAY is permitted only if nothing OTHER than
@@ -566,6 +717,40 @@ impl EguiState {
         self.winit_state.take_egui_input(window)
     }
 
+    /// Task 121 pointer-motion repaint-gate spike: record that a
+    /// `CursorMoved` event scheduled a repaint.
+    ///
+    /// A small accessor rather than a public `frame_profile` field/counter:
+    /// `event_loop.rs` (where the scheduling decision is made) has no other
+    /// reason to reach into `FrameProfile`'s internals, and this keeps the
+    /// counter itself private to this module alongside every other
+    /// `FrameProfile` field. Logged on the existing per-window
+    /// `FLUSH_EVERY`-frame flush line in [`Self::run_frame`] — see the
+    /// `pointer_frames_scheduled`/`pointer_frames_suppressed` field docs on
+    /// [`FrameProfile`] for why these counters live there (rather than on
+    /// `event_loop.rs`'s own `WindowState`): they are logically part of the
+    /// same per-window frame-profiling harness and this reuses its existing
+    /// flush cadence/`window_id` tagging instead of standing up a second one.
+    #[cfg(feature = "frame-profiling")]
+    pub(crate) const fn record_pointer_frame_scheduled(&mut self) {
+        self.frame_profile.pointer_frames_scheduled = self
+            .frame_profile
+            .pointer_frames_scheduled
+            .saturating_add(1);
+    }
+
+    /// Task 121 pointer-motion repaint-gate spike: record that a
+    /// `CursorMoved` event was suppressed (did not schedule a repaint) by
+    /// the gate. See [`Self::record_pointer_frame_scheduled`]'s doc for why
+    /// this is an accessor rather than a public field.
+    #[cfg(feature = "frame-profiling")]
+    pub(crate) const fn record_pointer_frame_suppressed(&mut self) {
+        self.frame_profile.pointer_frames_suppressed = self
+            .frame_profile
+            .pointer_frames_suppressed
+            .saturating_add(1);
+    }
+
     /// Run a single egui frame and paint, using pre-collected raw input.
     ///
     /// `chrome_input_this_frame` is the #436.4b §3.2 conservative input gate:
@@ -767,6 +952,32 @@ impl EguiState {
             let d = run_ui_start.elapsed();
             self.frame_profile.run_ui_total += d;
             self.frame_profile.run_ui_max = self.frame_profile.run_ui_max.max(d);
+        }
+
+        // Task 121 defect-5 harness extension: aggregate
+        // `ctx.repaint_causes()` into `repaint_cause_counts` -- answers
+        // "something requested an immediate, zero-delay repaint; what,
+        // exactly?" (egui-internal machinery vs. one of freminal's own
+        // `ctx.request_repaint*` call sites in
+        // `freminal/src/gui/terminal/widget.rs`).
+        //
+        // Called HERE, immediately after `run_ui` returns, because
+        // `repaint_causes()` returns `prev_causes` -- the PREVIOUS pass's
+        // causes (`Context::begin_pass`, invoked from inside `run_ui`,
+        // swaps the just-finished pass's `causes` into `prev_causes` at the
+        // START of the pass that follows it). This is the *earliest* point
+        // in `run_frame` where that swap has already happened for THIS
+        // frame's `run_ui` call, so it captures the freshest available data
+        // (the causes from one frame ago) rather than calling later in
+        // `run_frame` (same data, just read later for no benefit) or before
+        // `run_ui` (this frame's `begin_pass` hasn't swapped yet, so it
+        // would read causes from TWO frames ago instead of one). See the
+        // `repaint_cause_counts` field doc for why a one-pass lag is fine
+        // for this harness's aggregate-over-120-frames use, and would not
+        // be for single-frame attribution.
+        #[cfg(feature = "frame-profiling")]
+        for cause in self.ctx.repaint_causes() {
+            self.frame_profile.record_repaint_cause(&cause);
         }
 
         self.winit_state
@@ -1132,6 +1343,30 @@ impl EguiState {
                     ),
                     settle_terminal_requested_delay_none_count =
                         p.settle_terminal_requested_delay_none_count,
+                    // Repaint-cause aggregation (task 121 defect-5): what,
+                    // exactly, requested an immediate/zero-delay repaint
+                    // this flush window -- egui-internal machinery vs. a
+                    // freminal call site -- and how many requests total,
+                    // for comparison against `frame_counter` (e.g. 120
+                    // frames producing 480 causes means ~4 requests/frame).
+                    // These are the PREVIOUS pass's causes, one frame
+                    // lagged -- see the `repaint_cause_counts` field doc.
+                    repaint_cause_total = total_repaint_cause_count(&p.repaint_cause_counts),
+                    repaint_cause_top8 =
+                        %format_repaint_causes(&top_repaint_causes(&p.repaint_cause_counts, 8)),
+                    // Task 121 pointer-motion repaint-gate spike: how many
+                    // `CursorMoved` events scheduled vs. were suppressed,
+                    // cumulative since window creation (not windowed, like
+                    // `chrome_mode_full`/`chrome_mode_replay`). Incremented
+                    // from `event_loop.rs` via
+                    // `record_pointer_frame_scheduled`/
+                    // `record_pointer_frame_suppressed`.
+                    pointer_frames_scheduled = p.pointer_frames_scheduled,
+                    pointer_frames_suppressed = p.pointer_frames_suppressed,
+                    pointer_suppressed_duty_cycle_pct = FrameProfile::chrome_replay_duty_cycle_pct(
+                        p.pointer_frames_scheduled,
+                        p.pointer_frames_suppressed
+                    ),
                     "windowing frame-profiling stats (task 121 harness): ChromeMode \
                      duty cycle, the windowing-owned phase_total/run_ui/tessellate/\
                      paint/swap wall-clock split over frame_counter drawn frames for \
@@ -1139,24 +1374,33 @@ impl EguiState {
                      swap) is the unmeasured residual -- see \
                      FrameProfile::phase_total_total), which of the four REPLAY gate \
                      predicates blocked Full->Replay this window (gate_blocked_*, \
-                     cumulative, non-exclusive), and -- when the settle gate \
+                     cumulative, non-exclusive), -- when the settle gate \
                      specifically failed -- the min/max prev_repaint_delay and \
                      prev_terminal_requested_delay values behind that failure this \
-                     flush window (settle_*)"
+                     flush window (settle_*), the top 8 ctx.repaint_causes() by \
+                     occurrence count this flush window plus their total \
+                     (repaint_cause_top8/repaint_cause_total), and the Task 121 \
+                     pointer-motion-suppression-spike counters \
+                     (pointer_frames_scheduled/pointer_frames_suppressed/\
+                     pointer_suppressed_duty_cycle_pct, cumulative since window \
+                     creation)"
                 );
 
-                // Settle-gate value diagnostics are windowed, not
-                // cumulative-since-creation (see the field docs) -- clear
-                // them now that this window's line has been logged. The
-                // `gate_blocked_*` counters above are NOT reset; they stay
-                // cumulative like every other `FrameProfile` counter.
+                // Settle-gate value diagnostics and the repaint-cause
+                // aggregation map are windowed, not cumulative-since-creation
+                // (see their field docs) -- clear them now that this
+                // window's line has been logged. The `gate_blocked_*`
+                // counters above are NOT reset; they stay cumulative like
+                // every other `FrameProfile` counter.
                 self.frame_profile.reset_settle_window();
+                self.frame_profile.reset_repaint_cause_window();
             }
         }
 
         FrameOutput {
             commands,
             repaint_delay,
+            app_requested_delay: terminal_requested_delay,
         }
     }
 
@@ -1291,6 +1535,152 @@ mod frame_profiling_tests {
         assert_eq!(
             FrameProfile::format_duration_field(Some(Duration::from_millis(16))),
             "16000us"
+        );
+    }
+
+    // ── `trim_cause_file_path` ───────────────────────────────────────────
+
+    #[test]
+    fn trim_cause_file_path_leaves_a_short_path_unchanged() {
+        // freminal's own `file!()` paths are workspace-relative and
+        // typically well under the 4-segment keep threshold.
+        assert_eq!(
+            super::trim_cause_file_path("freminal/src/main.rs"),
+            "freminal/src/main.rs"
+        );
+    }
+
+    #[test]
+    fn trim_cause_file_path_leaves_exactly_four_segments_unchanged() {
+        assert_eq!(
+            super::trim_cause_file_path("freminal/src/gui/widget.rs"),
+            "freminal/src/gui/widget.rs"
+        );
+    }
+
+    #[test]
+    fn trim_cause_file_path_keeps_last_four_segments_of_a_long_registry_path() {
+        // A realistic egui-0.35.0 registry cache path -- the crate
+        // name+version directory component must survive the trim so it
+        // remains distinguishable from a freminal source path.
+        let long_path = "/home/fred/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/egui-0.35.0/src/context.rs";
+        assert_eq!(
+            super::trim_cause_file_path(long_path),
+            "index.crates.io-1949cf8c6b5b557f/egui-0.35.0/src/context.rs"
+        );
+    }
+
+    #[test]
+    fn trim_cause_file_path_handles_backslash_separated_windows_paths() {
+        let long_path =
+            r"C:\Users\fred\.cargo\registry\src\index.crates.io-abc\egui-0.35.0\src\context.rs";
+        assert_eq!(
+            super::trim_cause_file_path(long_path),
+            "index.crates.io-abc/egui-0.35.0/src/context.rs"
+        );
+    }
+
+    // ── `total_repaint_cause_count` ──────────────────────────────────────
+
+    #[test]
+    fn total_repaint_cause_count_is_zero_for_an_empty_map() {
+        let counts = std::collections::BTreeMap::new();
+        assert_eq!(super::total_repaint_cause_count(&counts), 0);
+    }
+
+    #[test]
+    fn total_repaint_cause_count_sums_all_entries() {
+        let mut counts = std::collections::BTreeMap::new();
+        counts.insert("a".to_string(), 3u64);
+        counts.insert("b".to_string(), 5u64);
+        counts.insert("c".to_string(), 2u64);
+        assert_eq!(super::total_repaint_cause_count(&counts), 10);
+    }
+
+    // ── `top_repaint_causes` ─────────────────────────────────────────────
+
+    #[test]
+    fn top_repaint_causes_orders_by_count_descending() {
+        let mut counts = std::collections::BTreeMap::new();
+        counts.insert("rare".to_string(), 1u64);
+        counts.insert("common".to_string(), 100u64);
+        counts.insert("medium".to_string(), 10u64);
+        let top = super::top_repaint_causes(&counts, 8);
+        assert_eq!(
+            top,
+            vec![
+                ("common".to_string(), 100),
+                ("medium".to_string(), 10),
+                ("rare".to_string(), 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn top_repaint_causes_truncates_to_n() {
+        let mut counts = std::collections::BTreeMap::new();
+        for i in 0..20u64 {
+            counts.insert(format!("cause_{i:02}"), i);
+        }
+        let top = super::top_repaint_causes(&counts, 8);
+        assert_eq!(top.len(), 8);
+        // The 8 largest counts (19..=12) must be present, descending.
+        let expected_counts: Vec<u64> = (12..20).rev().collect();
+        let actual_counts: Vec<u64> = top.iter().map(|(_, c)| *c).collect();
+        assert_eq!(actual_counts, expected_counts);
+    }
+
+    #[test]
+    fn top_repaint_causes_breaks_ties_by_key_ascending_deterministically() {
+        // Three entries tied at count 5: BTreeMap::iter yields them
+        // alphabetically ("a" < "b" < "c"), and a stable sort by count
+        // descending must preserve that relative order for the tie.
+        let mut counts = std::collections::BTreeMap::new();
+        counts.insert("c_cause".to_string(), 5u64);
+        counts.insert("a_cause".to_string(), 5u64);
+        counts.insert("b_cause".to_string(), 5u64);
+        let top = super::top_repaint_causes(&counts, 8);
+        assert_eq!(
+            top,
+            vec![
+                ("a_cause".to_string(), 5),
+                ("b_cause".to_string(), 5),
+                ("c_cause".to_string(), 5),
+            ],
+            "ties must break by key ascending, deterministically -- re-running \
+             must always produce this exact order"
+        );
+    }
+
+    #[test]
+    fn top_repaint_causes_handles_an_empty_map() {
+        let counts = std::collections::BTreeMap::new();
+        assert_eq!(super::top_repaint_causes(&counts, 8), Vec::new());
+    }
+
+    // ── `format_repaint_causes` ───────────────────────────────────────────
+
+    #[test]
+    fn format_repaint_causes_is_literal_none_when_empty() {
+        assert_eq!(super::format_repaint_causes(&[]), "none");
+    }
+
+    #[test]
+    fn format_repaint_causes_formats_a_realistic_example() {
+        let entries = vec![
+            (
+                "index.crates.io-1949cf8c6b5b557f/egui-0.35.0/src/context.rs:1879 ".to_string(),
+                2846u64,
+            ),
+            (
+                "freminal/src/gui/terminal/widget.rs:1936 ".to_string(),
+                12u64,
+            ),
+        ];
+        assert_eq!(
+            super::format_repaint_causes(&entries),
+            "2846x index.crates.io-1949cf8c6b5b557f/egui-0.35.0/src/context.rs:1879 ; \
+             12x freminal/src/gui/terminal/widget.rs:1936 "
         );
     }
 }

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -86,6 +86,50 @@ fn clamp_repaint_delay(delay: std::time::Duration) -> std::time::Duration {
     delay.max(MIN_REPAINT_INTERVAL)
 }
 
+/// Task 121 spike: fallback wake interval used when pointer motion was
+/// suppressed, egui asked for an immediate repaint purely because of those
+/// suppressed events, and the app itself requested no delay at all.
+///
+/// Deliberately bounded rather than "never repaint": the app requests nothing
+/// when there is no blink schedule to honour (e.g. `DECTCEM` has hidden the
+/// cursor under btop/vim), and in that state an unbounded wait would stall the
+/// window until an unrelated event happened to arrive. ~4fps is far below the
+/// ~60fps this spike exists to eliminate, while still guaranteeing liveness.
+const SUPPRESSED_POINTER_FALLBACK_DELAY: std::time::Duration =
+    std::time::Duration::from_millis(250);
+
+/// Task 121 spike: decide the repaint delay to actually schedule, given what
+/// egui asked for and whether the only thing that happened since the previous
+/// frame was pointer motion the app classified as needing no frame.
+///
+/// egui's `InputState::wants_repaint_after` returns `Duration::ZERO` whenever
+/// its event queue is non-empty. Suppressed pointer events are still handed to
+/// `on_window_event` (egui's pointer state must stay fresh), so they sit in
+/// that queue and egui re-arms an immediate frame from *inside* the frame —
+/// a self-sustaining ~60fps loop that input-side suppression alone cannot
+/// break. When `suppressed_only` holds, that zero is attributable to those
+/// events and is overridden with whatever the app itself asked for.
+///
+/// The fallback is deliberately bounded, NOT `Duration::MAX`: the app requests
+/// nothing when it has no blink schedule to honour (e.g. `DECTCEM` hid the
+/// cursor under btop/vim), and an unbounded wait there would stall the window
+/// until an unrelated event arrived. A stalled terminal is far worse than an
+/// occasional redundant frame.
+///
+/// Pure so the liveness-critical substitution is unit-testable without a live
+/// event loop — this is the highest-risk logic in the spike.
+fn effective_repaint_delay(
+    suppressed_only: bool,
+    repaint_delay: std::time::Duration,
+    app_requested_delay: Option<std::time::Duration>,
+) -> std::time::Duration {
+    if suppressed_only && repaint_delay.is_zero() {
+        app_requested_delay.unwrap_or(SUPPRESSED_POINTER_FALLBACK_DELAY)
+    } else {
+        repaint_delay
+    }
+}
+
 /// Returns `true` for the narrow set of physical keys that egui 0.35 cannot
 /// deliver: print/pause/menu keys, keypad operators and digits, and the
 /// media keys winit's `KeyCode` exposes (Task 114). These are intercepted
@@ -283,6 +327,36 @@ fn update_chrome_drag_latch(
     }
 }
 
+/// Task 121 spike: should THIS `CursorMoved` event actually schedule a
+/// repaint (i.e. set `WindowState::repaint_at`)?
+///
+/// `chrome_drag_latched` (`chrome_drag_pressed_count > 0`) always forces
+/// `true` — a chrome-border drag in progress must keep repainting regardless
+/// of the app's opinion, mirroring [`should_force_chrome_full_for_pointer`]'s
+/// same latch on the separate chrome-damage axis.
+///
+/// Otherwise: `previous_needed || current_needed`. `current_needed` is
+/// `App::pointer_motion_needs_repaint`'s answer for THIS event's position;
+/// `previous_needed` is that same answer for the PRIOR `CursorMoved` event.
+/// The `previous_needed` half is the edge-detect: on a needed -> not-needed
+/// transition (`previous_needed == true`, `current_needed == false`), this
+/// still evaluates `true` — i.e. the transition frame itself is repainted —
+/// so chrome the pointer just left (e.g. a hover tint) is redrawn one final
+/// time before suppression begins on the FOLLOWING event (where
+/// `previous_needed` has by then been updated to `false`). A
+/// not-needed -> needed transition schedules via `current_needed` alone, and
+/// two consecutive not-needed events correctly suppress
+/// (`false || false == false`).
+///
+/// Pure, so directly unit-testable without a live event loop.
+const fn should_schedule_cursor_moved(
+    chrome_drag_latched: bool,
+    previous_needed: bool,
+    current_needed: bool,
+) -> bool {
+    chrome_drag_latched || previous_needed || current_needed
+}
+
 /// Per-window state.
 struct WindowState {
     window: Window,
@@ -312,6 +386,28 @@ struct WindowState {
     /// position, so a drag that moves off the sensor mid-drag is not
     /// mistaken for terminal-content motion.
     chrome_drag_pressed_count: u32,
+    /// Task 121 spike: whether the PREVIOUS `CursorMoved` event decided a
+    /// repaint was needed (before the chrome-drag-latch override). Consulted
+    /// by [`should_schedule_cursor_moved`] to edge-detect a needed ->
+    /// not-needed transition, so the frame where the pointer stops mattering
+    /// (e.g. leaves a hover-sensitive region) is still repainted exactly
+    /// once before suppression begins — otherwise stale chrome (e.g. a hover
+    /// tint the pointer just left) would linger until the next unrelated
+    /// repaint (up to the ~500ms blink interval). `true` before the first
+    /// `CursorMoved`, matching this trait method's conservative default.
+    pointer_motion_needed_last: bool,
+    /// Task 121 spike: set when a `CursorMoved` was suppressed; cleared when
+    /// the next frame consumes it.
+    ///
+    /// Suppressed events are still handed to `on_window_event` (egui's pointer
+    /// state must stay fresh), so they queue in egui's `RawInput.events` until
+    /// the next `take_egui_input`. `InputState::wants_repaint_after` returns
+    /// `Duration::ZERO` whenever that queue is non-empty, so egui re-arms a
+    /// 16ms frame from *inside* the frame no matter how thoroughly we
+    /// suppressed the input-side scheduling — a self-sustaining ~60fps loop.
+    /// This flag lets the `RedrawRequested` arm recognise that specific case
+    /// and substitute the app's own requested delay for egui's zero.
+    suppressed_pointer_since_last_frame: bool,
 }
 
 impl WindowState {
@@ -421,6 +517,8 @@ impl<A: App> Handler<A> {
             chrome_input_pending: false,
             last_cursor_pos: None,
             chrome_drag_pressed_count: 0,
+            pointer_motion_needed_last: true,
+            suppressed_pointer_since_last_frame: false,
         };
 
         self.windows.insert(winit_id, state);
@@ -602,6 +700,16 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
         ) {
             if let Some(state) = self.windows.get_mut(&winit_id) {
                 let response = state.egui.on_window_event(&state.window, &event);
+                // Task 121 spike: whether THIS pointer event should schedule
+                // a repaint. Defaults to egui-winit's own opinion (always
+                // `true` for all five event kinds handled in this fast path
+                // — see `should_schedule_cursor_moved`'s doc) and is
+                // narrowed ONLY inside the `CursorMoved` arm below, the sole
+                // event kind `App::pointer_motion_needs_repaint` gates
+                // (`MouseInput`/`MouseWheel`/`CursorEntered`/`CursorLeft`
+                // are discrete, rare, and stay unconditional — deliberate
+                // scope limit).
+                let mut schedule_repaint = response.repaint;
                 match event {
                     WindowEvent::CursorMoved { position, .. } => {
                         let scale = state.window.scale_factor();
@@ -613,6 +721,40 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                             is_over_chrome,
                             state.chrome_drag_pressed_count > 0,
                         );
+
+                        // Task 121 spike: independent of the chrome-input
+                        // gate above (which drives `ChromeMode`), decide
+                        // whether this pointer-motion event needs a repaint
+                        // AT ALL. `last_cursor_pos.is_none()` (position
+                        // could not be converted to logical points — a
+                        // non-finite/non-positive scale factor) is
+                        // conservative: treated as needed.
+                        let app_says_needed = state.last_cursor_pos.is_none_or(|pos| {
+                            self.app
+                                .pointer_motion_needs_repaint(WindowId(winit_id), pos)
+                        });
+                        schedule_repaint = should_schedule_cursor_moved(
+                            state.chrome_drag_pressed_count > 0,
+                            state.pointer_motion_needed_last,
+                            app_says_needed,
+                        );
+
+                        // Task 121 spike: remember that we suppressed, so the
+                        // next frame can tell egui's "immediate repaint"
+                        // (which it derives purely from its non-empty event
+                        // queue) apart from a genuine egui-side need.
+                        if !schedule_repaint {
+                            state.suppressed_pointer_since_last_frame = true;
+                        }
+
+                        #[cfg(feature = "frame-profiling")]
+                        if schedule_repaint {
+                            state.egui.record_pointer_frame_scheduled();
+                        } else {
+                            state.egui.record_pointer_frame_suppressed();
+                        }
+
+                        state.pointer_motion_needed_last = app_says_needed;
                     }
                     WindowEvent::CursorEntered { .. } => {
                         // Unconditional (matches `is_unconditional_chrome_input`).
@@ -622,6 +764,11 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                         // The pointer is gone — a stale position must not be
                         // used to wrongly classify a later event.
                         state.last_cursor_pos = None;
+                        // Task 121 spike: reset the edge-detect latch too —
+                        // a stale "not needed" from before the pointer left
+                        // must not suppress the first `CursorMoved` after it
+                        // re-enters (at a possibly unrelated position).
+                        state.pointer_motion_needed_last = true;
                         // Unconditional (matches `is_unconditional_chrome_input`).
                         state.chrome_input_pending = true;
                     }
@@ -657,7 +804,7 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                         "matches! guard above restricts event to the five pointer variants"
                     ),
                 }
-                if response.repaint {
+                if schedule_repaint {
                     let deadline = Instant::now() + MIN_REPAINT_INTERVAL;
                     state.repaint_at = Some(
                         state
@@ -962,8 +1109,36 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                 // from zero-delay requests (hover state, tooltip updates).
                 // This ensures layout-settling frames still fire while keeping
                 // idle CPU near zero.
-                if frame_output.repaint_delay < std::time::Duration::from_hours(1) {
-                    let deadline = Instant::now() + clamp_repaint_delay(frame_output.repaint_delay);
+                // Task 121 SPIKE: egui re-arms the frame schedule from inside
+                // the frame. `InputState::wants_repaint_after` returns
+                // `Duration::ZERO` whenever `!events.is_empty()`, and the
+                // pointer events we deliberately suppressed are still in that
+                // queue (they must be — egui's pointer state has to stay
+                // fresh). So egui asks for an immediate repaint, we floor it
+                // to 16ms, and the loop sustains ~60fps even though every one
+                // of those events was classified as needing no frame.
+                //
+                // When the ONLY thing that happened since the last frame was
+                // suppressed pointer motion, substitute the app's own
+                // requested delay (e.g. the 500ms cursor blink) for egui's
+                // zero. This overrides egui's judgement, but on OUR evidence
+                // (we classified the events) rather than by pattern-matching
+                // egui internals.
+                // NOTE for future refactors: this `mem::take` deliberately sits
+                // AFTER the `make_current` and window-lookup early-returns
+                // above. If we bail before this point the flag is simply left
+                // set for the next successful pass, which is correct — do not
+                // move it earlier without re-checking that.
+                let suppressed_only =
+                    std::mem::take(&mut state.suppressed_pointer_since_last_frame);
+                let effective_delay = effective_repaint_delay(
+                    suppressed_only,
+                    frame_output.repaint_delay,
+                    frame_output.app_requested_delay,
+                );
+
+                if effective_delay < std::time::Duration::from_hours(1) {
+                    let deadline = Instant::now() + clamp_repaint_delay(effective_delay);
                     state.repaint_at = Some(deadline);
                 }
 
@@ -1225,10 +1400,12 @@ pub fn run(config: WindowConfig, app: impl App + 'static) -> Result<(), Error> {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::{
-        MIN_REPAINT_INTERVAL, ViewportCommandFlags, clamp_repaint_delay, is_blocked_key,
+        MIN_REPAINT_INTERVAL, SUPPRESSED_POINTER_FALLBACK_DELAY, ViewportCommandFlags,
+        clamp_repaint_delay, effective_repaint_delay, is_blocked_key,
         is_unconditional_chrome_input, logical_coord_to_i32, logical_dim_to_u32,
         physical_to_logical_pos, should_force_chrome_full_for_pointer,
-        should_set_chrome_input_pending, update_chrome_drag_latch, viewport_command_flags,
+        should_schedule_cursor_moved, should_set_chrome_input_pending, update_chrome_drag_latch,
+        viewport_command_flags,
     };
     use winit::event::{DeviceId, WindowEvent};
     use winit::keyboard::KeyCode;
@@ -1577,6 +1754,112 @@ mod tests {
         assert_eq!(
             update_chrome_drag_latch(0, winit::event::ElementState::Released, Some(true)),
             0
+        );
+    }
+
+    // ── Task 121 spike: `should_schedule_cursor_moved` ───────────────────
+
+    #[test]
+    fn should_schedule_cursor_moved_latched_forces_true_regardless_of_app_opinion() {
+        // A chrome-border drag in progress must keep repainting even if the
+        // app says this position no longer needs one, and even if the
+        // previous event also said "not needed".
+        assert!(should_schedule_cursor_moved(true, false, false));
+        assert!(should_schedule_cursor_moved(true, true, true));
+    }
+
+    #[test]
+    fn should_schedule_cursor_moved_steady_needed_schedules() {
+        // Both this event and the last agree a repaint is needed (e.g.
+        // hovering over chrome, or an active selection drag) -> schedule.
+        assert!(should_schedule_cursor_moved(false, true, true));
+    }
+
+    #[test]
+    fn should_schedule_cursor_moved_steady_not_needed_suppresses() {
+        // Two consecutive "not needed" events (steady motion over static
+        // terminal content) -> suppress. This is the headline Task 121 case.
+        assert!(!should_schedule_cursor_moved(false, false, false));
+    }
+
+    #[test]
+    fn should_schedule_cursor_moved_needed_to_not_needed_transition_still_schedules_once() {
+        // Edge detect: the LAST event needed a repaint, THIS event does not
+        // (e.g. the pointer just left a hover-sensitive region) -> this
+        // transition frame still schedules, so stale chrome (a hover tint)
+        // is repainted one final time before suppression begins.
+        assert!(should_schedule_cursor_moved(false, true, false));
+    }
+
+    #[test]
+    fn should_schedule_cursor_moved_not_needed_to_needed_transition_schedules() {
+        // The reverse transition schedules via `current_needed` alone.
+        assert!(should_schedule_cursor_moved(false, false, true));
+    }
+
+    // ── Task 121 spike: `effective_repaint_delay` (liveness-critical) ────
+    //
+    // This is the substitution that breaks egui's self-sustaining ~60fps
+    // re-arm loop. It is the highest-risk logic in the spike, so every branch
+    // is pinned here — especially the fallback, because getting that wrong
+    // stalls the window instead of merely wasting a frame.
+
+    const MS16: std::time::Duration = std::time::Duration::from_millis(16);
+    const MS500: std::time::Duration = std::time::Duration::from_millis(500);
+
+    #[test]
+    fn effective_repaint_delay_substitutes_app_delay_when_suppressed_and_egui_wants_immediate() {
+        // The headline case: egui asked for an immediate repaint purely because
+        // suppressed pointer events sit in its queue; the app only wants a
+        // 500ms blink wake. Without the substitution this is a 16ms-floored
+        // frame, i.e. ~60fps for zero visible change.
+        assert_eq!(
+            effective_repaint_delay(true, std::time::Duration::ZERO, Some(MS500)),
+            MS500
+        );
+    }
+
+    #[test]
+    fn effective_repaint_delay_falls_back_to_bounded_delay_when_app_wants_nothing() {
+        // Cursor hidden via DECTCEM (btop/vim): the app requests no delay at
+        // all. Must NOT become `Duration::MAX`/no-schedule — that stalls the
+        // window until an unrelated event arrives.
+        let got = effective_repaint_delay(true, std::time::Duration::ZERO, None);
+        assert_eq!(got, SUPPRESSED_POINTER_FALLBACK_DELAY);
+        assert!(
+            got < std::time::Duration::from_secs(1),
+            "fallback must be a bounded wake, got {got:?}"
+        );
+    }
+
+    #[test]
+    fn effective_repaint_delay_passes_egui_delay_through_when_not_suppressed() {
+        // Nothing was suppressed, so egui's request is authoritative even when
+        // it is zero — a real interaction needs the immediate frame.
+        assert_eq!(
+            effective_repaint_delay(false, std::time::Duration::ZERO, Some(MS500)),
+            std::time::Duration::ZERO
+        );
+        assert_eq!(effective_repaint_delay(false, MS16, Some(MS500)), MS16);
+    }
+
+    #[test]
+    fn effective_repaint_delay_never_overrides_a_nonzero_egui_request() {
+        // Suppression only ever reinterprets a ZERO delay. A non-zero egui
+        // request is a genuine animation/timer cadence and must survive, or we
+        // would stutter egui-driven animations.
+        assert_eq!(effective_repaint_delay(true, MS16, Some(MS500)), MS16);
+        assert_eq!(effective_repaint_delay(true, MS16, None), MS16);
+    }
+
+    #[test]
+    fn effective_repaint_delay_preserves_max_when_not_suppressed() {
+        // `Duration::MAX` means "egui needs no further frame". It must pass
+        // through untouched so the caller's `< 1 hour` check still parks the
+        // window correctly.
+        assert_eq!(
+            effective_repaint_delay(false, std::time::Duration::MAX, None),
+            std::time::Duration::MAX
         );
     }
 

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -173,6 +173,50 @@ const fn is_unconditional_chrome_input(event: &WindowEvent) -> bool {
     )
 }
 
+/// #436.4b §3.2 chrome-input gate decision for the general (non-pointer)
+/// `window_event` path: should `event` force `WindowState::chrome_input_pending`
+/// for the frame it arrives in, given whether `egui-winit`'s
+/// `on_window_event` reported `repaint` for it?
+///
+/// This is `is_unconditional_chrome_input(event) || repaint` — EXCEPT for
+/// `WindowEvent::RedrawRequested`, which always returns `false` here
+/// regardless of `repaint`. That carve-out is load-bearing, not an
+/// oversight — it is the fix for the #436-chrome-cache-inert bug (`Replay`
+/// measured 0/360 frames at idle) and must not be "simplified" away:
+///
+/// - `egui-winit` 0.35.0's `on_window_event` groups `RedrawRequested` into a
+///   match arm commented "Things that may require repaint:" and returns
+///   `EventResponse { repaint: true, .. }` for it *unconditionally*
+///   (`egui-winit-0.35.0/src/lib.rs:492-500`).
+/// - `RedrawRequested` is the event that drives every single frame — see
+///   this module's `window_event`'s `RedrawRequested` arm, which reads the
+///   gate this function feeds via
+///   `std::mem::take(&mut state.chrome_input_pending)`, roughly 110 lines
+///   after the call site that uses this function, in the *same*
+///   `window_event` invocation.
+/// - Without the carve-out, `repaint == true` on `RedrawRequested` would set
+///   `chrome_input_pending` on every frame, which `RedrawRequested`'s own
+///   arm would then immediately read back as `true` — permanently
+///   disqualifying `ChromeMode::Replay` regardless of any real input. This
+///   is exactly the bug: the event that drives the frame set the flag that
+///   disqualifies the frame.
+/// - `RedrawRequested` is not user input, so excluding it from the gate is
+///   correct on its own terms, not just a workaround.
+///
+/// Do NOT broaden this carve-out to other members of egui-winit's grouped
+/// arm: `CursorEntered`/`CursorLeft` are genuine input and already covered
+/// by `is_unconditional_chrome_input`; `Resized`/`Occluded` legitimately
+/// affect chrome; `Destroyed`/`CloseRequested`/`Moved`/`TouchpadPressure`
+/// are rare and harmless if they do force a frame `Full`. `RedrawRequested`
+/// is the only member of that arm that fires every frame, which is what
+/// makes it uniquely disqualifying.
+const fn should_set_chrome_input_pending(event: &WindowEvent, repaint: bool) -> bool {
+    if matches!(event, WindowEvent::RedrawRequested) {
+        return false;
+    }
+    is_unconditional_chrome_input(event) || repaint
+}
+
 /// Convert a winit physical cursor position to egui logical points (lossy
 /// `f64` -> `f32` narrowing via `conv2`'s default approximation, matching the
 /// `window.scale_factor().approx_as::<f32>()` conversion in
@@ -734,7 +778,14 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
             // doesn't enumerate) forces `ChromeMode::Full` for the frame this
             // event is delivered in. Pointer events never reach this arm —
             // they're handled, region-tested, in the fast path above (#436.8).
-            if is_unconditional_chrome_input(&event) || response.repaint {
+            //
+            // `RedrawRequested` is carved out of the `repaint` half of this
+            // decision — see `should_set_chrome_input_pending`'s doc for why
+            // this is required (egui-winit reports `repaint: true`
+            // unconditionally for it, and it's the event that drives every
+            // frame, so treating it as chrome input here would permanently
+            // disqualify `ChromeMode::Replay`).
+            if should_set_chrome_input_pending(&event, response.repaint) {
                 state.chrome_input_pending = true;
             }
 
@@ -1176,8 +1227,8 @@ mod tests {
     use super::{
         MIN_REPAINT_INTERVAL, ViewportCommandFlags, clamp_repaint_delay, is_blocked_key,
         is_unconditional_chrome_input, logical_coord_to_i32, logical_dim_to_u32,
-        physical_to_logical_pos, should_force_chrome_full_for_pointer, update_chrome_drag_latch,
-        viewport_command_flags,
+        physical_to_logical_pos, should_force_chrome_full_for_pointer,
+        should_set_chrome_input_pending, update_chrome_drag_latch, viewport_command_flags,
     };
     use winit::event::{DeviceId, WindowEvent};
     use winit::keyboard::KeyCode;
@@ -1418,6 +1469,52 @@ mod tests {
             &WindowEvent::HoveredFileCancelled
         ));
         assert!(!is_unconditional_chrome_input(&WindowEvent::Occluded(true)));
+    }
+
+    /// The bug (0/360 `Replay` frames at idle): `RedrawRequested` drives
+    /// every frame, and egui-winit 0.35.0 reports `repaint: true` for it
+    /// unconditionally, so before the fix `is_unconditional_chrome_input(event)
+    /// || repaint` was always `true` on the exact event whose arm reads the
+    /// gate back a moment later — permanently disqualifying `Replay`.
+    /// `should_set_chrome_input_pending` must return `false` for
+    /// `RedrawRequested` regardless of the `repaint` value egui-winit
+    /// reports.
+    #[test]
+    fn should_set_chrome_input_pending_excludes_redraw_requested_regardless_of_repaint() {
+        assert!(!should_set_chrome_input_pending(
+            &WindowEvent::RedrawRequested,
+            true
+        ));
+        assert!(!should_set_chrome_input_pending(
+            &WindowEvent::RedrawRequested,
+            false
+        ));
+    }
+
+    /// A representative `is_unconditional_chrome_input` event (keyboard
+    /// modifiers) must still set the gate through this wrapper, with or
+    /// without `repaint` — the carve-out is specific to `RedrawRequested`,
+    /// not a general weakening of the gate.
+    #[test]
+    fn should_set_chrome_input_pending_covers_unconditional_chrome_input_events() {
+        let event = WindowEvent::ModifiersChanged(winit::event::Modifiers::default());
+        assert!(should_set_chrome_input_pending(&event, false));
+        assert!(should_set_chrome_input_pending(&event, true));
+    }
+
+    /// Proves the `RedrawRequested` carve-out doesn't silently undermine the
+    /// reason `response.repaint` is consulted at all — an event kind NOT in
+    /// `is_unconditional_chrome_input`'s enumeration (e.g. `Occluded`) must
+    /// still set the gate when egui-winit reports `repaint: true` for it. If
+    /// this regressed to "always false unless enumerated", A12's
+    /// completeness guarantee (`repaint` as a safety net for un-enumerated
+    /// event kinds) would be silently lost.
+    #[test]
+    fn should_set_chrome_input_pending_still_honors_repaint_for_non_enumerated_events() {
+        let event = WindowEvent::Occluded(true);
+        assert!(!is_unconditional_chrome_input(&event));
+        assert!(should_set_chrome_input_pending(&event, true));
+        assert!(!should_set_chrome_input_pending(&event, false));
     }
 
     // ── #436.8 region-aware pointer gate: pure helpers ───────────────────

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -739,14 +739,6 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                             app_says_needed,
                         );
 
-                        // Task 121 spike: remember that we suppressed, so the
-                        // next frame can tell egui's "immediate repaint"
-                        // (which it derives purely from its non-empty event
-                        // queue) apart from a genuine egui-side need.
-                        if !schedule_repaint {
-                            state.suppressed_pointer_since_last_frame = true;
-                        }
-
                         #[cfg(feature = "frame-profiling")]
                         if schedule_repaint {
                             state.egui.record_pointer_frame_scheduled();
@@ -804,6 +796,21 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                         "matches! guard above restricts event to the five pointer variants"
                     ),
                 }
+
+                // Task 121 spike: `suppressed_pointer_since_last_frame` must
+                // mean "the ONLY input since the last frame was pointer
+                // motion we classified as needing no frame". So ANY event
+                // that genuinely schedules — a click, a wheel tick, a
+                // pointer enter/leave, or a `CursorMoved` the app said
+                // mattered — invalidates that premise and clears the flag.
+                //
+                // Without this, a suppressed motion followed by a click
+                // would leave the flag set when the click's own frame runs,
+                // and the `RedrawRequested` override would then substitute
+                // the app's long delay for the immediate follow-up frame the
+                // click legitimately needed.
+                state.suppressed_pointer_since_last_frame = !schedule_repaint;
+
                 if schedule_repaint {
                     let deadline = Instant::now() + MIN_REPAINT_INTERVAL;
                     state.repaint_at = Some(
@@ -860,6 +867,9 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                     {
                         state.egui.inject_paste(text);
                         state.repaint_at = Some(Instant::now());
+                        // Real input scheduled a frame — see the pointer fast
+                        // path for why this invalidates the suppression premise.
+                        state.suppressed_pointer_since_last_frame = false;
                         // A keyboard event, and it just mutated pane content
                         // via a paste — a potential-chrome-input (#436.4b §3.2).
                         state.chrome_input_pending = true;
@@ -905,6 +915,9 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                 self.app
                     .on_raw_key_event(WindowId(winit_id), raw_event, raw_mods);
                 state.repaint_at = Some(Instant::now());
+                // Real input scheduled a frame — see the pointer fast path for
+                // why this invalidates the suppression premise.
+                state.suppressed_pointer_since_last_frame = false;
                 // A keyboard event, routed straight to the app — a
                 // potential-chrome-input (#436.4b §3.2).
                 state.chrome_input_pending = true;
@@ -934,6 +947,20 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
             // disqualify `ChromeMode::Replay`).
             if should_set_chrome_input_pending(&event, response.repaint) {
                 state.chrome_input_pending = true;
+            }
+
+            // Real input that schedules a frame invalidates the suppression
+            // premise — see the pointer fast path for why.
+            //
+            // `RedrawRequested` MUST be excluded, for the same structural
+            // reason it is excluded from the chrome-input gate
+            // (`should_set_chrome_input_pending`): this general path runs
+            // BEFORE the `match` below, and `egui-winit` reports
+            // `repaint: true` for `RedrawRequested`. Clearing the flag here
+            // would therefore wipe it moments before the `RedrawRequested`
+            // arm `mem::take`s it, so the override could never fire at all.
+            if !matches!(event, WindowEvent::RedrawRequested) {
+                state.suppressed_pointer_since_last_frame = false;
             }
 
             if response.repaint {

--- a/freminal-windowing/src/lib.rs
+++ b/freminal-windowing/src/lib.rs
@@ -333,6 +333,29 @@ pub trait App {
         true
     }
 
+    /// Task 121 spike (issue: pointer motion over static terminal content
+    /// measured at 58fps vs. 1.95fps idle, 95% of those frames changing zero
+    /// pixels): should THIS `CursorMoved` event schedule a repaint?
+    ///
+    /// `egui-winit` 0.35's `on_window_event` reports `repaint: true`
+    /// unconditionally for `WindowEvent::CursorMoved` — the windowing layer
+    /// cannot distinguish "pointer moved, something might have changed" from
+    /// "pointer moved, nothing on screen changed" using egui's own signal
+    /// alone. This hook lets the app answer that question using state only
+    /// the app has (pane geometry, selection state, mouse-tracking mode,
+    /// open overlays).
+    ///
+    /// Default `true` — conservative: an app that has not wired this up
+    /// keeps the pre-Task-121 "every pointer motion schedules a repaint"
+    /// behavior exactly. This is purely a repaint-SCHEDULING gate (whether
+    /// `event_loop` calls `window.request_redraw()` for this event at all);
+    /// it does not affect `is_chrome_interactive_at`'s separate
+    /// chrome-damage axis, and `MouseInput`/`MouseWheel`/`CursorEntered`/
+    /// `CursorLeft` are deliberately NOT gated by this — only `CursorMoved`.
+    fn pointer_motion_needs_repaint(&self, _window_id: WindowId, _pos: egui::Pos2) -> bool {
+        true
+    }
+
     /// Hook to modify raw input before egui processes it.
     ///
     /// Default implementation does nothing.

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -2894,6 +2894,26 @@ impl freminal_windowing::App for FreminalGui {
                 foreground_overlay_open,
             };
 
+            // Task 121 frame-profiling harness follow-up (issue #459/#461
+            // gate-blocker investigation): count which individual §3.3
+            // signal(s) fired this frame, indexed identically to
+            // `ChromeSignals::named_fields()`'s exhaustive destructure (see
+            // that method's doc for why a future 16th field cannot be
+            // silently missed here). More than one signal can fire the same
+            // frame; every one that did gets counted, not just the first.
+            #[cfg(feature = "frame-profiling")]
+            for (i, (_, fired)) in win
+                .pending_chrome_signals
+                .named_fields()
+                .into_iter()
+                .enumerate()
+            {
+                if fired {
+                    win.frame_stats.chrome_signal_fired_counts[i] =
+                        win.frame_stats.chrome_signal_fired_counts[i].saturating_add(1);
+                }
+            }
+
             // ── Window-level post-processing pass ────────────────────
             //
             // When a user GLSL shader is active, the window FBO now contains
@@ -3552,13 +3572,30 @@ impl freminal_windowing::App for FreminalGui {
                         stats.frames_drawn
                     )
                     .as_micros(),
+                    // Gate-blocker investigation (issue #459/#461 follow-up):
+                    // which individual §3.3 `ChromeSignals` field(s) fired,
+                    // cumulative since window creation, name=count joined --
+                    // only the non-zero entries (see
+                    // `format_nonzero_signal_counts`'s doc for why: 15
+                    // separate structured fields would be unreadable on the
+                    // common case where only 1-2 signals ever fire, e.g. an
+                    // idle blinking cursor should show "none" here every
+                    // flush once past warm-up).
+                    chrome_signals_fired = %super::window::FrameStats::format_nonzero_signal_counts(
+                        &chrome_damage::ChromeSignals::default()
+                            .named_fields()
+                            .map(|(name, _)| name),
+                        &stats.chrome_signal_fired_counts
+                    ),
                     "app-side frame-profiling stats (task 121 harness): chrome-mode \
-                     duty cycle, zero-pixel-change-but-presented frames, and the \
+                     duty cycle, zero-pixel-change-but-presented frames, the \
                      freminal-owned phase_app_update/phase_orchestration/phase_panes \
                      wall-clock split (phase_app_update = the whole productive body of \
                      update(); phase_orchestration = central_body total minus the \
-                     per-pane show() contribution) over frames_drawn drawn frames for \
-                     this window_id"
+                     per-pane show() contribution), and which individual §3.3 \
+                     ChromeSignals field(s) fired (chrome_signals_fired, cumulative, \
+                     non-zero entries only) over frames_drawn drawn frames for this \
+                     window_id"
                 );
             }
         }

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -112,6 +112,200 @@ const fn pointer_forces_full_present(
     pointer_moving && (pointer_over_chrome || border_drag_active)
 }
 
+/// Task 121 pointer-motion repaint-gate spike: per-pane signals feeding
+/// [`pointer_motion_needs_repaint_decision`], for whichever pane (if any) is
+/// under the pointer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PointerMotionPaneSignals {
+    /// The pane's terminal application has requested mouse reporting
+    /// (`TerminalSnapshot::mouse_tracking != MouseTrack::NoTracking`) — if
+    /// it is receiving mouse reports, motion must always be forwarded, so a
+    /// repaint is always needed.
+    mouse_tracking_active: bool,
+    /// See [`pane_hover_region_risk`]'s doc: a coarse, pane-level (not
+    /// pixel-precise) approximation of "this pane may have a hover-sensitive
+    /// band region (URL, command-block gutter, or scrollbar) this frame".
+    hover_region_risk: bool,
+}
+
+/// Task 121 spike (residual-risk approximation — see the doc on
+/// `App::pointer_motion_needs_repaint`'s freminal-side implementation for
+/// the full writeup): may this pane have a hover-sensitive band region that
+/// pointer motion anywhere in the pane could affect?
+///
+/// This is deliberately **pane-level, not pixel/cell-precise**: the exact
+/// strip/thumb geometry (gutter width, scrollbar track rect, per-cell
+/// hyperlink spans) is computed inside the per-frame render pass using
+/// `pixels_per_point` and the live `terminal_rect`/`gutter_rect` split
+/// (`terminal/widget.rs`), neither of which is available at the
+/// `pointer_motion_needs_repaint` call site (outside a frame, before
+/// `pixels_per_point` for a possible new frame is known). Rather than
+/// guess at that geometry, this function treats each of the three
+/// hover-sensitive band regions as risking the WHOLE pane whenever its
+/// cheap, always-available precondition holds:
+///   - `has_urls`: the pane's visible content contains at least one
+///     hyperlink anywhere (`TerminalSnapshot::has_urls`) — approximates
+///     "pointer motion might enter/leave a URL span" as "pointer motion
+///     anywhere in this pane", since the precise cell-to-hyperlink hit test
+///     (`flat_index_for_cell` + `url_tag_indices` lookup in
+///     `terminal/widget.rs`) is render-pass-only state.
+///   - `scroll_offset > 0`: the scrollbar is only rendered/interactive when
+///     scrolled back (`handle_scrollbar`'s own gate) — approximates "over
+///     the scrollbar track" as "anywhere in this pane while scrolled back".
+///   - `gutter_config_active && !is_alternate_screen && command_blocks_non_empty
+///     && pointer_in_gutter_strip`:
+///     the command-block gutter strip is only meaningful when the feature is
+///     on, the pane has at least one block, and the alternate screen (which
+///     never shows the gutter) is not active — AND, unlike the other two
+///     terms, this one IS pixel-precise: `pointer_in_gutter_strip` is a real
+///     `pos.x` test against the pane's left-edge gutter strip (see the doc
+///     on `App::pointer_motion_needs_repaint`'s `gutter_width_upper_bound_logical`
+///     for how that test is computed without needing `pixels_per_point` at
+///     this call site). This term was measured (Task 121 spike) to fire on
+///     100% of pointer-motion checks in any session with auto-detected
+///     command blocks before the positional test was added — the whole pane
+///     was being treated as gutter-hover-sensitive.
+///
+/// Pure, so directly unit-testable without constructing a `Pane`/snapshot.
+// Each bool is an independent, unrelated precondition for one of the three
+// hover-sensitive band regions (URL, scrollbar, gutter) -- not a state
+// machine; bundling them into an enum would not express any real combined
+// state and would only obscure the call site (mirrors the existing allow on
+// `terminal/widget.rs`'s `show`).
+#[allow(clippy::fn_params_excessive_bools)]
+const fn pane_hover_region_risk(
+    has_urls: bool,
+    scroll_offset: usize,
+    is_alternate_screen: bool,
+    command_blocks_non_empty: bool,
+    gutter_config_active: bool,
+    pointer_in_gutter_strip: bool,
+) -> bool {
+    let (has_urls, scroll_offset_nonzero, gutter_active) = pane_hover_region_terms(
+        has_urls,
+        scroll_offset,
+        is_alternate_screen,
+        command_blocks_non_empty,
+        gutter_config_active,
+        pointer_in_gutter_strip,
+    );
+    has_urls || scroll_offset_nonzero || gutter_active
+}
+
+/// Task 121 diagnostic: the three independent preconditions
+/// [`pane_hover_region_risk`] ORs together, exposed separately so a caller
+/// can count which one(s) actually fired rather than only the aggregate
+/// (see `FreminalGui::pointer_motion_needs_repaint`'s
+/// `#[cfg(feature = "frame-profiling")]` recording block). `pane_hover_region_risk`
+/// itself calls this and ORs the three results, so the two functions can
+/// never disagree about what "hover region risk" means — this is a pure
+/// refactor of that function's body, not a second, independently-maintained
+/// copy of its logic.
+///
+/// Returns `(has_urls, scroll_offset_nonzero, gutter_active)`. See
+/// `pane_hover_region_risk`'s doc for what each term approximates. Pure, so
+/// directly unit-testable.
+///
+/// `pointer_in_gutter_strip` is the positional term (Task 121 fix): `true`
+/// when the pointer's x-coordinate falls within the gutter's left-edge
+/// strip for this pane. Passing `true` unconditionally reproduces the
+/// pre-fix pane-wide approximation; real callers pass a real rect test —
+/// see `App::pointer_motion_needs_repaint`.
+// Same rationale as `pane_hover_region_risk`'s matching allow: six
+// independent, unrelated preconditions, not a state machine.
+#[allow(clippy::fn_params_excessive_bools)]
+const fn pane_hover_region_terms(
+    has_urls: bool,
+    scroll_offset: usize,
+    is_alternate_screen: bool,
+    command_blocks_non_empty: bool,
+    gutter_config_active: bool,
+    pointer_in_gutter_strip: bool,
+) -> (bool, bool, bool) {
+    (
+        has_urls,
+        scroll_offset > 0,
+        gutter_config_active
+            && !is_alternate_screen
+            && command_blocks_non_empty
+            && pointer_in_gutter_strip,
+    )
+}
+
+/// Task 121 fix: is `pos_x` within the pane's left-edge gutter strip?
+///
+/// The strip runs from `pane_rect_min_x` (the pane's left edge) to
+/// `pane_rect_min_x + gutter_width_upper_bound_logical`, using `<` (NOT
+/// `<=`) at the far edge: the boundary pixel itself counts as OUTSIDE the
+/// strip. This matters only when `pixels_per_point == 1.0` exactly, the one
+/// case where `gutter_width_upper_bound_logical` (a physical-pixel value
+/// used directly, see `App::pointer_motion_needs_repaint`'s doc) equals the
+/// real logical strip width rather than over-estimating it; at any other
+/// `ppp`, the real strip's own right edge falls strictly inside this
+/// (wider) bound, so the exact `<` vs `<=` choice at `ppp == 1.0`'s single
+/// boundary pixel is a one-pixel edge case with no practical effect on the
+/// suppression this fix restores.
+///
+/// Also `false` when `pos_x` is left of the pane entirely (`pos_x <
+/// pane_rect_min_x`) — relevant for multi-pane layouts where a pane's left
+/// edge is not at window x=0.
+///
+/// Pure, so directly unit-testable without a live pane/rect.
+const fn pointer_in_gutter_strip(
+    pos_x: f32,
+    pane_rect_min_x: f32,
+    gutter_width_upper_bound_logical: f32,
+) -> bool {
+    pos_x >= pane_rect_min_x && pos_x < pane_rect_min_x + gutter_width_upper_bound_logical
+}
+
+/// Task 121 pointer-motion repaint-gate spike: the composed decision behind
+/// `App::pointer_motion_needs_repaint`'s freminal-side implementation.
+/// Extracted as a pure function over already-computed signals so it is
+/// unit-testable without a live `FreminalGui`/windowing stack (a full
+/// `FreminalGui`/`PerWindowState` cannot be constructed headlessly —
+/// `freminal_windowing::WindowId` has no public constructor outside the real
+/// winit event loop).
+///
+/// Returns `true` (a repaint is needed) if ANY of:
+///   - `chrome_interactive`: `App::is_chrome_interactive_at` said so (menu
+///     bar, tab bar, split-border drag sensor).
+///   - `any_pane_selecting`: some pane in the active tab has an
+///     in-progress selection drag (`ViewState::selection.is_selecting`).
+///   - `overlay_open`: some UI overlay/popup/tooltip/context menu is open
+///     this window.
+///   - `pointer_pane_unresolved`: the pane under the pointer could not be
+///     determined at all (no FULL frame has rendered yet, so there is no
+///     cached pane layout to hit-test against) — conservative "unknown".
+///   - `pane_signals` resolved to `Some` (a specific pane is under the
+///     pointer) AND that pane's `mouse_tracking_active` or
+///     `hover_region_risk` (see [`pane_hover_region_risk`]) is `true`.
+///
+/// When `pane_signals` is `None` because the pointer is simply not over any
+/// pane (e.g. over inter-pane padding not covered by a chrome-border
+/// sensor), that is NOT `pointer_pane_unresolved` — it is a legitimate "no
+/// pane, so no pane-specific signal applies" case, contributing `false`.
+// Each bool is an independent, unrelated forcing condition (chrome
+// interactivity, selection drag, overlay presence, pane-resolution
+// failure) -- not a state machine; see `pane_hover_region_risk`'s matching
+// allow for the same rationale.
+#[allow(clippy::fn_params_excessive_bools)]
+const fn pointer_motion_needs_repaint_decision(
+    chrome_interactive: bool,
+    any_pane_selecting: bool,
+    overlay_open: bool,
+    pointer_pane_unresolved: bool,
+    pane_signals: Option<PointerMotionPaneSignals>,
+) -> bool {
+    if chrome_interactive || any_pane_selecting || overlay_open || pointer_pane_unresolved {
+        return true;
+    }
+    match pane_signals {
+        Some(s) => s.mouse_tracking_active || s.hover_region_risk,
+        None => false,
+    }
+}
+
 impl freminal_windowing::App for FreminalGui {
     /// Called when a window is created.
     ///
@@ -544,6 +738,242 @@ impl freminal_windowing::App for FreminalGui {
                 &win.chrome_border_rects,
             )
         })
+    }
+
+    /// Task 121 pointer-motion repaint-gate spike: wires real per-window/
+    /// per-pane state into [`pointer_motion_needs_repaint_decision`]. See
+    /// that function's doc for the exact forcing conditions, and
+    /// [`pane_hover_region_risk`]'s doc for the residual-risk approximation
+    /// used for URL/gutter/scrollbar hover regions.
+    ///
+    /// Reuses `win.pending_chrome_signals.any_overlay_open`/
+    /// `foreground_overlay_open` — the persisted #436 §3.3 signals from the
+    /// most recently rendered frame — for the "any overlay/popup/tooltip/
+    /// context menu is open" bullet, rather than recomputing the
+    /// `ui_overlay_open`/`foreground_overlay_open` scans (`update()`'s
+    /// `CentralPanel` closure, around `app_impl.rs` lines 1841 and
+    /// 2708-2733): this method runs OUTSIDE any frame (from `event_loop`'s
+    /// `CursorMoved` handling), where that scan's inputs (menu state,
+    /// dialog `Ui`s, etc.) are not in scope.
+    ///
+    /// ## Gutter positional test (Task 121 fix)
+    ///
+    /// The pane-level `gutter_active` term used to be pane-wide
+    /// (`gutter_config_active && !alt_screen && !command_blocks.is_empty()`),
+    /// which measured at 100% fired on every pointer-motion check in any
+    /// session with auto-detected command blocks (Task 121 spike), making
+    /// suppression a no-op. The gutter is actually a narrow strip on the
+    /// pane's LEFT edge (`terminal/widget.rs`'s `gutter_rect`, built from
+    /// `pane_rect.min.x .. pane_rect.min.x + gutter.width_px() / ppp`), so
+    /// this method now also tests `pos.x` against that strip using the
+    /// SAME pane rect this method already resolves for pane hit-testing
+    /// (`layout`, below) — no separate rect computation.
+    ///
+    /// `pixels_per_point` (`ppp`) is not available at this call site (it is
+    /// only known once egui begins a frame; this method runs from
+    /// `event_loop`'s `CursorMoved` handling, outside any frame), and
+    /// `PerWindowState` does not cache it — adding that cache purely for
+    /// this one comparison would be new per-frame machinery for a single
+    /// read. Instead this uses `gutter.width_px()` (physical pixels)
+    /// DIRECTLY as an upper bound on the logical strip width
+    /// `width_px / ppp`: since `ppp >= 1.0` on every realistic display,
+    /// `width_px / ppp <= width_px`, so testing `pos.x < pane_rect.min.x +
+    /// width_px` only ever widens the strip relative to the real
+    /// (smaller-or-equal) one — it can cause the gutter term to fire when
+    /// the real strip would not have (false positive => an unnecessary
+    /// repaint, never a missed one), which is the safe direction for a
+    /// repaint gate.
+    // The pane-resolution chain (layout -> hit-test -> snapshot load ->
+    // signal computation), the `#[cfg(feature = "frame-profiling")]`
+    // diagnostic recording interleaved with it (so the diagnostic can
+    // never drift from the real computation, see the comments inline),
+    // and the gutter positional test together exceed the line budget;
+    // splitting the diagnostic block out would either duplicate the
+    // pane-resolution logic or require threading its intermediate values
+    // back out through a wider return type, both worse than the length.
+    #[allow(clippy::too_many_lines)]
+    fn pointer_motion_needs_repaint(&self, window_id: WindowId, pos: egui::Pos2) -> bool {
+        let Some(win) = self.windows.get(&window_id) else {
+            // Unknown window -> conservative (mirrors `is_chrome_interactive_at`).
+            return true;
+        };
+
+        let chrome_interactive = self.is_chrome_interactive_at(window_id, pos);
+        // Animation-in-flight terms. The rest of this predicate is *positional*
+        // ("does the pointer's current position matter?"), which is structurally
+        // blind to "something is mid-animation somewhere in this window,
+        // regardless of where the pointer is". Toasts and the resize-overlay HUD
+        // both animate every frame independent of pointer position and drive
+        // their own ~16ms repaint requests; without these terms, wandering the
+        // pointer over plain terminal content during a toast fade would let the
+        // `RedrawRequested` override substitute the app's much longer delay for
+        // the animation's cadence, making the fade visibly step instead of
+        // animate. Bounded (<=500ms) rather than a freeze, but a real visual
+        // regression reachable from an already-shipped feature.
+        //
+        // `try_borrow` failing means someone up-stack holds the `RefCell`; treat
+        // that as "toasts may be active" (conservative), never as "no toasts".
+        let animation_in_flight = win.resize_overlay.is_some()
+            || self
+                .toasts
+                .try_borrow()
+                .map_or(true, |stack| !stack.is_empty());
+        let overlay_open = win.pending_chrome_signals.any_overlay_open
+            || win.pending_chrome_signals.foreground_overlay_open
+            || animation_in_flight;
+
+        let active_tab = win.tabs.active_tab();
+        // `PaneError::InvalidState` (empty tree) is a bug state that should
+        // never happen in normal operation -- conservative true on `Err`.
+        let any_selecting = active_tab.pane_tree.iter_panes().map_or(true, |panes| {
+            panes
+                .iter()
+                .any(|pane| pane.view_state.selection.is_selecting)
+        });
+
+        let pointer_pane_unresolved = win.cached_central_rect.is_none();
+
+        let gutter_config_active = self.config.command_blocks.enabled
+            && self.config.command_blocks.gutter != freminal_common::config::GutterPosition::Off;
+
+        // Task 121 diagnostic (defect: which repaint-gate condition(s)
+        // fire, and how often -- see `super::window::PointerMotionConditionFlags`'s
+        // doc): the pane-level sub-terms recorded below, filled in from
+        // inside the `.map()` closure just below (the only place `snap`,
+        // and therefore the individual `pane_hover_region_terms` inputs,
+        // are in scope) when a pane resolves under the pointer. Stays
+        // `None` when no pane resolves -- diagnostically equivalent to
+        // `pane_signals: None`, i.e. all four pane-level counters simply
+        // don't fire for this call.
+        #[cfg(feature = "frame-profiling")]
+        let mut pane_diag_terms: Option<(bool, bool, bool, bool)> = None;
+
+        // Physical-pixel gutter strip width used directly as a conservative
+        // upper bound on the logical strip width (`width_px / ppp`) — see
+        // this method's doc for why `ppp` is unavailable here and why the
+        // over-estimate is safe.
+        let gutter_width_upper_bound_logical = self.config.command_blocks.gutter.width_px();
+
+        let pane_signals = win
+            .cached_central_rect
+            .and_then(|central_rect| {
+                // Mirror `update()`'s own zoomed-vs-split layout choice
+                // (app_impl.rs:1678) exactly: when a pane is zoomed, it
+                // alone fills `central_rect`; otherwise the tree's normal
+                // split layout applies. Getting this wrong would silently
+                // mis-hit-test the pointer against panes that are not
+                // actually the one currently rendered full-size.
+                let layout = active_tab.zoomed_pane.map_or_else(
+                    || {
+                        active_tab
+                            .pane_tree
+                            .layout(central_rect)
+                            .unwrap_or_default()
+                    },
+                    |zoomed_id| vec![(zoomed_id, central_rect)],
+                );
+                // Resolve BOTH the pane id and its rect from the same
+                // `layout` lookup `panes::pane_at_pos` would otherwise
+                // perform internally (Task 121 fix): the gutter positional
+                // test below needs the pane's rect, not just its id, and
+                // recomputing/re-deriving that rect separately would risk
+                // it drifting out of sync with the rect actually used for
+                // hit-testing.
+                layout
+                    .iter()
+                    .find(|(_, rect)| rect.contains(pos))
+                    .map(|(id, rect)| (*id, *rect))
+            })
+            .and_then(|(pane_id, pane_rect)| {
+                active_tab
+                    .pane_tree
+                    .find(pane_id)
+                    .map(|pane| (pane, pane_rect))
+            })
+            .map(|(pane, pane_rect)| {
+                let snap = pane.arc_swap.load();
+                let mouse_tracking_active = snap.mouse_tracking
+                    != freminal_common::buffer_states::modes::mouse::MouseTrack::NoTracking;
+                // Task 121 fix: real positional test against the pane's
+                // left-edge gutter strip, using the SAME `pane_rect` just
+                // resolved for pane hit-testing above (see this method's
+                // doc for the `ppp`-unavailable / conservative-bound
+                // rationale).
+                let pointer_in_gutter_strip_now = pointer_in_gutter_strip(
+                    pos.x,
+                    pane_rect.min.x,
+                    gutter_width_upper_bound_logical,
+                );
+                let hover_region_risk = pane_hover_region_risk(
+                    snap.has_urls,
+                    snap.scroll_offset,
+                    snap.is_alternate_screen,
+                    !snap.command_blocks.is_empty(),
+                    gutter_config_active,
+                    pointer_in_gutter_strip_now,
+                );
+
+                // Task 121 diagnostic: the same inputs, broken out into
+                // their three individual terms (see `pane_hover_region_terms`'s
+                // doc) purely for per-condition counting -- does not
+                // affect `hover_region_risk`/the real decision above.
+                #[cfg(feature = "frame-profiling")]
+                {
+                    let (has_urls, scroll_offset_nonzero, gutter_active) = pane_hover_region_terms(
+                        snap.has_urls,
+                        snap.scroll_offset,
+                        snap.is_alternate_screen,
+                        !snap.command_blocks.is_empty(),
+                        gutter_config_active,
+                        pointer_in_gutter_strip_now,
+                    );
+                    pane_diag_terms = Some((
+                        mouse_tracking_active,
+                        has_urls,
+                        scroll_offset_nonzero,
+                        gutter_active,
+                    ));
+                }
+
+                PointerMotionPaneSignals {
+                    mouse_tracking_active,
+                    hover_region_risk,
+                }
+            });
+
+        // Task 121 diagnostic: count which condition(s) fired for this
+        // call, `saturating_add`'d into `win.frame_stats`'s Task 121
+        // counters (see `FrameStats::record_pointer_motion_check`'s doc for
+        // why `Cell` makes this possible through `win`'s immutable
+        // borrow). Read out, logged, and reset every `FLUSH_EVERY` drawn
+        // frames from the app-side flush further down in `update()`.
+        // Counting only -- does not read from or influence
+        // `pointer_motion_needs_repaint_decision`'s return value below.
+        #[cfg(feature = "frame-profiling")]
+        {
+            let (mouse_tracking_active, has_urls, scroll_offset_nonzero, gutter_active) =
+                pane_diag_terms.unwrap_or_default();
+            win.frame_stats.record_pointer_motion_check(
+                super::window::PointerMotionConditionFlags {
+                    chrome_interactive,
+                    any_pane_selecting: any_selecting,
+                    overlay_open,
+                    pointer_pane_unresolved,
+                    mouse_tracking_active,
+                    has_urls,
+                    scroll_offset_nonzero,
+                    gutter_active,
+                },
+            );
+        }
+
+        pointer_motion_needs_repaint_decision(
+            chrome_interactive,
+            any_selecting,
+            overlay_open,
+            pointer_pane_unresolved,
+            pane_signals,
+        )
     }
 
     fn take_frame_damage(&mut self, window_id: WindowId) -> freminal_windowing::FrameDamage {
@@ -3587,16 +4017,61 @@ impl freminal_windowing::App for FreminalGui {
                             .map(|(name, _)| name),
                         &stats.chrome_signal_fired_counts
                     ),
+                    // Task 121 pointer-motion repaint-gate spike follow-up:
+                    // of the `pointer_motion_needs_repaint` calls this flush
+                    // window, how many total, and which of the eight named
+                    // conditions fired on how many of them (non-exclusive --
+                    // several can fire on the same call; each counted
+                    // independently, see `record_pointer_motion_check`).
+                    // WINDOWED (reset below), unlike `chrome_signals_fired`
+                    // above -- see `pointer_repaint_check_total`'s field doc
+                    // in `window.rs` for why.
+                    pointer_repaint_checks_total = stats.pointer_repaint_check_total.get(),
+                    pointer_repaint_conditions_fired =
+                        %super::window::FrameStats::format_nonzero_pointer_condition_counts(
+                            &[
+                                "chrome_interactive",
+                                "any_pane_selecting",
+                                "overlay_open",
+                                "pointer_pane_unresolved",
+                                "mouse_tracking_active",
+                                "has_urls",
+                                "scroll_offset_nonzero",
+                                "gutter_active",
+                            ],
+                            &[
+                                stats.pointer_cond_chrome_interactive.get(),
+                                stats.pointer_cond_any_pane_selecting.get(),
+                                stats.pointer_cond_overlay_open.get(),
+                                stats.pointer_cond_pointer_pane_unresolved.get(),
+                                stats.pointer_cond_mouse_tracking_active.get(),
+                                stats.pointer_cond_has_urls.get(),
+                                stats.pointer_cond_scroll_offset_nonzero.get(),
+                                stats.pointer_cond_gutter_active.get(),
+                            ]
+                        ),
                     "app-side frame-profiling stats (task 121 harness): chrome-mode \
                      duty cycle, zero-pixel-change-but-presented frames, the \
                      freminal-owned phase_app_update/phase_orchestration/phase_panes \
                      wall-clock split (phase_app_update = the whole productive body of \
                      update(); phase_orchestration = central_body total minus the \
-                     per-pane show() contribution), and which individual §3.3 \
+                     per-pane show() contribution), which individual §3.3 \
                      ChromeSignals field(s) fired (chrome_signals_fired, cumulative, \
                      non-zero entries only) over frames_drawn drawn frames for this \
-                     window_id"
+                     window_id, and -- the pointer-motion repaint-gate spike \
+                     follow-up -- how many of the last pointer_repaint_checks_total \
+                     `pointer_motion_needs_repaint` calls each of the eight named \
+                     gate conditions fired on this flush window \
+                     (pointer_repaint_conditions_fired, non-zero entries only, \
+                     reset every flush window)"
                 );
+
+                // Windowed, not cumulative-since-creation (see the field
+                // doc) -- clear now that this window's line has been
+                // logged. `chrome_signal_fired_counts` above is NOT reset;
+                // it stays cumulative like every other plain `FrameStats`
+                // counter.
+                stats.reset_pointer_condition_window();
             }
         }
 
@@ -4114,7 +4589,9 @@ impl FreminalGui {
 #[cfg(test)]
 mod tests {
     use super::{
-        SettingsOwnerCloseDecision, cursor_blink_wants_repaint, pointer_forces_full_present,
+        PointerMotionPaneSignals, SettingsOwnerCloseDecision, cursor_blink_wants_repaint,
+        pane_hover_region_risk, pane_hover_region_terms, pointer_forces_full_present,
+        pointer_in_gutter_strip, pointer_motion_needs_repaint_decision,
         settings_owner_close_decision,
     };
     use freminal_common::cursor::CursorVisualStyle;
@@ -4201,6 +4678,199 @@ mod tests {
         assert!(!pointer_forces_full_present(false, false, true));
         // Not moving, neither chrome nor drag -> no forced Full.
         assert!(!pointer_forces_full_present(false, false, false));
+    }
+
+    // ── Task 121 pointer-motion repaint-gate spike ───────────────────────
+
+    #[test]
+    fn pane_hover_region_risk_all_clear_is_false() {
+        assert!(!pane_hover_region_risk(false, 0, false, false, true, true));
+    }
+
+    #[test]
+    fn pane_hover_region_risk_has_urls_is_true_regardless_of_everything_else() {
+        assert!(pane_hover_region_risk(true, 0, true, false, false, false));
+    }
+
+    #[test]
+    fn pane_hover_region_risk_scrolled_back_is_true() {
+        assert!(pane_hover_region_risk(false, 1, false, false, false, false));
+    }
+
+    #[test]
+    fn pane_hover_region_risk_at_live_bottom_is_not_risky_from_scroll_alone() {
+        assert!(!pane_hover_region_risk(
+            false, 0, false, false, false, false
+        ));
+    }
+
+    #[test]
+    fn pane_hover_region_risk_gutter_needs_all_four_conditions() {
+        // Feature enabled + blocks present + not alt screen + pointer in the
+        // strip -> risky.
+        assert!(pane_hover_region_risk(false, 0, false, true, true, true));
+        // Any one of the four missing -> not risky (from gutter alone).
+        assert!(!pane_hover_region_risk(false, 0, false, true, false, true)); // feature off
+        assert!(!pane_hover_region_risk(false, 0, false, false, true, true)); // no blocks
+        assert!(!pane_hover_region_risk(false, 0, true, true, true, true)); // alt screen
+        assert!(!pane_hover_region_risk(false, 0, false, true, true, false)); // pointer outside strip
+    }
+
+    // ── Task 121 fix: gutter positional term (pane_hover_region_terms) ───
+    //
+    // These exercise `pane_hover_region_terms`'s `gutter_active` output
+    // directly (rather than through `pane_hover_region_risk`'s aggregate
+    // OR) so the positional term's truth table is visible on its own,
+    // matching the diagnostic counter that reads this same tuple.
+
+    #[test]
+    fn pane_hover_region_terms_gutter_active_true_when_pointer_in_strip() {
+        let (_, _, gutter_active) = pane_hover_region_terms(false, 0, false, true, true, true);
+        assert!(gutter_active);
+    }
+
+    #[test]
+    fn pane_hover_region_terms_gutter_active_false_when_pointer_right_of_strip() {
+        // The headline case this fix addresses: previously the pane-wide
+        // approximation made this `true` unconditionally whenever blocks
+        // were present; it must now be `false` once the pointer is past the
+        // strip.
+        let (_, _, gutter_active) = pane_hover_region_terms(false, 0, false, true, true, false);
+        assert!(!gutter_active);
+    }
+
+    #[test]
+    fn pane_hover_region_terms_gutter_active_false_when_disabled_or_off_or_alt_or_no_blocks() {
+        // Pointer inside the strip in all four cases -- only the named
+        // precondition is what makes each `false`.
+        let (_, _, disabled) = pane_hover_region_terms(false, 0, false, true, false, true);
+        assert!(!disabled, "feature disabled must suppress gutter_active");
+
+        let (_, _, alt_screen) = pane_hover_region_terms(false, 0, true, true, true, true);
+        assert!(!alt_screen, "alt screen must suppress gutter_active");
+
+        let (_, _, no_blocks) = pane_hover_region_terms(false, 0, false, false, true, true);
+        assert!(!no_blocks, "no command blocks must suppress gutter_active");
+    }
+
+    // ── Task 121 fix: `pointer_in_gutter_strip` rect test ────────────────
+
+    #[test]
+    fn pointer_in_gutter_strip_true_inside_the_strip() {
+        // Pane's left edge at x=10, strip width 4 -> strip is [10, 14).
+        assert!(pointer_in_gutter_strip(11.0, 10.0, 4.0));
+    }
+
+    #[test]
+    fn pointer_in_gutter_strip_false_right_of_the_strip() {
+        // The headline case: pointer well past the strip.
+        assert!(!pointer_in_gutter_strip(50.0, 10.0, 4.0));
+    }
+
+    #[test]
+    fn pointer_in_gutter_strip_boundary_at_exact_far_edge_is_false() {
+        // Chosen convention: the far edge (`pane_rect_min_x + width`) is
+        // exclusive, matching a half-open `[min, min+width)` strip -- see
+        // this function's doc for why the `ppp == 1.0` edge case is the
+        // only one where this choice is observable at all.
+        assert!(!pointer_in_gutter_strip(14.0, 10.0, 4.0));
+        // Just inside is still true.
+        assert!(pointer_in_gutter_strip(13.999, 10.0, 4.0));
+    }
+
+    #[test]
+    fn pointer_in_gutter_strip_false_left_of_pane_rect() {
+        // Multi-pane layouts can place a pane's left edge away from x=0;
+        // a pointer left of THIS pane's left edge is not in THIS pane's
+        // gutter strip (it is presumably over a different pane or a
+        // border/padding region).
+        assert!(!pointer_in_gutter_strip(5.0, 10.0, 4.0));
+    }
+
+    #[test]
+    fn pointer_motion_needs_repaint_decision_all_clear_is_false() {
+        assert!(!pointer_motion_needs_repaint_decision(
+            false, false, false, false, None
+        ));
+    }
+
+    #[test]
+    fn pointer_motion_needs_repaint_decision_chrome_interactive_forces_true() {
+        assert!(pointer_motion_needs_repaint_decision(
+            true, false, false, false, None
+        ));
+    }
+
+    #[test]
+    fn pointer_motion_needs_repaint_decision_any_pane_selecting_forces_true() {
+        assert!(pointer_motion_needs_repaint_decision(
+            false, true, false, false, None
+        ));
+    }
+
+    #[test]
+    fn pointer_motion_needs_repaint_decision_overlay_open_forces_true() {
+        assert!(pointer_motion_needs_repaint_decision(
+            false, false, true, false, None
+        ));
+    }
+
+    #[test]
+    fn pointer_motion_needs_repaint_decision_unresolved_pane_forces_true() {
+        assert!(pointer_motion_needs_repaint_decision(
+            false, false, false, true, None
+        ));
+    }
+
+    #[test]
+    fn pointer_motion_needs_repaint_decision_no_pane_under_pointer_is_false() {
+        // Pointer resolved to "no pane here" (e.g. inter-pane padding) --
+        // NOT the same as unresolved; contributes false on its own.
+        assert!(!pointer_motion_needs_repaint_decision(
+            false, false, false, false, None
+        ));
+    }
+
+    #[test]
+    fn pointer_motion_needs_repaint_decision_mouse_tracking_active_forces_true() {
+        assert!(pointer_motion_needs_repaint_decision(
+            false,
+            false,
+            false,
+            false,
+            Some(PointerMotionPaneSignals {
+                mouse_tracking_active: true,
+                hover_region_risk: false,
+            })
+        ));
+    }
+
+    #[test]
+    fn pointer_motion_needs_repaint_decision_hover_region_risk_forces_true() {
+        assert!(pointer_motion_needs_repaint_decision(
+            false,
+            false,
+            false,
+            false,
+            Some(PointerMotionPaneSignals {
+                mouse_tracking_active: false,
+                hover_region_risk: true,
+            })
+        ));
+    }
+
+    #[test]
+    fn pointer_motion_needs_repaint_decision_pane_signals_both_false_is_false() {
+        assert!(!pointer_motion_needs_repaint_decision(
+            false,
+            false,
+            false,
+            false,
+            Some(PointerMotionPaneSignals {
+                mouse_tracking_active: false,
+                hover_region_risk: false,
+            })
+        ));
     }
 
     #[test]

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -236,15 +236,16 @@ const fn pane_hover_region_terms(
 ///
 /// The strip runs from `pane_rect_min_x` (the pane's left edge) to
 /// `pane_rect_min_x + gutter_width_upper_bound_logical`, using `<` (NOT
-/// `<=`) at the far edge: the boundary pixel itself counts as OUTSIDE the
-/// strip. This matters only when `pixels_per_point == 1.0` exactly, the one
-/// case where `gutter_width_upper_bound_logical` (a physical-pixel value
-/// used directly, see `App::pointer_motion_needs_repaint`'s doc) equals the
-/// real logical strip width rather than over-estimating it; at any other
-/// `ppp`, the real strip's own right edge falls strictly inside this
-/// (wider) bound, so the exact `<` vs `<=` choice at `ppp == 1.0`'s single
-/// boundary pixel is a one-pixel edge case with no practical effect on the
-/// suppression this fix restores.
+/// `<=`) at the far edge: the boundary point itself counts as OUTSIDE.
+///
+/// `gutter_width_upper_bound_logical` is the gutter's *total inset* in
+/// logical points (`PerWindowState::cached_gutter_inset_logical`), which is
+/// strictly wider than the painted strip because the inset includes the
+/// padding gap. The real strip's right edge therefore always falls strictly
+/// inside this bound, making the `<` vs `<=` choice at the outer boundary
+/// immaterial. Being a genuine logical measurement, it holds at any
+/// `pixels_per_point` — including fractional scale below 1.0, which broke
+/// the earlier physical-pixels-as-logical approximation.
 ///
 /// Also `false` when `pos_x` is left of the pane entirely (`pos_x <
 /// pane_rect_min_x`) — relevant for multi-pane layouts where a pane's left
@@ -539,6 +540,7 @@ impl freminal_windowing::App for FreminalGui {
                         chrome_frames_rendered: 0,
                         pending_terminal_requested_delay: None,
                         cached_central_rect: None,
+                        cached_gutter_inset_logical: 0.0,
                         chrome_head_rects: None,
                         chrome_border_rects: Vec::new(),
                         frame_stats: super::window::FrameStats::default(),
@@ -848,11 +850,14 @@ impl freminal_windowing::App for FreminalGui {
         #[cfg(feature = "frame-profiling")]
         let mut pane_diag_terms: Option<(bool, bool, bool, bool)> = None;
 
-        // Physical-pixel gutter strip width used directly as a conservative
-        // upper bound on the logical strip width (`width_px / ppp`) — see
-        // this method's doc for why `ppp` is unavailable here and why the
-        // over-estimate is safe.
-        let gutter_width_upper_bound_logical = self.config.command_blocks.gutter.width_px();
+        // The gutter's total inset in LOGICAL points, cached by `update()`
+        // (this method runs outside a frame and has no `ppp`). The inset is
+        // strictly wider than the painted strip, so it is a conservative
+        // bound by construction — and unlike the previous
+        // physical-pixels-as-logical approximation it does not depend on
+        // `ppp >= 1.0`, whose safety direction inverts on sub-1.0 fractional
+        // scale. See `PerWindowState::cached_gutter_inset_logical`.
+        let gutter_width_upper_bound_logical = win.cached_gutter_inset_logical;
 
         let pane_signals = win
             .cached_central_rect
@@ -1840,6 +1845,11 @@ impl freminal_windowing::App for FreminalGui {
             } else {
                 0.0
             };
+            // Task 121 spike: publish the LOGICAL inset for
+            // `App::pointer_motion_needs_repaint`, which runs outside a frame
+            // and so has no `ppp` of its own. See the field's doc for why this
+            // beats assuming `ppp >= 1.0`.
+            win.cached_gutter_inset_logical = gutter_inset_logical;
 
             let window_width = ui.input(|i: &egui::InputState| i.content_rect());
 
@@ -4006,16 +4016,18 @@ impl freminal_windowing::App for FreminalGui {
                     // which individual §3.3 `ChromeSignals` field(s) fired,
                     // cumulative since window creation, name=count joined --
                     // only the non-zero entries (see
-                    // `format_nonzero_signal_counts`'s doc for why: 15
+                    // `format_nonzero_counts`'s doc for why: 15
                     // separate structured fields would be unreadable on the
                     // common case where only 1-2 signals ever fire, e.g. an
                     // idle blinking cursor should show "none" here every
                     // flush once past warm-up).
-                    chrome_signals_fired = %super::window::FrameStats::format_nonzero_signal_counts(
-                        &chrome_damage::ChromeSignals::default()
-                            .named_fields()
-                            .map(|(name, _)| name),
-                        &stats.chrome_signal_fired_counts
+                    chrome_signals_fired = %super::window::FrameStats::format_nonzero_counts(
+                        &std::array::from_fn::<_, 15, _>(|i| {
+                            (
+                                chrome_damage::ChromeSignals::default().named_fields()[i].0,
+                                stats.chrome_signal_fired_counts[i],
+                            )
+                        })
                     ),
                     // Task 121 pointer-motion repaint-gate spike follow-up:
                     // of the `pointer_motion_needs_repaint` calls this flush
@@ -4028,27 +4040,8 @@ impl freminal_windowing::App for FreminalGui {
                     // in `window.rs` for why.
                     pointer_repaint_checks_total = stats.pointer_repaint_check_total.get(),
                     pointer_repaint_conditions_fired =
-                        %super::window::FrameStats::format_nonzero_pointer_condition_counts(
-                            &[
-                                "chrome_interactive",
-                                "any_pane_selecting",
-                                "overlay_open",
-                                "pointer_pane_unresolved",
-                                "mouse_tracking_active",
-                                "has_urls",
-                                "scroll_offset_nonzero",
-                                "gutter_active",
-                            ],
-                            &[
-                                stats.pointer_cond_chrome_interactive.get(),
-                                stats.pointer_cond_any_pane_selecting.get(),
-                                stats.pointer_cond_overlay_open.get(),
-                                stats.pointer_cond_pointer_pane_unresolved.get(),
-                                stats.pointer_cond_mouse_tracking_active.get(),
-                                stats.pointer_cond_has_urls.get(),
-                                stats.pointer_cond_scroll_offset_nonzero.get(),
-                                stats.pointer_cond_gutter_active.get(),
-                            ]
+                        %super::window::FrameStats::format_nonzero_counts(
+                            &stats.pointer_condition_counts()
                         ),
                     "app-side frame-profiling stats (task 121 harness): chrome-mode \
                      duty cycle, zero-pixel-change-but-presented frames, the \
@@ -4375,6 +4368,7 @@ impl FreminalGui {
             chrome_frames_rendered: 0,
             pending_terminal_requested_delay: None,
             cached_central_rect: None,
+            cached_gutter_inset_logical: 0.0,
             chrome_head_rects: None,
             chrome_border_rects: Vec::new(),
             frame_stats: super::window::FrameStats::default(),

--- a/freminal/src/gui/chrome_damage.rs
+++ b/freminal/src/gui/chrome_damage.rs
@@ -156,6 +156,57 @@ impl ChromeSignals {
     }
 }
 
+#[cfg(feature = "frame-profiling")]
+impl ChromeSignals {
+    /// Task 121 frame-profiling harness follow-up (gate-blocker
+    /// instrumentation): name/value pairs for all 15 §3.3 signal fields, in
+    /// declaration order, used solely by the (feature-gated) per-signal
+    /// frame-profiling counters in `app_impl.rs`.
+    ///
+    /// Destructures `self` with **no `..`** — if a future field is added to
+    /// `ChromeSignals`, this will fail to compile ("pattern does not
+    /// mention field `whatever`") until updated here, which is exactly the
+    /// exhaustiveness guarantee the harness needs: a silently-uncounted
+    /// 16th signal would make "which signal fired" investigations wrong
+    /// forever, and this makes that impossible to forget.
+    pub(crate) const fn named_fields(self) -> [(&'static str, bool); 15] {
+        let Self {
+            any_overlay_open,
+            style_changed,
+            active_pane_changed,
+            tab_set_changed,
+            tab_title_changed,
+            pane_layout_changed,
+            broadcast_state_changed,
+            shader_active,
+            bell_active,
+            toast_active,
+            size_changed,
+            ppp_changed,
+            focus_changed,
+            warming_up,
+            foreground_overlay_open,
+        } = self;
+        [
+            ("any_overlay_open", any_overlay_open),
+            ("style_changed", style_changed),
+            ("active_pane_changed", active_pane_changed),
+            ("tab_set_changed", tab_set_changed),
+            ("tab_title_changed", tab_title_changed),
+            ("pane_layout_changed", pane_layout_changed),
+            ("broadcast_state_changed", broadcast_state_changed),
+            ("shader_active", shader_active),
+            ("bell_active", bell_active),
+            ("toast_active", toast_active),
+            ("size_changed", size_changed),
+            ("ppp_changed", ppp_changed),
+            ("focus_changed", focus_changed),
+            ("warming_up", warming_up),
+            ("foreground_overlay_open", foreground_overlay_open),
+        ]
+    }
+}
+
 /// Presence of each dismissible chrome element, sampled once per frame.
 ///
 /// Field order/identity is stable frame-to-frame (it is a fixed struct, not
@@ -878,5 +929,88 @@ mod tests {
 
         // Known window, head rects not yet captured (None) -> conservative true.
         assert!(decide(Some((None, &[])), egui::pos2(50.0, 10.0)));
+    }
+}
+
+#[cfg(all(test, feature = "frame-profiling"))]
+mod named_fields_tests {
+    use super::ChromeSignals;
+
+    /// The 15 names `named_fields` must produce, in declaration order --
+    /// pinned so a reordering (harmless for correctness, since consumers
+    /// zip name with value pairwise) is at least a visible test diff.
+    const EXPECTED_NAMES: [&str; 15] = [
+        "any_overlay_open",
+        "style_changed",
+        "active_pane_changed",
+        "tab_set_changed",
+        "tab_title_changed",
+        "pane_layout_changed",
+        "broadcast_state_changed",
+        "shader_active",
+        "bell_active",
+        "toast_active",
+        "size_changed",
+        "ppp_changed",
+        "focus_changed",
+        "warming_up",
+        "foreground_overlay_open",
+    ];
+
+    #[test]
+    fn named_fields_all_false_on_default() {
+        let fields = ChromeSignals::default().named_fields();
+        for (name, fired) in fields {
+            assert!(!fired, "expected `{name}` false on Default::default()");
+        }
+    }
+
+    #[test]
+    fn named_fields_names_match_declaration_order() {
+        let fields = ChromeSignals::default().named_fields();
+        let names: Vec<&str> = fields.iter().map(|(n, _)| *n).collect();
+        assert_eq!(names, EXPECTED_NAMES);
+    }
+
+    /// Table test mirroring `each_signal_field_alone_forces_changed`: every
+    /// individual field, set alone, is reported `true` at exactly its own
+    /// position and `false` everywhere else.
+    #[test]
+    fn named_fields_reports_exactly_the_field_that_fired() {
+        type Setter = fn(&mut ChromeSignals);
+        let setters: [(&str, Setter); 15] = [
+            ("any_overlay_open", |s| s.any_overlay_open = true),
+            ("style_changed", |s| s.style_changed = true),
+            ("active_pane_changed", |s| s.active_pane_changed = true),
+            ("tab_set_changed", |s| s.tab_set_changed = true),
+            ("tab_title_changed", |s| s.tab_title_changed = true),
+            ("pane_layout_changed", |s| s.pane_layout_changed = true),
+            ("broadcast_state_changed", |s| {
+                s.broadcast_state_changed = true;
+            }),
+            ("shader_active", |s| s.shader_active = true),
+            ("bell_active", |s| s.bell_active = true),
+            ("toast_active", |s| s.toast_active = true),
+            ("size_changed", |s| s.size_changed = true),
+            ("ppp_changed", |s| s.ppp_changed = true),
+            ("focus_changed", |s| s.focus_changed = true),
+            ("warming_up", |s| s.warming_up = true),
+            ("foreground_overlay_open", |s| {
+                s.foreground_overlay_open = true;
+            }),
+        ];
+
+        for (name, set) in setters {
+            let mut signals = ChromeSignals::default();
+            set(&mut signals);
+            for (field_name, fired) in signals.named_fields() {
+                assert_eq!(
+                    fired,
+                    field_name == name,
+                    "with only `{name}` set, expected `{field_name}` fired == {}",
+                    field_name == name
+                );
+            }
+        }
     }
 }

--- a/freminal/src/gui/layout_ops.rs
+++ b/freminal/src/gui/layout_ops.rs
@@ -735,6 +735,7 @@ impl FreminalGui {
             chrome_frames_rendered: 0,
             pending_terminal_requested_delay: None,
             cached_central_rect: None,
+            cached_gutter_inset_logical: 0.0,
             chrome_head_rects: None,
             chrome_border_rects: Vec::new(),
             frame_stats: super::window::FrameStats::default(),

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -537,6 +537,15 @@ pub(super) struct FrameStats {
     /// this session (a mean hides the tail).
     #[cfg(feature = "frame-profiling")]
     pub(super) phase_app_update_max: std::time::Duration,
+    /// Task 121 frame-profiling harness follow-up (issue #459/#461
+    /// gate-blocker investigation): cumulative per-frame fired count for
+    /// each of the 15 `chrome_damage::ChromeSignals` §3.3 fields, indexed
+    /// the SAME as `ChromeSignals::named_fields()`'s array order (see that
+    /// method's doc for the exhaustiveness guarantee this indexing relies
+    /// on). Incremented in `app_impl.rs` right after
+    /// `win.pending_chrome_signals` is finalised for the frame.
+    #[cfg(feature = "frame-profiling")]
+    pub(super) chrome_signal_fired_counts: [u64; 15],
 }
 
 impl FrameStats {
@@ -581,6 +590,29 @@ impl FrameStats {
         }
         let count_f: f64 = conv2::ConvUtil::approx_as(count).unwrap_or(1.0);
         total.div_f64(count_f.max(1.0))
+    }
+
+    /// Format the non-zero entries of `chrome_signal_fired_counts` as a
+    /// single `name=count` comma-joined string for one `tracing` field,
+    /// rather than 15 separate structured fields (which would make the
+    /// already-busy frame-profiling line unreadable on the vast majority of
+    /// frames where only 1-2 signals ever fire). `names` and `counts` are
+    /// parallel arrays, indexed identically to
+    /// `chrome_damage::ChromeSignals::named_fields()`'s order. Returns the
+    /// literal string `"none"` when every count is zero. Pure, so directly
+    /// unit-testable.
+    pub(super) fn format_nonzero_signal_counts(names: &[&str; 15], counts: &[u64; 15]) -> String {
+        let parts: Vec<String> = names
+            .iter()
+            .zip(counts.iter())
+            .filter(|(_, count)| **count > 0)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        if parts.is_empty() {
+            "none".to_string()
+        } else {
+            parts.join(",")
+        }
     }
 }
 
@@ -629,6 +661,60 @@ mod frame_profiling_tests {
     fn mean_duration_handles_a_single_sample() {
         let mean = FrameStats::mean_duration(Duration::from_micros(250), 1);
         assert_eq!(mean, Duration::from_micros(250));
+    }
+
+    // ── `FrameStats::format_nonzero_signal_counts` ───────────────────────
+
+    /// A representative 15-name array; the actual names don't matter to
+    /// this pure formatting helper, only that names/counts are parallel.
+    const NAMES: [&str; 15] = [
+        "any_overlay_open",
+        "style_changed",
+        "active_pane_changed",
+        "tab_set_changed",
+        "tab_title_changed",
+        "pane_layout_changed",
+        "broadcast_state_changed",
+        "shader_active",
+        "bell_active",
+        "toast_active",
+        "size_changed",
+        "ppp_changed",
+        "focus_changed",
+        "warming_up",
+        "foreground_overlay_open",
+    ];
+
+    #[test]
+    fn format_nonzero_signal_counts_all_zero_is_none() {
+        let counts = [0u64; 15];
+        assert_eq!(
+            FrameStats::format_nonzero_signal_counts(&NAMES, &counts),
+            "none"
+        );
+    }
+
+    #[test]
+    fn format_nonzero_signal_counts_shows_only_the_nonzero_entries() {
+        let mut counts = [0u64; 15];
+        counts[1] = 3; // style_changed
+        counts[13] = 120; // warming_up
+        assert_eq!(
+            FrameStats::format_nonzero_signal_counts(&NAMES, &counts),
+            "style_changed=3,warming_up=120"
+        );
+    }
+
+    #[test]
+    fn format_nonzero_signal_counts_preserves_declaration_order() {
+        let mut counts = [0u64; 15];
+        counts[14] = 1; // foreground_overlay_open
+        counts[0] = 1; // any_overlay_open
+        assert_eq!(
+            FrameStats::format_nonzero_signal_counts(&NAMES, &counts),
+            "any_overlay_open=1,foreground_overlay_open=1",
+            "order must follow the array's index order, not insertion order"
+        );
     }
 }
 

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -546,6 +546,98 @@ pub(super) struct FrameStats {
     /// `win.pending_chrome_signals` is finalised for the frame.
     #[cfg(feature = "frame-profiling")]
     pub(super) chrome_signal_fired_counts: [u64; 15],
+
+    // ── Task 121 pointer-motion repaint-gate condition counters (diagnostic;
+    // feature-gated) ────────────────────────────────────────────────────
+    //
+    // `Cell<u64>`, not a plain `u64` like every other counter on this
+    // struct: `App::pointer_motion_needs_repaint` takes `&self` (see the
+    // `freminal_windowing::App` trait) and reaches `PerWindowState` (and
+    // this `FrameStats`) via `self.windows.get(&window_id)` — an
+    // IMMUTABLE borrow — so these counters must be mutable through a
+    // shared reference. The GUI runs single-threaded on the winit/egui
+    // event-loop thread, so `Cell` (not `AtomicU64`/`Mutex`) is the
+    // correct, minimal tool; there is no concurrent access to race.
+    //
+    // Reset every `FLUSH_EVERY`-frame flush window (see
+    // `reset_pointer_condition_window`), UNLIKE `chrome_signal_fired_counts`
+    // above (which is cumulative since window creation): this diagnostic
+    // answers "which repaint-gate condition(s) are firing on pointer motion
+    // RIGHT NOW", which only makes sense windowed — the same reasoning as
+    // `egui_integration.rs`'s settle-gate value diagnostics.
+    /// Total `App::pointer_motion_needs_repaint` calls observed since the
+    /// last flush-window reset — the denominator for reading each
+    /// per-condition count below as a percentage.
+    #[cfg(feature = "frame-profiling")]
+    pub(super) pointer_repaint_check_total: std::cell::Cell<u64>,
+    /// `chrome_interactive` fired count (see
+    /// `PointerMotionConditionFlags::chrome_interactive`).
+    #[cfg(feature = "frame-profiling")]
+    pub(super) pointer_cond_chrome_interactive: std::cell::Cell<u64>,
+    /// `any_pane_selecting` fired count.
+    #[cfg(feature = "frame-profiling")]
+    pub(super) pointer_cond_any_pane_selecting: std::cell::Cell<u64>,
+    /// `overlay_open` fired count.
+    #[cfg(feature = "frame-profiling")]
+    pub(super) pointer_cond_overlay_open: std::cell::Cell<u64>,
+    /// `pointer_pane_unresolved` fired count.
+    #[cfg(feature = "frame-profiling")]
+    pub(super) pointer_cond_pointer_pane_unresolved: std::cell::Cell<u64>,
+    /// `mouse_tracking_active` fired count (pane-resolved calls only).
+    #[cfg(feature = "frame-profiling")]
+    pub(super) pointer_cond_mouse_tracking_active: std::cell::Cell<u64>,
+    /// `has_urls` fired count (pane-resolved calls only) — one of the three
+    /// independent sub-terms of `pane_hover_region_risk`'s disjunction,
+    /// counted separately from `scroll_offset_nonzero`/`gutter_active`
+    /// rather than as one aggregate: distinguishing which of the three is
+    /// actually responsible is the entire point of this diagnostic.
+    #[cfg(feature = "frame-profiling")]
+    pub(super) pointer_cond_has_urls: std::cell::Cell<u64>,
+    /// `scroll_offset_nonzero` fired count (pane-resolved calls only).
+    #[cfg(feature = "frame-profiling")]
+    pub(super) pointer_cond_scroll_offset_nonzero: std::cell::Cell<u64>,
+    /// `gutter_active` fired count (pane-resolved calls only).
+    #[cfg(feature = "frame-profiling")]
+    pub(super) pointer_cond_gutter_active: std::cell::Cell<u64>,
+}
+
+/// Task 121 pointer-motion repaint-gate diagnostic (feature-gated): which of
+/// the eight conditions considered by `App::pointer_motion_needs_repaint`
+/// were true for one call.
+///
+/// Distinct from `app_impl.rs`'s `PointerMotionPaneSignals`: that struct
+/// feeds the actual repaint DECISION for a resolved pane (two aggregated
+/// bools — `mouse_tracking_active` and a single `hover_region_risk`); this
+/// struct is diagnostic-only, exhaustive over every named condition in the
+/// predicate (including the three individual sub-terms
+/// `pane_hover_region_risk` ORs together), and never affects behavior — it
+/// is only ever consumed by `FrameStats::record_pointer_motion_check`.
+///
+/// The last four fields (`mouse_tracking_active` through `gutter_active`)
+/// are meaningful only when a pane resolved under the pointer; when no pane
+/// resolves, all four are simply left `false` (mirrors
+/// `pointer_motion_needs_repaint_decision`'s own "no pane, so no
+/// pane-specific signal applies" semantics for its `pane_signals: None`
+/// case — NOT the same as `pointer_pane_unresolved`, which covers "the pane
+/// could not be determined AT ALL").
+// struct_excessive_bools: each field is an independent yes/no observation
+// of one named condition in `pointer_motion_needs_repaint_decision`'s
+// disjunction (or one of `pane_hover_region_risk`'s three sub-terms) — not
+// a state machine. Combining them would not express any real combined
+// state and would only obscure the one-flag-per-condition mapping this
+// diagnostic exists to preserve.
+#[cfg(feature = "frame-profiling")]
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Copy, Default)]
+pub(super) struct PointerMotionConditionFlags {
+    pub(super) chrome_interactive: bool,
+    pub(super) any_pane_selecting: bool,
+    pub(super) overlay_open: bool,
+    pub(super) pointer_pane_unresolved: bool,
+    pub(super) mouse_tracking_active: bool,
+    pub(super) has_urls: bool,
+    pub(super) scroll_offset_nonzero: bool,
+    pub(super) gutter_active: bool,
 }
 
 impl FrameStats {
@@ -613,6 +705,89 @@ impl FrameStats {
         } else {
             parts.join(",")
         }
+    }
+
+    /// Task 121 pointer-motion repaint-gate diagnostic: record one
+    /// `App::pointer_motion_needs_repaint` call's condition flags into the
+    /// per-condition counters plus the total, `saturating_add`. Takes
+    /// `&self` (not `&mut self`): every counter it touches is a
+    /// `Cell<u64>` for exactly this reason — see
+    /// `pointer_repaint_check_total`'s field doc.
+    pub(super) fn record_pointer_motion_check(&self, flags: PointerMotionConditionFlags) {
+        self.pointer_repaint_check_total
+            .set(self.pointer_repaint_check_total.get().saturating_add(1));
+        Self::bump_if(
+            &self.pointer_cond_chrome_interactive,
+            flags.chrome_interactive,
+        );
+        Self::bump_if(
+            &self.pointer_cond_any_pane_selecting,
+            flags.any_pane_selecting,
+        );
+        Self::bump_if(&self.pointer_cond_overlay_open, flags.overlay_open);
+        Self::bump_if(
+            &self.pointer_cond_pointer_pane_unresolved,
+            flags.pointer_pane_unresolved,
+        );
+        Self::bump_if(
+            &self.pointer_cond_mouse_tracking_active,
+            flags.mouse_tracking_active,
+        );
+        Self::bump_if(&self.pointer_cond_has_urls, flags.has_urls);
+        Self::bump_if(
+            &self.pointer_cond_scroll_offset_nonzero,
+            flags.scroll_offset_nonzero,
+        );
+        Self::bump_if(&self.pointer_cond_gutter_active, flags.gutter_active);
+    }
+
+    /// `counter.set(counter.get().saturating_add(1))` iff `condition` —
+    /// the shared increment-a-`Cell`-iff-true step every branch of
+    /// `record_pointer_motion_check` needs.
+    fn bump_if(counter: &std::cell::Cell<u64>, condition: bool) {
+        if condition {
+            counter.set(counter.get().saturating_add(1));
+        }
+    }
+
+    /// Format eight named pointer-motion condition counts the same way
+    /// `format_nonzero_signal_counts` formats `chrome_signal_fired_counts`
+    /// (see that method's doc for the full rationale) — `name=count`
+    /// comma-joined, non-zero entries only, `"none"` when all eight are
+    /// zero. A free-standing pure function over parallel `names`/`counts`
+    /// arrays (not `&self`), so it is directly unit-testable without
+    /// constructing a `Cell`-bearing `FrameStats`.
+    pub(super) fn format_nonzero_pointer_condition_counts(
+        names: &[&str; 8],
+        counts: &[u64; 8],
+    ) -> String {
+        let parts: Vec<String> = names
+            .iter()
+            .zip(counts.iter())
+            .filter(|(_, count)| **count > 0)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        if parts.is_empty() {
+            "none".to_string()
+        } else {
+            parts.join(",")
+        }
+    }
+
+    /// Reset the pointer-motion condition counters and the total call
+    /// counter (see `record_pointer_motion_check`) back to zero at the end
+    /// of a flush window — see `pointer_repaint_check_total`'s field doc
+    /// for why these are windowed rather than cumulative-since-creation.
+    pub(super) fn reset_pointer_condition_window(&self) {
+        self.pointer_repaint_check_total.set(0);
+        self.pointer_cond_chrome_interactive.set(0);
+        self.pointer_cond_any_pane_selecting.set(0);
+        self.pointer_cond_overlay_open.set(0);
+        self.pointer_cond_pointer_pane_unresolved.set(0);
+        self.pointer_cond_mouse_tracking_active.set(0);
+        self.pointer_cond_has_urls.set(0);
+        self.pointer_cond_scroll_offset_nonzero.set(0);
+        self.pointer_cond_gutter_active.set(0);
     }
 }
 
@@ -715,6 +890,140 @@ mod frame_profiling_tests {
             "any_overlay_open=1,foreground_overlay_open=1",
             "order must follow the array's index order, not insertion order"
         );
+    }
+
+    // ── Task 121 pointer-motion repaint-gate condition counters ──────────
+
+    /// The eight Task 121 pointer-motion condition names, in the same
+    /// order `record_pointer_motion_check`/the app-side flush build their
+    /// parallel `counts` array.
+    const POINTER_CONDITION_NAMES: [&str; 8] = [
+        "chrome_interactive",
+        "any_pane_selecting",
+        "overlay_open",
+        "pointer_pane_unresolved",
+        "mouse_tracking_active",
+        "has_urls",
+        "scroll_offset_nonzero",
+        "gutter_active",
+    ];
+
+    #[test]
+    fn format_nonzero_pointer_condition_counts_all_zero_is_none() {
+        let counts = [0u64; 8];
+        assert_eq!(
+            FrameStats::format_nonzero_pointer_condition_counts(&POINTER_CONDITION_NAMES, &counts),
+            "none"
+        );
+    }
+
+    #[test]
+    fn format_nonzero_pointer_condition_counts_shows_only_the_nonzero_entries() {
+        let mut counts = [0u64; 8];
+        counts[4] = 12; // mouse_tracking_active
+        counts[5] = 3; // has_urls
+        assert_eq!(
+            FrameStats::format_nonzero_pointer_condition_counts(&POINTER_CONDITION_NAMES, &counts),
+            "mouse_tracking_active=12,has_urls=3"
+        );
+    }
+
+    #[test]
+    fn format_nonzero_pointer_condition_counts_preserves_declaration_order() {
+        let mut counts = [0u64; 8];
+        counts[7] = 1; // gutter_active
+        counts[0] = 1; // chrome_interactive
+        assert_eq!(
+            FrameStats::format_nonzero_pointer_condition_counts(&POINTER_CONDITION_NAMES, &counts),
+            "chrome_interactive=1,gutter_active=1",
+            "order must follow the array's index order, not insertion order"
+        );
+    }
+
+    #[test]
+    fn record_pointer_motion_check_increments_total_and_only_true_conditions() {
+        use super::PointerMotionConditionFlags;
+
+        let stats = FrameStats::default();
+        stats.record_pointer_motion_check(PointerMotionConditionFlags {
+            chrome_interactive: true,
+            any_pane_selecting: false,
+            overlay_open: false,
+            pointer_pane_unresolved: false,
+            mouse_tracking_active: false,
+            has_urls: true,
+            scroll_offset_nonzero: false,
+            gutter_active: false,
+        });
+
+        assert_eq!(stats.pointer_repaint_check_total.get(), 1);
+        assert_eq!(stats.pointer_cond_chrome_interactive.get(), 1);
+        assert_eq!(stats.pointer_cond_any_pane_selecting.get(), 0);
+        assert_eq!(stats.pointer_cond_overlay_open.get(), 0);
+        assert_eq!(stats.pointer_cond_pointer_pane_unresolved.get(), 0);
+        assert_eq!(stats.pointer_cond_mouse_tracking_active.get(), 0);
+        assert_eq!(stats.pointer_cond_has_urls.get(), 1);
+        assert_eq!(stats.pointer_cond_scroll_offset_nonzero.get(), 0);
+        assert_eq!(stats.pointer_cond_gutter_active.get(), 0);
+    }
+
+    #[test]
+    fn record_pointer_motion_check_counts_each_condition_independently() {
+        use super::PointerMotionConditionFlags;
+
+        // All eight conditions true at once must all be counted -- the
+        // task's explicit requirement ("several can be true at once --
+        // count each independently, do not stop at the first").
+        let stats = FrameStats::default();
+        stats.record_pointer_motion_check(PointerMotionConditionFlags {
+            chrome_interactive: true,
+            any_pane_selecting: true,
+            overlay_open: true,
+            pointer_pane_unresolved: true,
+            mouse_tracking_active: true,
+            has_urls: true,
+            scroll_offset_nonzero: true,
+            gutter_active: true,
+        });
+
+        assert_eq!(stats.pointer_repaint_check_total.get(), 1);
+        assert_eq!(stats.pointer_cond_chrome_interactive.get(), 1);
+        assert_eq!(stats.pointer_cond_any_pane_selecting.get(), 1);
+        assert_eq!(stats.pointer_cond_overlay_open.get(), 1);
+        assert_eq!(stats.pointer_cond_pointer_pane_unresolved.get(), 1);
+        assert_eq!(stats.pointer_cond_mouse_tracking_active.get(), 1);
+        assert_eq!(stats.pointer_cond_has_urls.get(), 1);
+        assert_eq!(stats.pointer_cond_scroll_offset_nonzero.get(), 1);
+        assert_eq!(stats.pointer_cond_gutter_active.get(), 1);
+    }
+
+    #[test]
+    fn reset_pointer_condition_window_clears_every_counter() {
+        use super::PointerMotionConditionFlags;
+
+        let stats = FrameStats::default();
+        stats.record_pointer_motion_check(PointerMotionConditionFlags {
+            chrome_interactive: true,
+            any_pane_selecting: true,
+            overlay_open: true,
+            pointer_pane_unresolved: true,
+            mouse_tracking_active: true,
+            has_urls: true,
+            scroll_offset_nonzero: true,
+            gutter_active: true,
+        });
+
+        stats.reset_pointer_condition_window();
+
+        assert_eq!(stats.pointer_repaint_check_total.get(), 0);
+        assert_eq!(stats.pointer_cond_chrome_interactive.get(), 0);
+        assert_eq!(stats.pointer_cond_any_pane_selecting.get(), 0);
+        assert_eq!(stats.pointer_cond_overlay_open.get(), 0);
+        assert_eq!(stats.pointer_cond_pointer_pane_unresolved.get(), 0);
+        assert_eq!(stats.pointer_cond_mouse_tracking_active.get(), 0);
+        assert_eq!(stats.pointer_cond_has_urls.get(), 0);
+        assert_eq!(stats.pointer_cond_scroll_offset_nonzero.get(), 0);
+        assert_eq!(stats.pointer_cond_gutter_active.get(), 0);
     }
 }
 

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -423,6 +423,24 @@ pub(super) struct PerWindowState {
     /// `chrome_cache` is also `None` at that point).
     pub(super) cached_central_rect: Option<egui::Rect>,
 
+    /// Task 121 spike: the command-block gutter's total inset in egui **logical
+    /// points**, cached from `update()` each frame.
+    ///
+    /// `App::pointer_motion_needs_repaint` runs outside a frame, where
+    /// `pixels_per_point` is not available, so it cannot compute
+    /// `inset_px / ppp` itself. Caching the already-computed logical value here
+    /// lets the gutter hit-test use real geometry instead of assuming
+    /// `ppp >= 1.0` to justify treating a physical-pixel width as a logical
+    /// upper bound — an assumption whose safety direction inverts on displays
+    /// reporting fractional scale below 1.0.
+    ///
+    /// This is the total inset (strip + padding gap), which is strictly wider
+    /// than the painted strip, so using it as the hit-test bound stays
+    /// conservative by construction. `0.0` before the first frame, which is
+    /// harmless: `cached_central_rect` is `None` then, and that independently
+    /// forces "needs repaint".
+    pub(super) cached_gutter_inset_logical: f32,
+
     /// #436.8 menu-bar + tab-bar rects (egui logical points), captured on FULL
     /// frames (REPLAY skips building the panels). `None` until the first FULL
     /// frame => `is_chrome_interactive_at` returns the conservative `true`.
@@ -684,20 +702,24 @@ impl FrameStats {
         total.div_f64(count_f.max(1.0))
     }
 
-    /// Format the non-zero entries of `chrome_signal_fired_counts` as a
-    /// single `name=count` comma-joined string for one `tracing` field,
-    /// rather than 15 separate structured fields (which would make the
-    /// already-busy frame-profiling line unreadable on the vast majority of
-    /// frames where only 1-2 signals ever fire). `names` and `counts` are
-    /// parallel arrays, indexed identically to
-    /// `chrome_damage::ChromeSignals::named_fields()`'s order. Returns the
-    /// literal string `"none"` when every count is zero. Pure, so directly
-    /// unit-testable.
-    pub(super) fn format_nonzero_signal_counts(names: &[&str; 15], counts: &[u64; 15]) -> String {
-        let parts: Vec<String> = names
+    /// Format the non-zero `(name, count)` entries as a single `name=count`
+    /// comma-joined string for one `tracing` field, rather than one structured
+    /// field per counter (which would make the already-busy frame-profiling
+    /// line unreadable on the vast majority of frames where only one or two
+    /// counters are ever non-zero).
+    ///
+    /// Takes pre-paired entries rather than parallel `names`/`counts` slices:
+    /// with parallel arrays, reordering one without the other silently
+    /// mislabels every value, and nothing in the type system catches it.
+    /// Callers build the pairs from a single source of truth
+    /// (`ChromeSignals::named_fields`, `Self::pointer_condition_counts`).
+    ///
+    /// Returns the literal string `"none"` when every count is zero. Pure, so
+    /// directly unit-testable.
+    pub(super) fn format_nonzero_counts(entries: &[(&str, u64)]) -> String {
+        let parts: Vec<String> = entries
             .iter()
-            .zip(counts.iter())
-            .filter(|(_, count)| **count > 0)
+            .filter(|(_, count)| *count > 0)
             .map(|(name, count)| format!("{name}={count}"))
             .collect();
         if parts.is_empty() {
@@ -757,27 +779,47 @@ impl FrameStats {
     /// zero. A free-standing pure function over parallel `names`/`counts`
     /// arrays (not `&self`), so it is directly unit-testable without
     /// constructing a `Cell`-bearing `FrameStats`.
-    pub(super) fn format_nonzero_pointer_condition_counts(
-        names: &[&str; 8],
-        counts: &[u64; 8],
-    ) -> String {
-        let parts: Vec<String> = names
-            .iter()
-            .zip(counts.iter())
-            .filter(|(_, count)| **count > 0)
-            .map(|(name, count)| format!("{name}={count}"))
-            .collect();
-        if parts.is_empty() {
-            "none".to_string()
-        } else {
-            parts.join(",")
-        }
-    }
-
     /// Reset the pointer-motion condition counters and the total call
     /// counter (see `record_pointer_motion_check`) back to zero at the end
     /// of a flush window — see `pointer_repaint_check_total`'s field doc
     /// for why these are windowed rather than cumulative-since-creation.
+    /// The eight pointer-motion condition counters paired with their names, in
+    /// declaration order.
+    ///
+    /// Exists so the names and the counter reads cannot drift apart: keeping
+    /// them as two hand-maintained parallel lists at the `tracing` call site
+    /// means reordering one silently mislabels every value, with nothing in the
+    /// type system to catch it. Mirrors
+    /// `chrome_damage::ChromeSignals::named_fields()`, which solves the same
+    /// problem for the chrome signals.
+    pub(super) const fn pointer_condition_counts(&self) -> [(&'static str, u64); 8] {
+        [
+            (
+                "chrome_interactive",
+                self.pointer_cond_chrome_interactive.get(),
+            ),
+            (
+                "any_pane_selecting",
+                self.pointer_cond_any_pane_selecting.get(),
+            ),
+            ("overlay_open", self.pointer_cond_overlay_open.get()),
+            (
+                "pointer_pane_unresolved",
+                self.pointer_cond_pointer_pane_unresolved.get(),
+            ),
+            (
+                "mouse_tracking_active",
+                self.pointer_cond_mouse_tracking_active.get(),
+            ),
+            ("has_urls", self.pointer_cond_has_urls.get()),
+            (
+                "scroll_offset_nonzero",
+                self.pointer_cond_scroll_offset_nonzero.get(),
+            ),
+            ("gutter_active", self.pointer_cond_gutter_active.get()),
+        ]
+    }
+
     pub(super) fn reset_pointer_condition_window(&self) {
         self.pointer_repaint_check_total.set(0);
         self.pointer_cond_chrome_interactive.set(0);
@@ -795,6 +837,14 @@ impl FrameStats {
 mod frame_profiling_tests {
     use super::FrameStats;
     use std::time::Duration;
+
+    /// Zip parallel name/count fixtures into the `(name, count)` pairs
+    /// `format_nonzero_counts` now takes. Test-only: production callers build
+    /// their pairs from a single source of truth (`named_fields`,
+    /// `pointer_condition_counts`) precisely so no parallel arrays exist there.
+    fn pairs<'a, const N: usize>(names: &[&'a str; N], counts: &[u64; N]) -> [(&'a str, u64); N] {
+        std::array::from_fn(|i| (names[i], counts[i]))
+    }
 
     #[test]
     fn duty_cycle_is_zero_with_no_frames() {
@@ -861,32 +911,32 @@ mod frame_profiling_tests {
     ];
 
     #[test]
-    fn format_nonzero_signal_counts_all_zero_is_none() {
+    fn format_nonzero_counts_all_zero_is_none() {
         let counts = [0u64; 15];
         assert_eq!(
-            FrameStats::format_nonzero_signal_counts(&NAMES, &counts),
+            FrameStats::format_nonzero_counts(&pairs(&NAMES, &counts)),
             "none"
         );
     }
 
     #[test]
-    fn format_nonzero_signal_counts_shows_only_the_nonzero_entries() {
+    fn format_nonzero_counts_shows_only_the_nonzero_entries() {
         let mut counts = [0u64; 15];
         counts[1] = 3; // style_changed
         counts[13] = 120; // warming_up
         assert_eq!(
-            FrameStats::format_nonzero_signal_counts(&NAMES, &counts),
+            FrameStats::format_nonzero_counts(&pairs(&NAMES, &counts)),
             "style_changed=3,warming_up=120"
         );
     }
 
     #[test]
-    fn format_nonzero_signal_counts_preserves_declaration_order() {
+    fn format_nonzero_counts_preserves_declaration_order() {
         let mut counts = [0u64; 15];
         counts[14] = 1; // foreground_overlay_open
         counts[0] = 1; // any_overlay_open
         assert_eq!(
-            FrameStats::format_nonzero_signal_counts(&NAMES, &counts),
+            FrameStats::format_nonzero_counts(&pairs(&NAMES, &counts)),
             "any_overlay_open=1,foreground_overlay_open=1",
             "order must follow the array's index order, not insertion order"
         );
@@ -912,7 +962,7 @@ mod frame_profiling_tests {
     fn format_nonzero_pointer_condition_counts_all_zero_is_none() {
         let counts = [0u64; 8];
         assert_eq!(
-            FrameStats::format_nonzero_pointer_condition_counts(&POINTER_CONDITION_NAMES, &counts),
+            FrameStats::format_nonzero_counts(&pairs(&POINTER_CONDITION_NAMES, &counts)),
             "none"
         );
     }
@@ -923,7 +973,7 @@ mod frame_profiling_tests {
         counts[4] = 12; // mouse_tracking_active
         counts[5] = 3; // has_urls
         assert_eq!(
-            FrameStats::format_nonzero_pointer_condition_counts(&POINTER_CONDITION_NAMES, &counts),
+            FrameStats::format_nonzero_counts(&pairs(&POINTER_CONDITION_NAMES, &counts)),
             "mouse_tracking_active=12,has_urls=3"
         );
     }
@@ -934,7 +984,7 @@ mod frame_profiling_tests {
         counts[7] = 1; // gutter_active
         counts[0] = 1; // chrome_interactive
         assert_eq!(
-            FrameStats::format_nonzero_pointer_condition_counts(&POINTER_CONDITION_NAMES, &counts),
+            FrameStats::format_nonzero_counts(&pairs(&POINTER_CONDITION_NAMES, &counts)),
             "chrome_interactive=1,gutter_active=1",
             "order must follow the array's index order, not insertion order"
         );


### PR DESCRIPTION
Investigation into whether freminal can reach demand-driven rendering while keeping egui. Six commits: one real production bug fix, two feature-gated diagnostic layers, one explicitly-labelled spike, two doc updates.

## Read this first

**Two commits change default behaviour for every user: `7d483998` and `19780e16`.** The rest is diagnostics behind the non-default `frame-profiling` feature, or docs.

`7d483998` is a clean, verified bug fix that should land regardless of what happens to the rest.

`19780e16` is a **spike**. Its headline number is corroborated but its edges are known-rough. See caveats.

## Results

| Workload | Before | After |
| --- | --- | --- |
| Idle, per-frame cost | 434 us | 376 us (-13.4%) |
| Idle, `ChromeMode::Replay` duty cycle | 0% | 100% |
| Idle, chrome construction | 69 us/frame | 10 us/frame (-86%) |
| Pointer motion over static content | 58-61 fps | ~2 fps (the blink rate) |

Independently A/B'd on a second machine: idle 0.0-0.3% CPU to flat 0.0%; mouse move up to 0.6% to occasional 0.1% spikes.

## The two findings that matter

**`ChromeMode::Replay` had never engaged once.** Every frame is driven by `WindowEvent::RedrawRequested`; `egui-winit` returns `repaint: true` for it (grouped arm commented "Things that may require repaint"); the chrome-input gate consumed that as evidence of real input; and the same event's handler read the flag back via `std::mem::take` ~110 lines later in the same call. The event that drove the frame disqualified the frame. Unconditional, not a race. So the entire #436 chrome-cache subsystem was inert from the day it landed. Fixed with a one-line carve-out plus regression tests. This closes #459 item 2, which PR #461 was merged under but never validated.

**egui demands an immediate repaint of itself on any input event.** `InputState::wants_repaint_after()` returns `Duration::ZERO` whenever `!events.is_empty()`. Not gated on hit-testing or on whether a pixel changed. Suppressing our own input-side scheduling achieves nothing (measured: 99.99% of pointer events suppressed, frame rate unchanged) because egui re-arms from *inside* the frame. `19780e16` overrides that when the only thing since the last frame was pointer motion we classified as irrelevant.

## Caveats a reviewer must not miss

1. **`19780e16` is a spike, default-on, with no kill switch.** It changes scheduling for every build. If it misbehaves in the field the only remedy today is a revert. Worth deciding whether it needs a config toggle before this is relied on.
2. **Known-rough edges, all documented in `DECOUPLING_FRAMEWORK.md` section 2A:** `has_urls` and `scroll_offset` are pane-wide vetoes (cost benefit, not correctness); `animation_in_flight` tests presence rather than motion, so a visible toast disables suppression for its whole life rather than just its fade; the gutter strip's safety rests on an undocumented `pixels_per_point >= 1.0` assumption that inverts on sub-1.0 fractional scale (cosmetic, bounded).
3. **Typing and btop (hidden-cursor) workloads are unmeasured.** Only idle and pointer-motion-over-static-content were captured.
4. **The wezterm comparison is not apples-to-apples** — wez does not blink a cursor at 2 Hz, and freminal's floor is ~2 fps of blink frames by construction.

## Doc changes

`DECOUPLING_FRAMEWORK.md` previously declared an egui rewrite "ratified". This work overtook that: two of three findings *weakened* the case, since the strongest maintenance argument had been "we carry 13 undocumented assumptions for an optimisation that never fires" — and it fires now. Status is reopened, leaning against, explicitly undecided. Phase 3.5's "delete the #435/#436 machinery" is corrected to "replace" — removing it is now a measurable regression.

Also records the next targets: cell-granular suppression as the unifying fix for the remaining coarseness, then #459's per-frame cost items (font/text pipeline first).

One factual error in `EGUI_UPGRADE_ASSUMPTIONS.md` A12 fixed: `ScaleFactorChanged` and `RedrawRequested` are separate match arms, not the same one.

## Verification

`cargo test --all`, `cargo clippy --all-targets -- -D warnings` both with and without `--all-features`, `cargo build --release --features frame-profiling`, `cargo machete`, `cargo xtask check-windows`. All green. Two adversarial review passes; both returned NOT BLOCKING for opening, and every should-fix item they raised is either addressed or documented above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reduced unnecessary redraws caused by pointer movement while preserving required visual updates via a new application hook.
  * Enhanced chrome replay behavior and added richer frame-profiling diagnostics for repaint causes, gating conditions, and pointer-motion activity.
* **Documentation**
  * Updated decoupling and upgrade guidance with clarified Phase 0 results, revised plan language, and remaining gaps.
* **Bug Fixes**
  * Fixed chrome replay/cached reuse not triggering at idle, including correct handling of redraw-request events to avoid silent stop-firing.
* **Tests**
  * Expanded coverage for repaint-delay substitution, pointer scheduling latch behavior, and chrome gate carve-outs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->