### PR TITLE
chore(ci): auto-regenerate nix/cargo-bundle.lock on cargo-bundle-src bumps

### DIFF
--- a/.github/workflows/update-flakes.yaml
+++ b/.github/workflows/update-flakes.yaml
@@ -62,3 +62,49 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-branch-prefix: update-
           automerge: true
+
+      # cargo-bundle-src is a non-flake `github:` input pointing at
+      # burtonageo/cargo-bundle, which stopped committing its own Cargo.lock
+      # after v0.9.0. flake.nix vendors nix/cargo-bundle.lock and builds
+      # cargo-bundle from that source via `cargoLock.lockFile`, so bumping
+      # the input without regenerating the vendored lockfile breaks the Nix
+      # build the moment upstream's Cargo.toml drifts from it (see PR #481).
+      # This mirrors, for this one hand-vendored lockfile, what Renovate's
+      # lockFileMaintenance does automatically for the main Cargo.lock.
+      - name: Regenerate nix/cargo-bundle.lock for cargo-bundle-src
+        if: matrix.flake == 'cargo-bundle-src'
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+          BRANCH: update-${{ matrix.flake }}
+        run: |
+          set -euo pipefail
+
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}"
+
+          if ! git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+            echo "No ${BRANCH} branch was created/updated this run; nothing to regenerate."
+            exit 0
+          fi
+
+          git fetch origin "${BRANCH}:${BRANCH}" --force
+          git checkout --force "${BRANCH}"
+
+          rev="$(jq -r '.nodes["cargo-bundle-src"].locked.rev' flake.lock)"
+          owner="$(jq -r '.nodes["cargo-bundle-src"].locked.owner' flake.lock)"
+          repo="$(jq -r '.nodes["cargo-bundle-src"].locked.repo' flake.lock)"
+
+          workdir="$(mktemp -d)"
+          git clone --quiet "https://github.com/${owner}/${repo}.git" "${workdir}"
+          git -C "${workdir}" checkout --quiet "${rev}"
+
+          nix shell nixpkgs#cargo nixpkgs#rustc -c \
+            cargo generate-lockfile --manifest-path "${workdir}/Cargo.toml"
+
+          if ! cmp -s "${workdir}/Cargo.lock" nix/cargo-bundle.lock; then
+            cp "${workdir}/Cargo.lock" nix/cargo-bundle.lock
+            git add nix/cargo-bundle.lock
+            git commit -m "chore(nix/cargo-bundle.lock): regenerate for cargo-bundle-src ${rev:0:8}"
+            git push origin "${BRANCH}"
+          else
+            echo "nix/cargo-bundle.lock already matches upstream; no changes needed."
+          fi


### PR DESCRIPTION
Fixes the failure mode that broke PR #481: `update-flakes.yaml` bumps the `cargo-bundle-src` flake input (a non-flake `github:` source with no `Cargo.lock` of its own) but never regenerated the vendored `nix/cargo-bundle.lock` that `cargoBundleLatest`'s `cargoLock.lockFile` verifies against. `flake.nix` documented this as a manual step ("regenerate with `cargo generate-lockfile` after a `nix flake update`") that nobody was doing.

This adds a follow-up step to the `update-flake` job, scoped to the `cargo-bundle-src` matrix entry, that runs after `flake-update-action`: clone `burtonageo/cargo-bundle` at the newly-pinned rev, run `cargo generate-lockfile` against it, and push the regenerated lockfile as an extra commit onto the same PR branch if it changed. Mirrors what Renovate's `lockFileMaintenance` does automatically for the main `Cargo.lock`, for this one hand-vendored lockfile Renovate can't see (no sibling `Cargo.toml` in the repo for it to pair with).

Verified locally:
- Cloned `burtonageo/cargo-bundle` at `4e45b98d` and ran `cargo generate-lockfile` — matches the fix applied in #481.
- `pre-commit run` (check-github-workflows, check-yaml, shellcheck-bash, prettier) passes on the new step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated update handling for bundled Rust source dependencies.
  - Generated lockfile changes are now committed only when updates are detected.
  - Update workflows now safely skip processing when no branch or changes are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->