### PR TITLE
docs: record 121.12-121.14 as merged (PR #467)

### DIFF
--- a/Documents/MASTER_PLAN.md
+++ b/Documents/MASTER_PLAN.md
@@ -476,9 +476,9 @@ Task 121 lives in the GUI and windowing frame path) and are fully parallelizable
 **Task 121 (v0.12.0, performance remediation):** the umbrella for all CPU work arising from
 issue #459's real-workload profiling. It ran for five merged pull requests
 (#458, #460, #461, #464 and #465) under a task number that existed only in branch names;
-creating it closes that tracking gap rather than starting new work. Eleven subtasks
-(121.1–121.11) are merged, and three of the bugs that work surfaced (121.12–121.14) are
-fixed and pending merge. Outstanding: 121.15 (left to 121.17, blocked behind Task 122),
+creating it closes that tracking gap rather than starting new work. Fourteen subtasks are
+merged: 121.1–121.11 from that original run, plus the Group B bug fixes 121.12–121.14
+(PR #467). Outstanding: 121.15 (left to 121.17, blocked behind Task 122),
 121.16 (withdrawn), 121.17, issue #459's unactioned candidate list (121.18–121.24),
 measurement debt (121.25–121.28), and two items the Group B fixes themselves surfaced
 (121.29–121.30). The
@@ -712,7 +712,7 @@ Update this section as tasks complete:
 | 115  | 2026-07-08 | 2026-07-08 | 115.1-115.4 DECSCNM per-pane per-cell XOR swap; chrome decoupled; on v0.11.1     |
 | 118  | 2026-07-14 | 2026-07-14 | 118.1-118.9 compact repr + idle compaction; default 4k->10k; 118.10 -> Task 120  |
 | 119  | 2026-07-20 | 2026-07-20 | 119.1-119.6 LZ4 block compression + idle-driven; ~13-22x vs cell; merged PR #419 |
-| 121  | 2026-07-27 |            | 121.1-121.11 merged; 121.12-121.14 pending merge; 121.15/121.17-121.30 open     |
+| 121  | 2026-07-27 |            | 121.1-121.14 merged (121.12-121.14 via PR #467); 121.15/121.17-121.30 open       |
 | 122  |            |            | v0.12.0. Not started; needs an activation pass (`DECOUPLING_FRAMEWORK.md` §8)    |
 
 ---

--- a/Documents/PLAN_121_PERF_REMEDIATION.md
+++ b/Documents/PLAN_121_PERF_REMEDIATION.md
@@ -1,10 +1,10 @@
 # PLAN_121_PERF_REMEDIATION.md — Task 121 "Performance Remediation"
 
-> **STATUS: IN PROGRESS.** Eleven subtasks have merged to `main` across five pull
-> requests (#458, #460, #461, #464, #465). Three more (121.12–121.14) are complete
-> and pending merge. The remainder — one bug blocked behind Task 122, one unifying
-> improvement, seven unactioned issue #459 items, four pieces of measurement debt,
-> and two items surfaced by the Group B work — are outstanding and unscheduled.
+> **STATUS: IN PROGRESS.** Fourteen subtasks have merged to `main` across six pull
+> requests (#458, #460, #461, #464, #465, #467). The remainder — one bug blocked
+> behind Task 122, one unifying improvement, seven unactioned issue #459 items, four
+> pieces of measurement debt, and two items surfaced by the Group B work — are
+> outstanding and unscheduled.
 
 Task 121 is carried by v0.12.0. The version-level summary lives in
 `PLAN_VERSION_120.md` ("Task 121 — Performance Remediation"); this document is the
@@ -74,7 +74,7 @@ creates — see that subtask.
 | Group                                   | Subtasks      | Status        |
 | --------------------------------------- | ------------- | ------------- |
 | A — Completed work (merged to `main`)   | 121.1–121.11  | Complete      |
-| B — Bugs found and fixed                | 121.12–121.14 | Pending merge |
+| B — Bugs found and fixed                | 121.12–121.14 | Complete      |
 | B — Bug blocked behind Task 122         | 121.15        | Not started   |
 | B — Withdrawn                           | 121.16        | Withdrawn     |
 | C — Unifying improvement                | 121.17        | Not started   |
@@ -233,10 +233,10 @@ Commit `f762ca02`. One real bug plus cleanups, from automated review of PR #465.
 
 ## Group B — Bugs found by Group A
 
-These were surfaced by Group A. 121.12, 121.13 and 121.14 are **fixed and pending
-merge** (branch `task-121/group-b`, one atomic commit each). 121.15 remains unfixed
-and is deliberately left to 121.17, which is blocked behind Task 122. 121.16 is
-withdrawn.
+These were surfaced by Group A. 121.12, 121.13 and 121.14 are **fixed and merged to
+`main`** via PR #467 (merge commit `f7dac216`, one atomic commit per subtask on
+`task-121/group-b`). 121.15 remains unfixed and is deliberately left to 121.17, which
+is blocked behind Task 122. 121.16 is withdrawn.
 
 ### 121.12 — The 250 ms fallback makes blink-off slower than blink-on
 
@@ -260,7 +260,7 @@ do not do after warm-up. This is a different defect on the same lines.
 requires `cursor.blink = false`, which previously landed on the worse of the two
 floors.
 
-### 121.12 outcome (DONE, pending merge)
+### 121.12 outcome (DONE — merged, PR #467)
 
 **This entry originally named three bypassing call sites. That was wrong — there are
 eight**, and the miscount changed what the fix buys. Recon found, in addition to the
@@ -311,7 +311,7 @@ settled. Consequence: `ChromeMode::Replay` sits at roughly 0.5% duty cycle while
 mouse is moving, against 100% at idle. The 121.8 win is silently switched off for
 exactly as long as the pointer moves.
 
-### 121.13 outcome (DONE, pending merge)
+### 121.13 outcome (DONE — merged, PR #467)
 
 Fixed with a narrow `EguiState::stash_effective_repaint_delay` called from the
 `RedrawRequested` arm once `effective_delay` is known. `run_frame` still performs
@@ -353,7 +353,7 @@ superset of correct, therefore safe, but wasteful.
 returned from `measure_inputs` at `toast.rs:1662`) as a real signal instead of
 testing for presence.
 
-### 121.14 outcome (DONE, pending merge)
+### 121.14 outcome (DONE — merged, PR #467)
 
 **Both halves fixed**, not just the toast half this entry's Fix bullet named — the
 resize-HUD half is cited in the bug text above and was trivially fixable.

--- a/Documents/PLAN_VERSION_120.md
+++ b/Documents/PLAN_VERSION_120.md
@@ -26,10 +26,10 @@ hot, so it ships together):
 **Theme 2 — CPU performance remediation:**
 
 - **Task 121 — Performance Remediation** (in progress): the umbrella for all work arising
-  from issue #459's real-workload CPU profiling. Eleven subtasks have merged and three more
-  (121.12–121.14) are pending merge; the remaining bugs, issue #459's unactioned candidate
-  list, and two items the Group B fixes surfaced are outstanding. Summarised below; the full
-  breakdown is in `PLAN_121_PERF_REMEDIATION.md`.
+  from issue #459's real-workload CPU profiling. Fourteen subtasks have merged, most recently
+  the Group B bug fixes 121.12–121.14 (PR #467); the remaining bug, issue #459's unactioned
+  candidate list, and two items the Group B fixes surfaced are outstanding. Summarised below;
+  the full breakdown is in `PLAN_121_PERF_REMEDIATION.md`.
 
 **Theme 3 — structural cleanup:**
 
@@ -836,7 +836,7 @@ redraw — to the level set by wezterm and ghostty on the same hardware.
 | Group                                 | Subtasks      | Status      | Covers                                                                    |
 | ------------------------------------- | ------------- | ----------- | ------------------------------------------------------------------------- |
 | A — Completed work                    | 121.1–121.11  | Complete      | PRs #458, #460, #461, #464, #465                                        |
-| B — Bugs found and fixed              | 121.12–121.14 | Pending merge | blink-off fallback, chrome cache off during motion, animation signal    |
+| B — Bugs found and fixed              | 121.12–121.14 | Complete      | blink-off fallback, chrome cache off during motion, animation signal    |
 | B — Bug blocked behind Task 122       | 121.15        | Not started   | pane-wide `has_urls` / `scroll_offset` vetoes; left to 121.17            |
 | B — Withdrawn                         | 121.16        | Withdrawn     | config kill switch — rejected; revert-and-fix is the remedy             |
 | C — Unifying improvement              | 121.17        | Not started   | cell-granular pointer suppression (depends on Task 122)                 |


### PR DESCRIPTION
Applies the merge-time status transition required by
`freminal-plan-status-lifecycle` now that PR #467 has merged into `main`
(`f7dac216`).

## Changes

- **Group B `Pending merge` → `Complete`** in both roll-up tables
  (`PLAN_121_PERF_REMEDIATION.md` and `PLAN_VERSION_120.md`).
- The three subtask outcome sections now read `DONE — merged, PR #467` and the
  Group B intro names the merge commit.
- Subtask counts updated: **fourteen merged across six PRs**
  (#458, #460, #461, #464, #465, #467).
- `MASTER_PLAN.md` Completion Tracking notes for Task 121 updated.

## What deliberately did *not* change

- **Task 121 stays `In progress`** in both `MASTER_PLAN.md` tables, with **no
  completion date**. It is an umbrella task; 121.15, 121.17–121.30 remain open,
  and per `PLAN_VERSION_120.md` the version does not gate on it reaching
  `Complete`.
- **The v0.12.0 version row stays `In progress`** — a version row goes `Complete`
  only when every member task is, and Tasks 120 and 122 are still stubs.
- The "ran for five merged pull requests under a task number that existed only in
  branch names" statements in `MASTER_PLAN.md` and `PLAN_VERSION_120.md` are left
  as-is. They are historical claims about the tracking gap Task 121 was created to
  close; #467 landed under a properly tracked task and is not part of that history.

## Consistency check

Per the skill's three-point check: no `Pending merge` string survives for merged
work; Task 121's status agrees across both tables and matches its empty
`Completed` cell; and the version row is not marked `Complete` while member tasks
are outstanding. `markdownlint` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated performance remediation tracking to show that 14 subtasks are merged and complete.
  * Marked subtasks 121.12–121.14 as completed and incorporated them into the v0.12.0 plan.
  * Revised outstanding work and progress counts to reflect the latest status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->