### PR TITLE
fix: 121.32 -- disable the #436 chrome cache by default (beta.7 tab-click regression)

### DIFF
--- a/Documents/PLAN_121_PERF_REMEDIATION.md
+++ b/Documents/PLAN_121_PERF_REMEDIATION.md
@@ -85,6 +85,8 @@ creates — see that subtask.
 | E — Measurement debt (partly captured)  | 121.25        | In progress   |
 | E — Blink-off comparison                | 121.26        | Complete      |
 | F — Surfaced by the Group B work        | 121.29–121.31 | Not started   |
+| G — beta.7 interaction regression       | 121.32        | Diagnosed     |
+| G — Surfaced by 121.32                  | 121.33        | Not started   |
 
 Subtask numbers are stable once assigned. A withdrawn or dissolved subtask keeps its
 number and records why (the convention Task 118 used for 118.10), so the decision is
@@ -237,10 +239,12 @@ Commit `f762ca02`. One real bug plus cleanups, from automated review of PR #465.
 
 ## Group B — Bugs found by Group A
 
-These were surfaced by Group A. 121.12, 121.13 and 121.14 are **fixed and merged to
-`main`** via PR #467 (merge commit `f7dac216`, one atomic commit per subtask on
-`task-121/group-b`). 121.15 remains unfixed and is deliberately left to 121.17, which
-is blocked behind Task 122. 121.16 is withdrawn.
+These were surfaced by Group A. 121.12, 121.13 and 121.14 were **merged to `main`** via
+PR #467 (merge commit `f7dac216`, one atomic commit per subtask on `task-121/group-b`).
+**121.13 was subsequently reverted (2026-08-02) — it shipped a user-visible interaction
+regression in 0.12.0-beta.7; see 121.32.** 121.12 and 121.14 stand. 121.15 remains
+unfixed and is deliberately left to 121.17, which is blocked behind Task 122. 121.16 is
+withdrawn.
 
 ### 121.12 — The 250 ms fallback makes blink-off slower than blink-on
 
@@ -315,7 +319,16 @@ settled. Consequence: `ChromeMode::Replay` sits at roughly 0.5% duty cycle while
 mouse is moving, against 100% at idle. The 121.8 win is silently switched off for
 exactly as long as the pointer moves.
 
-### 121.13 outcome (DONE — merged, PR #467)
+### 121.13 outcome (REVERTED 2026-08-02 — see 121.32)
+
+> **Status: reverted on `main`.** The fix below is correct about the scheduling bug it
+> set out to solve, and the revert is not a judgement on that reasoning. It was reverted
+> because raising `ChromeMode::Replay`'s duty cycle during pointer activity — the whole
+> point of the change — exposed a pre-existing unsoundness in the chrome cache: on
+> `Replay` the chrome widgets are not constructed, and egui resolves hit-testing and
+> click/drag validity against the previous frame's widget set. Tab clicks and
+> pane-border drags broke in 0.12.0-beta.7. **Read 121.32 in full, and satisfy the
+> constraint stated there, before re-landing any of this.**
 
 Fixed with a narrow `EguiState::stash_effective_repaint_delay` called from the
 `RedrawRequested` arm once `effective_delay` is known. `run_frame` still performs
@@ -795,6 +808,17 @@ The trigger to action this is the introduction of any `ctx.animate_*`-driven chr
 widget, or evidence of an `area.rs` cause arriving on a frame that *was* suppressed.
 Both mechanisms are documented at the constant.
 
+> **Correction (2026-08-02, from 121.32).** "Latent, not live" was wrong. This entry
+> reasoned about non-construction on `Replay` purely as an **animation** problem and
+> cleared it because freminal uses no `ctx.animate_*` in chrome. The reachable
+> consequence was **input**: egui resolves hit-testing and click/drag validity against
+> the previous frame's widget set, so widgets that are not built are not merely
+> unanimated, they are uninteractable — and in beta.7 that broke tab clicks and
+> pane-border drags badly enough to require reverting 121.13. The transferable lesson:
+> "the widgets are not built" is a statement about the widget **set**, and egui uses
+> that set for interaction as well as painting. Enumerating one consumer of it
+> under-scoped the risk.
+
 ### 121.31 — Every frame is a full present during pointer motion
 
 Observed while capturing 121.17's numbers, not yet diagnosed.
@@ -811,6 +835,95 @@ confound rather than a bug.
 **Diagnose before fixing**, and re-run without the startup toast present. Second-order
 against 121.17 (which cuts the frame count on the path where this costs most), so
 schedule it after. Cheap read-only recon; do not change the damage logic speculatively.
+
+### 121.32 — `ChromeMode::Replay` breaks egui interaction (121.13 reverted)
+
+**Live regression shipped in 0.12.0-beta.7. 121.13 was reverted 2026-08-02 to restore a
+usable terminal. Diagnosis below is partial — do not treat it as complete.**
+
+Symptoms: clicking a tab mostly did nothing; pane-border drag-to-resize was inconsistent
+to unusable. Markedly worse while a TUI (`btop` etc.) was running in a pane. Hover
+highlighting on tabs appeared to work throughout.
+
+**Established fact (verified against `egui-0.35.0` source, not inferred).** egui resolves
+interaction entirely against the **previous** frame's widget set:
+
+- `context.rs:475` — `hit_test(&viewport.prev_pass.widgets, …)`
+- `context.rs:488` — `interact(…, &viewport.prev_pass.widgets, …)`
+- `interaction.rs:109-123` — if `potential_click_id` is not in that set it is cleared
+  (*"The widget we were interested in clicking is gone"*); same for `potential_drag_id`
+
+Consequences, both load-bearing:
+
+1. A press on frame N can only hit a widget that was **built on frame N-1**.
+2. A **single** `Replay` frame anywhere in a gesture discards the in-flight click/drag.
+
+Since freminal builds the tab strip only on `ChromeMode::Full`, any `Replay` frame
+adjacent to a click is fatal to it. **Hover is not evidence against this**: on a `Replay`
+frame the cached chrome texture is replayed *including the highlight drawn on the last
+`Full` frame*, so hover looks live while the widget set backing it is absent. That
+appearance misled the first two diagnosis attempts.
+
+Why a TUI made it worse: with the pointer at rest, `CursorMoved` stops firing, so nothing
+sets `chrome_input_pending`. A TUI supplies a continuous stream of PTY-driven frames,
+every one of which is then eligible for `Replay`. With no TUI, an idle app produces no
+such frames, the last `Full` frame persists, and the click lands.
+
+**Two contributing defects were identified. Neither is fixed.**
+
+- **The #436.8 drag latch is only half-wired.** `chrome_input_pending` is
+  edge-triggered (set only by an arriving input event) and drained per frame;
+  `chrome_drag_pressed_count` is level-triggered but is consulted only at the four
+  pointer-event sites, never at the `RedrawRequested` drain. A frame driven by anything
+  other than a pointer event therefore ignores a held chrome drag. This is genuinely
+  wrong independent of 121.13.
+- **The `Full`/`Replay` `Ui` id divergence (121.33) is probably an active participant,
+  not the latent risk it was filed as.** See that entry.
+
+**A fix was attempted and withdrawn.** OR-ing the latch into the frame drain
+(`pending || drag_latched`) was implemented, unit-tested, mutation-checked, and
+manually tested. It **reduced** tab-click failures but did not eliminate them — expected
+in hindsight, since it protects the span *after* the press registers and does nothing
+about frame N-1 — and it made pane-border drags **worse**, plausibly because forcing a
+`Replay`→`Full` transition at the press churns the border sensor's id (121.33) and
+clears `potential_drag_id`. The change is not on any branch; this entry is the record.
+
+**Constraint on any re-landing of 121.13.** A chrome cache that skips widget
+construction is only sound if `Full` is guaranteed on **every frame the user could
+interact with chrome on, and the frame before it**. Edge-triggered input flags cannot
+provide that guarantee, because the decisive frame is the one *preceding* an event that
+has not happened yet. A level-triggered signal (e.g. "pointer is currently over a
+chrome-interactive region", evaluated every frame) is the minimum, and it must be paired
+with 121.33 so that entering or leaving the cache mid-gesture cannot churn widget ids.
+
+**Do not re-land 121.13 on a code-reading argument.** Two such arguments were wrong
+here, and 121.13's own test module states its wiring has no automated coverage. Next
+step is measurement: the `frame-profiling` counters already in `egui_integration.rs`
+(including `gate_blocked_chrome_input`) should be used to capture the `Full`/`Replay`
+mix during a few seconds of hovering over chrome with a TUI running. If `Replay` frames
+occur while the pointer is over chrome, the level-triggered requirement above is
+confirmed directly rather than argued.
+
+### 121.33 — `Full` / `Replay` `Ui` id divergence
+
+Surfaced by 121.32. `central_body`'s `Ui` is allocated by `CentralPanel::show` on `Full`
+(an unsalted `new_child`, id auto-derived from the root id plus a per-frame child-index
+counter) and by a bare `egui::Ui::new(ctx, Id::new("freminal_root"), …)` on `Replay`.
+Any widget inside it keying persistent state off its `Ui`-derived id churns that state
+across a mode toggle.
+
+Pane-border drag sensors are exactly such a widget, and unlike the tab strip they **are**
+built on both paths — so they fail by id churn rather than by absence.
+
+The in-code comment calls this "inert" because "real user interaction with such a widget
+forces `ChromeMode::Full` on the same frame". **That premise is false** — it is precisely
+what 121.32 disproved — and the comment should be corrected whether or not the
+divergence is fixed. Forcing `Full` on the same frame is also insufficient on its own,
+per 121.32's point 1.
+
+Scope of fix: give both paths the same explicit, stable id salt so neither depends on
+egui's child-index counter. Approach: pin the current `Full`-path id with a test first,
+then make `Replay` match. Prerequisite for any re-landing of 121.13.
 
 ---
 

--- a/Documents/PLAN_121_PERF_REMEDIATION.md
+++ b/Documents/PLAN_121_PERF_REMEDIATION.md
@@ -85,7 +85,7 @@ creates — see that subtask.
 | E — Measurement debt (partly captured)  | 121.25        | In progress   |
 | E — Blink-off comparison                | 121.26        | Complete      |
 | F — Surfaced by the Group B work        | 121.29–121.31 | Not started   |
-| G — beta.7 interaction regression       | 121.32        | Diagnosed     |
+| G — beta.7 interaction regression       | 121.32        | Provisional   |
 | G — Surfaced by 121.32                  | 121.33        | Not started   |
 
 Subtask numbers are stable once assigned. A withdrawn or dissolved subtask keeps its
@@ -319,16 +319,36 @@ settled. Consequence: `ChromeMode::Replay` sits at roughly 0.5% duty cycle while
 mouse is moving, against 100% at idle. The 121.8 win is silently switched off for
 exactly as long as the pointer moves.
 
-### 121.13 outcome (REVERTED 2026-08-02 — see 121.32)
+### 121.13 outcome (REVERTED 2026-08-02 — but NOT the cause of the beta.7 bug)
 
-> **Status: reverted on `main`.** The fix below is correct about the scheduling bug it
-> set out to solve, and the revert is not a judgement on that reasoning. It was reverted
-> because raising `ChromeMode::Replay`'s duty cycle during pointer activity — the whole
-> point of the change — exposed a pre-existing unsoundness in the chrome cache: on
-> `Replay` the chrome widgets are not constructed, and egui resolves hit-testing and
-> click/drag validity against the previous frame's widget set. Tab clicks and
-> pane-border drags broke in 0.12.0-beta.7. **Read 121.32 in full, and satisfy the
-> constraint stated there, before re-landing any of this.**
+> **READ THIS BEFORE RE-LITIGATING 121.13. It was investigated at length on
+> 2026-08-02 and the conclusions below are measured, not argued.**
+>
+> **Status: reverted on `main`.** The scheduling analysis below is **correct** and was
+> never disproved: `run_frame` really did stash the raw
+> `ViewportOutput::repaint_delay`; that value really is always zero while pointer
+> events sit in egui's queue; `ChromeMode::Replay` really was pinned near 0% duty
+> cycle while the mouse moved. Substituting the effective delay really did fix that.
+>
+> **121.13 was NOT the proximate cause of the beta.7 tab-click / border-drag
+> regression.** That was the initial hypothesis, it drove the revert, and **reverting
+> it did not fix the symptom** — verified by the maintainer against a system build.
+> Do not re-derive that hypothesis; it is closed.
+>
+> What 121.13 *did* do is raise `Replay`'s duty cycle, which increases exposure to a
+> **structural unsoundness in the chrome cache that is older than 121.13 and
+> independent of it** (121.32). 121.14 raises that duty cycle too, and the
+> unsoundness is reachable without either.
+>
+> **The revert is retained for a different reason than it was made:** with the chrome
+> cache now disabled by default (121.32), 121.13's substitution only affects *when*
+> `Replay` would be chosen, and `Replay` is never chosen. It is dead code with a
+> subtle double-write contract, so it stays reverted until and unless the cache is
+> re-enabled soundly.
+>
+> **If you are re-enabling the chrome cache, 121.13's reasoning is worth restoring —
+> but only after 121.32's structural constraint is satisfied. Restoring 121.13 alone
+> re-creates the exposure without fixing anything.**
 
 Fixed with a narrow `EguiState::stash_effective_repaint_delay` called from the
 `RedrawRequested` arm once `effective_delay` is known. `run_frame` still performs
@@ -836,14 +856,37 @@ confound rather than a bug.
 against 121.17 (which cuts the frame count on the path where this costs most), so
 schedule it after. Cheap read-only recon; do not change the damage logic speculatively.
 
-### 121.32 — `ChromeMode::Replay` breaks egui interaction (121.13 reverted)
+### 121.32 — The chrome cache is structurally unsound; disabled by default
 
-**Live regression shipped in 0.12.0-beta.7. 121.13 was reverted 2026-08-02 to restore a
-usable terminal. Diagnosis below is partial — do not treat it as complete.**
+**Live regression shipped in 0.12.0-beta.7. Resolved 2026-08-02 by disabling the #436
+chrome cache by default (`FREMINAL_CHROME_CACHE=1` re-enables it).**
 
 Symptoms: clicking a tab mostly did nothing; pane-border drag-to-resize was inconsistent
 to unusable. Markedly worse while a TUI (`btop` etc.) was running in a pane. Hover
 highlighting on tabs appeared to work throughout.
+
+#### What was tried and FALSIFIED — do not re-derive these
+
+Recorded so future work does not repeat the sequence. Each was a plausible,
+code-reading-derived hypothesis; each was disproved by a maintainer build test.
+
+| # | Hypothesis                                                      | Result                                                                                   |
+| - | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| 1 | Half-wired #436.8 drag latch: OR the latch into the frame drain | **Falsified.** Reduced tab-click failures, made border drags *worse*. Withdrawn.          |
+| 2 | 121.13 raised `Replay` duty cycle and is the cause; revert it   | **Falsified.** Revert verified present in the build; symptom persisted.                   |
+| 3 | Dependency change in the beta.6→beta.7 window                   | **Ruled out** statically: only `toml 1.1.3→1.1.4`. egui stack pinned and untouched.      |
+
+Hypothesis 1 was wrong because it protects the span *after* a press registers, and the
+decisive frame is the one *before* it (see below). Hypothesis 2 was wrong because
+121.13 only changes *how often* `Replay` is chosen — 121.14 also raises it, and the
+underlying defect does not need either commit to be reachable.
+
+**Methodological note, which is the durable lesson.** All three hypotheses came from
+reading code, and two survived adversarial sub-agent review before being disproved by a
+single click test. This bug is timing-, GL- and window-dependent; static reasoning
+repeatedly produced confident wrong answers. 121.13 shipped the same way — its own test
+module states its wiring has no automated coverage. **Do not accept a code-reading
+argument about this subsystem. Measure it** (see "How to measure" below).
 
 **Established fact (verified against `egui-0.35.0` source, not inferred).** egui resolves
 interaction entirely against the **previous** frame's widget set:
@@ -869,7 +912,31 @@ sets `chrome_input_pending`. A TUI supplies a continuous stream of PTY-driven fr
 every one of which is then eligible for `Replay`. With no TUI, an idle app produces no
 such frames, the last `Full` frame persists, and the click lands.
 
-**Two contributing defects were identified. Neither is fixed.**
+#### Resolution: the cache is off by default
+
+`chrome_cache_enabled()` in `egui_integration.rs` gates the whole mechanism and
+**defaults to disabled**; `chrome_mode` is then unconditionally `Full`. Set
+`FREMINAL_CHROME_CACHE=1` to re-enable, which exists so both states can be A/B'd in one
+binary against the `frame-profiling` counters without a rebuild between samples.
+
+This is not a workaround pending a "real" fix. The unsoundness is structural: `Replay`
+skips *constructing* the widgets, and egui needs the widget set for **interaction**, not
+only painting. There is no scheduling policy that repairs that, because the frame whose
+mode decides whether a click can land is the frame *before* an event that has not
+happened yet. The only sound designs are:
+
+1. Make `Replay` still construct the chrome widgets and skip only tessellation/paint —
+   i.e. cache the *output*, not the *pass*. This preserves the widget set and is the
+   only variant that keeps the optimisation.
+2. Delete the chrome cache. **Actively under consideration by the maintainer**
+   (2026-08-02): the measured win is small and process memory has grown substantially
+   since #436 introduced it. If this is chosen, 121.13, 121.14's chrome half, and the
+   whole `ChromeGatePredicates` apparatus go with it.
+
+Do not re-enable the cache without picking (1) or (2) explicitly.
+
+**Two further contributing defects were identified. Neither is fixed, and neither is
+sufficient on its own to explain the symptom.**
 
 - **The #436.8 drag latch is only half-wired.** `chrome_input_pending` is
   edge-triggered (set only by an arriving input event) and drained per frame;
@@ -880,29 +947,40 @@ such frames, the last `Full` frame persists, and the click lands.
 - **The `Full`/`Replay` `Ui` id divergence (121.33) is probably an active participant,
   not the latent risk it was filed as.** See that entry.
 
-**A fix was attempted and withdrawn.** OR-ing the latch into the frame drain
-(`pending || drag_latched`) was implemented, unit-tested, mutation-checked, and
-manually tested. It **reduced** tab-click failures but did not eliminate them — expected
-in hindsight, since it protects the span *after* the press registers and does nothing
-about frame N-1 — and it made pane-border drags **worse**, plausibly because forcing a
-`Replay`→`Full` transition at the press churns the border sensor's id (121.33) and
-clears `potential_drag_id`. The change is not on any branch; this entry is the record.
+**How to measure (use this instead of arguing).** The `frame-profiling` counters
+already exist and answer the question directly:
 
-**Constraint on any re-landing of 121.13.** A chrome cache that skips widget
-construction is only sound if `Full` is guaranteed on **every frame the user could
-interact with chrome on, and the frame before it**. Edge-triggered input flags cannot
-provide that guarantee, because the decisive frame is the one *preceding* an event that
-has not happened yet. A level-triggered signal (e.g. "pointer is currently over a
-chrome-interactive region", evaluated every frame) is the minimum, and it must be paired
-with 121.33 so that entering or leaving the cache mid-gesture cannot churn widget ids.
+```text
+cargo build --release --features frame-profiling
+RUST_LOG=none,freminal_windowing=debug ./target/release/freminal
+```
 
-**Do not re-land 121.13 on a code-reading argument.** Two such arguments were wrong
-here, and 121.13's own test module states its wiring has no automated coverage. Next
-step is measurement: the `frame-profiling` counters already in `egui_integration.rs`
-(including `gate_blocked_chrome_input`) should be used to capture the `Full`/`Replay`
-mix during a few seconds of hovering over chrome with a TUI running. If `Replay` frames
-occur while the pointer is over chrome, the level-triggered requirement above is
-confirmed directly rather than argued.
+A line flushes every 120 frames carrying `chrome_mode_full`, `chrome_mode_replay`,
+`chrome_replay_duty_cycle_pct` and the four `gate_blocked_*` breakdowns; deltas between
+consecutive lines give per-interval behaviour. The acceptance test for any re-enabled
+cache is two-condition and falsifiable: hovering over chrome must produce **zero**
+`Replay` frames, and hovering over the terminal must produce **many**.
+
+**Verification status — READ BEFORE BUILDING ON THIS.** As of the commit that
+introduced the default-off switch, the evidence is **provisional**:
+
+- Maintainer's assessment of the default-off build was *"hard to say, I think it's
+  fixed"* — an improvement, not a confirmation. It was committed specifically so it
+  could be installed as the system terminal and exercised under real daily use, which
+  is the only workload that reliably reproduced the bug.
+- The A/B against `FREMINAL_CHROME_CACHE=1` has **not** been run.
+
+So "the chrome cache causes it" is well-supported by the egui source (the `prev_pass`
+citations above are fact) but is **not yet pinned by experiment**. Two outcomes to watch
+for, both of which invalidate part of this entry:
+
+1. Symptom persists with the cache **off** → the cache is not the cause, this entry is
+   wrong, and the search must widen beyond PR #467 entirely, including to code older
+   than beta.6.
+2. Symptom does not reproduce with the cache **on** → the correlation with `Replay` is
+   wrong and the beta.6→beta.7 bisect boundary should be re-examined.
+
+Update this section with the result either way. Do not let it stand as settled.
 
 ### 121.33 — `Full` / `Replay` `Ui` id divergence
 

--- a/freminal-windowing/src/egui_integration.rs
+++ b/freminal-windowing/src/egui_integration.rs
@@ -583,6 +583,46 @@ struct ChromeGatePredicates {
     no_chrome_input: bool,
 }
 
+/// Is the #436 chrome cache (`ChromeMode::Replay`) enabled at all?
+///
+/// **Default: DISABLED.** Set `FREMINAL_CHROME_CACHE=1` to re-enable.
+///
+/// The cache is a painting optimisation that skips constructing the chrome
+/// widgets and replays a cached texture instead. That is only sound if egui
+/// never needs the chrome widgets on a `Replay` frame — and it does, because
+/// egui resolves *interaction*, not just painting, against the widget set:
+///
+/// | Site                  | Code                                            |
+/// | --------------------- | ----------------------------------------------- |
+/// | `context.rs:475`      | `hit_test(&viewport.prev_pass.widgets, …)`      |
+/// | `context.rs:488`      | `interact(…, &viewport.prev_pass.widgets, …)`   |
+/// | `interaction.rs:109`  | clears `potential_click_id` if absent from it   |
+///
+/// Note `prev_pass` — the PREVIOUS frame's set. So a press on frame N can
+/// only hit a widget built on frame N-1, and a single `Replay` frame
+/// anywhere in a gesture discards the in-flight click or drag. In
+/// 0.12.0-beta.7 this made tab clicks mostly fail and pane-border drags
+/// unusable, worst while a TUI ran in a pane (a TUI supplies a stream of
+/// PTY-driven frames, every one eligible for `Replay`, during the moment the
+/// pointer is at rest before a click).
+///
+/// It is off by default because that unsoundness is structural, not a tuning
+/// error: no amount of adjusting *when* `Replay` is chosen fixes the fact
+/// that `Replay` frames do not register widgets. Any re-enabling must first
+/// make `Replay` construct the chrome widgets (and only skip their
+/// tessellation/paint), or otherwise guarantee `Full` on every frame the user
+/// could interact on **and the frame before it**. See 121.32 / 121.33 in
+/// `Documents/PLAN_121_PERF_REMEDIATION.md`.
+///
+/// The env var exists so the two states can be A/B'd in one binary, using the
+/// `frame-profiling` counters, without a rebuild between samples.
+fn chrome_cache_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("FREMINAL_CHROME_CACHE").is_ok_and(|v| v != "0" && !v.is_empty())
+    })
+}
+
 impl ChromeGatePredicates {
     /// A REPLAY is permitted only when every predicate holds.
     const fn all_pass(&self) -> bool {
@@ -828,7 +868,11 @@ impl EguiState {
             self.prev_chrome_damage,
             chrome_input_this_frame,
         );
-        let chrome_mode = gate.chrome_mode();
+        let chrome_mode = if chrome_cache_enabled() {
+            gate.chrome_mode()
+        } else {
+            crate::ChromeMode::Full
+        };
 
         // Task 121 frame-profiling harness: count which `ChromeMode` was
         // just decided. Cross-checkable against `freminal`'s own

--- a/freminal-windowing/src/egui_integration.rs
+++ b/freminal-windowing/src/egui_integration.rs
@@ -1214,25 +1214,6 @@ impl EguiState {
         // returns immediately (macOS with vsync disabled).
 
         // Stash this frame's signals for next frame's `chrome_mode` decision.
-        //
-        // Subtask 121.13: this is egui's RAW `repaint_delay`, not the value
-        // `event_loop.rs`'s `RedrawRequested` arm actually stashes for the
-        // chrome gate via `effective_chrome_gate_delay` (a sibling of, but
-        // NOT the same as, the `effective_repaint_delay` used to decide what
-        // to schedule — see that function's doc for why the two questions
-        // differ). On a suppressed-pointer frame the raw value here is
-        // always `ZERO` (egui's event queue is non-empty because the
-        // suppressed pointer events are still handed to `on_window_event`),
-        // which makes `chrome_repaint_settled` see "not settled" and hold
-        // the chrome cache in `ChromeMode::Full` for as long as the pointer
-        // moves. `event_loop.rs` calls `stash_effective_repaint_delay`
-        // immediately after this write to overwrite it with the gate value
-        // — see that method's doc for why this double-write is intentional
-        // and not a race. Do NOT delete either write without re-reading both
-        // docs: deleting this one leaves the field unwritten on any path
-        // that never reaches the event loop's override, and deleting that
-        // one silently reintroduces the "chrome cache disabled during
-        // pointer motion" bug.
         self.prev_repaint_delay = repaint_delay;
         self.prev_chrome_damage = chrome_damage;
         self.prev_terminal_requested_delay = terminal_requested_delay;
@@ -1431,40 +1412,6 @@ impl EguiState {
     /// by an internal `destroyed` flag), so calling it more than once is safe.
     pub(crate) fn destroy_painter(&mut self) {
         self.painter.destroy();
-    }
-
-    /// Subtask 121.13 + residual-gap fix (maintainer decision): overwrite
-    /// `prev_repaint_delay` with the value `event_loop.rs`'s
-    /// `RedrawRequested` arm computes via `effective_chrome_gate_delay` —
-    /// NOT the raw `frame_output.repaint_delay` that `run_frame` stashed a
-    /// few lines earlier in the same event-loop pass, and NOT
-    /// `effective_repaint_delay`'s return value either (that function
-    /// answers "what do we schedule?", a bounded-liveness question; this
-    /// stash answers "did anything want a repaint?", for which an
-    /// unbounded/`MAX` answer is correct when nothing did). See
-    /// `effective_chrome_gate_delay`'s doc for the exact single case where
-    /// the two diverge.
-    ///
-    /// WHY the value must be substituted at all: on a frame where the only
-    /// thing that happened was suppressed pointer motion, egui's raw delay
-    /// is always `ZERO` (its input queue is non-empty because the suppressed
-    /// pointer events are still delivered to `on_window_event`, even though
-    /// the event-loop classified them as needing no repaint). Feeding that
-    /// raw zero into `chrome_repaint_settled` next frame permanently reads
-    /// as "not settled" for as long as the pointer keeps moving, which holds
-    /// `ChromeMode` at `Full` and disables the #436 chrome cache exactly
-    /// when it matters most (continuous pointer motion is the common case).
-    /// The substituted delay reflects what was ACTUALLY scheduled/wanted —
-    /// the app's own requested delay when suppression applied, or
-    /// `Duration::MAX` when the app wanted nothing at all — so the settle
-    /// check reasons about reality instead of an artifact of how egui's
-    /// input queue works.
-    ///
-    /// This is a deliberate second write to `prev_repaint_delay` immediately
-    /// after `run_frame`'s own stash (see the comment there). Do not remove
-    /// either write in isolation — see that comment for what breaks.
-    pub(crate) const fn stash_effective_repaint_delay(&mut self, delay: std::time::Duration) {
-        self.prev_repaint_delay = delay;
     }
 }
 
@@ -2010,105 +1957,6 @@ mod tests {
             .chrome_mode(),
             crate::ChromeMode::Replay
         );
-    }
-
-    // ── Subtask 121.13 (+ residual-gap fix): suppressed-pointer-motion
-    //    chrome-cache regression ──
-    //
-    // `evaluate_chrome_gate`/`chrome_repaint_settled` are pure and know
-    // nothing about `effective_repaint_delay`/`effective_chrome_gate_delay`
-    // (those functions live in `event_loop.rs` and are private there, so
-    // they cannot be called from this module's tests directly) — these
-    // tests instead pin the `prev_repaint_delay` values those functions can
-    // produce for a suppressed-pointer frame, proving the gate reacts to
-    // each exactly as `EguiState::stash_effective_repaint_delay`'s doc
-    // claims.
-    //
-    // IMPORTANT SCOPE NOTE (review item 5b): these tests exercise ONLY the
-    // pure decision functions in THIS module. Neither 121.13 nor the
-    // residual-gap fix changed `chrome_repaint_settled` or
-    // `evaluate_chrome_gate` themselves — both subtasks changed what
-    // `event_loop.rs` stashes into `prev_repaint_delay` BEFORE it reaches
-    // these functions. That means these tests would pass identically
-    // against the pre-121.13 code: they pin the REASONING ("given this
-    // stashed value, what does the gate decide?"), not the WIRING ("does
-    // `event_loop.rs` actually stash the right value, at the right point,
-    // on every reachable path?"). The wiring has no automated coverage
-    // because it needs a live winit window and GL context to exercise
-    // `Handler::window_event`'s `RedrawRequested` arm end-to-end. A future
-    // refactor that reorders, deletes, or misroutes the
-    // `stash_effective_repaint_delay` call would NOT be caught by anything
-    // in this file — do not read a green run of these tests as proof the
-    // wiring is intact.
-
-    /// BEFORE 121.13: `run_frame` stashed egui's RAW `repaint_delay`, which
-    /// `InputState::wants_repaint_after` always returns as `ZERO` while the
-    /// suppressed pointer events are still sitting in egui's input queue —
-    /// regardless of whether the app itself requested anything. Pinning
-    /// this as `Full` documents the bug: the chrome cache reads as
-    /// "unsettled" for as long as the pointer moves, even with an active
-    /// 500ms blink schedule that, substituted, would settle just fine (see
-    /// the next test).
-    #[test]
-    fn raw_zero_delay_during_suppressed_pointer_motion_decides_full() {
-        let inputs = Inputs {
-            prev_repaint_delay: Duration::ZERO,
-            prev_terminal_requested_delay: Some(Duration::from_millis(500)),
-            ..Inputs::all_clear()
-        };
-        assert_eq!(inputs.decide(), crate::ChromeMode::Full);
-    }
-
-    /// AFTER 121.13: `event_loop.rs`'s `RedrawRequested` arm overwrites the
-    /// raw zero with `effective_repaint_delay`'s substituted value, which
-    /// equals `app_requested_delay` whenever that is `Some` (the
-    /// `suppressed_only && repaint_delay.is_zero()` branch). This is the
-    /// fix's intended outcome: a suppressed-pointer frame with an active
-    /// app-side schedule (the common blinking-cursor-while-mouse-moves
-    /// case) now settles and permits `Replay`, instead of being pinned to
-    /// `Full` at ~0.5% duty cycle for as long as the pointer moves.
-    #[test]
-    fn substituted_delay_during_suppressed_pointer_motion_decides_replay() {
-        let inputs = Inputs {
-            // What `effective_repaint_delay(true, Duration::ZERO,
-            // Some(500ms))` returns: the app's own request, substituted for
-            // egui's raw zero.
-            prev_repaint_delay: Duration::from_millis(500),
-            prev_terminal_requested_delay: Some(Duration::from_millis(500)),
-            ..Inputs::all_clear()
-        };
-        assert_eq!(inputs.decide(), crate::ChromeMode::Replay);
-    }
-
-    /// Residual-gap fix (maintainer decision, follow-up to 121.13): when the
-    /// app requested NOTHING this frame (no blink schedule, no animation, no
-    /// toast — `app_requested_delay: None`, e.g. `DECTCEM` hid the cursor),
-    /// the value stashed for the chrome gate is now
-    /// `effective_chrome_gate_delay`'s `Duration::MAX` — NOT
-    /// `effective_repaint_delay`'s bounded
-    /// `SUPPRESSED_POINTER_FALLBACK_DELAY` (500ms), which is what gets
-    /// SCHEDULED but must not be fed to the settle check (see
-    /// `effective_chrome_gate_delay`'s doc). Before the residual-gap fix,
-    /// `event_loop.rs` stashed the same 500ms value it scheduled, which
-    /// `chrome_repaint_settled`'s `None` arm reads as "unsettled" (it
-    /// requires EXACTLY `Duration::MAX`), pinning `ChromeMode::Full` for the
-    /// entire duration of suppressed pointer motion whenever nothing else
-    /// was scheduled — the btop/`DECTCEM`-hidden-cursor workload. This test
-    /// used to pin that unfixed `Full` outcome; it now pins the fixed
-    /// `Replay` outcome, since `None` app-request is exactly the case where
-    /// nothing wanted a repaint.
-    #[test]
-    fn no_app_request_during_suppressed_pointer_motion_now_decides_replay() {
-        let inputs = Inputs {
-            // What `effective_chrome_gate_delay(true, Duration::ZERO, None)`
-            // returns: `Duration::MAX`, i.e. proof nothing wanted a repaint
-            // (as opposed to `effective_repaint_delay`'s bounded fallback,
-            // which answers a different, scheduling-only question).
-            prev_repaint_delay: Duration::MAX,
-            prev_terminal_requested_delay: None,
-            ..Inputs::all_clear()
-        };
-        assert_eq!(inputs.decide(), crate::ChromeMode::Replay);
     }
 
     // ── #436.7: multi-frame FULL/REPLAY sequence properties ─────────────

--- a/freminal-windowing/src/event_loop.rs
+++ b/freminal-windowing/src/event_loop.rs
@@ -141,15 +141,6 @@ fn clamp_repaint_delay(delay: std::time::Duration) -> std::time::Duration {
 /// chrome input forces Full), so the one interactive widget most likely to
 /// carry egui-internal animation state cannot itself be open during a
 /// `Replay` frame.
-///
-/// The Item 1 residual-gap fix (`effective_chrome_gate_delay`, see its doc)
-/// widens this latent window: settling the chrome gate on `app_requested_delay:
-/// None` now permits `Replay` in the "app requested nothing" case that used to
-/// pin `Full`, so both mechanisms above are reachable in a strictly larger set
-/// of frames than before that fix. This was a deliberate, accepted trade
-/// (maintainer decision) — the primary win (correct settling for the
-/// btop/`DECTCEM`-hidden-cursor workload) outweighs a latent risk with no
-/// currently-existing trigger.
 const SUPPRESSED_POINTER_FALLBACK_DELAY: std::time::Duration =
     std::time::Duration::from_millis(500);
 
@@ -180,47 +171,6 @@ fn effective_repaint_delay(
 ) -> std::time::Duration {
     if suppressed_only && repaint_delay.is_zero() {
         app_requested_delay.unwrap_or(SUPPRESSED_POINTER_FALLBACK_DELAY)
-    } else {
-        repaint_delay
-    }
-}
-
-/// Subtask 121.13 residual-gap fix (maintainer decision): the value stashed
-/// for next frame's chrome-settle check (see [`chrome_repaint_settled`] via
-/// `EguiState::stash_effective_repaint_delay`), which answers a DIFFERENT
-/// question than [`effective_repaint_delay`] despite sharing its inputs and
-/// its substitution condition.
-///
-/// [`effective_repaint_delay`] answers "what delay do we actually schedule
-/// the next wake at?" — and the answer there MUST be bounded
-/// ([`SUPPRESSED_POINTER_FALLBACK_DELAY`]) when the app requested nothing,
-/// because we cannot prove nothing needs drawing and an unbounded wait would
-/// stall the window.
-///
-/// This function answers "did anything actually WANT a repaint this frame?"
-/// — and when the app requested nothing, the absence of any request IS the
-/// proof that nothing wanted one. Substituting the synthetic liveness poll
-/// interval here would make it masquerade as evidence of a real want, which
-/// is exactly the residual gap the maintainer flagged: `chrome_repaint_settled`'s
-/// `None` arm requires the delay to equal `Duration::MAX` to call the frame
-/// settled, so feeding it 500ms permanently reads as "unsettled" for as long
-/// as suppressed pointer motion continues, even though nothing chrome-relevant
-/// is scheduled.
-///
-/// The two functions diverge in EXACTLY one case: `suppressed_only &&
-/// repaint_delay.is_zero() && app_requested_delay.is_none()`. Every other
-/// input combination yields the same output from both — when `app_requested_delay`
-/// is `Some(_)` the substitution is identical; when substitution does not
-/// apply, both pass `repaint_delay` through unchanged.
-///
-/// Pure so the divergence itself is unit-testable without a live event loop.
-fn effective_chrome_gate_delay(
-    suppressed_only: bool,
-    repaint_delay: std::time::Duration,
-    app_requested_delay: Option<std::time::Duration>,
-) -> std::time::Duration {
-    if suppressed_only && repaint_delay.is_zero() {
-        app_requested_delay.unwrap_or(std::time::Duration::MAX)
     } else {
         repaint_delay
     }
@@ -1260,38 +1210,6 @@ impl<A: App> ApplicationHandler<UserEvent> for Handler<A> {
                     frame_output.app_requested_delay,
                 );
 
-                // Subtask 121.13 + residual-gap fix (maintainer decision):
-                // `run_frame` (inside `state.egui`) already stashed the RAW
-                // `frame_output.repaint_delay` for next frame's chrome-settle
-                // check. Overwrite it here with `effective_chrome_gate_delay`
-                // — NOT `effective_delay`/`effective_repaint_delay` above,
-                // which answers a different question (what to schedule) and
-                // therefore must stay bounded even when the app requested
-                // nothing. The gate value must NOT be bounded in that case:
-                // see `effective_chrome_gate_delay`'s doc for why the two
-                // diverge in exactly one case, and
-                // `EguiState::stash_effective_repaint_delay`'s doc for why
-                // this is a deliberate second write over `run_frame`'s stash.
-                //
-                // Unconditional rather than "only when it differs": the two
-                // gate-delay branches are equal to `repaint_delay` whenever
-                // `suppressed_only` was false, so an unconditional write is a
-                // no-op on every non-suppressed frame and therefore
-                // behaviourally identical to a guarded write, just without
-                // the extra comparison.
-                //
-                // Must run on every path that reaches this point (no early
-                // return follows it in this arm) — the field would go stale
-                // on any suppressed-pointer frame that skipped it.
-                let effective_gate_delay = effective_chrome_gate_delay(
-                    suppressed_only,
-                    frame_output.repaint_delay,
-                    frame_output.app_requested_delay,
-                );
-                state
-                    .egui
-                    .stash_effective_repaint_delay(effective_gate_delay);
-
                 if effective_delay < std::time::Duration::from_hours(1) {
                     let deadline = Instant::now() + clamp_repaint_delay(effective_delay);
                     state.repaint_at = Some(deadline);
@@ -1556,7 +1474,7 @@ pub fn run(config: WindowConfig, app: impl App + 'static) -> Result<(), Error> {
 mod tests {
     use super::{
         MIN_REPAINT_INTERVAL, SUPPRESSED_POINTER_FALLBACK_DELAY, ViewportCommandFlags,
-        clamp_repaint_delay, effective_chrome_gate_delay, effective_repaint_delay, is_blocked_key,
+        clamp_repaint_delay, effective_repaint_delay, is_blocked_key,
         is_unconditional_chrome_input, logical_coord_to_i32, logical_dim_to_u32,
         physical_to_logical_pos, should_force_chrome_full_for_pointer,
         should_schedule_cursor_moved, should_set_chrome_input_pending, update_chrome_drag_latch,
@@ -2031,82 +1949,6 @@ mod tests {
         assert_eq!(
             effective_repaint_delay(false, std::time::Duration::MAX, None),
             std::time::Duration::MAX
-        );
-    }
-
-    // ── Residual-gap fix (maintainer decision): `effective_chrome_gate_delay` ──
-    //
-    // Mirrors the `effective_repaint_delay` tests above for its sibling: same
-    // branches, same inputs, but the `None`-substitution branch answers
-    // `Duration::MAX` instead of the bounded fallback, because this function
-    // answers "did anything want a repaint?" rather than "what do we
-    // schedule?". See the divergence-pinning test at the end of this block.
-
-    #[test]
-    fn effective_chrome_gate_delay_substitutes_app_delay_when_suppressed_and_egui_wants_immediate()
-    {
-        // Identical to `effective_repaint_delay`'s headline case: the app's
-        // own request substitutes for egui's queue-artifact zero.
-        assert_eq!(
-            effective_chrome_gate_delay(true, std::time::Duration::ZERO, Some(MS500)),
-            MS500
-        );
-    }
-
-    #[test]
-    fn effective_chrome_gate_delay_becomes_max_when_app_wants_nothing() {
-        // THIS is where the two functions diverge: `effective_repaint_delay`
-        // must stay bounded here (liveness), but the gate delay must become
-        // `Duration::MAX` — the absence of any app request IS the proof that
-        // nothing wanted a repaint, so the synthetic liveness poll interval
-        // must not masquerade as evidence of one.
-        assert_eq!(
-            effective_chrome_gate_delay(true, std::time::Duration::ZERO, None),
-            std::time::Duration::MAX
-        );
-    }
-
-    #[test]
-    fn effective_chrome_gate_delay_passes_egui_delay_through_when_not_suppressed() {
-        assert_eq!(
-            effective_chrome_gate_delay(false, std::time::Duration::ZERO, Some(MS500)),
-            std::time::Duration::ZERO
-        );
-        assert_eq!(effective_chrome_gate_delay(false, MS16, Some(MS500)), MS16);
-    }
-
-    #[test]
-    fn effective_chrome_gate_delay_never_overrides_a_nonzero_egui_request() {
-        assert_eq!(effective_chrome_gate_delay(true, MS16, Some(MS500)), MS16);
-        assert_eq!(effective_chrome_gate_delay(true, MS16, None), MS16);
-    }
-
-    #[test]
-    fn effective_chrome_gate_delay_preserves_max_when_not_suppressed() {
-        assert_eq!(
-            effective_chrome_gate_delay(false, std::time::Duration::MAX, None),
-            std::time::Duration::MAX
-        );
-    }
-
-    #[test]
-    fn effective_repaint_delay_and_effective_chrome_gate_delay_diverge_only_when_app_requested_nothing()
-     {
-        // Pin the divergence explicitly: same `suppressed_only`/`repaint_delay`
-        // inputs, `app_requested_delay: None`, and the two functions now
-        // disagree on purpose. `effective_repaint_delay` returns the bounded
-        // liveness fallback (what we schedule); `effective_chrome_gate_delay`
-        // returns `Duration::MAX` (nothing wanted a repaint).
-        let scheduled = effective_repaint_delay(true, std::time::Duration::ZERO, None);
-        let gated = effective_chrome_gate_delay(true, std::time::Duration::ZERO, None);
-
-        assert_eq!(scheduled, SUPPRESSED_POINTER_FALLBACK_DELAY);
-        assert_eq!(gated, std::time::Duration::MAX);
-        assert_ne!(
-            scheduled, gated,
-            "the two questions ('what to schedule' vs 'did anything want a \
-             repaint') must diverge in this exact case, or the residual gap \
-             this fix closes has regressed"
         );
     }
 


### PR DESCRIPTION
## What

Disables the #436 chrome cache by default. `chrome_mode` is now unconditionally `Full`; `FREMINAL_CHROME_CACHE=1` re-enables the old behaviour for A/B measurement.

Also reverts `6607a908` (121.13) — see below, the reason is **not** the one the first commit on this branch claims.

Fixes the 0.12.0-beta.7 regression: tab clicks mostly did not register, pane-border drag-to-resize was unusable, both markedly worse with a TUI running in a pane.

## Root cause

`ChromeMode::Replay` skips **constructing** the chrome widgets. egui resolves *interaction*, not just painting, against the widget set — and against the **previous** frame's set:

| Site | Code |
| --- | --- |
| `context.rs:475` | `hit_test(&viewport.prev_pass.widgets, …)` |
| `context.rs:488` | `interact(…, &viewport.prev_pass.widgets, …)` |
| `interaction.rs:109` | clears `potential_click_id` when absent from that set |

So a press on frame N can only hit a widget built on frame **N-1**, and a **single** `Replay` frame anywhere in a gesture discards the in-flight click or drag. A TUI supplies a continuous stream of PTY-driven frames — every one eligible for `Replay` — during exactly the moment the pointer is at rest before a click.

**Hover kept working**, which is what hid this: the replayed texture still contains the highlight painted on the last `Full` frame, so hover looks live while the widget set backing it is gone.

## Why not a tuning fix

No scheduling policy repairs this. The frame that decides whether a click can land is the frame *before* an event that has not happened yet. The only sound designs are to cache the **output** rather than the **pass** (construct widgets, skip only tessellation), or to delete the chrome cache outright. That choice is deliberately left open — deletion is under active consideration, since the measured win is small and process memory has grown since #436 landed.

## Two hypotheses were falsified first

Recorded in the plan so they are not re-derived:

1. **Half-wired #436.8 drag latch** — OR the latch into the frame drain. Reduced tab-click failures, made border drags *worse*. Withdrawn, never shipped.
2. **121.13 is the cause** — revert verified present in the tree, symptom persisted. 121.13 raises `Replay`'s duty cycle but is **not** the cause; its own scheduling analysis was never disproved. The revert is retained only because the substitution is dead code while the cache is off.

Both came from reading code, and both survived adversarial review before failing a single click test. This subsystem is timing- and window-dependent; three confident static answers were wrong.

## Verification is PROVISIONAL

- Maintainer's read of the default-off build: *"hard to say, I think it's fixed"* — an improvement, not a confirmation. Merged so it can be installed as the system terminal and exercised under the workload that actually reproduced the bug.
- The A/B against `FREMINAL_CHROME_CACHE=1` has **not** been run.

`PLAN_121_PERF_REMEDIATION.md` §121.32 states both outcomes that would invalidate this diagnosis and asks for the section to be updated either way.

Suites green: `cargo test --all`, `--features frame-profiling`, both clippy forms, `cargo machete`, `cargo xtask check-windows`.

## Docs

- **121.32** — full diagnosis, the falsified-hypothesis table, the measurement recipe, and the two sound redesigns
- **121.33** — `Full`/`Replay` `Ui` id divergence, whose in-code comment justifies itself with the premise this bug disproved
- **121.13** — rewritten: reverted, but explicitly *not* the cause; guards against re-litigation
- **121.30** — corrected; it had assessed non-construction on `Replay` as *"latent, not live"* by considering only animation, not input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window rendering reliability by disabling experimental chrome replay by default.
  * Full rendering now serves as the standard fallback, reducing risks with pane interactions and hit testing.
  * Simplified redraw scheduling for more predictable repaint behavior.

* **Documentation**
  * Updated performance remediation records with findings, verification status, and guidance for safely revisiting experimental rendering optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->