### PR TITLE
Task 121 Group B: repaint-delay routing, chrome cache during pointer motion, animation signal

### DIFF
--- a/Documents/MASTER_PLAN.md
+++ b/Documents/MASTER_PLAN.md
@@ -477,10 +477,11 @@ Task 121 lives in the GUI and windowing frame path) and are fully parallelizable
 issue #459's real-workload profiling. It ran for five merged pull requests
 (#458, #460, #461, #464 and #465) under a task number that existed only in branch names;
 creating it closes that tracking gap rather than starting new work. Eleven subtasks
-(121.1–121.11) are merged; the bugs and improvements that work surfaced
-(121.12–121.17, of which 121.16 is withdrawn) and issue #459's unactioned candidate
-list (121.18–121.24) plus measurement debt
-(121.25–121.28) are outstanding and unscheduled. The
+(121.1–121.11) are merged, and three of the bugs that work surfaced (121.12–121.14) are
+fixed and pending merge. Outstanding: 121.15 (left to 121.17, blocked behind Task 122),
+121.16 (withdrawn), 121.17, issue #459's unactioned candidate list (121.18–121.24),
+measurement debt (121.25–121.28), and two items the Group B fixes themselves surfaced
+(121.29–121.30). The
 task is an umbrella, so several subtasks will outlive v0.12.0; the version does not gate on
 Task 121 reaching Complete. **Task 121 is not the egui-decoupling decision** —
 `Documents/DECOUPLING_FRAMEWORK.md` is the decision record for whether freminal should stop
@@ -711,7 +712,7 @@ Update this section as tasks complete:
 | 115  | 2026-07-08 | 2026-07-08 | 115.1-115.4 DECSCNM per-pane per-cell XOR swap; chrome decoupled; on v0.11.1     |
 | 118  | 2026-07-14 | 2026-07-14 | 118.1-118.9 compact repr + idle compaction; default 4k->10k; 118.10 -> Task 120  |
 | 119  | 2026-07-20 | 2026-07-20 | 119.1-119.6 LZ4 block compression + idle-driven; ~13-22x vs cell; merged PR #419 |
-| 121  | 2026-07-27 |            | 121.1-121.11 merged (PRs #458/#460/#461/#464/#465); 121.12-121.28 outstanding    |
+| 121  | 2026-07-27 |            | 121.1-121.11 merged; 121.12-121.14 pending merge; 121.15/121.17-121.30 open     |
 | 122  |            |            | v0.12.0. Not started; needs an activation pass (`DECOUPLING_FRAMEWORK.md` §8)    |
 
 ---
@@ -729,7 +730,7 @@ Update this section as tasks complete:
 - `Documents/PLAN_VERSION_110.md` — v0.11.0 "Kitty: Notifications & Graphics" (Tasks 99–101, 114, decomposed)
 - `Documents/PLAN_VERSION_111.md` — v0.11.1 "Correctness Fixes" (Tasks 115–117, decomposed)
 - `Documents/PLAN_VERSION_120.md` — v0.12.0 "Scrollback Memory & Performance" (Tasks 118–122; 118–119 decomposed and complete, 120 and 122 stubs, 121 summary)
-- `Documents/PLAN_121_PERF_REMEDIATION.md` — Task 121 "Performance Remediation" full breakdown (121.1–121.28)
+- `Documents/PLAN_121_PERF_REMEDIATION.md` — Task 121 "Performance Remediation" full breakdown (121.1–121.30)
 - `Documents/DECOUPLING_FRAMEWORK.md` — decision record for the egui main-window rewrite question (reopened, leaning against); not a plan document and not tracked in this file
 - `Documents/PLAN_VERSION_130.md` — v0.13.0 "Kitty: Transfer, Cursors & Text Sizing" (Tasks 102–104, decomposed)
 - `Documents/PLAN_VERSION_140.md` — v0.14.0 "Power-User Toolkit" (stubs, Tasks 78–83, 96–97)

--- a/Documents/PLAN_121_PERF_REMEDIATION.md
+++ b/Documents/PLAN_121_PERF_REMEDIATION.md
@@ -1,9 +1,10 @@
 # PLAN_121_PERF_REMEDIATION.md — Task 121 "Performance Remediation"
 
 > **STATUS: IN PROGRESS.** Eleven subtasks have merged to `main` across five pull
-> requests (#458, #460, #461, #464, #465). The remainder — five known bugs, one
-> unifying improvement, seven unactioned issue #459 items, and four pieces of
-> measurement debt — are outstanding and unscheduled.
+> requests (#458, #460, #461, #464, #465). Three more (121.12–121.14) are complete
+> and pending merge. The remainder — one bug blocked behind Task 122, one unifying
+> improvement, seven unactioned issue #459 items, four pieces of measurement debt,
+> and two items surfaced by the Group B work — are outstanding and unscheduled.
 
 Task 121 is carried by v0.12.0. The version-level summary lives in
 `PLAN_VERSION_120.md` ("Task 121 — Performance Remediation"); this document is the
@@ -70,14 +71,16 @@ creates — see that subtask.
 
 ## Subtask summary
 
-| Group                                   | Subtasks      | Status      |
-| --------------------------------------- | ------------- | ----------- |
-| A — Completed work (merged to `main`)   | 121.1–121.11  | Complete    |
-| B — Bugs found but unfixed              | 121.12–121.15 | Not started |
-| B — Withdrawn                           | 121.16        | Withdrawn   |
-| C — Unifying improvement                | 121.17        | Not started |
-| D — Unactioned issue #459 items         | 121.18–121.24 | Not started |
-| E — Measurement debt                    | 121.25–121.28 | Not started |
+| Group                                   | Subtasks      | Status        |
+| --------------------------------------- | ------------- | ------------- |
+| A — Completed work (merged to `main`)   | 121.1–121.11  | Complete      |
+| B — Bugs found and fixed                | 121.12–121.14 | Pending merge |
+| B — Bug blocked behind Task 122         | 121.15        | Not started   |
+| B — Withdrawn                           | 121.16        | Withdrawn     |
+| C — Unifying improvement                | 121.17        | Not started   |
+| D — Unactioned issue #459 items         | 121.18–121.24 | Not started   |
+| E — Measurement debt                    | 121.25–121.28 | Not started   |
+| F — Surfaced by the Group B work        | 121.29–121.30 | Not started   |
 
 Subtask numbers are stable once assigned. A withdrawn or dissolved subtask keeps its
 number and records why (the convention Task 118 used for 118.10), so the decision is
@@ -228,10 +231,12 @@ Commit `f762ca02`. One real bug plus cleanups, from automated review of PR #465.
 
 ---
 
-## Group B — Bugs found but unfixed
+## Group B — Bugs found by Group A
 
-These were surfaced by Group A and are known-broken or known-coarse today. None is
-scheduled.
+These were surfaced by Group A. 121.12, 121.13 and 121.14 are **fixed and pending
+merge** (branch `task-121/group-b`, one atomic commit each). 121.15 remains unfixed
+and is deliberately left to 121.17, which is blocked behind Task 122. 121.16 is
+withdrawn.
 
 ### 121.12 — The 250 ms fallback makes blink-off slower than blink-on
 
@@ -247,25 +252,54 @@ suppressed floor is 2 fps. With blinking **off**, the app requests nothing, the
 250 ms fallback applies, and the floor becomes **4 fps** — turning the blink off
 makes freminal schedule twice as many frames.
 
-**Fix:** three call sites bypass `App::update`'s `shortest_repaint_delay`
-aggregation and call `ui.ctx().request_repaint()` directly, so the delay they need
-never reaches `app_requested_delay`:
-
-- `freminal/src/gui/terminal/widget.rs:1936` — gutter hover needs-repaint
-- `freminal/src/gui/terminal/widget.rs:1942` — gutter clearing frame
-- `freminal/src/gui/terminal/widget.rs:3228` — scrollbar damage decision
-
-Route all three through `shortest_repaint_delay` (as `app_impl.rs:3023` and
-`app_impl.rs:3436` already do for their own sources). Once every real repaint need
-is represented in `app_requested_delay`, `SUPPRESSED_POINTER_FALLBACK_DELAY` can
-become `Duration::MAX` and the liveness argument for the bounded fallback goes away.
-
 Note these are **not** the two call sites `DECOUPLING_FRAMEWORK.md` §8 subtask 0.1
 ruled benign — 0.1 was about those sites forcing `not_settled` at idle, which they
 do not do after warm-up. This is a different defect on the same lines.
 
 **Also unblocks 121.26**: the honest apples-to-apples comparison against wezterm
-requires `cursor.blink = false`, which today lands on the worse of the two floors.
+requires `cursor.blink = false`, which previously landed on the worse of the two
+floors.
+
+### 121.12 outcome (DONE, pending merge)
+
+**This entry originally named three bypassing call sites. That was wrong — there are
+eight**, and the miscount changed what the fix buys. Recon found, in addition to the
+three gutter/scrollbar sites: `widget.rs`'s bell-flash fade, cursor-trail animation
+and animated-image tick; `app_impl.rs`'s resize-overlay HUD (inside `central_body`,
+with the aggregate local in scope); and `toast.rs`'s toast cadence (outside
+`central_body`, after the aggregate is published).
+
+That miscount concealed a **live visual bug this entry never described**: because
+those animations' 16ms requests never reached `app_requested_delay`, and egui's raw
+delay is zero during pointer motion regardless, the substitution fired, found
+`None`, and returned the fallback. The bell flash, cursor trail and animated images
+were animating at **4fps instead of 60fps whenever the mouse was moving** over
+terminal content. Routing them is a correctness fix in its own right, independent of
+the fallback constant.
+
+All eight now fold into the aggregate: six via a new
+`PaneRenderCache::pending_repaint_delay` drained after `show()` returns
+(`paint_bell_flash` returns `Option<Duration>` rather than requesting a repaint
+itself), one directly, and `ToastStack::show` returning its delay for a second
+aggregation point. The three formerly-bare `request_repaint()` sites fold **16ms,
+not `Duration::ZERO`** — scheduling is identical because `clamp_repaint_delay`
+already floored at `MIN_REPAINT_INTERVAL`, but a zero app-side ask would make
+`chrome_repaint_settled`'s `repaint_delay >= app_delay` test permanently vacuous.
+
+**`Duration::MAX` was considered and rejected.** This entry's closing claim — that
+once every real repaint need is represented the liveness argument goes away — does
+not hold: `app_requested_delay` can only ever represent *freminal's* needs, and
+**egui's own chrome animations are unrepresentable in it** and are masked by egui's
+events-driven zero. Unbounded would freeze such an animation at partial alpha until
+an unrelated event arrived. `SUPPRESSED_POINTER_FALLBACK_DELAY` is therefore
+**250ms → 500ms**, chosen to equal the cursor-blink period so blink-off can never
+schedule more frames than blink-on, which is the perversity this entry is about. A
+regression test pins `>= 500ms` so it cannot be reintroduced.
+
+A mechanism *does* exist to make unbounded safe — `Context::repaint_causes()` — but
+consuming it costs five egui-internals dependencies, two of which are present-day
+holes. See **121.29**, which records the full analysis so it is not re-litigated.
+The measured prize over 500ms is ~0.075% of a core.
 
 ### 121.13 — Chrome cache is disabled during pointer motion
 
@@ -276,6 +310,35 @@ egui's raw `0` on every suppressed-pointer frame and concludes the chrome has no
 settled. Consequence: `ChromeMode::Replay` sits at roughly 0.5% duty cycle while the
 mouse is moving, against 100% at idle. The 121.8 win is silently switched off for
 exactly as long as the pointer moves.
+
+### 121.13 outcome (DONE, pending merge)
+
+Fixed with a narrow `EguiState::stash_effective_repaint_delay` called from the
+`RedrawRequested` arm once `effective_delay` is known. `run_frame` still performs
+the raw write, so the field is never left unwritten on a path that does not reach
+the override; the deliberate double-write is documented at both ends.
+
+**The stashed value is not the scheduled one, and that distinction is the fix.** One
+value cannot answer both "what do we schedule?" (bounded — we cannot prove nothing
+needs drawing) and "did anything actually *want* a repaint?" (no — the absence of an
+app request is itself the proof). Stashing the scheduled value would have left the
+`app_requested_delay == None` case exactly as broken: the synthetic 500ms liveness
+poll would be stashed, `chrome_repaint_settled`'s `None` arm would compare it
+against `Duration::MAX`, and the gate would still decide `Full`. **That case is
+precisely the btop / `DECTCEM`-hidden-cursor workload named in 121.25.** Scheduling
+therefore uses `effective_repaint_delay`; the gate is fed a sibling,
+`effective_chrome_gate_delay`, differing in exactly one branch (`None` yields
+`Duration::MAX`).
+
+Replay stays independently gated on `cache_matches`, `damage_unchanged` and
+`no_chrome_input`, and both `toast_active` and `any_overlay_open` force
+`ChromeDamage::Changed` every frame they hold, so a genuinely changed chrome still
+cannot be replayed.
+
+Residual, documented in code and tracked as **121.30**: chrome widgets are not
+constructed at all on `Replay`, so an egui-internal chrome animation would not
+merely be scheduled less often — its advancing logic would not run. Latent, not
+live. The wiring itself has no automated coverage (see 121.28).
 
 ### 121.14 — `animation_in_flight` tests presence, not motion
 
@@ -290,11 +353,58 @@ superset of correct, therefore safe, but wasteful.
 returned from `measure_inputs` at `toast.rs:1662`) as a real signal instead of
 testing for presence.
 
+### 121.14 outcome (DONE, pending merge)
+
+**Both halves fixed**, not just the toast half this entry's Fix bullet named — the
+resize-HUD half is cited in the bug text above and was trivially fixable.
+
+Resize HUD: a pure `resize_overlay_is_animating` replaces `is_some()`. It reports
+`true` past `linger` as well as during the fade, because the overlay is only cleared
+by a rendered frame; going false there would strand the HUD on screen at partial
+alpha. **Narrowing the predicate alone would have achieved nothing** — after 121.12
+the HUD folds a delay into the aggregate every frame it is alive, so
+`app_requested_delay` would have stayed 16ms and scheduling would have stayed at
+60fps. It now requests the time remaining until the fade begins while opaque. A
+property test pins the coupling between the two functions (the originally proposed
+`is_animating == (delay <= 16ms)` invariant is **false** — in the opaque phase the
+countdown is transiently `<= 16ms` while `is_animating` is still false; the real
+coupling is: `animating` implies exactly 16ms, and `!animating` implies exactly
+`fade_start - elapsed`).
+
+Toasts: cached on `ToastStack`, read via `is_animating()`, because the predicate runs
+outside any frame. `push()` sets the flag eagerly — exact rather than merely
+conservative, since a new toast is always mid-entry-animation — closing the priming
+gap between a push and the next render. `try_borrow`-fails-means-`true` preserved.
+
+**A hover regression had to be fixed to make the toast half safe at all.**
+`is_chrome_interactive_at` tested only head and border rects; toast rects were not in
+the pointer-interactive set, and it was toast *presence* that had been keeping hover
+alive. Suppressing during the steady hold would have left the close-button highlight
+and hover-to-pause resolving only at the 250ms cadence. `ToastStack::show` now also
+returns its laid-out rects, cached in a dedicated `chrome_toast_rects` and tested by
+a widened `point_in_chrome_rects`. This also correctly forces `ChromeMode::Full`
+while the pointer is over a toast.
+
+Accepted residuals, documented in code: the cached rects are one frame stale, so a
+hover can be missed for a frame while the stack reflows; and `chrome_toast_rects`
+goes stale on `App::update`'s `CLEANUP-436-A` early return, symmetrically with
+`chrome_head_rects` and `chrome_border_rects` (pre-existing, a documented
+should-never-happen branch). The toast's 16ms/250ms cadence is deliberately
+unchanged — unlike the HUD it has hover-extension and expiry logic driven per frame.
+The presence-based `toast_active` chrome-damage signal is untouched; it is
+presence-based by design.
+
 ### 121.15 — `has_urls` and `scroll_offset > 0` are pane-wide vetoes
 
 Any pane containing a hyperlink, or scrolled back at all, reverts to full-rate
 scheduling for pointer motion anywhere in it. Conservative direction: it costs
 benefit, not correctness. Subsumed by 121.17, which is the preferred fix.
+
+**Deliberately excluded from the Group B fix (maintainer decision).** 121.12–121.14
+shipped without it. An interim narrowing here would mean adding a fifth round to the
+suppression predicate in its current shape — exactly what 121.17 warns is how the
+maintainability argument for the egui rewrite gets stronger for no good reason. It
+stays blocked behind Task 122 → 121.17.
 
 ### 121.16 — Config kill switch for the suppression (WITHDRAWN)
 
@@ -460,6 +570,77 @@ landed. Everything in Groups A through D is validated by counters, `perf` sample
 and human observation — never by pixels. Any regression in the suppression or
 chrome-cache paths that changes what is drawn rather than how often is currently
 undetectable in CI.
+
+Group B added two concrete instances. (1) 121.13's tests exercise the pure
+`chrome_repaint_settled` / `evaluate_chrome_gate` functions, which that subtask did
+not modify — they pin the reasoning, not the wiring, and would pass against
+pre-121.13 code. The wiring (that `event_loop.rs` calls the stash at the right point
+with the right value on every reachable path) needs a live winit window and GL
+context and has none. (2) 121.29 cannot be attempted safely without this harness.
+
+---
+
+## Group F — Surfaced by the Group B work
+
+### 121.29 — Unbounded suppressed-pointer fallback via `repaint_causes()`
+
+`SUPPRESSED_POINTER_FALLBACK_DELAY` is bounded (500ms after 121.12) because
+`app_requested_delay` represents only freminal's repaint needs. egui's own chrome
+animations are unrepresentable in it and are masked by egui's events-driven zero, so
+`Duration::MAX` would freeze such an animation at partial alpha until an unrelated
+event arrived.
+
+A mechanism exists to discriminate. `egui-0.35.0/src/context.rs:524-525` pushes the
+events-driven zero as a `RepaintCause`, and `ContextImpl::request_repaint_after`
+pushes `causes` **unconditionally**, before the `delay < repaint_delay` early-out, so
+the list survives even though the delay value is flattened to zero.
+`Context::repaint_causes()` exposes it. If the only cause is the `begin_pass` events
+cause, nothing but suppressed pointer motion wants a frame and unbounded is safe.
+
+**This was investigated and rejected for now.** Consuming it depends on five egui
+internals, two of which are present-day holes rather than future-bump risks:
+
+1. The events-driven zero is recorded as a cause at all, identifiable by `file`+`line`
+   — making an egui *source line number* load-bearing runtime data, in a repo whose
+   own upgrade checklist says line numbers drift and must not be trusted.
+2. `causes.push` happening unconditionally (`context.rs:157-159`).
+3. `repaint_causes()` returning `prev_causes` — exactly one pass stale
+   (`context.rs:102-105`).
+4. **`outstanding`-driven repaints push no cause at all** (`context.rs:110-118`).
+   Every zero-delay `request_repaint()` sets `outstanding = 1` ("Each request results
+   in two repaints, just to give some things time to settle"); the following pass is
+   forced to `ZERO` down a path that never touches `causes`. A cause-based test is
+   structurally blind to egui's own settling mechanism.
+5. **`run_dyn` is a multi-pass loop** (`context.rs:822-860`); `request_discard`
+   reruns `begin_pass`/`end_pass`, swapping `causes` again, so after a discarded pass
+   `repaint_causes()` is the second-to-last pass's causes.
+
+`set_request_repaint_callback` looked like the documented escape hatch but is not: it
+fires only when `delay < repaint_delay`, so once the events-zero lands at
+`begin_pass` every later request is silent.
+
+The correctness argument therefore requires reasoning about three interacting
+internal mechanisms and is unfalsifiable without **121.28**. The measured prize over
+the 500ms fallback is ~**0.075% of a core** (2 wakes/s × the 376µs idle frame cost
+from 121.8), which 121.24 independently corroborates. Blocked on 121.28; would also
+need a new `EGUI_UPGRADE_ASSUMPTIONS.md` entry. **Do not re-derive this analysis.**
+
+### 121.30 — Chrome widgets are not constructed at all on `Replay`
+
+`SUPPRESSED_POINTER_FALLBACK_DELAY`'s original doc framed the residual risk purely as
+scheduling cadence. There is a second, distinct mechanism: freminal's chrome widgets
+(menu bar, tab bar) are not constructed on `ChromeMode::Replay`, so while continuous
+pointer motion keeps the gate settled, an egui-internal chrome animation would not
+merely be scheduled less often — its own advancing logic would not run, and it would
+freeze rather than degrade.
+
+**Latent, not live.** freminal uses no `ctx.animate_bool` / `ctx.animate_value`
+anywhere in chrome (verified by search), and an open menu forces `Full` through
+`any_overlay_open` via an unrelated gate. 121.13 widened the latent window to the
+"app requested nothing" case as a deliberate, accepted trade.
+
+The trigger to action this is the introduction of **any** `ctx.animate_*`-driven
+chrome widget. Both mechanisms are now documented at the constant.
 
 ---
 

--- a/Documents/PLAN_VERSION_120.md
+++ b/Documents/PLAN_VERSION_120.md
@@ -26,9 +26,10 @@ hot, so it ships together):
 **Theme 2 — CPU performance remediation:**
 
 - **Task 121 — Performance Remediation** (in progress): the umbrella for all work arising
-  from issue #459's real-workload CPU profiling. Eleven subtasks have merged; the bugs that
-  work surfaced and issue #459's unactioned candidate list are outstanding. Summarised
-  below; the full breakdown is in `PLAN_121_PERF_REMEDIATION.md`.
+  from issue #459's real-workload CPU profiling. Eleven subtasks have merged and three more
+  (121.12–121.14) are pending merge; the remaining bugs, issue #459's unactioned candidate
+  list, and two items the Group B fixes surfaced are outstanding. Summarised below; the full
+  breakdown is in `PLAN_121_PERF_REMEDIATION.md`.
 
 **Theme 3 — structural cleanup:**
 
@@ -834,12 +835,14 @@ redraw — to the level set by wezterm and ghostty on the same hardware.
 
 | Group                                 | Subtasks      | Status      | Covers                                                                    |
 | ------------------------------------- | ------------- | ----------- | ------------------------------------------------------------------------- |
-| A — Completed work                    | 121.1–121.11  | Complete    | PRs #458, #460, #461, #464, #465                                          |
-| B — Bugs found but unfixed            | 121.12–121.15 | Not started | blink-off fallback, chrome cache off during motion, animation signal, pane-wide vetoes |
-| B — Withdrawn                         | 121.16        | Withdrawn   | config kill switch — rejected; revert-and-fix is the remedy               |
-| C — Unifying improvement              | 121.17        | Not started | cell-granular pointer suppression (depends on Task 122)                   |
-| D — Unactioned issue #459 items       | 121.18–121.24 | Not started | items 3–8 plus per-`CursorMoved` allocations                              |
-| E — Measurement debt                  | 121.25–121.28 | Not started | typing/btop, blink-off A/B, `DESIGN_DECISIONS.md` entry, issue #440 harness |
+| A — Completed work                    | 121.1–121.11  | Complete      | PRs #458, #460, #461, #464, #465                                        |
+| B — Bugs found and fixed              | 121.12–121.14 | Pending merge | blink-off fallback, chrome cache off during motion, animation signal    |
+| B — Bug blocked behind Task 122       | 121.15        | Not started   | pane-wide `has_urls` / `scroll_offset` vetoes; left to 121.17            |
+| B — Withdrawn                         | 121.16        | Withdrawn     | config kill switch — rejected; revert-and-fix is the remedy             |
+| C — Unifying improvement              | 121.17        | Not started   | cell-granular pointer suppression (depends on Task 122)                 |
+| D — Unactioned issue #459 items       | 121.18–121.24 | Not started   | items 3–8 plus per-`CursorMoved` allocations                            |
+| E — Measurement debt                  | 121.25–121.28 | Not started   | typing/btop, blink-off A/B, `DESIGN_DECISIONS.md` entry, issue #440 harness |
+| F — Surfaced by the Group B work      | 121.29–121.30 | Not started   | `repaint_causes()` unbounded fallback; chrome not built on `Replay`      |
 
 ### 121 Headline result
 

--- a/freminal-windowing/src/egui_integration.rs
+++ b/freminal-windowing/src/egui_integration.rs
@@ -1214,6 +1214,25 @@ impl EguiState {
         // returns immediately (macOS with vsync disabled).
 
         // Stash this frame's signals for next frame's `chrome_mode` decision.
+        //
+        // Subtask 121.13: this is egui's RAW `repaint_delay`, not the value
+        // `event_loop.rs`'s `RedrawRequested` arm actually stashes for the
+        // chrome gate via `effective_chrome_gate_delay` (a sibling of, but
+        // NOT the same as, the `effective_repaint_delay` used to decide what
+        // to schedule — see that function's doc for why the two questions
+        // differ). On a suppressed-pointer frame the raw value here is
+        // always `ZERO` (egui's event queue is non-empty because the
+        // suppressed pointer events are still handed to `on_window_event`),
+        // which makes `chrome_repaint_settled` see "not settled" and hold
+        // the chrome cache in `ChromeMode::Full` for as long as the pointer
+        // moves. `event_loop.rs` calls `stash_effective_repaint_delay`
+        // immediately after this write to overwrite it with the gate value
+        // — see that method's doc for why this double-write is intentional
+        // and not a race. Do NOT delete either write without re-reading both
+        // docs: deleting this one leaves the field unwritten on any path
+        // that never reaches the event loop's override, and deleting that
+        // one silently reintroduces the "chrome cache disabled during
+        // pointer motion" bug.
         self.prev_repaint_delay = repaint_delay;
         self.prev_chrome_damage = chrome_damage;
         self.prev_terminal_requested_delay = terminal_requested_delay;
@@ -1412,6 +1431,40 @@ impl EguiState {
     /// by an internal `destroyed` flag), so calling it more than once is safe.
     pub(crate) fn destroy_painter(&mut self) {
         self.painter.destroy();
+    }
+
+    /// Subtask 121.13 + residual-gap fix (maintainer decision): overwrite
+    /// `prev_repaint_delay` with the value `event_loop.rs`'s
+    /// `RedrawRequested` arm computes via `effective_chrome_gate_delay` —
+    /// NOT the raw `frame_output.repaint_delay` that `run_frame` stashed a
+    /// few lines earlier in the same event-loop pass, and NOT
+    /// `effective_repaint_delay`'s return value either (that function
+    /// answers "what do we schedule?", a bounded-liveness question; this
+    /// stash answers "did anything want a repaint?", for which an
+    /// unbounded/`MAX` answer is correct when nothing did). See
+    /// `effective_chrome_gate_delay`'s doc for the exact single case where
+    /// the two diverge.
+    ///
+    /// WHY the value must be substituted at all: on a frame where the only
+    /// thing that happened was suppressed pointer motion, egui's raw delay
+    /// is always `ZERO` (its input queue is non-empty because the suppressed
+    /// pointer events are still delivered to `on_window_event`, even though
+    /// the event-loop classified them as needing no repaint). Feeding that
+    /// raw zero into `chrome_repaint_settled` next frame permanently reads
+    /// as "not settled" for as long as the pointer keeps moving, which holds
+    /// `ChromeMode` at `Full` and disables the #436 chrome cache exactly
+    /// when it matters most (continuous pointer motion is the common case).
+    /// The substituted delay reflects what was ACTUALLY scheduled/wanted —
+    /// the app's own requested delay when suppression applied, or
+    /// `Duration::MAX` when the app wanted nothing at all — so the settle
+    /// check reasons about reality instead of an artifact of how egui's
+    /// input queue works.
+    ///
+    /// This is a deliberate second write to `prev_repaint_delay` immediately
+    /// after `run_frame`'s own stash (see the comment there). Do not remove
+    /// either write in isolation — see that comment for what breaks.
+    pub(crate) const fn stash_effective_repaint_delay(&mut self, delay: std::time::Duration) {
+        self.prev_repaint_delay = delay;
     }
 }
 
@@ -1957,6 +2010,105 @@ mod tests {
             .chrome_mode(),
             crate::ChromeMode::Replay
         );
+    }
+
+    // ── Subtask 121.13 (+ residual-gap fix): suppressed-pointer-motion
+    //    chrome-cache regression ──
+    //
+    // `evaluate_chrome_gate`/`chrome_repaint_settled` are pure and know
+    // nothing about `effective_repaint_delay`/`effective_chrome_gate_delay`
+    // (those functions live in `event_loop.rs` and are private there, so
+    // they cannot be called from this module's tests directly) — these
+    // tests instead pin the `prev_repaint_delay` values those functions can
+    // produce for a suppressed-pointer frame, proving the gate reacts to
+    // each exactly as `EguiState::stash_effective_repaint_delay`'s doc
+    // claims.
+    //
+    // IMPORTANT SCOPE NOTE (review item 5b): these tests exercise ONLY the
+    // pure decision functions in THIS module. Neither 121.13 nor the
+    // residual-gap fix changed `chrome_repaint_settled` or
+    // `evaluate_chrome_gate` themselves — both subtasks changed what
+    // `event_loop.rs` stashes into `prev_repaint_delay` BEFORE it reaches
+    // these functions. That means these tests would pass identically
+    // against the pre-121.13 code: they pin the REASONING ("given this
+    // stashed value, what does the gate decide?"), not the WIRING ("does
+    // `event_loop.rs` actually stash the right value, at the right point,
+    // on every reachable path?"). The wiring has no automated coverage
+    // because it needs a live winit window and GL context to exercise
+    // `Handler::window_event`'s `RedrawRequested` arm end-to-end. A future
+    // refactor that reorders, deletes, or misroutes the
+    // `stash_effective_repaint_delay` call would NOT be caught by anything
+    // in this file — do not read a green run of these tests as proof the
+    // wiring is intact.
+
+    /// BEFORE 121.13: `run_frame` stashed egui's RAW `repaint_delay`, which
+    /// `InputState::wants_repaint_after` always returns as `ZERO` while the
+    /// suppressed pointer events are still sitting in egui's input queue —
+    /// regardless of whether the app itself requested anything. Pinning
+    /// this as `Full` documents the bug: the chrome cache reads as
+    /// "unsettled" for as long as the pointer moves, even with an active
+    /// 500ms blink schedule that, substituted, would settle just fine (see
+    /// the next test).
+    #[test]
+    fn raw_zero_delay_during_suppressed_pointer_motion_decides_full() {
+        let inputs = Inputs {
+            prev_repaint_delay: Duration::ZERO,
+            prev_terminal_requested_delay: Some(Duration::from_millis(500)),
+            ..Inputs::all_clear()
+        };
+        assert_eq!(inputs.decide(), crate::ChromeMode::Full);
+    }
+
+    /// AFTER 121.13: `event_loop.rs`'s `RedrawRequested` arm overwrites the
+    /// raw zero with `effective_repaint_delay`'s substituted value, which
+    /// equals `app_requested_delay` whenever that is `Some` (the
+    /// `suppressed_only && repaint_delay.is_zero()` branch). This is the
+    /// fix's intended outcome: a suppressed-pointer frame with an active
+    /// app-side schedule (the common blinking-cursor-while-mouse-moves
+    /// case) now settles and permits `Replay`, instead of being pinned to
+    /// `Full` at ~0.5% duty cycle for as long as the pointer moves.
+    #[test]
+    fn substituted_delay_during_suppressed_pointer_motion_decides_replay() {
+        let inputs = Inputs {
+            // What `effective_repaint_delay(true, Duration::ZERO,
+            // Some(500ms))` returns: the app's own request, substituted for
+            // egui's raw zero.
+            prev_repaint_delay: Duration::from_millis(500),
+            prev_terminal_requested_delay: Some(Duration::from_millis(500)),
+            ..Inputs::all_clear()
+        };
+        assert_eq!(inputs.decide(), crate::ChromeMode::Replay);
+    }
+
+    /// Residual-gap fix (maintainer decision, follow-up to 121.13): when the
+    /// app requested NOTHING this frame (no blink schedule, no animation, no
+    /// toast — `app_requested_delay: None`, e.g. `DECTCEM` hid the cursor),
+    /// the value stashed for the chrome gate is now
+    /// `effective_chrome_gate_delay`'s `Duration::MAX` — NOT
+    /// `effective_repaint_delay`'s bounded
+    /// `SUPPRESSED_POINTER_FALLBACK_DELAY` (500ms), which is what gets
+    /// SCHEDULED but must not be fed to the settle check (see
+    /// `effective_chrome_gate_delay`'s doc). Before the residual-gap fix,
+    /// `event_loop.rs` stashed the same 500ms value it scheduled, which
+    /// `chrome_repaint_settled`'s `None` arm reads as "unsettled" (it
+    /// requires EXACTLY `Duration::MAX`), pinning `ChromeMode::Full` for the
+    /// entire duration of suppressed pointer motion whenever nothing else
+    /// was scheduled — the btop/`DECTCEM`-hidden-cursor workload. This test
+    /// used to pin that unfixed `Full` outcome; it now pins the fixed
+    /// `Replay` outcome, since `None` app-request is exactly the case where
+    /// nothing wanted a repaint.
+    #[test]
+    fn no_app_request_during_suppressed_pointer_motion_now_decides_replay() {
+        let inputs = Inputs {
+            // What `effective_chrome_gate_delay(true, Duration::ZERO, None)`
+            // returns: `Duration::MAX`, i.e. proof nothing wanted a repaint
+            // (as opposed to `effective_repaint_delay`'s bounded fallback,
+            // which answers a different, scheduling-only question).
+            prev_repaint_delay: Duration::MAX,
+            prev_terminal_requested_delay: None,
+            ..Inputs::all_clear()
+        };
+        assert_eq!(inputs.decide(), crate::ChromeMode::Replay);
     }
 
     // ── #436.7: multi-frame FULL/REPLAY sequence properties ─────────────

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -141,6 +141,15 @@ fn clamp_repaint_delay(delay: std::time::Duration) -> std::time::Duration {
 /// chrome input forces Full), so the one interactive widget most likely to
 /// carry egui-internal animation state cannot itself be open during a
 /// `Replay` frame.
+///
+/// The Item 1 residual-gap fix (`effective_chrome_gate_delay`, see its doc)
+/// widens this latent window: settling the chrome gate on `app_requested_delay:
+/// None` now permits `Replay` in the "app requested nothing" case that used to
+/// pin `Full`, so both mechanisms above are reachable in a strictly larger set
+/// of frames than before that fix. This was a deliberate, accepted trade
+/// (maintainer decision) — the primary win (correct settling for the
+/// btop/`DECTCEM`-hidden-cursor workload) outweighs a latent risk with no
+/// currently-existing trigger.
 const SUPPRESSED_POINTER_FALLBACK_DELAY: std::time::Duration =
     std::time::Duration::from_millis(500);
 
@@ -171,6 +180,47 @@ fn effective_repaint_delay(
 ) -> std::time::Duration {
     if suppressed_only && repaint_delay.is_zero() {
         app_requested_delay.unwrap_or(SUPPRESSED_POINTER_FALLBACK_DELAY)
+    } else {
+        repaint_delay
+    }
+}
+
+/// Subtask 121.13 residual-gap fix (maintainer decision): the value stashed
+/// for next frame's chrome-settle check (see [`chrome_repaint_settled`] via
+/// `EguiState::stash_effective_repaint_delay`), which answers a DIFFERENT
+/// question than [`effective_repaint_delay`] despite sharing its inputs and
+/// its substitution condition.
+///
+/// [`effective_repaint_delay`] answers "what delay do we actually schedule
+/// the next wake at?" — and the answer there MUST be bounded
+/// ([`SUPPRESSED_POINTER_FALLBACK_DELAY`]) when the app requested nothing,
+/// because we cannot prove nothing needs drawing and an unbounded wait would
+/// stall the window.
+///
+/// This function answers "did anything actually WANT a repaint this frame?"
+/// — and when the app requested nothing, the absence of any request IS the
+/// proof that nothing wanted one. Substituting the synthetic liveness poll
+/// interval here would make it masquerade as evidence of a real want, which
+/// is exactly the residual gap the maintainer flagged: `chrome_repaint_settled`'s
+/// `None` arm requires the delay to equal `Duration::MAX` to call the frame
+/// settled, so feeding it 500ms permanently reads as "unsettled" for as long
+/// as suppressed pointer motion continues, even though nothing chrome-relevant
+/// is scheduled.
+///
+/// The two functions diverge in EXACTLY one case: `suppressed_only &&
+/// repaint_delay.is_zero() && app_requested_delay.is_none()`. Every other
+/// input combination yields the same output from both — when `app_requested_delay`
+/// is `Some(_)` the substitution is identical; when substitution does not
+/// apply, both pass `repaint_delay` through unchanged.
+///
+/// Pure so the divergence itself is unit-testable without a live event loop.
+fn effective_chrome_gate_delay(
+    suppressed_only: bool,
+    repaint_delay: std::time::Duration,
+    app_requested_delay: Option<std::time::Duration>,
+) -> std::time::Duration {
+    if suppressed_only && repaint_delay.is_zero() {
+        app_requested_delay.unwrap_or(std::time::Duration::MAX)
     } else {
         repaint_delay
     }
@@ -1210,6 +1260,38 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                     frame_output.app_requested_delay,
                 );
 
+                // Subtask 121.13 + residual-gap fix (maintainer decision):
+                // `run_frame` (inside `state.egui`) already stashed the RAW
+                // `frame_output.repaint_delay` for next frame's chrome-settle
+                // check. Overwrite it here with `effective_chrome_gate_delay`
+                // — NOT `effective_delay`/`effective_repaint_delay` above,
+                // which answers a different question (what to schedule) and
+                // therefore must stay bounded even when the app requested
+                // nothing. The gate value must NOT be bounded in that case:
+                // see `effective_chrome_gate_delay`'s doc for why the two
+                // diverge in exactly one case, and
+                // `EguiState::stash_effective_repaint_delay`'s doc for why
+                // this is a deliberate second write over `run_frame`'s stash.
+                //
+                // Unconditional rather than "only when it differs": the two
+                // gate-delay branches are equal to `repaint_delay` whenever
+                // `suppressed_only` was false, so an unconditional write is a
+                // no-op on every non-suppressed frame and therefore
+                // behaviourally identical to a guarded write, just without
+                // the extra comparison.
+                //
+                // Must run on every path that reaches this point (no early
+                // return follows it in this arm) — the field would go stale
+                // on any suppressed-pointer frame that skipped it.
+                let effective_gate_delay = effective_chrome_gate_delay(
+                    suppressed_only,
+                    frame_output.repaint_delay,
+                    frame_output.app_requested_delay,
+                );
+                state
+                    .egui
+                    .stash_effective_repaint_delay(effective_gate_delay);
+
                 if effective_delay < std::time::Duration::from_hours(1) {
                     let deadline = Instant::now() + clamp_repaint_delay(effective_delay);
                     state.repaint_at = Some(deadline);
@@ -1474,7 +1556,7 @@ pub fn run(config: WindowConfig, app: impl App + 'static) -> Result<(), Error> {
 mod tests {
     use super::{
         MIN_REPAINT_INTERVAL, SUPPRESSED_POINTER_FALLBACK_DELAY, ViewportCommandFlags,
-        clamp_repaint_delay, effective_repaint_delay, is_blocked_key,
+        clamp_repaint_delay, effective_chrome_gate_delay, effective_repaint_delay, is_blocked_key,
         is_unconditional_chrome_input, logical_coord_to_i32, logical_dim_to_u32,
         physical_to_logical_pos, should_force_chrome_full_for_pointer,
         should_schedule_cursor_moved, should_set_chrome_input_pending, update_chrome_drag_latch,
@@ -1949,6 +2031,82 @@ mod tests {
         assert_eq!(
             effective_repaint_delay(false, std::time::Duration::MAX, None),
             std::time::Duration::MAX
+        );
+    }
+
+    // ── Residual-gap fix (maintainer decision): `effective_chrome_gate_delay` ──
+    //
+    // Mirrors the `effective_repaint_delay` tests above for its sibling: same
+    // branches, same inputs, but the `None`-substitution branch answers
+    // `Duration::MAX` instead of the bounded fallback, because this function
+    // answers "did anything want a repaint?" rather than "what do we
+    // schedule?". See the divergence-pinning test at the end of this block.
+
+    #[test]
+    fn effective_chrome_gate_delay_substitutes_app_delay_when_suppressed_and_egui_wants_immediate()
+    {
+        // Identical to `effective_repaint_delay`'s headline case: the app's
+        // own request substitutes for egui's queue-artifact zero.
+        assert_eq!(
+            effective_chrome_gate_delay(true, std::time::Duration::ZERO, Some(MS500)),
+            MS500
+        );
+    }
+
+    #[test]
+    fn effective_chrome_gate_delay_becomes_max_when_app_wants_nothing() {
+        // THIS is where the two functions diverge: `effective_repaint_delay`
+        // must stay bounded here (liveness), but the gate delay must become
+        // `Duration::MAX` — the absence of any app request IS the proof that
+        // nothing wanted a repaint, so the synthetic liveness poll interval
+        // must not masquerade as evidence of one.
+        assert_eq!(
+            effective_chrome_gate_delay(true, std::time::Duration::ZERO, None),
+            std::time::Duration::MAX
+        );
+    }
+
+    #[test]
+    fn effective_chrome_gate_delay_passes_egui_delay_through_when_not_suppressed() {
+        assert_eq!(
+            effective_chrome_gate_delay(false, std::time::Duration::ZERO, Some(MS500)),
+            std::time::Duration::ZERO
+        );
+        assert_eq!(effective_chrome_gate_delay(false, MS16, Some(MS500)), MS16);
+    }
+
+    #[test]
+    fn effective_chrome_gate_delay_never_overrides_a_nonzero_egui_request() {
+        assert_eq!(effective_chrome_gate_delay(true, MS16, Some(MS500)), MS16);
+        assert_eq!(effective_chrome_gate_delay(true, MS16, None), MS16);
+    }
+
+    #[test]
+    fn effective_chrome_gate_delay_preserves_max_when_not_suppressed() {
+        assert_eq!(
+            effective_chrome_gate_delay(false, std::time::Duration::MAX, None),
+            std::time::Duration::MAX
+        );
+    }
+
+    #[test]
+    fn effective_repaint_delay_and_effective_chrome_gate_delay_diverge_only_when_app_requested_nothing()
+     {
+        // Pin the divergence explicitly: same `suppressed_only`/`repaint_delay`
+        // inputs, `app_requested_delay: None`, and the two functions now
+        // disagree on purpose. `effective_repaint_delay` returns the bounded
+        // liveness fallback (what we schedule); `effective_chrome_gate_delay`
+        // returns `Duration::MAX` (nothing wanted a repaint).
+        let scheduled = effective_repaint_delay(true, std::time::Duration::ZERO, None);
+        let gated = effective_chrome_gate_delay(true, std::time::Duration::ZERO, None);
+
+        assert_eq!(scheduled, SUPPRESSED_POINTER_FALLBACK_DELAY);
+        assert_eq!(gated, std::time::Duration::MAX);
+        assert_ne!(
+            scheduled, gated,
+            "the two questions ('what to schedule' vs 'did anything want a \
+             repaint') must diverge in this exact case, or the residual gap \
+             this fix closes has regressed"
         );
     }
 

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -93,10 +93,56 @@ fn clamp_repaint_delay(delay: std::time::Duration) -> std::time::Duration {
 /// Deliberately bounded rather than "never repaint": the app requests nothing
 /// when there is no blink schedule to honour (e.g. `DECTCEM` has hidden the
 /// cursor under btop/vim), and in that state an unbounded wait would stall the
-/// window until an unrelated event happened to arrive. ~4fps is far below the
-/// ~60fps this spike exists to eliminate, while still guaranteeing liveness.
+/// window until an unrelated event happened to arrive.
+///
+/// Subtask 121.12 routed every in-frame freminal repaint need (bell flash,
+/// cursor trail, animated images, gutter hover, scrollbar damage) through
+/// `app_requested_delay`, so the only remaining unrepresented need here is
+/// egui's OWN chrome animation — e.g. a hover/tooltip fade still settling
+/// after the pointer moved off chrome onto terminal content. egui's raw
+/// delay is `ZERO` from the suppressed events regardless, so that need is
+/// indistinguishable from "nothing needs a repaint" and the fallback must
+/// stay bounded — `Duration::MAX` would freeze such a fade at partial alpha
+/// until an unrelated event arrived.
+///
+/// 500ms (not the previous 250ms) is chosen to equal the cursor-blink period
+/// requested at `app_impl.rs`'s per-pane scheduling, so that turning the
+/// cursor blink OFF can never schedule MORE frames than leaving it on. The
+/// old 250ms produced exactly that perversity: blink-on floored at a 2fps
+/// wake, blink-off (no `app_requested_delay` at all) fell back to 4fps —
+/// disabling the blink made the idle GUI repaint *more* often, not less.
+///
+/// ## Two distinct, honest gaps (review SHOULD-FIX #2/#3)
+///
+/// The "egui-internal chrome animation" risk above is actually TWO separate
+/// mechanisms, and conflating them understates the second:
+///
+///   1. **Scheduling cadence.** Even when something egui-internal legitimately
+///      wants a wake, this fallback only guarantees a wake every 500ms rather
+///      than every frame — a bounded but coarser cadence than an unsuppressed
+///      frame would give it. This is the risk the paragraph above describes.
+///   2. **Non-construction, not just under-scheduling.** freminal's own chrome
+///      widgets (menu bar, tab bar) are not merely repainted less often on a
+///      settled/`Replay` frame — see `app_impl.rs`'s "FULL vs REPLAY chrome
+///      construction" comment — they are not CONSTRUCTED at all. An
+///      egui-internal animation living inside one of those widgets (e.g. a
+///      hover-fade `Response` that needs `ctx.request_repaint` called again
+///      next frame to keep advancing) would not just be scheduled less often
+///      under continuous suppressed pointer motion; its own advancing logic
+///      would simply not run, because the widget that would have driven it is
+///      not built on `Replay` frames.
+///
+/// **This is latent, not live.** A repo-wide search confirms freminal's chrome
+/// uses no `ctx.animate_bool` / `ctx.animate_value` anywhere (egui's own
+/// per-frame animation-state helpers) — nothing in this codebase currently
+/// relies on mechanism 2 actually recurring frame-over-frame while chrome is
+/// unconstructed. Separately, opening a menu forces `ChromeMode::Full` via
+/// `any_overlay_open` through an unrelated gate (menus are chrome input, and
+/// chrome input forces Full), so the one interactive widget most likely to
+/// carry egui-internal animation state cannot itself be open during a
+/// `Replay` frame.
 const SUPPRESSED_POINTER_FALLBACK_DELAY: std::time::Duration =
-    std::time::Duration::from_millis(250);
+    std::time::Duration::from_millis(500);
 
 /// Task 121 spike: decide the repaint delay to actually schedule, given what
 /// egui asked for and whether the only thing that happened since the previous
@@ -1856,6 +1902,22 @@ mod tests {
         assert!(
             got < std::time::Duration::from_secs(1),
             "fallback must be a bounded wake, got {got:?}"
+        );
+    }
+
+    #[test]
+    fn effective_repaint_delay_fallback_is_never_faster_than_the_blink_period() {
+        // 121.12 perversity pin: the fallback must be `>= 500ms`, the
+        // cursor-blink period `app_impl.rs` schedules per-pane. Before this
+        // subtask the fallback was 250ms, so turning the cursor blink OFF
+        // (no `app_requested_delay` at all -> this fallback) scheduled MORE
+        // frames (4fps) than leaving the blink ON (2fps at the 500ms floor).
+        // A future edit that shrinks this constant back below the blink
+        // period would silently reintroduce that "blink-off is worse than
+        // blink-on" perversity — this test exists so that regresses loudly.
+        assert!(
+            SUPPRESSED_POINTER_FALLBACK_DELAY >= std::time::Duration::from_millis(500),
+            "fallback ({SUPPRESSED_POINTER_FALLBACK_DELAY:?}) must be >= the 500ms blink period"
         );
     }
 

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -260,6 +260,21 @@ const fn pointer_in_gutter_strip(
     pos_x >= pane_rect_min_x && pos_x < pane_rect_min_x + gutter_width_upper_bound_logical
 }
 
+/// Subtask 121.14: pure composition of the "some animation is in flight
+/// somewhere in this window, independent of pointer position" term used by
+/// `pointer_motion_needs_repaint`. Extracted so it is unit-testable without
+/// a live `FreminalGui`/`PerWindowState` (see
+/// `pointer_motion_needs_repaint_decision`'s doc for why the wrapping
+/// method cannot be constructed headlessly). Trivial (an OR of two already-
+/// computed booleans), but named and tested on its own so the composition
+/// itself — as distinct from how each term is computed — is pinned.
+const fn animation_in_flight_composed(
+    resize_overlay_animating: bool,
+    toast_animating: bool,
+) -> bool {
+    resize_overlay_animating || toast_animating
+}
+
 /// Task 121 pointer-motion repaint-gate spike: the composed decision behind
 /// `App::pointer_motion_needs_repaint`'s freminal-side implementation.
 /// Extracted as a pure function over already-computed signals so it is
@@ -543,6 +558,7 @@ impl freminal_windowing::App for FreminalGui {
                         cached_gutter_inset_logical: 0.0,
                         chrome_head_rects: None,
                         chrome_border_rects: Vec::new(),
+                        chrome_toast_rects: Vec::new(),
                         frame_stats: super::window::FrameStats::default(),
                     };
                     self.windows.insert(window_id, win);
@@ -738,6 +754,16 @@ impl freminal_windowing::App for FreminalGui {
                 pos,
                 win.chrome_head_rects.as_deref(),
                 &win.chrome_border_rects,
+                // Subtask 121.14 (review item 2 follow-up): the most
+                // recently laid-out toast pill rects, in their own field —
+                // see that field's doc in `window.rs` for the staleness
+                // discipline. Hovering a toast DOES change chrome pixels
+                // (close-button highlight, hover-pauses-expiry), so this
+                // correctly, as a consequence, also makes
+                // `should_force_chrome_full_for_pointer` (in
+                // `freminal-windowing`, which calls this method) force
+                // `ChromeMode::Full` while the pointer is over a toast.
+                &win.chrome_toast_rects,
             )
         })
     }
@@ -805,21 +831,38 @@ impl freminal_windowing::App for FreminalGui {
         // ("does the pointer's current position matter?"), which is structurally
         // blind to "something is mid-animation somewhere in this window,
         // regardless of where the pointer is". Toasts and the resize-overlay HUD
-        // both animate every frame independent of pointer position and drive
-        // their own ~16ms repaint requests; without these terms, wandering the
-        // pointer over plain terminal content during a toast fade would let the
-        // `RedrawRequested` override substitute the app's much longer delay for
-        // the animation's cadence, making the fade visibly step instead of
-        // animate. Bounded (<=500ms) rather than a freeze, but a real visual
-        // regression reachable from an already-shipped feature.
+        // are the two things that can animate independent of pointer position;
+        // without these terms, wandering the pointer over plain terminal content
+        // during one of their fades would let the `RedrawRequested` override
+        // substitute the app's much longer delay for the animation's cadence,
+        // making the fade visibly step instead of animate. Bounded (<=500ms)
+        // rather than a freeze, but a real visual regression reachable from an
+        // already-shipped feature.
         //
+        // Subtask 121.14: both terms below test ANIMATION, not PRESENCE — the
+        // superset-but-wasteful bug this subtask fixes. A toast spends most of
+        // its life fully settled in its steady hold; the resize HUD is fully
+        // opaque for the first `RESIZE_OVERLAY_LINGER - RESIZE_OVERLAY_FADE` of
+        // its life. Presence alone (the old `win.resize_overlay.is_some()` /
+        // `!stack.is_empty()`) disabled suppression for their entire lives
+        // instead of just the genuinely-animating tail.
+        let resize_overlay_animating = win.resize_overlay.is_some_and(|overlay| {
+            let elapsed = std::time::Instant::now().saturating_duration_since(overlay.last_update);
+            super::window::resize_overlay_is_animating(
+                elapsed,
+                super::window::RESIZE_OVERLAY_LINGER,
+                super::window::RESIZE_OVERLAY_FADE,
+            )
+        });
         // `try_borrow` failing means someone up-stack holds the `RefCell`; treat
-        // that as "toasts may be active" (conservative), never as "no toasts".
-        let animation_in_flight = win.resize_overlay.is_some()
-            || self
-                .toasts
-                .try_borrow()
-                .map_or(true, |stack| !stack.is_empty());
+        // that as "toasts may be animating" (conservative), never as "no
+        // toasts"/"not animating".
+        let toast_animating = self
+            .toasts
+            .try_borrow()
+            .map_or(true, |stack| !stack.is_empty() && stack.is_animating());
+        let animation_in_flight =
+            animation_in_flight_composed(resize_overlay_animating, toast_animating);
         let overlay_open = win.pending_chrome_signals.any_overlay_open
             || win.pending_chrome_signals.foreground_overlay_open
             || animation_in_flight;
@@ -3118,6 +3161,7 @@ impl freminal_windowing::App for FreminalGui {
                     pos,
                     win.chrome_head_rects.as_deref(),
                     &win.chrome_border_rects,
+                    &win.chrome_toast_rects,
                 )
             });
             let force_full = ui_overlay_open
@@ -3657,7 +3701,28 @@ impl freminal_windowing::App for FreminalGui {
                     // moving over terminal content. Only the delivery
                     // mechanism changes; the overlay's own timing/alpha is
                     // untouched.
-                    let hud_delay = std::time::Duration::from_millis(16);
+                    //
+                    // Subtask 121.14: request only the delay actually
+                    // needed rather than an unconditional 16ms every frame
+                    // the HUD is alive — a wake timed to land exactly at
+                    // fade-start while still opaque, then 16ms once
+                    // genuinely animating. This MUST stay consistent with
+                    // `resize_overlay_is_animating` (the suppression
+                    // predicate `pointer_motion_needs_repaint` uses): if the
+                    // two disagree, the HUD either janks (suppression
+                    // engages while this still requested a fast wake) or
+                    // never sleeps (this keeps requesting 16ms while
+                    // suppression was already judged safe). Without this
+                    // step, Part A's suppression fix would be worthless: the
+                    // unconditional 16ms request folded into
+                    // `shortest_repaint_delay` every frame would still
+                    // schedule the window at 60fps regardless of what the
+                    // suppression predicate allowed.
+                    let hud_delay = super::window::resize_overlay_repaint_delay(
+                        elapsed,
+                        super::window::RESIZE_OVERLAY_LINGER,
+                        super::window::RESIZE_OVERLAY_FADE,
+                    );
                     shortest_repaint_delay =
                         Some(shortest_repaint_delay.map_or(hud_delay, |prev| prev.min(hud_delay)));
                 }
@@ -3839,71 +3904,89 @@ impl freminal_windowing::App for FreminalGui {
         // frame it is (`ChromeSignals::toast_active`), so a REPLAY frame can
         // only ever be entered while the stack is provably empty, making
         // `.show()` a no-op here anyway.
-        if chrome_mode == freminal_windowing::ChromeMode::Full
-            && let Ok(mut stack) = self.toasts.try_borrow_mut()
-            && !stack.is_empty()
-        {
-            // Rebuild the same geometry `central_body` used to populate
-            // `cached_central_rect`/the pane layout — `win` is a local
-            // variable here (removed from `self.windows` above, reinserted
-            // below), so this cannot reuse `central_body`'s own locals
-            // (`pane_layout`, `available_rect`), which are scoped to that
-            // closure.
-            let content_rect = win
-                .cached_central_rect
-                .unwrap_or_else(|| ctx.input(egui::InputState::content_rect));
-            // Pre-resolve the active tab's pane layout into owned locals so
-            // the `resolve_pane_rect` closure below does not borrow `win`
-            // (it only captures `Copy`/owned data) — it needs to coexist
-            // with the `win.terminal_widget.font_manager_mut()` borrow
-            // passed alongside it to `stack.show`.
-            let active_tab = win.tabs.active_tab();
-            let zoomed_pane = active_tab.zoomed_pane;
-            let pane_layout: Vec<(crate::gui::panes::PaneId, egui::Rect)> = active_tab
-                .pane_tree
-                .layout(content_rect)
-                .unwrap_or_default();
-            let resolve_pane_rect =
-                move |pane_id: crate::gui::panes::PaneId| -> Option<egui::Rect> {
-                    if let Some(zoomed_id) = zoomed_pane {
-                        return (zoomed_id == pane_id).then_some(content_rect);
-                    }
-                    pane_layout
-                        .iter()
-                        .find(|(id, _)| *id == pane_id)
-                        .map(|(_, r)| *r)
-                };
-            let pixels_per_point = ctx.pixels_per_point();
-            let resources = super::toast::ToastFrameResources {
-                render_state: &win.toast_render_state,
-                font_manager: win.terminal_widget.font_manager_mut(),
-            };
-            let repaint_delay = stack.show(
-                ctx,
-                content_rect,
-                window_id,
-                resolve_pane_rect,
-                resources,
-                pixels_per_point,
-            );
+        if chrome_mode == freminal_windowing::ChromeMode::Full {
+            // Review item 2 follow-up to 121.14: `win.chrome_toast_rects`
+            // must be written on EVERY `Full` frame reaching this point, not
+            // only when the block below actually runs `stack.show()` — see
+            // that field's doc in `window.rs` for why (an emptied stack
+            // would otherwise leave stale rects behind forever). Default to
+            // cleared; the inner block below overwrites with fresh rects
+            // when it runs.
+            win.chrome_toast_rects.clear();
 
-            // Subtask 121.12: `ToastStack::show` returns its wanted delay
-            // rather than calling `ctx.request_repaint_after()` itself. This
-            // runs AFTER `central_body` already published
-            // `win.pending_terminal_requested_delay` (~3768 above), so it is
-            // a second aggregation point — the toast stack renders outside
-            // `central_body`, once per window, after the per-window local
-            // aggregate has already been folded and published. Fold it into
-            // that published field too (so `chrome_repaint_settled`'s
-            // suppressed-pointer / next-frame comparisons see it) and
-            // schedule it directly, since `central_body`'s own scheduling
-            // call has already run and will not run again this frame.
-            if let Some(delay) = repaint_delay {
-                win.pending_terminal_requested_delay = Some(
-                    win.pending_terminal_requested_delay
-                        .map_or(delay, |prev| prev.min(delay)),
+            if let Ok(mut stack) = self.toasts.try_borrow_mut()
+                && !stack.is_empty()
+            {
+                // Rebuild the same geometry `central_body` used to populate
+                // `cached_central_rect`/the pane layout — `win` is a local
+                // variable here (removed from `self.windows` above, reinserted
+                // below), so this cannot reuse `central_body`'s own locals
+                // (`pane_layout`, `available_rect`), which are scoped to that
+                // closure.
+                let content_rect = win
+                    .cached_central_rect
+                    .unwrap_or_else(|| ctx.input(egui::InputState::content_rect));
+                // Pre-resolve the active tab's pane layout into owned locals so
+                // the `resolve_pane_rect` closure below does not borrow `win`
+                // (it only captures `Copy`/owned data) — it needs to coexist
+                // with the `win.terminal_widget.font_manager_mut()` borrow
+                // passed alongside it to `stack.show`.
+                let active_tab = win.tabs.active_tab();
+                let zoomed_pane = active_tab.zoomed_pane;
+                let pane_layout: Vec<(crate::gui::panes::PaneId, egui::Rect)> = active_tab
+                    .pane_tree
+                    .layout(content_rect)
+                    .unwrap_or_default();
+                let resolve_pane_rect =
+                    move |pane_id: crate::gui::panes::PaneId| -> Option<egui::Rect> {
+                        if let Some(zoomed_id) = zoomed_pane {
+                            return (zoomed_id == pane_id).then_some(content_rect);
+                        }
+                        pane_layout
+                            .iter()
+                            .find(|(id, _)| *id == pane_id)
+                            .map(|(_, r)| *r)
+                    };
+                let pixels_per_point = ctx.pixels_per_point();
+                let resources = super::toast::ToastFrameResources {
+                    render_state: &win.toast_render_state,
+                    font_manager: win.terminal_widget.font_manager_mut(),
+                };
+                let outcome = stack.show(
+                    ctx,
+                    content_rect,
+                    window_id,
+                    resolve_pane_rect,
+                    resources,
+                    pixels_per_point,
                 );
-                ctx.request_repaint_after(delay);
+
+                // Subtask 121.14 (review item 2 follow-up): the laid-out
+                // toast pill rects go into their own `chrome_toast_rects`
+                // field, not `chrome_border_rects` — see that field's doc
+                // in `window.rs` for the full staleness-discipline
+                // reasoning and why a dedicated field replaced the
+                // original append-to-border-rects approach.
+                win.chrome_toast_rects = outcome.rects;
+
+                // Subtask 121.12: `ToastStack::show` returns its wanted delay
+                // rather than calling `ctx.request_repaint_after()` itself. This
+                // runs AFTER `central_body` already published
+                // `win.pending_terminal_requested_delay` (~3768 above), so it is
+                // a second aggregation point — the toast stack renders outside
+                // `central_body`, once per window, after the per-window local
+                // aggregate has already been folded and published. Fold it into
+                // that published field too (so `chrome_repaint_settled`'s
+                // suppressed-pointer / next-frame comparisons see it) and
+                // schedule it directly, since `central_body`'s own scheduling
+                // call has already run and will not run again this frame.
+                if let Some(delay) = outcome.repaint_delay {
+                    win.pending_terminal_requested_delay = Some(
+                        win.pending_terminal_requested_delay
+                            .map_or(delay, |prev| prev.min(delay)),
+                    );
+                    ctx.request_repaint_after(delay);
+                }
             }
         }
 
@@ -4412,6 +4495,7 @@ impl FreminalGui {
             cached_gutter_inset_logical: 0.0,
             chrome_head_rects: None,
             chrome_border_rects: Vec::new(),
+            chrome_toast_rects: Vec::new(),
             frame_stats: super::window::FrameStats::default(),
         }
     }
@@ -4624,10 +4708,10 @@ impl FreminalGui {
 #[cfg(test)]
 mod tests {
     use super::{
-        PointerMotionPaneSignals, SettingsOwnerCloseDecision, cursor_blink_wants_repaint,
-        pane_hover_region_risk, pane_hover_region_terms, pointer_forces_full_present,
-        pointer_in_gutter_strip, pointer_motion_needs_repaint_decision,
-        settings_owner_close_decision,
+        PointerMotionPaneSignals, SettingsOwnerCloseDecision, animation_in_flight_composed,
+        cursor_blink_wants_repaint, pane_hover_region_risk, pane_hover_region_terms,
+        pointer_forces_full_present, pointer_in_gutter_strip,
+        pointer_motion_needs_repaint_decision, settings_owner_close_decision,
     };
     use freminal_common::cursor::CursorVisualStyle;
 
@@ -4713,6 +4797,28 @@ mod tests {
         assert!(!pointer_forces_full_present(false, false, true));
         // Not moving, neither chrome nor drag -> no forced Full.
         assert!(!pointer_forces_full_present(false, false, false));
+    }
+
+    // ── Subtask 121.14: `animation_in_flight_composed` ───────────────────
+
+    #[test]
+    fn animation_in_flight_composed_both_false_is_false() {
+        assert!(!animation_in_flight_composed(false, false));
+    }
+
+    #[test]
+    fn animation_in_flight_composed_resize_overlay_alone_forces_true() {
+        assert!(animation_in_flight_composed(true, false));
+    }
+
+    #[test]
+    fn animation_in_flight_composed_toast_alone_forces_true() {
+        assert!(animation_in_flight_composed(false, true));
+    }
+
+    #[test]
+    fn animation_in_flight_composed_both_true_is_true() {
+        assert!(animation_in_flight_composed(true, true));
     }
 
     // ── Task 121 pointer-motion repaint-gate spike ───────────────────────

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -2809,6 +2809,17 @@ impl freminal_windowing::App for FreminalGui {
                 let (left_clicked, copied_to_clipboard, deferred_actions) = show_result.inner;
                 all_deferred_actions.extend(deferred_actions);
 
+                // Subtask 121.12: drain this pane's in-frame repaint needs
+                // (bell flash, cursor trail, animated image, gutter hover,
+                // scrollbar damage — folded into `pane.render_cache` by
+                // `show()` rather than requested on the `Context` directly)
+                // and fold the shortest into the frame-wide aggregate so the
+                // need is visible to `App::take_terminal_requested_delay`.
+                if let Some(delay) = pane.render_cache.take_pending_repaint_delay() {
+                    shortest_repaint_delay =
+                        Some(shortest_repaint_delay.map_or(delay, |prev| prev.min(delay)));
+                }
+
                 if copied_to_clipboard {
                     self.route_freminal_toast(
                         freminal_common::config::FreminalToastCategory::ClipboardCopy,
@@ -3637,7 +3648,18 @@ impl freminal_windowing::App for FreminalGui {
                     painter.rect_filled(text_rect, 6.0, egui::Color32::from_black_alpha(bg_alpha));
                     painter.galley(text_rect.min + egui::vec2(12.0, 12.0), galley, text_color);
                     // Keep animating/timing-out even without further input.
-                    ctx.request_repaint_after(std::time::Duration::from_millis(16));
+                    // Subtask 121.12: fold into `shortest_repaint_delay`
+                    // (same closure, in scope here) instead of calling
+                    // `ctx.request_repaint_after()` directly — a direct call
+                    // would be invisible to `effective_repaint_delay`'s
+                    // suppressed-pointer substitution and would be silently
+                    // downgraded to the fallback interval while the mouse is
+                    // moving over terminal content. Only the delivery
+                    // mechanism changes; the overlay's own timing/alpha is
+                    // untouched.
+                    let hud_delay = std::time::Duration::from_millis(16);
+                    shortest_repaint_delay =
+                        Some(shortest_repaint_delay.map_or(hud_delay, |prev| prev.min(hud_delay)));
                 }
             }
 
@@ -3856,7 +3878,7 @@ impl freminal_windowing::App for FreminalGui {
                 render_state: &win.toast_render_state,
                 font_manager: win.terminal_widget.font_manager_mut(),
             };
-            stack.show(
+            let repaint_delay = stack.show(
                 ctx,
                 content_rect,
                 window_id,
@@ -3864,6 +3886,25 @@ impl freminal_windowing::App for FreminalGui {
                 resources,
                 pixels_per_point,
             );
+
+            // Subtask 121.12: `ToastStack::show` returns its wanted delay
+            // rather than calling `ctx.request_repaint_after()` itself. This
+            // runs AFTER `central_body` already published
+            // `win.pending_terminal_requested_delay` (~3768 above), so it is
+            // a second aggregation point — the toast stack renders outside
+            // `central_body`, once per window, after the per-window local
+            // aggregate has already been folded and published. Fold it into
+            // that published field too (so `chrome_repaint_settled`'s
+            // suppressed-pointer / next-frame comparisons see it) and
+            // schedule it directly, since `central_body`'s own scheduling
+            // call has already run and will not run again this frame.
+            if let Some(delay) = repaint_delay {
+                win.pending_terminal_requested_delay = Some(
+                    win.pending_terminal_requested_delay
+                        .map_or(delay, |prev| prev.min(delay)),
+                );
+                ctx.request_repaint_after(delay);
+            }
         }
 
         // ── Chrome-damage (#436.3): §3.5 "after" sample + final decision ─────

--- a/freminal/src/gui/chrome_damage.rs
+++ b/freminal/src/gui/chrome_damage.rs
@@ -341,13 +341,25 @@ pub const fn decide_chrome_damage(
 /// #436.8: is `pos` over any chrome-interactive rect? `head_rects == None`
 /// means no FULL frame has captured them yet -> conservative `true`.
 #[must_use]
+///
+/// `toast_rects` (review item 2 follow-up to subtask 121.14) is the most
+/// recently laid-out toast pill hit-rects, tested the same way as
+/// `border_rects` — hovering a toast changes chrome pixels (close-button
+/// highlight, hover-pauses-expiry) even though toasts are neither
+/// menu/tab-bar chrome nor split-border drag sensors. Kept as an explicit
+/// third parameter (rather than pre-merging into `border_rects` at the call
+/// site, or duplicating this function's `rect.contains(pos)` scan at each
+/// caller) so both consumers share one tested implementation.
 pub fn point_in_chrome_rects(
     pos: egui::Pos2,
     head_rects: Option<&[egui::Rect]>,
     border_rects: &[egui::Rect],
+    toast_rects: &[egui::Rect],
 ) -> bool {
     let Some(head) = head_rects else { return true };
-    head.iter().any(|r| r.contains(pos)) || border_rects.iter().any(|r| r.contains(pos))
+    head.iter().any(|r| r.contains(pos))
+        || border_rects.iter().any(|r| r.contains(pos))
+        || toast_rects.iter().any(|r| r.contains(pos))
 }
 
 #[cfg(test)]
@@ -805,16 +817,23 @@ mod tests {
     #[test]
     fn point_in_chrome_rects_none_head_is_conservative_true() {
         // No FULL frame has captured head rects yet -> unknown -> true.
-        assert!(point_in_chrome_rects(egui::pos2(10.0, 10.0), None, &[],));
+        assert!(point_in_chrome_rects(
+            egui::pos2(10.0, 10.0),
+            None,
+            &[],
+            &[],
+        ));
     }
 
     #[test]
     fn point_in_chrome_rects_empty_rects_is_false() {
         // A FULL frame captured (empty) head rects (e.g. hidden menu bar, no
-        // tab bar) and there are no border sensors: nothing is chrome.
+        // tab bar) and there are no border sensors or toast rects: nothing
+        // is chrome.
         assert!(!point_in_chrome_rects(
             egui::pos2(10.0, 10.0),
             Some(&[]),
+            &[],
             &[],
         ));
     }
@@ -829,6 +848,7 @@ mod tests {
             egui::pos2(50.0, 10.0),
             Some(&head),
             &[],
+            &[],
         ));
     }
 
@@ -841,6 +861,7 @@ mod tests {
         assert!(!point_in_chrome_rects(
             egui::pos2(50.0, 100.0),
             Some(&head),
+            &[],
             &[],
         ));
     }
@@ -855,6 +876,7 @@ mod tests {
             egui::pos2(100.0, 50.0),
             Some(&[]),
             &border,
+            &[],
         ));
     }
 
@@ -868,6 +890,7 @@ mod tests {
             egui::pos2(300.0, 50.0),
             Some(&[]),
             &border,
+            &[],
         ));
     }
 
@@ -885,6 +908,62 @@ mod tests {
             egui::pos2(500.0, 500.0),
             Some(&head),
             &border,
+            &[],
+        ));
+    }
+
+    // ── Review item 2 follow-up to 121.14: the dedicated `toast_rects` param ──
+
+    #[test]
+    fn point_in_chrome_rects_inside_toast_rect_is_true() {
+        // A toast rect alone (no head/border overlap) must still register as
+        // chrome-interactive -- this is the whole point of giving toasts
+        // their own parameter instead of silently dropping them.
+        let toast = [egui::Rect::from_min_max(
+            egui::pos2(200.0, 200.0),
+            egui::pos2(300.0, 240.0),
+        )];
+        assert!(point_in_chrome_rects(
+            egui::pos2(250.0, 220.0),
+            Some(&[]),
+            &[],
+            &toast,
+        ));
+    }
+
+    #[test]
+    fn point_in_chrome_rects_outside_toast_rect_is_false() {
+        let toast = [egui::Rect::from_min_max(
+            egui::pos2(200.0, 200.0),
+            egui::pos2(300.0, 240.0),
+        )];
+        assert!(!point_in_chrome_rects(
+            egui::pos2(10.0, 10.0),
+            Some(&[]),
+            &[],
+            &toast,
+        ));
+    }
+
+    #[test]
+    fn point_in_chrome_rects_inside_none_of_head_border_toast_is_false() {
+        let head = [egui::Rect::from_min_max(
+            egui::pos2(0.0, 0.0),
+            egui::pos2(100.0, 20.0),
+        )];
+        let border = [egui::Rect::from_min_max(
+            egui::pos2(97.0, 0.0),
+            egui::pos2(103.0, 200.0),
+        )];
+        let toast = [egui::Rect::from_min_max(
+            egui::pos2(200.0, 200.0),
+            egui::pos2(300.0, 240.0),
+        )];
+        assert!(!point_in_chrome_rects(
+            egui::pos2(500.0, 500.0),
+            Some(&head),
+            &border,
+            &toast,
         ));
     }
 
@@ -892,7 +971,8 @@ mod tests {
     //
     // `FreminalGui::is_chrome_interactive_at` (app_impl.rs) is
     //   `self.windows.get(&window_id).is_none_or(|win|
-    //        point_in_chrome_rects(pos, win.chrome_head_rects, win.chrome_border_rects))`
+    //        point_in_chrome_rects(pos, win.chrome_head_rects,
+    //            win.chrome_border_rects, win.chrome_toast_rects))`
     // The point-in-rects half is pinned exhaustively above. The distinct
     // behavior the wrapper adds is the `is_none_or` fallback: an UNKNOWN
     // `window_id` (no `PerWindowState` entry) is conservatively chrome-
@@ -904,13 +984,18 @@ mod tests {
     // composition (e.g. flipping the unknown-window default to `false`, which
     // would silently starve a chrome interaction of repaints on a window whose
     // state is mid-teardown).
+    /// Test-only alias for the mirrored `is_chrome_interactive_at` closure's
+    /// "known window" state below: `(head_rects, border_rects, toast_rects)`.
+    /// Named purely to satisfy `clippy::type_complexity` -- has no
+    /// production counterpart.
+    type WindowRectsFixture<'a> = (Option<&'a [egui::Rect]>, &'a [egui::Rect], &'a [egui::Rect]);
+
     #[test]
     fn is_chrome_interactive_at_unknown_window_is_conservative_true() {
         // Mirror of the wrapper: `None` window => true, else delegate.
-        let decide = |window_present: Option<(Option<&[egui::Rect]>, &[egui::Rect])>,
-                      pos: egui::Pos2|
-         -> bool {
-            window_present.is_none_or(|(head, border)| point_in_chrome_rects(pos, head, border))
+        let decide = |window_present: Option<WindowRectsFixture<'_>>, pos: egui::Pos2| -> bool {
+            window_present
+                .is_none_or(|(head, border, toast)| point_in_chrome_rects(pos, head, border, toast))
         };
 
         // Unknown window (None) -> true regardless of position.
@@ -918,17 +1003,35 @@ mod tests {
 
         // Known window, point over terminal content, captured (empty) rects
         // -> false (delegates to point_in_chrome_rects, which is false).
-        assert!(!decide(Some((Some(&[]), &[])), egui::pos2(500.0, 500.0)));
+        assert!(!decide(
+            Some((Some(&[]), &[], &[])),
+            egui::pos2(500.0, 500.0)
+        ));
 
         // Known window, point inside a captured head rect -> true.
         let head = [egui::Rect::from_min_max(
             egui::pos2(0.0, 0.0),
             egui::pos2(100.0, 20.0),
         )];
-        assert!(decide(Some((Some(&head), &[])), egui::pos2(50.0, 10.0)));
+        assert!(decide(
+            Some((Some(&head), &[], &[])),
+            egui::pos2(50.0, 10.0)
+        ));
 
         // Known window, head rects not yet captured (None) -> conservative true.
-        assert!(decide(Some((None, &[])), egui::pos2(50.0, 10.0)));
+        assert!(decide(Some((None, &[], &[])), egui::pos2(50.0, 10.0)));
+
+        // Known window, point inside a captured toast rect -> true (review
+        // item 2: toasts have their own field/param now, not folded into
+        // `border_rects`).
+        let toast = [egui::Rect::from_min_max(
+            egui::pos2(200.0, 200.0),
+            egui::pos2(300.0, 240.0),
+        )];
+        assert!(decide(
+            Some((Some(&[]), &[], &toast)),
+            egui::pos2(250.0, 220.0)
+        ));
     }
 }
 

--- a/freminal/src/gui/layout_ops.rs
+++ b/freminal/src/gui/layout_ops.rs
@@ -738,6 +738,7 @@ impl FreminalGui {
             cached_gutter_inset_logical: 0.0,
             chrome_head_rects: None,
             chrome_border_rects: Vec::new(),
+            chrome_toast_rects: Vec::new(),
             frame_stats: super::window::FrameStats::default(),
         };
         self.windows.insert(window_id, win);

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -668,6 +668,18 @@ enum BellFlashOutcome {
     Cleared,
 }
 
+/// Pure mapping from a [`BellFlashOutcome`] to the repaint delay
+/// [`paint_bell_flash`] needs (subtask 121.12), factored out so the
+/// delay-selection logic is unit-testable without a live `egui::Ui` — see
+/// [`paint_bell_flash`]'s doc for why the delay is returned rather than
+/// requested on the `Context` directly.
+const fn bell_flash_repaint_delay(outcome: BellFlashOutcome) -> Option<std::time::Duration> {
+    match outcome {
+        BellFlashOutcome::Fading { .. } => Some(std::time::Duration::from_millis(16)),
+        BellFlashOutcome::Persistent { .. } | BellFlashOutcome::Cleared => None,
+    }
+}
+
 /// Pure decision logic for [`paint_bell_flash`], factored out so it is
 /// unit-testable without a live `egui::Ui`/`Context`.
 ///
@@ -716,13 +728,27 @@ fn bell_flash_outcome(window_focused: bool, elapsed: Duration) -> BellFlashOutco
 /// below (regression fixed here: a bell firing in a background/inactive
 /// pane, or a newly created split/tab that never itself received a real
 /// focus transition, would flash once and then never clear).
-fn paint_bell_flash(ui: &Ui, terminal_rect: Rect, view_state: &mut ViewState) {
-    let Some(since) = view_state.bell_since else {
-        return;
-    };
+///
+/// Returns the repaint delay this call needs (subtask 121.12): `Some(16ms)`
+/// while a fade is in progress (so the fade continues smoothly next frame),
+/// `None` for the static persistent overlay and the cleared case. THE
+/// CALLER MUST FOLD THE RETURNED DELAY INTO THE PANE'S [`PaneRenderCache`]
+/// via `PaneRenderCache::request_repaint_after` — this function deliberately
+/// does NOT call `ui.ctx().request_repaint_after()` itself, because that
+/// would be invisible to `effective_repaint_delay`'s suppressed-pointer
+/// substitution (in `freminal-windowing`) and would be silently downgraded
+/// to the much longer fallback interval while the mouse is moving over
+/// terminal content.
+fn paint_bell_flash(
+    ui: &Ui,
+    terminal_rect: Rect,
+    view_state: &mut ViewState,
+) -> Option<std::time::Duration> {
+    let since = view_state.bell_since?;
 
     let window_focused = ui.ctx().input(|i| i.focused);
-    match bell_flash_outcome(window_focused, since.elapsed()) {
+    let outcome = bell_flash_outcome(window_focused, since.elapsed());
+    match outcome {
         BellFlashOutcome::Persistent { alpha } => {
             // No repaint request — the overlay is static and doesn't need
             // continuous redraws while the window is in the background.
@@ -732,15 +758,12 @@ fn paint_bell_flash(ui: &Ui, terminal_rect: Rect, view_state: &mut ViewState) {
         BellFlashOutcome::Fading { alpha } => {
             let overlay_color = Color32::from_rgba_premultiplied(alpha, alpha, alpha, alpha);
             ui.painter().rect_filled(terminal_rect, 0.0, overlay_color);
-
-            // Request a repaint so the fade-out continues next frame (~60 fps cap).
-            ui.ctx()
-                .request_repaint_after(std::time::Duration::from_millis(16));
         }
         BellFlashOutcome::Cleared => {
             view_state.bell_since = None;
         }
     }
+    bell_flash_repaint_delay(outcome)
 }
 
 /// Context menu action produced by the right-click popup.
@@ -1411,6 +1434,14 @@ pub struct PaneRenderCache {
     /// [`PaneFrameDamage`]: crate::gui::renderer::PaneFrameDamage
     /// [`PaneFrameDamage::Unchanged`]: crate::gui::renderer::PaneFrameDamage::Unchanged
     pub(crate) last_frame_cursor_damage: crate::gui::renderer::PaneFrameDamage,
+    /// Repaint delay this pane's `show()` needs, folded to the shortest across
+    /// every in-frame requester. Drained by `central_body` after `show()`
+    /// returns and folded into `shortest_repaint_delay`, so the need is visible
+    /// in `App::take_terminal_requested_delay` (subtask 121.12). Requesting a
+    /// repaint directly on the `Context` here would be invisible to
+    /// `effective_repaint_delay`'s suppressed-pointer substitution and would be
+    /// silently downgraded to the fallback interval.
+    pub(crate) pending_repaint_delay: Option<std::time::Duration>,
 }
 
 impl PaneRenderCache {
@@ -1452,6 +1483,7 @@ impl PaneRenderCache {
             placeholder_hit_rects: Vec::new(),
             last_rendered_image_pixel_ptrs: std::collections::HashMap::new(),
             last_frame_cursor_damage: crate::gui::renderer::PaneFrameDamage::Unchanged,
+            pending_repaint_delay: None,
         }
     }
 
@@ -1518,6 +1550,32 @@ impl PaneRenderCache {
         self.last_rendered_line_widths = None;
         self.shaping_cache.clear();
         self.last_rendered_image_pixel_ptrs.clear();
+    }
+
+    /// Record that some in-frame animation (bell flash, cursor trail,
+    /// animated image, gutter hover clear, scrollbar damage) needs another
+    /// repaint after `delay`, folding to the shortest delay requested so far
+    /// this frame (subtask 121.12).
+    ///
+    /// Every in-frame repaint need must be routed through this method rather
+    /// than calling `ui.ctx().request_repaint_after()` directly — see the
+    /// doc comment on [`Self::pending_repaint_delay`] for why a direct
+    /// `Context` call is invisible to `effective_repaint_delay`'s
+    /// suppressed-pointer substitution.
+    pub(crate) fn request_repaint_after(&mut self, delay: std::time::Duration) {
+        self.pending_repaint_delay = Some(
+            self.pending_repaint_delay
+                .map_or(delay, |prev| prev.min(delay)),
+        );
+    }
+
+    /// Drain and return the repaint delay accumulated this frame via
+    /// [`Self::request_repaint_after`], if any. Called once per frame by
+    /// `app_impl`'s `central_body` after `show()` returns, so a stale delay
+    /// from a previous frame is never re-folded into the next frame's
+    /// aggregate.
+    pub(crate) const fn take_pending_repaint_delay(&mut self) -> Option<std::time::Duration> {
+        self.pending_repaint_delay.take()
     }
 }
 
@@ -1933,13 +1991,32 @@ impl FreminalTerminalWidget {
                 ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
             }
             if needs_repaint {
-                ui.ctx().request_repaint();
+                // 16ms, not `Duration::ZERO` (subtask 121.12, comment
+                // corrected per review NIT #10): scheduling is unchanged
+                // (`clamp_repaint_delay` already floors any delay, including
+                // a bare `request_repaint()`, at `MIN_REPAINT_INTERVAL` =
+                // 16ms). The reason it must not be `Duration::ZERO` is NOT
+                // that zero would flip `chrome_repaint_settled`'s outcome on
+                // THIS frame — `repaint_delay >= terminal_requested_delay`
+                // is trivially true for equal values regardless of which one
+                // is used. The real reason: an app-side ask of EXACTLY
+                // `Duration::ZERO` makes that settle check permanently
+                // vacuous — nothing can ever be detected as wanting a
+                // repaint sooner than "immediate", so the gate loses its
+                // ability to notice a coincidental concurrent egui-internal
+                // want on any LATER frame where this need recurs. 16ms
+                // preserves that discriminating power, and is
+                // scheduling-equivalent because `clamp_repaint_delay` floors
+                // everything at `MIN_REPAINT_INTERVAL` = 16ms anyway.
+                cache.request_repaint_after(std::time::Duration::from_millis(16));
             }
             cache.pointer_in_gutter_last_frame = effectively_hovered;
         } else if cache.pointer_in_gutter_last_frame {
             // Feature toggled off / alt-screen entered while we were hovering:
-            // draw one clearing frame.
-            ui.ctx().request_repaint();
+            // draw one clearing frame. See the comment above for why 16ms,
+            // not zero, is used here (settle-check discriminating power, not
+            // this frame's outcome).
+            cache.request_repaint_after(std::time::Duration::from_millis(16));
             cache.pointer_in_gutter_last_frame = false;
         }
 
@@ -2971,15 +3048,16 @@ impl FreminalTerminalWidget {
 
             // Drive the cursor trail animation: request a repaint on the next
             // frame so the interpolation continues smoothly until it completes.
+            // Folded into `cache` (subtask 121.12), not requested on the
+            // `Context` directly — see `PaneRenderCache::request_repaint_after`.
             if cursor_animating {
-                ui.ctx()
-                    .request_repaint_after(std::time::Duration::from_millis(16));
+                cache.request_repaint_after(std::time::Duration::from_millis(16));
             }
 
             // Drive animated image playback: request a repaint when the next
             // frame is due so animations keep advancing while otherwise idle.
             if let Some(due) = anim_tick.next_due {
-                ui.ctx().request_repaint_after(due);
+                cache.request_repaint_after(due);
             }
         }
 
@@ -3225,14 +3303,25 @@ impl FreminalTerminalWidget {
             effectively_hovered: cache.scrollbar_was_hovered_last_frame,
         };
         if scrollbar_damage_decision(current_scrollbar_state, previous_scrollbar_state) {
-            ui.ctx().request_repaint();
+            // 16ms, not `Duration::ZERO` (subtask 121.12) — see the
+            // gutter-hover comment above for the corrected reasoning:
+            // scheduling is unchanged (already floored at 16ms by
+            // `clamp_repaint_delay`), but a zero app-side ask would make
+            // `chrome_repaint_settled`'s check permanently vacuous rather
+            // than merely changing this frame's outcome.
+            cache.request_repaint_after(std::time::Duration::from_millis(16));
             cache.last_frame_cursor_damage = crate::gui::renderer::PaneFrameDamage::Full;
         }
         cache.scrollbar_was_rendered_last_frame = scrollbar_outcome.rendered;
         cache.scrollbar_was_hovered_last_frame = scrollbar_outcome.hovered;
 
         // ── Visual bell flash overlay ────────────────────────────────
-        paint_bell_flash(ui, rect, view_state);
+        // Fold the returned delay into `cache` (subtask 121.12) — see
+        // `paint_bell_flash`'s doc comment for why it does not request the
+        // repaint on the `Context` directly.
+        if let Some(delay) = paint_bell_flash(ui, rect, view_state) {
+            cache.request_repaint_after(delay);
+        }
 
         // ── Password-prompt lock indicator ───────────────────────────
         // When echo-off is detected (password prompt), paint a lock icon
@@ -4010,7 +4099,7 @@ mod bell_flash_tests {
 
     use super::{
         BELL_FLASH_DURATION, BELL_FLASH_MAX_ALPHA, BELL_PERSISTENT_ALPHA, BellFlashOutcome,
-        bell_flash_outcome,
+        bell_flash_outcome, bell_flash_repaint_delay,
     };
     use std::time::Duration;
 
@@ -4077,6 +4166,36 @@ mod bell_flash_tests {
                 alpha: BELL_PERSISTENT_ALPHA
             }
         );
+    }
+
+    // ── Subtask 121.12: `bell_flash_repaint_delay` ────────────────────────
+    // `paint_bell_flash` itself needs a live `egui::Ui` and cannot be driven
+    // headlessly, so its delay-selection logic is factored into this pure
+    // function and pinned directly here.
+
+    #[test]
+    fn fading_outcome_wants_a_16ms_repaint() {
+        assert_eq!(
+            bell_flash_repaint_delay(BellFlashOutcome::Fading {
+                alpha: BELL_FLASH_MAX_ALPHA
+            }),
+            Some(Duration::from_millis(16))
+        );
+    }
+
+    #[test]
+    fn persistent_outcome_wants_no_repaint() {
+        assert_eq!(
+            bell_flash_repaint_delay(BellFlashOutcome::Persistent {
+                alpha: BELL_PERSISTENT_ALPHA
+            }),
+            None
+        );
+    }
+
+    #[test]
+    fn cleared_outcome_wants_no_repaint() {
+        assert_eq!(bell_flash_repaint_delay(BellFlashOutcome::Cleared), None);
     }
 }
 
@@ -4952,5 +5071,66 @@ mod placeholder_tests {
         ];
         assert_eq!(hit_test_placeholder(&rects, pos2(50.0, 50.0)), Some(id_b));
         assert_eq!(hit_test_placeholder(&rects, pos2(50.0, 10.0)), Some(id_a));
+    }
+}
+
+#[cfg(test)]
+mod pane_render_cache_repaint_delay_tests {
+    //! Subtask 121.12: [`PaneRenderCache::request_repaint_after`] /
+    //! [`PaneRenderCache::take_pending_repaint_delay`] — the per-pane
+    //! aggregation seam every in-frame repaint requester now folds through,
+    //! instead of calling `ui.ctx().request_repaint_after()` directly.
+
+    use super::PaneRenderCache;
+    use std::time::Duration;
+
+    #[test]
+    fn no_request_drains_to_none() {
+        let mut cache = PaneRenderCache::new();
+        assert_eq!(cache.take_pending_repaint_delay(), None);
+    }
+
+    #[test]
+    fn single_request_is_returned_unchanged() {
+        let mut cache = PaneRenderCache::new();
+        cache.request_repaint_after(Duration::from_millis(16));
+        assert_eq!(
+            cache.take_pending_repaint_delay(),
+            Some(Duration::from_millis(16))
+        );
+    }
+
+    #[test]
+    fn repeated_requests_fold_to_the_minimum_regardless_of_order() {
+        let mut cache = PaneRenderCache::new();
+        cache.request_repaint_after(Duration::from_millis(250));
+        cache.request_repaint_after(Duration::from_millis(16));
+        cache.request_repaint_after(Duration::from_millis(100));
+        assert_eq!(
+            cache.take_pending_repaint_delay(),
+            Some(Duration::from_millis(16))
+        );
+
+        // Order must not matter — smallest-wins either way.
+        let mut cache = PaneRenderCache::new();
+        cache.request_repaint_after(Duration::from_millis(16));
+        cache.request_repaint_after(Duration::from_millis(250));
+        assert_eq!(
+            cache.take_pending_repaint_delay(),
+            Some(Duration::from_millis(16))
+        );
+    }
+
+    #[test]
+    fn take_drains_the_cache_so_a_stale_delay_never_survives_into_the_next_frame() {
+        let mut cache = PaneRenderCache::new();
+        cache.request_repaint_after(Duration::from_millis(16));
+        assert_eq!(
+            cache.take_pending_repaint_delay(),
+            Some(Duration::from_millis(16))
+        );
+        // Second drain (as if a new frame started with no new requests):
+        // must be `None`, not the previous frame's value.
+        assert_eq!(cache.take_pending_repaint_delay(), None);
     }
 }

--- a/freminal/src/gui/toast.rs
+++ b/freminal/src/gui/toast.rs
@@ -1411,6 +1411,16 @@ impl ToastStack {
     /// Clears auto-expired toasts and any the user dismissed by clicking
     /// anywhere within a toast's pill (its `hit_rect_logical`, computed by
     /// `layout_toasts`).
+    ///
+    /// Returns the repaint delay this call needs to keep expiry/animation
+    /// going without further input (subtask 121.12: `Some(16ms)` while any
+    /// toast is animating, `Some(250ms)` if the stack is non-empty but
+    /// settled, `None` when empty). THE CALLER MUST SCHEDULE THE RETURNED
+    /// DELAY — this method deliberately does NOT call
+    /// `ctx.request_repaint_after()` itself, because that would be invisible
+    /// to `effective_repaint_delay`'s suppressed-pointer substitution (in
+    /// `freminal-windowing`) and would be silently downgraded to the
+    /// fallback interval while the mouse is moving over terminal content.
     pub(super) fn show(
         &mut self,
         ctx: &egui::Context,
@@ -1419,9 +1429,9 @@ impl ToastStack {
         resolve_pane_rect: impl Fn(PaneId) -> Option<egui::Rect>,
         resources: ToastFrameResources<'_>,
         pixels_per_point: f32,
-    ) {
+    ) -> Option<Duration> {
         if self.entries.is_empty() {
-            return;
+            return None;
         }
 
         let ToastFrameResources {
@@ -1500,17 +1510,17 @@ impl ToastStack {
         // Remove expired toasts.
         self.entries.retain(|t| !t.is_expired(now));
 
-        // Request a repaint soon so expiry/animation happens even without
+        // Report the delay needed so expiry/animation happens even without
         // input: a fast (16ms, ~60fps) cadence while any toast is animating
         // (entry/exit fade+slide+scale), otherwise a slow (250ms) cadence
-        // just to catch expiry.
-        if !self.entries.is_empty() {
-            let delay = if any_animating {
-                Duration::from_millis(16)
-            } else {
-                Duration::from_millis(250)
-            };
-            ctx.request_repaint_after(delay);
+        // just to catch expiry. The caller schedules this (subtask 121.12) —
+        // see this method's doc comment for why.
+        if self.entries.is_empty() {
+            None
+        } else if any_animating {
+            Some(Duration::from_millis(16))
+        } else {
+            Some(Duration::from_millis(250))
         }
     }
 

--- a/freminal/src/gui/toast.rs
+++ b/freminal/src/gui/toast.rs
@@ -1274,6 +1274,14 @@ fn group_and_layout(
 pub(super) struct ToastStack {
     entries: Vec<Toast>,
     next_id: u64,
+    /// Cached "is any toast currently mid-animation" signal (subtask
+    /// 121.14), recomputed at the end of every [`Self::show`] call and
+    /// consulted by [`Self::is_animating`]. `App::pointer_motion_needs_repaint`
+    /// runs OUTSIDE any frame (from `event_loop`'s `CursorMoved` handling),
+    /// where [`Self::measure_inputs`] cannot be called — this field is what
+    /// lets that method see the answer without re-running the per-frame
+    /// measurement. `false` on a fresh/default stack (nothing to animate).
+    cached_is_animating: bool,
 }
 
 /// Maximum simultaneous toasts.  Older ones are evicted.
@@ -1308,6 +1316,30 @@ pub(super) struct ToastFrameResources<'a> {
     pub render_state: &'a std::sync::Arc<std::sync::Mutex<ToastRenderState>>,
     /// This window's shared font manager, for text measure/shape only.
     pub font_manager: &'a mut FontManager,
+}
+
+/// [`ToastStack::show`]'s return value (subtask 121.14): bundles the
+/// repaint delay it needs (subtask 121.12) with the laid-out pill hit-rects,
+/// so the caller can cache both without a second pass over the stack.
+pub(super) struct ToastShowOutcome {
+    /// The delay `App::update` should schedule for this window this frame
+    /// (subtask 121.12) — see [`ToastStack::show`]'s doc.
+    pub(super) repaint_delay: Option<Duration>,
+    /// Every toast's `hit_rect_logical`, converted to `egui::Rect` (logical
+    /// points, window space) — see [`ToastStack::show`]'s doc for why the
+    /// caller needs these.
+    pub(super) rects: Vec<egui::Rect>,
+}
+
+impl ToastShowOutcome {
+    /// The outcome for a stack with nothing to show: no delay requested, no
+    /// rects to cache.
+    const fn empty() -> Self {
+        Self {
+            repaint_delay: None,
+            rects: Vec::new(),
+        }
+    }
 }
 
 impl ToastStack {
@@ -1366,6 +1398,23 @@ impl ToastStack {
         self.entries.is_empty()
     }
 
+    /// Whether any toast on the stack is currently mid-animation (entry/exit
+    /// fade+slide+scale), as of the most recent [`Self::show`] call or
+    /// [`Self::push`] (subtask 121.14).
+    ///
+    /// Mere presence (`!is_empty()`) is NOT sufficient grounds to treat a
+    /// toast as needing continuous repaints — a toast spends most of its
+    /// 1-3s (up to 15s) life fully settled in its steady hold, animating
+    /// only during its 300ms entry fade and 400ms exit fade. Callers that
+    /// need "is a repaint needed to keep this toast's animation smooth"
+    /// (as opposed to "is a toast visible at all", which has its own,
+    /// deliberately presence-based, use at `app_impl.rs`'s
+    /// `toast_active` — see that field's doc) must combine this with
+    /// `!is_empty()` themselves.
+    pub(super) const fn is_animating(&self) -> bool {
+        self.cached_is_animating
+    }
+
     fn push(
         &mut self,
         kind: ToastKind,
@@ -1381,6 +1430,16 @@ impl ToastStack {
         while self.entries.len() > MAX_TOASTS {
             self.entries.remove(0);
         }
+        // Subtask 121.14: eagerly mark the stack as animating. A freshly
+        // pushed toast is always at the start of its entry animation (age
+        // 0 < `ANIM_IN`), so this is exact, not merely conservative. It
+        // closes the priming gap between this `push()` and the next
+        // `show()` call (the only other place `cached_is_animating` is
+        // set): without it, a pointer-motion check landing in that window
+        // would read whatever the field held before the push -- `false` if
+        // the stack had been empty -- and wrongly suppress a repaint the
+        // entry animation's first frames need.
+        self.cached_is_animating = true;
     }
 
     /// Font size (physical pixels, pre-`pixels_per_point` scaling) the toast
@@ -1412,15 +1471,20 @@ impl ToastStack {
     /// anywhere within a toast's pill (its `hit_rect_logical`, computed by
     /// `layout_toasts`).
     ///
-    /// Returns the repaint delay this call needs to keep expiry/animation
-    /// going without further input (subtask 121.12: `Some(16ms)` while any
-    /// toast is animating, `Some(250ms)` if the stack is non-empty but
-    /// settled, `None` when empty). THE CALLER MUST SCHEDULE THE RETURNED
-    /// DELAY — this method deliberately does NOT call
-    /// `ctx.request_repaint_after()` itself, because that would be invisible
-    /// to `effective_repaint_delay`'s suppressed-pointer substitution (in
-    /// `freminal-windowing`) and would be silently downgraded to the
-    /// fallback interval while the mouse is moving over terminal content.
+    /// Returns a [`ToastShowOutcome`] bundling the repaint delay this call
+    /// needs to keep expiry/animation going without further input (subtask
+    /// 121.12: `Some(16ms)` while any toast is animating, `Some(250ms)` if
+    /// the stack is non-empty but settled, `None` when empty) and the laid-
+    /// out pill hit-rects (subtask 121.14, logical points, window space —
+    /// same rects [`Self::hit_test`] hit-tests against). THE CALLER MUST
+    /// SCHEDULE THE RETURNED DELAY AND CACHE THE RETURNED RECTS — this
+    /// method deliberately does NOT call `ctx.request_repaint_after()`
+    /// itself, because that would be invisible to `effective_repaint_delay`'s
+    /// suppressed-pointer substitution (in `freminal-windowing`) and would be
+    /// silently downgraded to the fallback interval while the mouse is
+    /// moving over terminal content; and the rects are needed by
+    /// `App::pointer_motion_needs_repaint`, which runs outside any frame and
+    /// so cannot call this method itself.
     pub(super) fn show(
         &mut self,
         ctx: &egui::Context,
@@ -1429,9 +1493,10 @@ impl ToastStack {
         resolve_pane_rect: impl Fn(PaneId) -> Option<egui::Rect>,
         resources: ToastFrameResources<'_>,
         pixels_per_point: f32,
-    ) -> Option<Duration> {
+    ) -> ToastShowOutcome {
         if self.entries.is_empty() {
-            return None;
+            self.cached_is_animating = false;
+            return ToastShowOutcome::empty();
         }
 
         let ToastFrameResources {
@@ -1501,6 +1566,20 @@ impl ToastStack {
             rs.text.build_instances(&runs, font_manager)
         };
         let pills: Vec<ToastQuad> = outputs.iter().map(|o| o.pill).collect();
+        // Subtask 121.14: the same hit rects `hit_test` above just tested the
+        // pointer against, in the same logical-point/window-space coordinates
+        // `chrome_head_rects`/`chrome_border_rects` use — cached by the
+        // caller for `App::pointer_motion_needs_repaint` (see this method's
+        // doc). Computed from `outputs`, which describes what was ACTUALLY
+        // rendered this frame (before the dismiss/expire retains below), so
+        // it matches the pills just painted rather than what remains after.
+        let rects: Vec<egui::Rect> = outputs
+            .iter()
+            .map(|o| {
+                let [min_x, min_y, max_x, max_y] = o.hit_rect_logical;
+                egui::Rect::from_min_max(egui::pos2(min_x, min_y), egui::pos2(max_x, max_y))
+            })
+            .collect();
         Self::paint_toasts(ctx, render_state, pills, text_instances);
 
         // Remove dismissed toasts.
@@ -1515,12 +1594,23 @@ impl ToastStack {
         // (entry/exit fade+slide+scale), otherwise a slow (250ms) cadence
         // just to catch expiry. The caller schedules this (subtask 121.12) —
         // see this method's doc comment for why.
-        if self.entries.is_empty() {
+        //
+        // Also caches `is_animating` (subtask 121.14) from the SAME
+        // `entries.is_empty()` / `any_animating` decision, so the two never
+        // disagree.
+        let repaint_delay = if self.entries.is_empty() {
+            self.cached_is_animating = false;
             None
         } else if any_animating {
+            self.cached_is_animating = true;
             Some(Duration::from_millis(16))
         } else {
+            self.cached_is_animating = false;
             Some(Duration::from_millis(250))
+        };
+        ToastShowOutcome {
+            repaint_delay,
+            rects,
         }
     }
 
@@ -1811,6 +1901,49 @@ mod tests {
     fn stack_starts_empty() {
         let s = ToastStack::default();
         assert!(s.entries.is_empty());
+    }
+
+    // ── Subtask 121.14: `ToastStack::is_animating` / `cached_is_animating` ──
+    //
+    // `ToastStack::show` needs a live `WindowId` (no public constructor
+    // outside the real winit event loop — see `layout_positioned`'s doc), so
+    // it cannot be driven headlessly here. These tests instead cover the
+    // reachable half: the cached flag's default and `push`'s eager-`true`
+    // write. The `show()`-side half (recomputing the flag from
+    // `any_animating`) is covered instead at the `measure_inputs` level by
+    // `measure_inputs_leaves_a_short_toast_unchanged` /
+    // `measure_inputs_truncates_long_detail_and_pill_stays_within_max_width`
+    // above, which assert `any_animating` directly.
+
+    #[test]
+    fn cached_is_animating_starts_false_on_a_default_stack() {
+        let s = ToastStack::default();
+        assert!(!s.is_animating());
+    }
+
+    #[test]
+    fn push_sets_cached_is_animating_true() {
+        let mut s = ToastStack::default();
+        assert!(!s.is_animating());
+        s.error("something failed", None);
+        // Subtask 121.14: exact, not conservative — a freshly pushed toast
+        // is always at the start of its entry animation.
+        assert!(s.is_animating());
+    }
+
+    #[test]
+    fn push_sets_cached_is_animating_true_even_when_stack_was_already_non_empty() {
+        let mut s = ToastStack::default();
+        s.info("first", None);
+        // Simulate a `show()` having already settled the flag back to
+        // `false` (the first toast finished its entry fade).
+        s.cached_is_animating = false;
+        s.error("second", None);
+        assert!(
+            s.is_animating(),
+            "a second push must re-arm the flag even if the stack was \
+             already non-empty and settled"
+        );
     }
 
     #[test]
@@ -2295,9 +2428,16 @@ mod tests {
     #[test]
     fn measure_inputs_leaves_a_short_toast_unchanged() {
         let mut stack = ToastStack::default();
-        stack.error("short", None);
         let rs = ToastRenderState::default();
+        // `test_font_manager()` does real font loading and can take
+        // meaningfully long (well over `ANIM_IN`'s 300ms) on a cold cache or
+        // loaded CI runner — see the `flaky-tests-are-bugs` skill. Do it
+        // BEFORE pushing the toast, so no real wall-clock time elapses
+        // between `push` (which stamps `created = Instant::now()`) and the
+        // `Instant::now()` passed to `measure_inputs` below, and the
+        // any-animating assertion cannot flake on setup being slow.
         let mut fm = test_font_manager();
+        stack.error("short", None);
         let ppp = 1.0;
         let sizes = ToastMeasureSizes {
             label_size_px: ToastStack::LABEL_SIZE_PTS * ppp,
@@ -2305,10 +2445,16 @@ mod tests {
             icon_size_px: ToastStack::LABEL_SIZE_PTS * ppp,
             ppp,
         };
-        let (inputs, _any_animating) = stack.measure_inputs(&rs, &mut fm, sizes, Instant::now());
+        let (inputs, any_animating) = stack.measure_inputs(&rs, &mut fm, sizes, Instant::now());
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].label_text, "Error: short");
         assert!(!inputs[0].label_text.ends_with('…'));
+        // Subtask 121.14: measured immediately after `push`, so the toast is
+        // still within its entry-animation window (age 0 < `ANIM_IN`).
+        assert!(
+            any_animating,
+            "a just-pushed toast must report as animating (entry fade in progress)"
+        );
     }
 
     #[test]
@@ -2318,9 +2464,12 @@ mod tests {
         // (`push_error_toast("Shader error", Some(msg))`) that produced the
         // overflow this fixes.
         let long_detail = "ERROR: 0:12: 'foo' : undeclared identifier\n".repeat(20);
-        stack.error("Shader error", Some(long_detail));
         let rs = ToastRenderState::default();
+        // See the comment in `measure_inputs_leaves_a_short_toast_unchanged`:
+        // font-manager construction happens BEFORE the push so no real time
+        // elapses between `push` and the `any_animating` measurement below.
         let mut fm = test_font_manager();
+        stack.error("Shader error", Some(long_detail));
         let ppp = 1.0;
         let sizes = ToastMeasureSizes {
             label_size_px: ToastStack::LABEL_SIZE_PTS * ppp,
@@ -2328,7 +2477,7 @@ mod tests {
             icon_size_px: ToastStack::LABEL_SIZE_PTS * ppp,
             ppp,
         };
-        let (inputs, _any_animating) = stack.measure_inputs(&rs, &mut fm, sizes, Instant::now());
+        let (inputs, any_animating) = stack.measure_inputs(&rs, &mut fm, sizes, Instant::now());
         assert_eq!(inputs.len(), 1);
         let input = &inputs[0];
         assert!(
@@ -2337,6 +2486,11 @@ mod tests {
             input.detail_text
         );
         assert!(input.detail_text.ends_with('…'));
+        // Subtask 121.14: same reasoning as the short-toast test above.
+        assert!(
+            any_animating,
+            "a just-pushed toast must report as animating (entry fade in progress)"
+        );
 
         let (width, _height) = settled_pill_size(input, ppp);
         assert!(

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -65,6 +65,73 @@ pub(super) fn resize_overlay_alpha(
     }
 }
 
+/// Whether the resize overlay is currently mid-fade (or past `linger`) at
+/// `elapsed` since the last genuine resize event (subtask 121.14).
+///
+/// `false` only during the fully-opaque phase (`elapsed < linger - fade`),
+/// where the overlay's painted pixels are not changing frame-to-frame, so a
+/// caller may safely treat "no animation is in flight" as true for it —
+/// this is the predicate `pointer_motion_needs_repaint` consults instead of
+/// the old `resize_overlay.is_some()` presence test, which disabled
+/// suppression for the overlay's ENTIRE 900ms life instead of just the
+/// final 250ms fade.
+///
+/// **Returns `true` for `elapsed >= linger`, NOT `false`.** This is the
+/// non-obvious part: the overlay is only ever cleared to `None` by a
+/// rendered frame reaching the `win.resize_overlay = None` branch in
+/// `app_impl.rs`'s resize-overlay block — nothing else clears it. If this
+/// predicate went `false` again past `linger` (before that clearing frame
+/// had actually run), a caller using it to gate "may I suppress waking this
+/// window" would stop scheduling frames while the overlay was still
+/// `Some`, and the HUD would be stranded on screen at whatever it was last
+/// painted with — never reaching the frame that removes it. Treating "at or
+/// past `linger`" as still-animating guarantees at least one more wake
+/// reaches that clearing frame.
+///
+/// Pure function so the timing math is unit-testable without an egui frame,
+/// mirroring [`resize_overlay_alpha`].
+pub(super) fn resize_overlay_is_animating(
+    elapsed: std::time::Duration,
+    linger: std::time::Duration,
+    fade: std::time::Duration,
+) -> bool {
+    elapsed >= linger.saturating_sub(fade)
+}
+
+/// The repaint delay the resize-overlay HUD should request at `elapsed`
+/// since the last genuine resize event (subtask 121.14, Part A step 3).
+///
+/// While still fully opaque (`elapsed < linger - fade`), the overlay's
+/// pixels are not changing, so requesting an unconditional 16ms cadence
+/// every frame it is alive is wasted work — a wake timed to land exactly at
+/// fade-start is sufficient (and gives an equally smooth start to the fade
+/// once it begins). Once fading — or at/past `linger`, mirroring
+/// [`resize_overlay_is_animating`]'s boundary and its "still needs a wake"
+/// reasoning — request the fast 16ms cadence so the fade (or the final
+/// frame that clears the overlay) proceeds smoothly.
+///
+/// **MUST stay consistent with [`resize_overlay_is_animating`]'s boundary.**
+/// The two are read together at two different call sites (this decides what
+/// the HUD itself asks for; that decides whether pointer-motion suppression
+/// may engage) — if they disagree, the HUD either janks (suppression
+/// engages while this still asks for 16ms, evidence of "still animating"
+/// otherwise ignored) or never sleeps (this keeps asking for 16ms while
+/// suppression has already been judged safe to allow).
+///
+/// Pure function so the schedule is unit-testable without an egui frame.
+pub(super) fn resize_overlay_repaint_delay(
+    elapsed: std::time::Duration,
+    linger: std::time::Duration,
+    fade: std::time::Duration,
+) -> std::time::Duration {
+    let fade_start = linger.saturating_sub(fade);
+    if elapsed < fade_start {
+        fade_start.saturating_sub(elapsed)
+    } else {
+        std::time::Duration::from_millis(16)
+    }
+}
+
 /// Whether an observed char-grid size change is a GENUINE OS-window resize,
 /// rather than the spurious `last_sent_size` churn caused by new
 /// window/tab/split/pane-close/zoom transitions (which reset `last_sent_size`
@@ -445,10 +512,73 @@ pub(super) struct PerWindowState {
     /// frames (REPLAY skips building the panels). `None` until the first FULL
     /// frame => `is_chrome_interactive_at` returns the conservative `true`.
     pub(super) chrome_head_rects: Option<Vec<egui::Rect>>,
-    /// #436.8 split-border drag-sensor rects (egui logical points), rebuilt every
-    /// frame; explicitly cleared on frames that build no sensors (single pane /
-    /// zoomed / overlay open).
+    /// #436.8 split-border drag-sensor rects (egui logical points), rebuilt
+    /// every frame; explicitly cleared on frames that build no sensors
+    /// (single pane / zoomed / overlay open).
     pub(super) chrome_border_rects: Vec<egui::Rect>,
+
+    /// Subtask 121.14 (review item 2 follow-up): the most recently laid-out
+    /// toast pill hit-rects, appended by the app-level toast-rendering block
+    /// (in `app_impl.rs`, after `central_body` returns) whenever it actually
+    /// runs `ToastStack::show()`. `App::pointer_motion_needs_repaint` runs
+    /// OUTSIDE any frame (from `event_loop`'s `CursorMoved` handling) and
+    /// needs a cached rect list to test whether the pointer is over a
+    /// toast — hovering one changes chrome pixels (close-button highlight,
+    /// hover-pauses-expiry) even though toasts are not menu/tab-bar/split-
+    /// border chrome.
+    ///
+    /// A dedicated field rather than appending to [`Self::chrome_border_rects`]
+    /// (121.14's original approach, corrected by review): that field's name
+    /// and doc describe split-border drag sensors specifically, and any
+    /// future consumer correlating `chrome_border_rects[i]` with
+    /// `pane_tree.split_borders()[i]` by index would silently get corrupted
+    /// indices whenever a toast is showing. See
+    /// `crate::gui::chrome_damage::point_in_chrome_rects`, which both
+    /// consumers now call with this field as an explicit extra parameter
+    /// rather than duplicating a `rect.contains(pos)` scan at each call site.
+    ///
+    /// **Staleness discipline — this field is NOT rebuilt in `central_body`
+    /// the way [`Self::chrome_border_rects`] is, so it must be written
+    /// explicitly on every reachable path:**
+    ///
+    ///   - On every `ChromeMode::Full` frame, write this field — new rects
+    ///     when the toast block actually runs (`chrome_mode == Full &&
+    ///     !stack.is_empty()`), or an emptied `Vec` when it does not (stack
+    ///     empty, or toast rendering otherwise skipped). Writing
+    ///     unconditionally on `Full` (rather than only inside the toast
+    ///     block) is what prevents an emptied stack from leaving stale rects
+    ///     behind forever, which would otherwise permanently force
+    ///     `ChromeMode::Full`/hover-interactive over that now-vacated screen
+    ///     region.
+    ///   - On every `ChromeMode::Replay` frame, leave this field untouched.
+    ///     A `Replay` frame can only be entered while the toast stack is
+    ///     provably empty: the `toast_active` local (`app_impl.rs`'s
+    ///     `App::update`, ~3180) is threaded into the
+    ///     `ChromeSignals { .. toast_active, .. }` literal assigned to
+    ///     `win.pending_chrome_signals` (`app_impl.rs`, ~3374-3390, field at
+    ///     ~3384), which `ChromeSignals::any_fired` (`chrome_damage.rs`,
+    ///     ~140-156) checks — forcing `ChromeDamage::Changed` — and
+    ///     therefore `ChromeMode::Full` — for as long as any toast exists, so
+    ///     by the time a `Replay` frame is reached this field is already
+    ///     correctly empty (or, before then, already reflects the
+    ///     truly-last `Full` frame's rects, which is what a `Replay` frame
+    ///     reuses for everything else it does not rebuild). One frame stale
+    ///     by construction (like `chrome_head_rects`): while the stack
+    ///     reflows (e.g. a dismissed toast shifts its neighbours), a hover
+    ///     can be missed for a single frame. (Citations are name-first so
+    ///     they stay useful if the line numbers drift again.)
+    ///
+    ///   - There is a third, pre-existing path where this field goes stale
+    ///     that the two bullets above don't cover: `App::update`'s
+    ///     "active tab has no active pane" bail-out (the `CLEANUP-436-A`
+    ///     branch, `app_impl.rs`, ~1615-1627) reinserts `win` into
+    ///     `self.windows` and returns without tearing the window down or
+    ///     writing this field. That is a documented should-never-happen
+    ///     defensive branch (guarded by a `warn!`, not expected in normal
+    ///     operation), and the resulting staleness is shared symmetrically
+    ///     with [`Self::chrome_head_rects`] and [`Self::chrome_border_rects`]
+    ///     — this field does not introduce it.
+    pub(super) chrome_toast_rects: Vec<egui::Rect>,
 
     /// Per-frame render attribution counters (diagnostic), flushed to a
     /// `debug` log line every [`FrameStats::FLUSH_EVERY`] drawn frames. Lets
@@ -1081,6 +1211,7 @@ mod frame_profiling_tests {
 mod resize_overlay_tests {
     use super::{
         RESIZE_OVERLAY_FADE, RESIZE_OVERLAY_LINGER, resize_is_genuine, resize_overlay_alpha,
+        resize_overlay_is_animating, resize_overlay_repaint_delay,
     };
     use std::time::Duration;
 
@@ -1144,5 +1275,258 @@ mod resize_overlay_tests {
         // The only genuine case: a real OS-window resize alongside a char-grid
         // change.
         assert!(resize_is_genuine(true, true));
+    }
+
+    // ── Subtask 121.14: `resize_overlay_is_animating` ────────────────────
+
+    #[test]
+    fn is_animating_false_in_the_opaque_phase() {
+        // linger=900ms, fade=250ms -> fade starts at elapsed=650ms.
+        let elapsed = RESIZE_OVERLAY_LINGER
+            .saturating_sub(RESIZE_OVERLAY_FADE)
+            .checked_sub(Duration::from_millis(1))
+            .unwrap_or(Duration::ZERO);
+        assert!(!resize_overlay_is_animating(
+            elapsed,
+            RESIZE_OVERLAY_LINGER,
+            RESIZE_OVERLAY_FADE
+        ));
+    }
+
+    #[test]
+    fn is_animating_true_at_the_exact_fade_start_boundary() {
+        let fade_start = RESIZE_OVERLAY_LINGER.saturating_sub(RESIZE_OVERLAY_FADE);
+        assert!(resize_overlay_is_animating(
+            fade_start,
+            RESIZE_OVERLAY_LINGER,
+            RESIZE_OVERLAY_FADE
+        ));
+    }
+
+    #[test]
+    fn is_animating_true_through_the_fade() {
+        let elapsed = RESIZE_OVERLAY_LINGER.saturating_sub(RESIZE_OVERLAY_FADE / 2);
+        assert!(resize_overlay_is_animating(
+            elapsed,
+            RESIZE_OVERLAY_LINGER,
+            RESIZE_OVERLAY_FADE
+        ));
+    }
+
+    #[test]
+    fn is_animating_true_past_linger() {
+        // The load-bearing case: the overlay is only cleared by a rendered
+        // frame, so this must stay `true` past `linger`, not fall back to
+        // `false` — see this function's doc for what would be stranded if
+        // it did not.
+        assert!(resize_overlay_is_animating(
+            RESIZE_OVERLAY_LINGER,
+            RESIZE_OVERLAY_LINGER,
+            RESIZE_OVERLAY_FADE
+        ));
+        assert!(resize_overlay_is_animating(
+            RESIZE_OVERLAY_LINGER + Duration::from_secs(5),
+            RESIZE_OVERLAY_LINGER,
+            RESIZE_OVERLAY_FADE
+        ));
+    }
+
+    #[test]
+    fn is_animating_with_zero_fade_flips_exactly_at_linger() {
+        // fade=0 -> fade_start == linger: opaque for the entire linger
+        // window, then immediately "animating" (the instantaneous snap to
+        // invisible) at/after linger.
+        assert!(!resize_overlay_is_animating(
+            RESIZE_OVERLAY_LINGER
+                .checked_sub(Duration::from_millis(1))
+                .unwrap_or(Duration::ZERO),
+            RESIZE_OVERLAY_LINGER,
+            Duration::ZERO
+        ));
+        assert!(resize_overlay_is_animating(
+            RESIZE_OVERLAY_LINGER,
+            RESIZE_OVERLAY_LINGER,
+            Duration::ZERO
+        ));
+    }
+
+    #[test]
+    fn is_animating_with_fade_longer_than_linger_is_always_animating() {
+        // fade > linger -> `linger.saturating_sub(fade)` saturates to ZERO,
+        // so every `elapsed >= 0` (i.e. always) reads as animating.
+        let fade = RESIZE_OVERLAY_LINGER + Duration::from_secs(1);
+        assert!(resize_overlay_is_animating(
+            Duration::ZERO,
+            RESIZE_OVERLAY_LINGER,
+            fade
+        ));
+        assert!(resize_overlay_is_animating(
+            RESIZE_OVERLAY_LINGER,
+            RESIZE_OVERLAY_LINGER,
+            fade
+        ));
+    }
+
+    // ── Subtask 121.14: `resize_overlay_repaint_delay` ───────────────────
+
+    #[test]
+    fn repaint_delay_in_the_opaque_phase_wakes_exactly_at_fade_start() {
+        let elapsed = Duration::ZERO;
+        let fade_start = RESIZE_OVERLAY_LINGER.saturating_sub(RESIZE_OVERLAY_FADE);
+        assert_eq!(
+            resize_overlay_repaint_delay(elapsed, RESIZE_OVERLAY_LINGER, RESIZE_OVERLAY_FADE),
+            fade_start
+        );
+
+        // Partway through the opaque phase: delay is the remaining time to
+        // fade-start, not the whole window.
+        let elapsed = Duration::from_millis(100);
+        assert_eq!(
+            resize_overlay_repaint_delay(elapsed, RESIZE_OVERLAY_LINGER, RESIZE_OVERLAY_FADE),
+            fade_start.saturating_sub(elapsed)
+        );
+    }
+
+    #[test]
+    fn repaint_delay_once_animating_is_16ms() {
+        let fade_start = RESIZE_OVERLAY_LINGER.saturating_sub(RESIZE_OVERLAY_FADE);
+        assert_eq!(
+            resize_overlay_repaint_delay(fade_start, RESIZE_OVERLAY_LINGER, RESIZE_OVERLAY_FADE),
+            Duration::from_millis(16)
+        );
+        assert_eq!(
+            resize_overlay_repaint_delay(
+                RESIZE_OVERLAY_LINGER,
+                RESIZE_OVERLAY_LINGER,
+                RESIZE_OVERLAY_FADE
+            ),
+            Duration::from_millis(16)
+        );
+        assert_eq!(
+            resize_overlay_repaint_delay(
+                RESIZE_OVERLAY_LINGER + Duration::from_secs(5),
+                RESIZE_OVERLAY_LINGER,
+                RESIZE_OVERLAY_FADE
+            ),
+            Duration::from_millis(16)
+        );
+    }
+
+    #[test]
+    fn repaint_delay_boundary_matches_is_animating_boundary() {
+        // The two functions must agree at every boundary they share -- this
+        // is the "MUST stay consistent" invariant from both docs, pinned
+        // directly: wherever `resize_overlay_is_animating` is `true`, the
+        // delay must be exactly 16ms; wherever it is `false` (the opaque
+        // phase), the delay must be exactly the time remaining until
+        // fade-start -- which can itself be arbitrarily small (e.g. 1ms
+        // just before the boundary), so the two functions are compared
+        // against the same formula rather than an inequality against 16ms.
+        let fade_start = RESIZE_OVERLAY_LINGER.saturating_sub(RESIZE_OVERLAY_FADE);
+        for millis in [0, 1, 100, 649, 650, 651, 899, 900, 901, 5000] {
+            let elapsed = Duration::from_millis(millis);
+            let animating =
+                resize_overlay_is_animating(elapsed, RESIZE_OVERLAY_LINGER, RESIZE_OVERLAY_FADE);
+            let delay =
+                resize_overlay_repaint_delay(elapsed, RESIZE_OVERLAY_LINGER, RESIZE_OVERLAY_FADE);
+            if animating {
+                assert_eq!(delay, Duration::from_millis(16), "elapsed={elapsed:?}");
+            } else {
+                assert_eq!(
+                    delay,
+                    fade_start.saturating_sub(elapsed),
+                    "elapsed={elapsed:?} delay={delay:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn repaint_delay_with_fade_longer_than_linger_is_always_16ms() {
+        let fade = RESIZE_OVERLAY_LINGER + Duration::from_secs(1);
+        assert_eq!(
+            resize_overlay_repaint_delay(Duration::ZERO, RESIZE_OVERLAY_LINGER, fade),
+            Duration::from_millis(16)
+        );
+    }
+
+    // ── Item 4 (review CONSIDER #4): pin the HUD consistency invariant ────
+
+    #[test]
+    fn resize_overlay_is_animating_and_repaint_delay_stay_consistent_across_ranges() {
+        // The two functions' docs call their mutual consistency
+        // "load-bearing" (disagreement either janks the HUD or never lets it
+        // sleep) but share the `fade_start = linger.saturating_sub(fade)`
+        // formula only by duplication -- nothing previously caught a future
+        // edit to one without the other across anything but the production
+        // LINGER/FADE constants (`repaint_delay_boundary_matches_is_animating_boundary`
+        // above). This generalizes that check across several linger/fade
+        // combinations, including the edge cases the review explicitly
+        // called out: `fade == 0` and `fade > linger`.
+        //
+        // CORRECTNESS NOTE on the invariant actually pinned here: the task
+        // that produced this test described the invariant as
+        // `is_animating(e, l, f) == (repaint_delay(e, l, f) <= 16ms)`. That
+        // formulation is subtly wrong and is deliberately NOT what is
+        // asserted below. Counterexample: with `linger = 900ms`,
+        // `fade = 250ms` (`fade_start = 650ms`), at `elapsed = 640ms`,
+        // `resize_overlay_is_animating` is `false` (still opaque, `640 <
+        // 650`) but `resize_overlay_repaint_delay` returns `10ms`, which
+        // is `<= 16ms` -- the opaque-phase delay counts down toward
+        // `fade_start` and is transiently small in the last <=16ms before
+        // that boundary, with `is_animating` still `false` the whole time.
+        // A literal `<= 16ms` comparison would therefore fail on that
+        // legitimate, correctly-behaving case. The REAL, load-bearing
+        // coupling -- confirmed against both functions' bodies -- is the
+        // exact formula each doc already claims:
+        //   - `animating`  => `repaint_delay == 16ms` (exactly, the fast
+        //     cadence)
+        //   - `!animating` => `repaint_delay == fade_start.saturating_sub(elapsed)`
+        //     (the countdown to fade-start, which may itself be smaller
+        //     than 16ms near the boundary)
+        // That is what is pinned below, per-combination and per-sample.
+        let combos = [
+            (RESIZE_OVERLAY_LINGER, RESIZE_OVERLAY_FADE), // production defaults
+            (Duration::from_millis(900), Duration::ZERO), // fade == 0
+            (Duration::from_millis(900), Duration::from_millis(900)), // fade == linger
+            (Duration::from_millis(500), Duration::from_millis(900)), // fade > linger
+            (Duration::ZERO, Duration::ZERO),             // degenerate: both zero
+        ];
+
+        for (linger, fade) in combos {
+            let fade_start = linger.saturating_sub(fade);
+            let mut samples = vec![
+                Duration::ZERO,
+                fade_start.saturating_sub(Duration::from_millis(1)),
+                fade_start,
+                fade_start + Duration::from_millis(1),
+                linger.saturating_sub(Duration::from_millis(1)),
+                linger,
+                linger + Duration::from_millis(1),
+                linger + Duration::from_secs(5),
+            ];
+            samples.sort();
+            samples.dedup();
+
+            for elapsed in samples {
+                let animating = resize_overlay_is_animating(elapsed, linger, fade);
+                let delay = resize_overlay_repaint_delay(elapsed, linger, fade);
+                if animating {
+                    assert_eq!(
+                        delay,
+                        Duration::from_millis(16),
+                        "linger={linger:?} fade={fade:?} elapsed={elapsed:?}: \
+                         animating must always request exactly 16ms"
+                    );
+                } else {
+                    assert_eq!(
+                        delay,
+                        fade_start.saturating_sub(elapsed),
+                        "linger={linger:?} fade={fade:?} elapsed={elapsed:?}: \
+                         opaque phase must request exactly the countdown to fade-start"
+                    );
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes subtasks **121.12**, **121.13** and **121.14** from
`Documents/PLAN_121_PERF_REMEDIATION.md` Group B — the bugs the Task 121
performance work surfaced but did not fix. One atomic commit each, plus a docs
commit. 121.15 is deliberately excluded (see below).

## 121.12 — route every in-frame repaint request through the delay aggregation

`effective_repaint_delay` substitutes the app's own requested delay when the only
input since the last frame was pointer motion classified as needing no frame. That
substitution reads `app_requested_delay`, i.e. the `shortest_repaint_delay` aggregate.

**The plan named three bypassing call sites. There are eight** — and the miscount hid
a live visual bug the plan never described. Because the bell flash, cursor trail and
animated-image ticks requested repaints directly on the `Context`, their delay never
reached `app_requested_delay`; egui's raw delay is zero during pointer motion
regardless, so the substitution fired, found `None`, and returned the fallback.
**Those animations were running at 4fps instead of 60fps whenever the mouse moved
over terminal content.** All eight now fold into the aggregate.

The three formerly-bare `request_repaint()` sites fold **16ms, not `Duration::ZERO`** —
scheduling is identical (`clamp_repaint_delay` already floored at
`MIN_REPAINT_INTERVAL`), but a zero app-side ask would make `chrome_repaint_settled`'s
`repaint_delay >= app_delay` test permanently vacuous.

`SUPPRESSED_POINTER_FALLBACK_DELAY` goes **250ms → 500ms**, not `Duration::MAX` as the
plan suggested. The plan's reasoning — "once every real repaint need is represented,
the liveness argument goes away" — does not hold: `app_requested_delay` can only
represent *freminal's* needs, and egui's own chrome animations are unrepresentable in
it and masked by egui's events-driven zero, so unbounded would freeze one at partial
alpha until an unrelated event arrived. 500ms equals the cursor-blink period, so
blink-off can no longer schedule *more* frames than blink-on — which is the perversity
121.12 exists to remove (2fps blink-on vs 4fps blink-off at 250ms). A test pins
`>= 500ms`. **Unblocks 121.26.**

## 121.13 — the chrome cache was disabled for the duration of pointer motion

`prev_repaint_delay` was stashed from the **raw** `ViewportOutput::repaint_delay`,
which is always zero while pointer events sit in egui's queue. `chrome_repaint_settled`
therefore concluded chrome had not settled, and `ChromeMode::Replay` sat at ~0.5% duty
cycle while the mouse moved, against 100% at idle — the entire #436 chrome-cache
subsystem that 121.8 resurrected was silently off for exactly as long as the pointer
moved.

The stashed value is now the substituted one, and crucially **not** the scheduled one.
One value cannot answer both questions:

| Question | Answer when the app requested nothing |
| --- | --- |
| What do we schedule? | bounded — we cannot prove nothing needs drawing |
| Did anything actually *want* a repaint? | no — the absence of a request is the proof |

Stashing the scheduled value would have left the `app_requested_delay == None` case
exactly as broken, and **that case is precisely the btop / `DECTCEM`-hidden-cursor
workload named in 121.25**. So scheduling uses `effective_repaint_delay`, while the
gate is fed a sibling `effective_chrome_gate_delay` differing in exactly one branch.

Replay stays independently gated on `cache_matches`, `damage_unchanged` and
`no_chrome_input`, and `toast_active` / `any_overlay_open` force
`ChromeDamage::Changed` every frame they hold, so genuinely-changed chrome still
cannot be replayed.

## 121.14 — narrow `animation_in_flight` from presence to actual motion

Suppression was disabled for a toast's whole 1–15s life and the resize HUD's whole
900ms life, though a toast animates only during its 300ms entry and 400ms exit fades
and the HUD is opaque for 650ms of its 900ms. **Both halves fixed**, not just the toast
half the plan's Fix bullet named.

Two non-obvious parts:

- **Narrowing the HUD predicate alone achieves nothing.** After 121.12 the HUD folds a
  delay into the aggregate every frame it is alive, so scheduling would have stayed at
  60fps. It now requests the time remaining until the fade begins while opaque.
- **The toast half needed a hover fix to be safe at all.** `is_chrome_interactive_at`
  tested only head and border rects — it was toast *presence* keeping hover alive.
  Suppressing during the steady hold would have left the close-button highlight and
  hover-to-pause resolving only at the 250ms cadence. Toast rects are now cached in a
  dedicated `chrome_toast_rects` and included in the hit-test.

`push()` sets the cached animating flag eagerly — exact, not merely conservative, since
a new toast is always mid-entry-animation — closing the gap between a push and the next
render. `try_borrow`-fails-means-`true` is preserved. The presence-based `toast_active`
chrome-damage signal is untouched; it is presence-based by design.

## Not in this PR

- **121.15** (`has_urls` / `scroll_offset` pane-wide vetoes) — deliberately excluded.
  An interim narrowing means a fifth round on the suppression predicate in its current
  shape, which is what 121.17 warns against. Stays blocked behind Task 122 → 121.17.
- **121.29** (new) — `Context::repaint_causes()` would make an unbounded fallback safe.
  Investigated and rejected for now: it costs five egui-internals dependencies, two of
  which are present-day holes (`outstanding`-driven repaints push no cause;
  `run_dyn` is a multi-pass loop), for a measured ~0.075% of a core. Blocked on 121.28.
  The analysis is recorded in the plan so it is not re-derived.
- **121.30** (new) — chrome widgets are not constructed at all on `Replay`, so an
  egui-internal chrome animation would freeze rather than degrade. Latent, not live: no
  `ctx.animate_*` exists in freminal's chrome. Documented at the constant.

## Verification

`cargo test --all`, `cargo clippy --all-targets --all-features -- -D warnings`,
`cargo machete`, `cargo fmt --all -- --check` and `cargo xtask check-windows` all green,
and re-verified at **each** of the three implementation commits individually.

Two adversarial review passes were run. The second found no reachable correctness bug
in the runtime behaviour; its one substantive finding (a field overload) is fixed in
this diff, and its `ci.yml` "BLOCKING" finding was a false positive from branch
staleness, since resolved by fast-forwarding onto current `main`.

## Known limitations, stated plainly

- The 121.13 tests exercise the pure gate functions, which that subtask does not
  modify — **they pin the reasoning, not the wiring.** The wiring needs a live winit
  window and GL context and has no automated coverage (121.28). A note in the test
  module says so.
- `ToastStack::show`'s return value cannot be tested headlessly at all —
  `WindowId` has no public constructor outside a real winit event loop.
- The cached toast rects are one frame stale, so a hover can be missed for a frame
  while the stack reflows.
- The HUD consistency property test shares its formula with the implementation, so it
  pins the *coupling* between the two functions, not their independent correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved repaint scheduling for cursor trails, visual alerts, pane updates, resize overlays, and animated notifications.
  - Fixed cases where pointer movement could prevent interface updates.
  - Improved toast hover detection and resize-overlay animation handling.
  - Reduced unnecessary repainting when animations are inactive.

- **Documentation**
  - Updated performance-remediation tracking, task status, subtask coverage, and outstanding work across the v0.12.0 planning documents.

- **Tests**
  - Added regression coverage for repaint timing, animation states, toast hit detection, and scheduling edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->