### PR TITLE
chore(deps): update egui stack to 0.36.1, holding glow at 0.17

### DIFF
--- a/.opencode/skills/freminal-egui-upgrade/SKILL.md
+++ b/.opencode/skills/freminal-egui-upgrade/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: freminal-egui-upgrade
-description: Use ONLY when working in the freminal repository AND bumping, unpinning, or otherwise changing the version of any crate in the egui rendering stack — `egui`, `epaint`, `egui_glow`, `egui-winit` (and closely-coupled `glow` / `glutin` / `winit` / `raw-window-handle`) — or editing their `=0.35.0` exact pins in the workspace `Cargo.toml`, or touching the Renovate "egui + windowing stack" group. The chrome-caching work (#435/#436) relies on undocumented internal behaviour of egui 0.35.0; this skill mandates walking the `Documents/EGUI_UPGRADE_ASSUMPTIONS.md` re-verification checklist and running the pixel-level smoke before any such bump lands, and explains why the exact pins and the no-auto-merge Renovate rule are deliberate.
+description: Use ONLY when working in the freminal repository AND bumping, unpinning, or otherwise changing the version of any crate in the egui rendering stack — `egui`, `epaint`, `egui_glow`, `egui-winit` (and closely-coupled `glow` / `glutin` / `winit` / `raw-window-handle`) — or editing their exact-version pins in the workspace `Cargo.toml`, or touching the Renovate "egui + windowing stack" group. The chrome-caching work (#435/#436) relies on undocumented internal behaviour of the pinned egui version; this skill mandates walking the `Documents/EGUI_UPGRADE_ASSUMPTIONS.md` re-verification checklist and running the pixel-level smoke before any such bump lands, and explains why the exact pins and the no-auto-merge Renovate rule are deliberate.
 ---
 
 # Freminal: verify the egui stack before bumping it
@@ -9,7 +9,8 @@ The chrome-caching work (issues #435 and #436) makes the GUI skip
 re-recording / re-tessellating / re-painting chrome on frames where the
 chrome did not change. To do this it depends on a set of **undocumented,
 internal behaviours** of the egui stack (`egui`, `epaint`, `egui_glow`,
-`egui-winit`) at version **0.35.0** — things that are not part of any
+`egui-winit`) at the exact version pinned in the workspace `Cargo.toml`
+(currently **0.36.1**) — things that are not part of any
 crate's public API contract and can change silently across versions.
 
 The failure mode is the dangerous kind: **no compile error, no headless
@@ -18,19 +19,28 @@ ghosted chrome, or stale overlays at runtime.
 
 ## The rules
 
-1. **`egui`, `egui_glow`, and `egui-winit` are exact-pinned (`=0.35.0`) as a
+1. **`egui`, `egui_glow`, and `egui-winit` are exact-pinned (`=`) as a
    matched set** in the workspace `Cargo.toml`. This is deliberate. Do **not**
    relax them to a caret range as a "cleanup". A patch bump can change the
    internal behaviour we rely on.
 
-2. **Never auto-merge an egui-stack bump.** Renovate's "egui + windowing
+2. **`glow` is not ours to bump — it follows `egui_glow`.** `egui_glow`
+   declares `glow = "0.17.0"` and upstream cannot move to 0.18, because
+   wgpu 30's `wgpu-hal` pins glow 0.17. We pass `Arc<glow::Context>` straight
+   into `egui_glow::Painter`, so two glow versions in the graph is a **type
+   error**, not merely a duplicate dependency. `renovate.json` constrains glow
+   to `<0.18` for this reason; Renovate's group will otherwise propose a bump
+   that cannot resolve. Before bumping glow, read the _new_ `egui_glow`'s
+   `Cargo.toml` and only follow what it declares.
+
+3. **Never auto-merge an egui-stack bump.** Renovate's "egui + windowing
    stack" group is configured with `automerge: false` and
    `dependencyDashboardApproval: true`, so a bump PR is not even opened until a
    human approves it on the Dependency Dashboard. Do not remove those settings.
    (Dependabot cargo updates are disabled entirely via
    `open-pull-requests-limit: 0`.)
 
-3. **Before bumping any crate in the egui stack, walk every row of
+4. **Before bumping any crate in the egui stack, walk every row of
    `Documents/EGUI_UPGRADE_ASSUMPTIONS.md`** against the new version's source.
    For each assumption:
    - Read the new version's equivalent upstream code (line numbers will have
@@ -39,7 +49,7 @@ ghosted chrome, or stale overlays at runtime.
    - If it changed, fix the corresponding `Our code` site and update the
      assumptions doc _in the same PR_.
 
-4. **A green `cargo test --all` is NOT sufficient.** It only catches the
+5. **A green `cargo test --all` is NOT sufficient.** It only catches the
    headless-verifiable subset (callback ordering, atlas-growth detection logic,
    the FULL/REPLAY decision, the damage composition). The load-bearing failures
    are pixel-only. You must additionally run the pixel-level verification:
@@ -50,7 +60,8 @@ ghosted chrome, or stale overlays at runtime.
      menu / search bar / command palette / URL-hover tooltip left idle, an OS
      dark/light switch, a DPI/scale-factor change).
 
-5. **Only after all of the above passes may the `=0.35.0` pins move.**
+6. **Only after all of the above passes may the exact pins move**, and the
+   verification log at the bottom of the assumptions doc gains an entry.
 
 ## Why this is worth the friction
 
@@ -72,4 +83,5 @@ verified act rather than an automated one.
 
 See `Documents/EGUI_UPGRADE_ASSUMPTIONS.md` for the full assumption table
 (A1–A12): what we rely on, where our code depends on it, the upstream source
-that proves it in 0.35.0, and the visible symptom if a bump breaks it.
+that proves it in the pinned version, and the visible symptom if a bump
+breaks it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ dependencies = [
  "ndk-context",
  "ndk-sys",
  "num_enum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -621,7 +621,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -692,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -725,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1112,9 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "ecolor"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6758be723a3f298bbfda4db75748bc2ba0abafe096b6383c7c32da264764fbc3"
+checksum = "fc883f505d446814c0226bef4b64564b9adb9966fc00c88c57ce6d827dd152d6"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1123,16 +1123,16 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796c98d50b79631281d516343a6f6e93c0666462ca36e2c93b39f25d7793325"
+checksum = "c977ac91dfaa651633fd9722e4ce9ccb32cda4c748b89a5cb57e504036e37c13"
 dependencies = [
  "accesskit",
  "ahash",
  "bitflags 2.13.1",
  "emath",
  "epaint",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "nohash-hasher",
  "profiling",
@@ -1140,13 +1140,14 @@ dependencies = [
  "serde",
  "smallvec",
  "unicode-segmentation",
+ "web-sys",
 ]
 
 [[package]]
 name = "egui-winit"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea6bf3608db949588b95b8b341ee358d0c3f95cf4dc3f53d8d76717edee87db"
+checksum = "9327fc8edef2c57db9bcbcacc82c8a4b1e8cc64cd41a67db4419dcf643d88c83"
 dependencies = [
  "arboard",
  "bytemuck",
@@ -1165,15 +1166,14 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52274b9bfb8d8e252cd0f00c9f6214f360d75a0962baa77a2d62ddb002fe99d4"
+checksum = "69b65e45f8d8d7c6d848b3ec41f642b54ad828033f1511d4b4c9adc09040166a"
 dependencies = [
  "bytemuck",
  "egui",
  "glow",
  "log",
- "memoffset",
  "profiling",
 ]
 
@@ -1185,9 +1185,9 @@ checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "emath"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4ec073c9898516584d8c6cfdcee95b530b3d941cd5031ef4050aa36812308b"
+checksum = "dce03cf1604f74515830012c29991beb0b58f69e4e43f5afe22fa7afed65ccd5"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1255,16 +1255,16 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e60a8888b51da911df23918fd7301359b1d43a406a0ff3b8863af093dd7fc6c"
+checksum = "11863a6b2b7823010c1090ddf4706947bdda46766742def0673195cbf7ff4a73"
 dependencies = [
  "ahash",
  "bytemuck",
  "ecolor",
  "emath",
  "epaint_default_fonts",
- "font-types 0.11.3",
+ "font-types",
  "harfrust",
  "log",
  "nohash-hasher",
@@ -1272,7 +1272,7 @@ dependencies = [
  "profiling",
  "self_cell",
  "serde",
- "skrifa 0.42.1",
+ "skrifa",
  "smallvec",
  "unicode-general-category",
  "unicode-segmentation",
@@ -1281,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ee4e1f553a3584c301f3a56ff1a775f1384781396cea301c8d952e9b93f560"
+checksum = "18dee69613aac468922cf28a32025eb7d7ed6985b61f73245848e58f37876c98"
 
 [[package]]
 name = "equivalent"
@@ -1433,21 +1433,12 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
-dependencies = [
- "bytemuck",
- "serde",
-]
-
-[[package]]
-name = "font-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a7299a780854a6d391be2ae1c8521c9368471b559dbfd6a8dbd9f407eaff100"
 dependencies = [
  "bytemuck",
+ "serde",
 ]
 
 [[package]]
@@ -1536,7 +1527,7 @@ dependencies = [
  "swash",
  "sysinfo",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -1573,7 +1564,7 @@ dependencies = [
  "serde",
  "tempfile",
  "test-log",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "toml",
  "tracing",
  "unicode-segmentation",
@@ -1602,7 +1593,7 @@ dependencies = [
  "tar",
  "tempfile",
  "test-log",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "vergen",
  "winapi",
@@ -1620,16 +1611,16 @@ dependencies = [
  "glutin",
  "glutin-winit",
  "raw-window-handle",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "winit",
 ]
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1642,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1652,15 +1643,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1669,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -1688,32 +1679,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1799,16 +1790,16 @@ dependencies = [
 
 [[package]]
 name = "glifo"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99fc21d493812643aae86d53b7bbd02f376434a90317e8a790bc209fdd6605e"
+checksum = "ed4a1bb24121291d27230c1b1b44e07d6a9b28cefdb32fe1581dfb84e14f940a"
 dependencies = [
  "bytemuck",
  "foldhash",
  "hashbrown",
  "log",
  "peniko",
- "skrifa 0.42.1",
+ "skrifa",
  "smallvec",
  "vello_common",
 ]
@@ -1913,13 +1904,13 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.7.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0431e8e389aa0f1e72bb9d1c2db8957a1a7a3580e8ed97db819c14837aac9b3e"
+checksum = "c03d949a14aa089bbb282f7dd76a498a7f684428e4257202efc119ec010376f9"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
- "read-fonts 0.39.2",
+ "read-fonts",
  "smallvec",
 ]
 
@@ -2140,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -2165,7 +2156,7 @@ dependencies = [
  "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link 0.2.1",
 ]
@@ -2874,9 +2865,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "open"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b3d059e795d52b8a72fef45658620edd4d9c359b338564aa14391ffa511ed5"
+checksum = "f9cfef937e9c486488c7e3d949ae31c0f1d06bdacd75b99c086cb35356e30408"
 dependencies = [
  "is-wsl",
  "libc",
@@ -3347,22 +3338,12 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.39.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
-dependencies = [
- "bytemuck",
- "font-types 0.11.3",
-]
-
-[[package]]
-name = "read-fonts"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
 dependencies = [
  "bytemuck",
- "font-types 0.12.2",
+ "font-types",
  "once_cell",
 ]
 
@@ -3401,7 +3382,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3782,22 +3763,12 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "skrifa"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
-dependencies = [
- "bytemuck",
- "read-fonts 0.39.2",
-]
-
-[[package]]
-name = "skrifa"
 version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819ab7d62b1d3e72d9d9dea5650bac30424f9111364bb94928dbf5ecad1baa68"
 dependencies = [
  "bytemuck",
- "read-fonts 0.41.0",
+ "read-fonts",
 ]
 
 [[package]]
@@ -3863,7 +3834,7 @@ dependencies = [
  "log",
  "memmap2",
  "rustix 1.1.4",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
@@ -3937,7 +3908,7 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2499c2d826531388872b2268718aed907a39bd785ab0dcfe57fab26283f92e"
 dependencies = [
- "skrifa 0.44.0",
+ "skrifa",
  "yazi",
  "zeno",
 ]
@@ -4022,7 +3993,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "windows 0.61.3",
  "windows-version",
 ]
@@ -4089,11 +4060,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -4109,9 +4080,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4304,7 +4275,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tracing-subscriber",
 ]
@@ -4500,25 +4471,24 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vello_common"
-version = "0.0.9"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d672facaa2d697285a786cd9d44d614cd2ce54cdc022504bf339f8fff3b750"
+checksum = "b2e9aed918117e8152c9eddfd8362d73c465c23f26c44786aa331707b8a64fa2"
 dependencies = [
  "bytemuck",
  "fearless_simd",
  "guillotiere",
- "hashbrown",
  "log",
  "peniko",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "vello_cpu"
-version = "0.0.9"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588691169aed86b5c8fb487266afee01323234e6fd0a3f2aaec0eaa8e4007f23"
+checksum = "ac7349e1f55f6b801c7c277958df4ea53e7f20f21e8014910ad888b2ecda93ea"
 dependencies = [
  "bytemuck",
  "glifo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ arc-swap = "1.9.1"
 assert_cmd = "2.2.2"
 bitflags = "2.13.1"
 cargo_metadata = "0.23.1"
-clap = { version = "4.6.1", features = ["derive"] }
+clap = { version = "4.6.6", features = ["derive"] }
 clap-cargo = { version = "0.18.3", features = ["cargo_metadata"] }
 clap-verbosity-flag = "3.0.4"
 color-eyre = "0.6.5"
@@ -33,18 +33,27 @@ crossbeam-channel = "0.5.16"
 directories = "6.0.0"
 downcast-rs = "2.0.2"
 duct = "1.1.1"
-# Exact-pinned (`=`) as a matched set: #436 relies on egui_glow 0.35.0's
+# Exact-pinned (`=`) as a matched set: #436 relies on egui_glow's
 # (undocumented) tolerance of multiple `paint_primitives` calls per frame for
 # the chrome-cache head/band/tail split, so even a patch bump must be a
-# deliberate, re-verified change. egui / egui_glow / egui-winit must move in
-# lockstep, so all three are exact-pinned together.
-egui = { version = "=0.35.0", default-features = false, features = ["default_fonts", "persistence"] }
-egui_glow = { version = "=0.35.0", default-features = false }
-egui-winit = "=0.35.0"
+# deliberate, re-verified change against every assumption in
+# `Documents/EGUI_UPGRADE_ASSUMPTIONS.md`. egui / egui_glow / egui-winit must
+# move in lockstep, so all three are exact-pinned together.
+egui = { version = "=0.36.1", default-features = false, features = ["default_fonts", "persistence"] }
+egui_glow = { version = "=0.36.1", default-features = false }
+egui-winit = "=0.36.1"
 filedescriptor = "0.8.3"
 flate2 = "1.1.9"
 fontdb = "0.24.0"
-futures = "0.3.32"
+futures = "0.3.34"
+# Held at 0.17 deliberately: `egui_glow` 0.36.1 declares `glow = "0.17.0"`, and
+# upstream cannot move to 0.18 because wgpu 30's `wgpu-hal` pins glow 0.17 (a
+# bump would split glow into two versions in egui's own graph). We hand
+# `Arc<glow::Context>` straight to `egui_glow::Painter`, so a mismatch here is
+# not merely a duplicate dependency -- it is a type error across two copies of
+# the crate. Bump only once `egui_glow`'s own declared glow requirement moves.
+# `renovate.json` constrains glow to `<0.18` so the egui group stops proposing
+# an update that cannot resolve.
 glow = "0.17.0"
 glutin = "0.32.3"
 glutin-winit = "0.5.0"
@@ -65,7 +74,7 @@ nix = "0.31.3"
 # notify-rust's heavier `images` feature (its own codecs + rayon) is
 # deliberately NOT used.
 notify-rust = { version = "4.18.0", features = ["images_no_default_features", "z"] }
-open = "5.4.0"
+open = "5.4.1"
 predicates = "3.1.4"
 proptest = "1.11.0"
 raw-window-handle = "0.6.2"
@@ -87,7 +96,7 @@ sysinfo = { version = "0.39.6", default-features = false, features = ["system"] 
 tar = "0.4.46"
 tempfile = "3.27.0"
 test-log = { version = "0.2.21", features = ["trace"] }
-thiserror = "2.0.19"
+thiserror = "2.0.20"
 toml = "1.1.4"
 tracing = "0.1.44"
 tracing-appender = "0.2.4"

--- a/Documents/EGUI_UPGRADE_ASSUMPTIONS.md
+++ b/Documents/EGUI_UPGRADE_ASSUMPTIONS.md
@@ -11,7 +11,7 @@ re-tessellating, and re-painting the "chrome" (menu bar, tab bar, borders,
 overlays) on frames where the chrome provably did not change, while always
 freshly rebuilding the terminal band. To do this correctly it relies on a
 number of **undocumented, internal behaviours** of the egui stack
-(`egui`, `epaint`, `egui_glow`, `egui-winit`) at version **0.35.0**.
+(`egui`, `epaint`, `egui_glow`, `egui-winit`) at version **0.36.1**.
 
 These behaviours are not part of any crate's public API contract. A version
 bump — even a patch bump — could silently change one of them. The failure mode
@@ -21,9 +21,16 @@ runtime.
 
 To contain that risk:
 
-- `egui`, `egui_glow`, and `egui-winit` are **exact-pinned** (`=0.35.0`) in the
+- `egui`, `egui_glow`, and `egui-winit` are **exact-pinned** (`=0.36.1`) in the
   workspace `Cargo.toml`, as a matched set. This is deliberate — do not "clean
   it up" to a caret range.
+- `glow` is separately held at **0.17** (a caret range, not an exact pin)
+  because `egui_glow` declares `glow = "0.17.0"` and upstream cannot move:
+  wgpu 30's `wgpu-hal` pins glow 0.17. We hand `Arc<glow::Context>` straight to
+  `egui_glow::Painter`, so two glow versions in the graph is a _type error_, not
+  merely a duplicate dependency. `renovate.json` constrains glow to `<0.18` so
+  the group stops proposing an unresolvable bump; lift that constraint only when
+  `egui_glow`'s own declared glow requirement moves.
 - Renovate is configured so the "egui + windowing stack" group **never
   auto-merges** and requires explicit Dependency-Dashboard approval before a
   bump PR is even opened (see `renovate.json`). Dependabot cargo updates are
@@ -39,9 +46,14 @@ must be adapted (and this file updated) before the bump can land.
 
 ## How to use this on a bump
 
-1. Read the new version's source for each `Upstream (0.35.0)` location below
+1. Read the new version's source for each `Upstream (0.36.1)` location below
    and confirm the behaviour still holds. Line numbers will drift between
    versions; find the equivalent code, do not trust the line number blindly.
+
+   The fastest reliable method, used for the 0.35.0 → 0.36.1 walk: fetch the
+   new crates, extract them, and `diff -u` each file named below against the
+   copy already in `~/.cargo/registry/src/*/`. A zero-line diff discharges
+   every assumption resting on that file at once; anything else you read.
 2. For any assumption that changed, fix the corresponding `Our code` site and
    update this table.
 3. Run `cargo test --all` (catches the headless-verifiable subset — callback
@@ -50,12 +62,14 @@ must be adapted (and this file updated) before the bump can land.
 4. Run the pixel-level verification for every "Symptom if broken" scenario. A
    green `cargo test` is **not** sufficient — the load-bearing failures are
    pixel-only.
-5. Only then update the `=0.35.0` pins.
+5. Only then update the exact pins.
+6. Record the walk in the verification log at the bottom of this file, so the
+   next bump can see what was checked and how.
 
 ## The assumptions
 
 Each row: what we rely on, where our code depends on it, the upstream source
-that proves it in 0.35.0, and what breaks (visibly) if a bump invalidates it.
+that proves it in 0.36.1, and what breaks (visibly) if a bump invalidates it.
 
 ### A1 — `paint_primitives` fully re-establishes GL state per call (except FBO)
 
@@ -69,27 +83,64 @@ for restoring that.
 
 - **Our code:** `freminal-windowing/src/egui_integration.rs` (the three
   `paint_primitives` calls in `run_frame`, head/band/tail).
-- **Upstream (0.35.0):** `egui_glow/src/painter.rs` — `prepare_painting`
+- **Upstream (0.36.1):** `egui_glow/src/painter.rs` — `prepare_painting`
   (`~300-349`), called at `paint_primitives` entry (`~405`) and after each
   callback (`~450`). No `bind_framebuffer` anywhere in `prepare_painting`.
 - **Symptom if broken:** garbled / mis-clipped / wrongly-blended chrome or
   terminal content; state from the band leaking into chrome paint (or vice
   versa). Multi-pane with an active post-process shader is the sharpest test.
 
-### A2 — `paint_and_update_textures` is set-all then paint then free-all
+### A2 — `paint_and_update_textures` is set-all then paint then free-all, and each delta is applied exactly once
 
 We do not call `paint_and_update_textures`; we hand-inline its three phases
-(upload every `textures_delta.set`, then our three `paint_primitives` calls,
+(apply every `textures_delta.set`, then our three `paint_primitives` calls,
 then free every `textures_delta.free`) so the band can be painted separately.
 This is only correct if that is exactly what the upstream method does.
 
+Two sub-assumptions, both load-bearing:
+
+1. **Phase order** is set-all → paint → free-all. Unchanged since 0.35.0.
+2. **Each delta is consumed exactly once.** Since egui 0.36 this is enforced,
+   not merely conventional — see below.
+
+**Changed in 0.36 (upstream #8356, "Prevent accidentally dropping
+`TexturesDelta`").** Three things moved at once:
+
+- `TexturesDelta::set` went from an ordered `Vec<(TextureId, ImageDelta)>` to a
+  `HashMap<TextureId, SmallVec<[ImageDelta; 1]>>`, and `free` from a `Vec` to a
+  `HashSet`. **One texture can now carry several queued deltas.** Cross-texture
+  ordering became nondeterministic, which is harmless (textures upload
+  independently), but per-texture order is significant and `SmallVec`
+  preserves it.
+- `TexturesDelta` gained a `Drop` impl that `debug_assert!`s it is empty.
+  Iterating the deltas **by reference** therefore panics in debug builds when
+  the frame's `FullOutput` falls out of scope. Upstream's own
+  `paint_and_update_textures` now takes `&mut` and `drain()`s both halves; ours
+  drains to match. `FullOutput::drop_without_applying_deltas()` (or
+  `textures_delta.clear()` where the output has been partially moved) is the
+  sanctioned escape hatch for a test or bench with no painter.
+- `TexturesDelta::push` replaces the queued vector when the incoming delta is
+  whole, but _appends_ partial deltas after it. This is what makes A6's
+  predicate "any delta is whole" rather than "the delta is whole".
+
 - **Our code:** `freminal-windowing/src/egui_integration.rs` (the
-  `set_texture` loop, three paints, `free_texture` loop in `run_frame`).
-- **Upstream (0.35.0):** `egui_glow/src/painter.rs` —
-  `paint_and_update_textures` (`~356-374`).
+  draining `set_texture` loop, three paints, draining `free_texture` loop in
+  `run_frame`; `full_output` is bound `mut` for this). Every painter-less
+  `run_ui` in the test/bench suites defuses the drop-bomb explicitly —
+  `freminal/src/gui/app_impl.rs`, `freminal/src/gui/frame_drain.rs`,
+  `freminal/benches/render_loop_bench.rs`, and this file's own test module.
+- **Upstream (0.36.1):** `egui_glow/src/painter.rs` —
+  `paint_and_update_textures` (`~356-378`, note the `drain()` on both halves
+  and the nested loop over each texture's deltas); `epaint/src/textures.rs` —
+  `TexturesDelta` (`~283-345`, the new collection types, `push`, and the `Drop`
+  bomb at `~337`); `egui/src/data/output.rs` —
+  `FullOutput::drop_without_applying_deltas` (`~74-76`).
 - **Symptom if broken:** a texture referenced by a primitive is freed too
   early or uploaded too late — missing glyphs, blank text, or a use-after-free
-  crash in the GL layer.
+  crash in the GL layer. If the drop-bomb half regresses (we stop draining), a
+  debug build panics at end of frame with "Dropped TexturesDelta with N
+  unapplied deltas"; a release build silently leaks the deltas instead, so the
+  atlas upload for a newly shaped glyph never reaches the GPU.
 
 ### A3 — the background layer drains first and contiguously into `FullOutput.shapes`
 
@@ -103,7 +154,7 @@ by egui).
 - **Our code:** `freminal/src/gui/app_impl.rs` (`band_shape_start` /
   `band_shape_end` capture); `freminal-windowing/src/egui_integration.rs`
   (the head/band/tail slice of `full_output.shapes`).
-- **Upstream (0.35.0):** `egui/src/layers.rs` — `enum Order` (`Background`
+- **Upstream (0.36.1):** `egui/src/layers.rs` — `enum Order` (`Background`
   first), `Order::ALL`, `GraphicLayers::drain` (`~213-260`, iterates
   `Order::ALL`, appends into one `Vec`).
 - **Symptom if broken:** the band paints at the wrong z-position (under chrome,
@@ -124,7 +175,7 @@ dependency pulls a `rayon` we never build against).
   callbacks), `freminal/src/gui/terminal/widget.rs` (per-pane callback); test
   `band_gl_callbacks_stay_contiguous_and_ordered_across_the_split` in
   `freminal-windowing/src/egui_integration.rs`.
-- **Upstream (0.35.0):** `epaint/src/tessellator.rs` —
+- **Upstream (0.36.1):** `epaint/src/tessellator.rs` —
   `tessellate_clipped_shape` callback branch (`~1375-1394`), the
   `Primitive::Callback(_) => true` merge-break, the sequential
   `tessellate_shapes` loop (`~2230`), and the rayon `should_parallelize`
@@ -143,7 +194,7 @@ the atlas-resize self-heal (A6).
 - **Our code:** `freminal-windowing/src/egui_integration.rs` (the REPLAY
   atlas-grow self-heal re-tessellating cached chrome shapes); test
   `atlas_growth_invalidates_cached_text_uvs_and_retessellation_fixes_it`.
-- **Upstream (0.35.0):** `egui/src/context.rs` — `tessellate` (`~2757-2795`,
+- **Upstream (0.36.1):** `egui/src/context.rs` — `tessellate` (`~2757-2795`,
   reads `texture_atlas.size()` fresh, builds a new `Tessellator`);
   `epaint/src/tessellator.rs` — `tessellate_text` UV normalization by
   `font_tex_size` (`~2029-2030`).
@@ -159,9 +210,21 @@ never relocates already-allocated glyphs and only marks the whole image dirty
 on a resize/recreate — so there is no way for existing UVs to become stale
 without a whole-upload delta.
 
+**The predicate is "ANY delta for the font atlas is whole."** Since egui 0.36
+(#8356, see A2) `TexturesDelta::set` holds a _vector_ of deltas per texture, and
+`TexturesDelta::push` only collapses that vector when the incoming delta is
+whole — partials pushed afterwards are appended. A frame that resizes the atlas
+and then allocates further glyphs into the resized atlas therefore leaves
+`[whole, partial, …]`. Reading only one delta per texture (the natural shape of
+the pre-0.36 predicate, when `set` was a flat ordered `Vec`) would miss that
+frame's growth, skip the self-heal, and garble cached chrome text with no
+visible cause. Pinned by
+`atlas_grew_true_when_a_partial_is_queued_after_the_whole_upload` and its
+negative twin.
+
 - **Our code:** `freminal-windowing/src/egui_integration.rs` — the
   `atlas_grew` helper.
-- **Upstream (0.35.0):** `epaint/src/texture_atlas.rs` — `allocate`
+- **Upstream (0.36.1):** `epaint/src/texture_atlas.rs` — `allocate`
   (`~220-263`, forward-only cursor, never repositions), `resize_to_min_height`
   (sets `dirty = Rectu::EVERYTHING`), `take_delta` (turns `EVERYTHING` into
   `ImageDelta::full`); `epaint/src/image.rs` — `ImageDelta::is_whole`
@@ -177,7 +240,7 @@ without a whole-upload delta.
 first and stable for the whole `Context` lifetime. A6's detector keys on it.
 
 - **Our code:** `freminal-windowing/src/egui_integration.rs` — `atlas_grew`.
-- **Upstream (0.35.0):** `egui/src/context.rs` —
+- **Upstream (0.36.1):** `egui/src/context.rs` —
   `WrappedTextureManager::default` (`~73-91`, allocates the font texture first
   with an `assert_eq!(font_id, TextureId::default())`);
   `epaint/src/textures.rs` — `TextureManager::alloc` doc (`~24-28`).
@@ -193,7 +256,7 @@ closure) to bracket the band range. This works because `ctx.graphics()` /
 
 - **Our code:** `freminal/src/gui/app_impl.rs` — `band_shape_start` /
   `band_shape_end` captures via `ctx.graphics(...)`.
-- **Upstream (0.35.0):** `egui/src/context.rs` — `graphics` / `graphics_mut`
+- **Upstream (0.36.1):** `egui/src/context.rs` — `graphics` / `graphics_mut`
   (`~971-981`), and `end_pass` draining `viewport.graphics` (`~2617-2619`).
 - **Symptom if broken:** the band range is captured against the wrong or an
   empty layer set — the band is mis-sliced (blank terminal or duplicated
@@ -209,7 +272,7 @@ overridden.
 
 - **Our code:** `freminal/src/gui/app_impl.rs` — the root Ui construction and
   the REPLAY `band_ui` construction (explicit `.layer_id(background())`).
-- **Upstream (0.35.0):** `egui/src/ui.rs` — `Ui::new`
+- **Upstream (0.36.1):** `egui/src/ui.rs` — `Ui::new`
   (`layer_id.unwrap_or_else(LayerId::background)`, `~124`), `Ui::new_child`
   (`~224-231`, clones parent painter, only overrides layer if the builder
   supplies one).
@@ -230,7 +293,7 @@ our own blink/content scheduling wants an earlier wake."
   `chrome_repaint_settled`; `freminal/src/gui/app_impl.rs` —
   `shortest_repaint_delay` / `request_repaint_after` /
   `take_terminal_requested_delay`.
-- **Upstream (0.35.0):** `egui/src/context.rs` — `request_repaint_after`
+- **Upstream (0.36.1):** `egui/src/context.rs` — `request_repaint_after`
   effect writes `viewport.repaint.repaint_delay` (`~158-159`); the same field
   is read into `ViewportOutput.repaint_delay` (`~2719`); egui-internal
   scheduling writes it too (`~111`, `~113`).
@@ -252,9 +315,14 @@ hide the gutter-hover / interaction widgets.
   approach (band stays in background layer); regression tests
   `same_layer_widget_is_not_hidden_by_containing_widget` and
   `dedicated_background_layer_hides_contained_widget_cross_layer`.
-- **Upstream (0.35.0):** `egui/src/hit_test.rs` — the hidden-rule loop
+- **Upstream (0.36.1):** `egui/src/hit_test.rs` — the hidden-rule loop
   (`~143-151`: `contains_rect(...) && current.layer_id != next.layer_id =>
-  hidden.insert(...)`).
+  hidden.insert(...)`). Note that 0.36 added a filter _upstream of_ this loop
+  (`egui/src/context.rs`, `begin_pass`: layers are now collected through
+  `memory.areas().is_interactable(layer_id)`, so non-interactable areas are
+  click-through and never reach the hit-test). That narrows which layers are
+  considered but does not change the rule this assumption rests on; both
+  regression tests below still pass unchanged.
 - **Symptom if broken:** if the rule is removed or changed, the "band must stay
   in background layer" constraint may relax — but do not rely on that; the
   regression tests pin the current behaviour. If they fail on a bump, the
@@ -270,13 +338,13 @@ event.
 
 **Carve-out (found post-#436, fixed after #436 landed): `RedrawRequested` must
 be excluded from the `response.repaint` half of this gate.** `egui-winit`
-0.35.0 returns `EventResponse { repaint: true, .. }` for
+returns `EventResponse { repaint: true, .. }` for
 `WindowEvent::RedrawRequested` _unconditionally_, via a grouped match arm
 commented "Things that may require repaint:" that also covers
 `CursorEntered`/`Destroyed`/`Occluded`/`Resized`/`Moved`/`TouchpadPressure`/
-`CloseRequested` (`egui-winit-0.35.0/src/lib.rs:489-500`). Note this is a
+`CloseRequested` (`egui-winit-0.36.1/src/lib.rs:512-522`). Note this is a
 _different_ arm from `ScaleFactorChanged`'s, which is its own separate arm
-(`~310-324`) that happens to return `repaint: true` too — the two are not
+(`~324-338`) that happens to return `repaint: true` too — the two are not
 grouped together, they merely share the outcome this gate relies on. But `RedrawRequested` is also the
 event that drives every single frame, and `window_event`'s `RedrawRequested`
 arm reads this gate back (via `std::mem::take(&mut
@@ -303,9 +371,9 @@ becomes a harmless no-op rather than wrong.
   `is_unconditional_chrome_input`, `should_set_chrome_input_pending` (the
   `RedrawRequested` carve-out), and the general event arm's call to it in
   place of the old inline `|| response.repaint` OR.
-- **Upstream (0.35.0):** `egui-winit/src/lib.rs` —
-  `WindowEvent::ScaleFactorChanged { .. }` (`~310-324`) and
-  `WindowEvent::RedrawRequested` (`~489-500`, in the grouped "Things that may
+- **Upstream (0.36.1):** `egui-winit/src/lib.rs` —
+  `WindowEvent::ScaleFactorChanged { .. }` (`~324-338`) and
+  `WindowEvent::RedrawRequested` (`~512-522`, in the grouped "Things that may
   require repaint:" arm) each return `EventResponse { repaint: true, .. }`
   unconditionally, from **separate** match arms. On a bump, re-verify both
   that `ScaleFactorChanged` still flags a repaint (the gate's completeness
@@ -343,7 +411,7 @@ this by setting `Options::zoom_with_keyboard = false` and never calling
 - **Our code:** `freminal-windowing/src/event_loop.rs` —
   `physical_to_logical_pos` (divides by `window.scale_factor()`);
   `freminal/src/gui/rendering.rs` — `options.zoom_with_keyboard = false`.
-- **Upstream (0.35.0):** `egui-winit/src/lib.rs` — `pixels_per_point(ctx,
+- **Upstream (0.36.1):** `egui-winit/src/lib.rs` — `pixels_per_point(ctx,
   window) = window.scale_factor() * ctx.zoom_factor()`; egui zoom is driven
   only by `egui::gui_zoom::zoom_with_keyboard` (gated on the option) or an
   explicit `set_zoom_factor`.
@@ -360,3 +428,60 @@ Behaviours that _are_ part of a stable public API (e.g. `Context::run_ui`,
 `Context::tessellate` signatures, `PaintCallback` shape) are not listed — a
 version bump that changes those is a compile error and needs no special
 checklist. This file is only for the silent, undocumented, internal behaviours.
+
+## Verification log
+
+One entry per bump. Record what was checked and how, so the next bump can tell
+a genuine re-verification from a rubber stamp.
+
+### 0.35.0 → 0.36.1
+
+Method: extracted the 0.36.1 `egui`, `epaint`, `egui_glow` and `egui-winit`
+crates and `diff -u`'d every file named in the table above against the 0.35.0
+copies in `~/.cargo/registry/src/*/`.
+
+| File | Diff | Assumptions discharged |
+| --- | --- | --- |
+| `egui/src/layers.rs` | identical | A3 |
+| `epaint/src/texture_atlas.rs` | identical | A6 (upstream half) |
+| `epaint/src/image.rs` | identical | A6 (delta half) |
+| `egui/src/ui.rs` | identical | A9 |
+| `epaint/src/tessellator.rs` | cosmetic only (`fast_midpoint`, an import) | A4, A5 |
+| `egui/src/hit_test.rs` | one `expect` attribute removed | A11 |
+| `egui_glow/src/painter.rs` | `paint_and_update_textures` only | A1 holds, **A2 changed** |
+| `egui/src/context.rs` | `run_logic`, `sync_window_theme`, hit-test filter | A5, A7, A8, A10 |
+| `epaint/src/textures.rs` | `TexturesDelta` reshaped | **A2 changed** |
+| `egui-winit/src/lib.rs` | modifiers, dropped files, IME purpose | A12, A13 |
+
+Outcome: **A2 changed** (see its entry — the `TexturesDelta` reshape and drop
+bomb, upstream #8356); **A6 held upstream but its consumer needed rewriting**
+for the new per-texture delta vector. All eleven others held unchanged.
+
+Absorbed alongside, all of them ordinary compile-time API changes rather than
+silent behaviour (so not assumption rows):
+
+- `RawInput::modifiers` was removed in favour of `egui::Event::ModifiersChanged`
+  (#8336), and `egui_winit::State`'s replacement copy is **private with no
+  accessor**. `Context::input(|i| i.modifiers)` is not a substitute: it only
+  advances when a pass runs, so the pre-egui interception paths in
+  `event_loop.rs` (the Wayland paste work-around and the Task 114 blocked-key
+  routing) would read the _previous frame's_ modifiers and miss a `Ctrl` pressed
+  in the same frame interval as the `V` that follows it. Hence
+  `freminal-windowing/src/modifier_tracker.rs`, which mirrors the state from the
+  same winit events, applying the same platform `command` rule and the same
+  focus-loss reset.
+- `RawInput::dropped_files` became `Vec<Arc<dyn DroppedFile>>`, whose `path()`
+  returns `&Path` rather than the old `Option<PathBuf>` field. Behaviour is
+  unchanged on native, where the `Option` was always `Some`.
+- `Options::sync_window_theme` is new and **defaults to `true`**. It is a no-op
+  for freminal: it emits `ViewportCommand::SetTheme` derived from egui's own
+  `Options::theme_preference`, which freminal never sets (it manages themes
+  entirely through its own palette system), and
+  `event_loop.rs::process_viewport_command` does not handle `SetTheme` — the
+  command falls into the catch-all and is logged at `trace`. If we ever _want_
+  the OS titlebar to follow freminal's theme, this option plus a `SetTheme` arm
+  is the route.
+
+Pixel verification: see the "Symptom if broken" scenarios; `cargo test --all`,
+`cargo clippy --all-targets --all-features -D warnings`, `cargo machete` and
+`cargo xtask check-windows` all green.

--- a/freminal-windowing/src/egui_integration.rs
+++ b/freminal-windowing/src/egui_integration.rs
@@ -12,6 +12,7 @@ use winit::window::Window;
 
 use crate::error::Error;
 use crate::gl_context::GlState;
+use crate::modifier_tracker::ModifierTracker;
 
 /// Output from a single egui frame.
 pub struct FrameOutput {
@@ -70,6 +71,11 @@ pub struct EguiState {
     pub(crate) ctx: egui::Context,
     pub(crate) winit_state: egui_winit::State,
     pub(crate) painter: egui_glow::Painter,
+    /// Live modifier state for this window. Mirrors what `egui-winit` tracks
+    /// privately, because egui 0.36 removed `RawInput::modifiers` and exposes
+    /// no accessor for its replacement — see [`ModifierTracker`] for why the
+    /// egui-side `Context::input(|i| i.modifiers)` is not a substitute.
+    modifier_tracker: ModifierTracker,
     /// Cached chrome primitives from the last FULL frame — see [`ChromeCache`].
     chrome_cache: Option<ChromeCache>,
     /// The repaint delay `run_frame` returned last frame. Consulted, via
@@ -555,11 +561,20 @@ fn chrome_repaint_settled(
 ///
 /// Pure (no `self`/`egui::Context` state needed beyond the delta itself),
 /// so directly unit-testable.
+///
+/// egui 0.36 (upstream #8356) reshaped `TexturesDelta::set` from an ordered
+/// `Vec<(TextureId, ImageDelta)>` into a `HashMap<TextureId, SmallVec<[ImageDelta; 1]>>`,
+/// so one texture can now carry several queued deltas. `TexturesDelta::push`
+/// collapses the vector to a single entry when the incoming delta is whole, but
+/// *partial* deltas queued afterwards are appended to it — so a frame that both
+/// resizes the atlas and then allocates further glyphs into it leaves
+/// `[whole, partial, ..]`. The predicate is therefore "**any** delta for the
+/// font atlas is whole", not "the delta for the font atlas is whole".
 fn atlas_grew(textures_delta: &egui::TexturesDelta) -> bool {
     textures_delta
         .set
-        .iter()
-        .any(|(id, delta)| *id == egui::TextureId::default() && delta.is_whole())
+        .get(&egui::TextureId::default())
+        .is_some_and(|deltas| deltas.iter().any(egui::epaint::ImageDelta::is_whole))
 }
 
 /// The four independent REPLAY gate predicates from [`decide_chrome_mode`]'s
@@ -719,6 +734,7 @@ impl EguiState {
             ctx,
             winit_state,
             painter,
+            modifier_tracker: ModifierTracker::default(),
             chrome_cache: None,
             prev_repaint_delay: std::time::Duration::MAX,
             prev_chrome_damage: crate::ChromeDamage::Changed,
@@ -956,7 +972,10 @@ impl EguiState {
         // the windowing side.
         #[cfg(feature = "frame-profiling")]
         let run_ui_start = std::time::Instant::now();
-        let full_output = self.ctx.run_ui(raw_input, |root_ui| {
+        // `mut` because the texture-delta application below drains
+        // `full_output.textures_delta` in place (egui 0.36 / #8356 — see the
+        // comment at the drain site).
+        let mut full_output = self.ctx.run_ui(raw_input, |root_ui| {
             let signals = ui_fn(&*root_ui, &gl_state.glow_context, chrome_mode);
             frame_damage = signals.frame_damage;
             band_range = signals.band_range;
@@ -1199,9 +1218,26 @@ impl EguiState {
         // first (e.g. the `CentralPanel` background fill, which must be
         // UNDER the band), then band, then tail (overlays/borders, which
         // must be OVER the band).
+        //
+        // egui 0.36 (upstream #8356) made `TexturesDelta` a drop-bomb: it
+        // `debug_assert!`s that it is empty when dropped, and upstream's
+        // `paint_and_update_textures` now `drain()`s both halves rather than
+        // iterating them by reference. So these two loops must drain too —
+        // iterating by reference would leave the delta populated and panic in
+        // debug builds at the end of the frame. Draining also matches the
+        // upstream contract that each delta is applied exactly once.
+        //
+        // `set` is a `HashMap<TextureId, SmallVec<[ImageDelta; 1]>>` as of
+        // 0.36 (it was an ordered `Vec` before). Cross-texture ordering is
+        // irrelevant — each texture is uploaded independently — but the
+        // per-texture order within a `SmallVec` is significant (a whole upload
+        // followed by partial patches of it), and `SmallVec`'s iteration
+        // preserves it.
         let size_px = [size.width, size.height];
-        for (id, image_delta) in &full_output.textures_delta.set {
-            self.painter.set_texture(*id, image_delta);
+        for (id, image_deltas) in full_output.textures_delta.set.drain() {
+            for image_delta in image_deltas {
+                self.painter.set_texture(id, &image_delta);
+            }
         }
         // Task 121 frame-profiling harness: time the three `paint_primitives`
         // calls, summed (a contiguous span across all three, since nothing
@@ -1220,8 +1256,8 @@ impl EguiState {
             self.frame_profile.paint_total += d;
             self.frame_profile.paint_max = self.frame_profile.paint_max.max(d);
         }
-        for id in &full_output.textures_delta.free {
-            self.painter.free_texture(*id);
+        for id in full_output.textures_delta.free.drain() {
+            self.painter.free_texture(id);
         }
 
         // Pre-present notify for Wayland frame pacing
@@ -1428,6 +1464,10 @@ impl EguiState {
         window: &Window,
         event: &winit::event::WindowEvent,
     ) -> egui_winit::EventResponse {
+        // Mirror the modifier state BEFORE egui-winit consumes the event, so
+        // `modifiers()` is current for the interception paths in
+        // `event_loop::window_event` that read it after this call.
+        self.modifier_tracker.on_window_event(event);
         self.winit_state.on_window_event(window, event)
     }
 
@@ -1445,8 +1485,13 @@ impl EguiState {
     }
 
     /// Read the current egui modifier state.
-    pub(crate) fn modifiers(&self) -> egui::Modifiers {
-        self.winit_state.egui_input().modifiers
+    ///
+    /// Sourced from [`ModifierTracker`], not from egui: egui 0.36 removed
+    /// `RawInput::modifiers`, and `Context::input(|i| i.modifiers)` only
+    /// advances when a pass runs, so it would report last frame's modifiers to
+    /// the pre-egui interception paths that call this.
+    pub(crate) const fn modifiers(&self) -> egui::Modifiers {
+        self.modifier_tracker.current()
     }
 
     /// Free the painter's OpenGL resources.
@@ -2157,6 +2202,32 @@ mod tests {
         )))
     }
 
+    /// Run `atlas_grew` over a hand-built delta, then discard the delta
+    /// safely.
+    ///
+    /// egui 0.36 (#8356) gave `TexturesDelta` a `Drop` impl that
+    /// `debug_assert!`s the delta was emptied by a painter, so a test that
+    /// merely lets a populated one fall out of scope panics. `clear()` is the
+    /// sanctioned "I am deliberately dropping this" escape hatch; every test
+    /// below goes through this helper so none of them can forget it.
+    fn atlas_grew_of(deltas: &[(TextureId, ImageDelta)]) -> bool {
+        let mut textures_delta = TexturesDelta::default();
+        for (id, delta) in deltas {
+            textures_delta.push(*id, delta.clone());
+        }
+        let grew = atlas_grew(&textures_delta);
+        textures_delta.clear();
+        grew
+    }
+
+    fn whole() -> ImageDelta {
+        ImageDelta::full(tiny_image(), TextureOptions::default())
+    }
+
+    fn patch() -> ImageDelta {
+        ImageDelta::partial([0, 0], tiny_image(), TextureOptions::default())
+    }
+
     #[test]
     fn atlas_grew_false_on_empty_delta() {
         assert!(!atlas_grew(&TexturesDelta::default()));
@@ -2167,11 +2238,8 @@ mod tests {
         // `ImageDelta::full` sets `pos: None` -- `is_whole() == true` --
         // exactly the resize/respecify marker the self-heal watches for,
         // on `TextureId::default()` (the font atlas).
-        let delta = ImageDelta::full(tiny_image(), TextureOptions::default());
-        assert!(delta.is_whole(), "sanity: ImageDelta::full is whole");
-        let mut textures_delta = TexturesDelta::default();
-        textures_delta.set.push((TextureId::default(), delta));
-        assert!(atlas_grew(&textures_delta));
+        assert!(whole().is_whole(), "sanity: ImageDelta::full is whole");
+        assert!(atlas_grew_of(&[(TextureId::default(), whole())]));
     }
 
     #[test]
@@ -2179,14 +2247,11 @@ mod tests {
         // `ImageDelta::partial` sets `pos: Some(_)` -- a normal
         // new-glyph-added-to-the-existing-atlas upload, NOT a resize. Must
         // NOT be mistaken for atlas growth.
-        let delta = ImageDelta::partial([0, 0], tiny_image(), TextureOptions::default());
         assert!(
-            !delta.is_whole(),
+            !patch().is_whole(),
             "sanity: ImageDelta::partial is not whole"
         );
-        let mut textures_delta = TexturesDelta::default();
-        textures_delta.set.push((TextureId::default(), delta));
-        assert!(!atlas_grew(&textures_delta));
+        assert!(!atlas_grew_of(&[(TextureId::default(), patch())]));
     }
 
     #[test]
@@ -2194,10 +2259,7 @@ mod tests {
         // A whole-texture upload of some OTHER texture (e.g. an
         // image-protocol texture) is not the font atlas and must not
         // trigger the chrome-UV self-heal.
-        let delta = ImageDelta::full(tiny_image(), TextureOptions::default());
-        let mut textures_delta = TexturesDelta::default();
-        textures_delta.set.push((TextureId::User(42), delta));
-        assert!(!atlas_grew(&textures_delta));
+        assert!(!atlas_grew_of(&[(TextureId::User(42), whole())]));
     }
 
     #[test]
@@ -2205,16 +2267,37 @@ mod tests {
         // A realistic frame may carry multiple texture deltas; growth must
         // be detected even when the font-atlas entry is not the only one
         // (or not first).
-        let mut textures_delta = TexturesDelta::default();
-        textures_delta.set.push((
-            TextureId::User(7),
-            ImageDelta::partial([0, 0], tiny_image(), TextureOptions::default()),
-        ));
-        textures_delta.set.push((
-            TextureId::default(),
-            ImageDelta::full(tiny_image(), TextureOptions::default()),
-        ));
-        assert!(atlas_grew(&textures_delta));
+        assert!(atlas_grew_of(&[
+            (TextureId::User(7), patch()),
+            (TextureId::default(), whole()),
+        ]));
+    }
+
+    /// egui 0.36 regression guard (#8356 reshape).
+    ///
+    /// `TexturesDelta::set` now holds a *vector* of deltas per texture, and
+    /// `TexturesDelta::push` only collapses it when the incoming delta is
+    /// whole — a partial pushed afterwards is appended. So a frame that
+    /// resizes the atlas and then allocates further glyphs into the resized
+    /// atlas leaves `[whole, partial]`. Reading only one entry per texture
+    /// (the shape of the pre-0.36 predicate) would miss the growth and skip
+    /// the self-heal, garbling cached chrome text with no visible cause.
+    #[test]
+    fn atlas_grew_true_when_a_partial_is_queued_after_the_whole_upload() {
+        assert!(atlas_grew_of(&[
+            (TextureId::default(), whole()),
+            (TextureId::default(), patch()),
+        ]));
+    }
+
+    /// The mirror of the above: several partials and no whole upload is the
+    /// ordinary "new glyphs, same atlas" frame, which must NOT self-heal.
+    #[test]
+    fn atlas_grew_false_on_several_font_atlas_patches_without_a_whole_upload() {
+        assert!(!atlas_grew_of(&[
+            (TextureId::default(), patch()),
+            (TextureId::default(), patch()),
+        ]));
     }
 
     /// Reproduces the exact §5.2 hazard end-to-end using only
@@ -2260,9 +2343,12 @@ mod tests {
         // atlas and a cached shape list + its tessellation — this stands
         // in for `ChromeCache::{head_shapes, head_primitives}` after a
         // FULL frame.
-        let chrome_output = ctx.run_ui(egui::RawInput::default(), |ui| {
+        // No painter here, so the egui 0.36 `TexturesDelta` drop-bomb (#8356)
+        // must be defused explicitly -- see A2 in EGUI_UPGRADE_ASSUMPTIONS.md.
+        let mut chrome_output = ctx.run_ui(egui::RawInput::default(), |ui| {
             ui.label("Chrome");
         });
+        chrome_output.textures_delta.clear();
         let cached_shapes = chrome_output.shapes;
         let cached_primitives_before = ctx.tessellate(cached_shapes.clone(), ppp);
 
@@ -2280,7 +2366,9 @@ mod tests {
         let big_text: String = (0x4E00u32..0x4E00u32 + 300)
             .filter_map(char::from_u32)
             .collect();
-        let band_output = ctx.run_ui(egui::RawInput::default(), |ui| {
+        // No painter here, so the egui 0.36 `TexturesDelta` drop-bomb (#8356)
+        // must be defused explicitly -- see A2 in EGUI_UPGRADE_ASSUMPTIONS.md.
+        let mut band_output = ctx.run_ui(egui::RawInput::default(), |ui| {
             ui.label(egui::RichText::new(big_text.clone()).size(80.0));
         });
 
@@ -2289,6 +2377,9 @@ mod tests {
             "sanity: the band frame must actually grow the font atlas for \
              this test to exercise the hazard"
         );
+        // Only NOW is the delta spent: the assert above is the whole point of
+        // this frame, so the drop-bomb defusal has to come after it.
+        band_output.textures_delta.clear();
 
         // The hazard: painting `cached_primitives_before` now (after
         // growth, without re-tessellating) would sample the WRONG atlas
@@ -2407,7 +2498,9 @@ mod tests {
         let ctx = egui::Context::default();
         let pixels_per_point = 1.0;
 
-        let full_output = ctx.run_ui(egui::RawInput::default(), |ui| {
+        // No painter here, so the egui 0.36 `TexturesDelta` drop-bomb (#8356)
+        // must be defused explicitly -- see A2 in EGUI_UPGRADE_ASSUMPTIONS.md.
+        let mut full_output = ctx.run_ui(egui::RawInput::default(), |ui| {
             // Shape 0: "head" (chrome painted before the band).
             ui.painter().rect_filled(
                 Rect::from_min_size(pos2(0.0, 0.0), vec2(5.0, 5.0)),
@@ -2432,6 +2525,7 @@ mod tests {
                 Color32::YELLOW,
             );
         });
+        full_output.textures_delta.clear();
 
         let shapes = full_output.shapes;
         assert_eq!(shapes.len(), 4, "sanity: exactly the four shapes painted");
@@ -2508,7 +2602,9 @@ mod tests {
     fn default_band_range_puts_everything_in_tail() {
         let ctx = egui::Context::default();
 
-        let full_output = ctx.run_ui(egui::RawInput::default(), |ui| {
+        // No painter here, so the egui 0.36 `TexturesDelta` drop-bomb (#8356)
+        // must be defused explicitly -- see A2 in EGUI_UPGRADE_ASSUMPTIONS.md.
+        let mut full_output = ctx.run_ui(egui::RawInput::default(), |ui| {
             ui.painter().rect_filled(
                 Rect::from_min_size(pos2(0.0, 0.0), vec2(5.0, 5.0)),
                 0.0,
@@ -2520,6 +2616,7 @@ mod tests {
                 Color32::GREEN,
             );
         });
+        full_output.textures_delta.clear();
 
         let shapes = full_output.shapes;
         assert_eq!(shapes.len(), 2, "sanity: exactly the two shapes painted");
@@ -2592,7 +2689,9 @@ mod tests {
         let ctx = egui::Context::default();
         let pixels_per_point = 1.0;
 
-        let full_output = ctx.run_ui(egui::RawInput::default(), |ui| {
+        // No painter here, so the egui 0.36 `TexturesDelta` drop-bomb (#8356)
+        // must be defused explicitly -- see A2 in EGUI_UPGRADE_ASSUMPTIONS.md.
+        let mut full_output = ctx.run_ui(egui::RawInput::default(), |ui| {
             // HEAD: chrome painted before the band (menu/tab bar stand-in).
             ui.painter().rect_filled(
                 Rect::from_min_size(pos2(0.0, 0.0), vec2(5.0, 5.0)),
@@ -2621,6 +2720,7 @@ mod tests {
                 Color32::YELLOW,
             );
         });
+        full_output.textures_delta.clear();
 
         let shapes = full_output.shapes;
         // 1 head rect + 4 callbacks + 1 border rect + 1 tail rect.

--- a/freminal-windowing/src/egui_integration.rs
+++ b/freminal-windowing/src/egui_integration.rs
@@ -1464,9 +1464,17 @@ impl EguiState {
         window: &Window,
         event: &winit::event::WindowEvent,
     ) -> egui_winit::EventResponse {
-        // Mirror the modifier state BEFORE egui-winit consumes the event, so
-        // `modifiers()` is current for the interception paths in
-        // `event_loop::window_event` that read it after this call.
+        // Mirror the modifier state before handing the event to egui-winit.
+        //
+        // Note what this does NOT claim: `event_loop::window_event` reads
+        // `modifiers()` at its interception paths *before* it reaches this
+        // call for the event in hand (and may early-return without reaching
+        // it at all). Correctness comes from the events being different ones
+        // -- modifier state arrives as its own `ModifiersChanged`, which no
+        // interception path claims, so it lands here during an earlier
+        // `window_event` call than the `KeyboardInput` that reads the result.
+        // See `ModifierTracker`'s module doc for the full invariant and the
+        // one way to break it.
         self.modifier_tracker.on_window_event(event);
         self.winit_state.on_window_event(window, event)
     }

--- a/freminal-windowing/src/lib.rs
+++ b/freminal-windowing/src/lib.rs
@@ -33,6 +33,7 @@ pub mod error;
 mod egui_integration;
 mod event_loop;
 mod gl_context;
+mod modifier_tracker;
 
 pub use error::Error;
 pub use event_loop::run;

--- a/freminal-windowing/src/modifier_tracker.rs
+++ b/freminal-windowing/src/modifier_tracker.rs
@@ -30,13 +30,28 @@
 //! # Invariant
 //!
 //! [`ModifierTracker::current`] returns the modifiers implied by the most
-//! recent [`WindowEvent::ModifiersChanged`] this window has received, and is
-//! reset to "nothing held" by [`WindowEvent::Focused(false)`]. It is updated
-//! by [`ModifierTracker::on_window_event`], which
-//! [`crate::egui_integration::EguiWindow::on_window_event`] calls on every
-//! event **before** forwarding it to `egui-winit` — so a read during an
-//! interception path that runs after that forwarding always sees the current
-//! event's effect, never a stale one.
+//! recent `WindowEvent::ModifiersChanged` this window has received, and is
+//! reset to "nothing held" by `WindowEvent::Focused(false)`. It is updated by
+//! [`ModifierTracker::on_window_event`], which
+//! `EguiState::on_window_event` calls on every event before forwarding that
+//! event to `egui-winit`.
+//!
+//! **What makes a read correct is event ordering across calls, not within
+//! one.** `event_loop::window_event` reads `EguiState::modifiers` from its
+//! interception paths *before* it reaches the `on_window_event` forwarding
+//! call for the event it is currently handling. That is fine, because the
+//! events involved are different ones: modifier state changes arrive as their
+//! own `ModifiersChanged` event, which **no interception path claims**, so it
+//! always reaches `on_window_event` — and therefore this tracker — during an
+//! earlier `window_event` call than the `KeyboardInput` that later reads the
+//! result. The `KeyboardInput` event being intercepted does not itself carry
+//! modifier state.
+//!
+//! The corollary is the thing to preserve: **if a future interception path
+//! ever early-returns on `ModifiersChanged` or `Focused` without forwarding
+//! it, this tracker goes stale and the paste / blocked-key intercepts start
+//! misreading modifiers.** Intercepts that consume other event kinds are
+//! unaffected.
 //!
 //! The focus reset mirrors `egui-winit` 0.36.1's own (`lib.rs`, the
 //! `WindowEvent::Focused` arm): without it, alt-tabbing away while holding a
@@ -203,6 +218,31 @@ mod tests {
             tracker.current().ctrl,
             "only focus LOSS resets; `Focused(true)` must leave the state alone"
         );
+    }
+
+    /// Pins the ordering the module doc describes: the modifier state is
+    /// established by a `ModifiersChanged` event, and is then read correctly
+    /// while handling a *later, separate* `KeyboardInput` event — which is
+    /// itself irrelevant to the tracker. This is the exact two-event sequence
+    /// behind `Ctrl+V` reaching the Wayland paste intercept.
+    #[test]
+    fn modifiers_survive_until_a_later_keyboard_event_reads_them() {
+        let mut tracker = ModifierTracker::default();
+
+        // Event 1: the modifier press. Never intercepted, so it always
+        // reaches `on_window_event` and therefore this tracker.
+        tracker.on_window_event(&modifiers_changed(ModifiersState::CONTROL));
+
+        // Event 2: the key press that the paste intercept claims. It is
+        // handled in a later `window_event` call, and reads the state above.
+        // Feeding it here proves it neither clears nor alters that state.
+        tracker.on_window_event(&WindowEvent::RedrawRequested);
+        assert!(
+            tracker.current().command || cfg!(target_os = "macos"),
+            "the Ctrl established by the earlier event must still be readable \
+             when the later key event is handled"
+        );
+        assert!(tracker.current().ctrl);
     }
 
     #[test]

--- a/freminal-windowing/src/modifier_tracker.rs
+++ b/freminal-windowing/src/modifier_tracker.rs
@@ -1,0 +1,217 @@
+// Copyright (C) 2024-2026 Fred Clausen
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Live keyboard-modifier state for one window, mirrored from winit.
+//!
+//! # Why this exists
+//!
+//! `freminal-windowing` intercepts two narrow classes of keyboard event
+//! *before* handing them to `egui-winit` — the Wayland paste work-around and
+//! the Task 114 blocked-key routing (both in [`crate::event_loop`]). Both need
+//! to know which modifiers are held **at the moment the intercepted key
+//! arrives**.
+//!
+//! Up to egui 0.35.0 that state was readable from `egui-winit`'s
+//! `State::egui_input().modifiers`. egui 0.36.0 removed `RawInput::modifiers`
+//! (upstream #8336, "Remove `Modifiers` from `RawInput` and make it a
+//! `egui::Event`") and moved the running state into a **private** field on
+//! `egui_winit::State`, with no accessor. The remaining egui-side reader,
+//! `Context::input(|i| i.modifiers)`, is not a substitute: it only advances
+//! when a pass runs, so between passes it reports the modifier state of the
+//! *previous* frame. A `Ctrl` press and the `V` that follows it can both
+//! arrive inside one frame interval, which would make the paste intercept miss
+//! the `Ctrl` and fall through to egui as a literal `v`.
+//!
+//! So this tracker mirrors the state itself, from the same winit events
+//! `egui-winit` uses, applying the same rules.
+//!
+//! # Invariant
+//!
+//! [`ModifierTracker::current`] returns the modifiers implied by the most
+//! recent [`WindowEvent::ModifiersChanged`] this window has received, and is
+//! reset to "nothing held" by [`WindowEvent::Focused(false)`]. It is updated
+//! by [`ModifierTracker::on_window_event`], which
+//! [`crate::egui_integration::EguiWindow::on_window_event`] calls on every
+//! event **before** forwarding it to `egui-winit` — so a read during an
+//! interception path that runs after that forwarding always sees the current
+//! event's effect, never a stale one.
+//!
+//! The focus reset mirrors `egui-winit` 0.36.1's own (`lib.rs`, the
+//! `WindowEvent::Focused` arm): without it, alt-tabbing away while holding a
+//! modifier leaves it stuck down, because the release arrives at whichever
+//! window has focus by then — not this one.
+
+use winit::event::WindowEvent;
+use winit::keyboard::ModifiersState;
+
+/// Mirror of `egui-winit`'s private running modifier state for one window.
+///
+/// See the module documentation for why this duplication exists and what
+/// invariant it maintains.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ModifierTracker {
+    modifiers: egui::Modifiers,
+}
+
+impl ModifierTracker {
+    /// The modifiers currently held, as of the last
+    /// [`WindowEvent::ModifiersChanged`] (or "none" since the last focus loss).
+    pub(crate) const fn current(self) -> egui::Modifiers {
+        self.modifiers
+    }
+
+    /// Update the tracked state from a window event.
+    ///
+    /// Ignores every event except [`WindowEvent::ModifiersChanged`] and
+    /// [`WindowEvent::Focused`]; safe (and intended) to call unconditionally
+    /// for every event the window receives.
+    pub(crate) fn on_window_event(&mut self, event: &WindowEvent) {
+        match event {
+            WindowEvent::ModifiersChanged(modifiers) => {
+                self.modifiers = to_egui_modifiers(modifiers.state());
+            }
+            // See the module doc: dropping the state on focus loss prevents a
+            // modifier held across an alt-tab from sticking down forever.
+            WindowEvent::Focused(false) => self.modifiers = egui::Modifiers::default(),
+            _ => {}
+        }
+    }
+}
+
+/// Map a winit [`ModifiersState`] to [`egui::Modifiers`].
+///
+/// Mirrors `egui-winit` 0.36.1's `WindowEvent::ModifiersChanged` arm exactly,
+/// including the platform split on `command`: on macOS the "command" modifier
+/// is the Super/⌘ key (and `mac_cmd` is set alongside it), everywhere else it
+/// is Ctrl.
+fn to_egui_modifiers(state: ModifiersState) -> egui::Modifiers {
+    let ctrl = state.control_key();
+    let super_ = state.super_key();
+
+    egui::Modifiers {
+        alt: state.alt_key(),
+        ctrl,
+        shift: state.shift_key(),
+        mac_cmd: cfg!(target_os = "macos") && super_,
+        command: if cfg!(target_os = "macos") {
+            super_
+        } else {
+            ctrl
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ModifierTracker, to_egui_modifiers};
+    use winit::event::WindowEvent;
+    use winit::keyboard::ModifiersState;
+
+    // `ModifiersState` is a bitflags type, so the named constants compose
+    // directly at each call site (`CONTROL | SHIFT`). A `state(ctrl, shift,
+    // alt, super_)` helper taking four bools would read worse and is
+    // forbidden outright -- see the `state-representation` skill on bool
+    // parameters.
+
+    fn modifiers_changed(state: ModifiersState) -> WindowEvent {
+        WindowEvent::ModifiersChanged(state.into())
+    }
+
+    #[test]
+    fn empty_state_maps_to_no_modifiers() {
+        let m = to_egui_modifiers(ModifiersState::empty());
+        assert!(!m.alt);
+        assert!(!m.ctrl);
+        assert!(!m.shift);
+        assert!(!m.mac_cmd);
+        assert!(!m.command);
+    }
+
+    #[test]
+    fn each_plain_modifier_maps_one_to_one() {
+        assert!(to_egui_modifiers(ModifiersState::CONTROL).ctrl);
+        assert!(to_egui_modifiers(ModifiersState::SHIFT).shift);
+        assert!(to_egui_modifiers(ModifiersState::ALT).alt);
+    }
+
+    /// The `command` mapping is the whole reason this is a named function
+    /// rather than five inline field assignments: it is Ctrl off-macOS and
+    /// Super on macOS, and the paste intercept reads `command`.
+    #[test]
+    fn command_follows_the_platform_convention() {
+        let ctrl_only = to_egui_modifiers(ModifiersState::CONTROL);
+        let super_only = to_egui_modifiers(ModifiersState::SUPER);
+
+        if cfg!(target_os = "macos") {
+            assert!(!ctrl_only.command, "on macOS Ctrl is not `command`");
+            assert!(super_only.command, "on macOS Super is `command`");
+            assert!(super_only.mac_cmd, "on macOS Super also sets `mac_cmd`");
+        } else {
+            assert!(ctrl_only.command, "off macOS Ctrl is `command`");
+            assert!(!super_only.command, "off macOS Super is not `command`");
+            assert!(!super_only.mac_cmd, "`mac_cmd` is macOS-only");
+        }
+    }
+
+    #[test]
+    fn tracker_starts_with_nothing_held() {
+        let m = ModifierTracker::default().current();
+        assert!(!m.ctrl);
+        assert!(!m.shift);
+        assert!(!m.alt);
+    }
+
+    #[test]
+    fn tracker_adopts_the_latest_modifiers_changed() {
+        let mut tracker = ModifierTracker::default();
+
+        tracker.on_window_event(&modifiers_changed(
+            ModifiersState::CONTROL | ModifiersState::SHIFT,
+        ));
+        assert!(tracker.current().ctrl);
+        assert!(tracker.current().shift);
+
+        // A later event fully replaces the state — it is not merged.
+        tracker.on_window_event(&modifiers_changed(ModifiersState::ALT));
+        assert!(!tracker.current().ctrl);
+        assert!(!tracker.current().shift);
+        assert!(tracker.current().alt);
+    }
+
+    #[test]
+    fn losing_focus_clears_held_modifiers() {
+        let mut tracker = ModifierTracker::default();
+        tracker.on_window_event(&modifiers_changed(ModifiersState::CONTROL));
+        assert!(tracker.current().ctrl);
+
+        tracker.on_window_event(&WindowEvent::Focused(false));
+        assert!(
+            !tracker.current().ctrl,
+            "a modifier held across a focus loss must not stick down"
+        );
+    }
+
+    #[test]
+    fn gaining_focus_does_not_clear_held_modifiers() {
+        let mut tracker = ModifierTracker::default();
+        tracker.on_window_event(&modifiers_changed(ModifiersState::CONTROL));
+
+        tracker.on_window_event(&WindowEvent::Focused(true));
+        assert!(
+            tracker.current().ctrl,
+            "only focus LOSS resets; `Focused(true)` must leave the state alone"
+        );
+    }
+
+    #[test]
+    fn unrelated_events_leave_the_state_untouched() {
+        let mut tracker = ModifierTracker::default();
+        tracker.on_window_event(&modifiers_changed(ModifiersState::CONTROL));
+
+        tracker.on_window_event(&WindowEvent::RedrawRequested);
+        tracker.on_window_event(&WindowEvent::CloseRequested);
+        assert!(tracker.current().ctrl);
+    }
+}

--- a/freminal-windowing/src/modifier_tracker.rs
+++ b/freminal-windowing/src/modifier_tracker.rs
@@ -220,31 +220,20 @@ mod tests {
         );
     }
 
-    /// Pins the ordering the module doc describes: the modifier state is
-    /// established by a `ModifiersChanged` event, and is then read correctly
-    /// while handling a *later, separate* `KeyboardInput` event — which is
-    /// itself irrelevant to the tracker. This is the exact two-event sequence
-    /// behind `Ctrl+V` reaching the Wayland paste intercept.
-    #[test]
-    fn modifiers_survive_until_a_later_keyboard_event_reads_them() {
-        let mut tracker = ModifierTracker::default();
-
-        // Event 1: the modifier press. Never intercepted, so it always
-        // reaches `on_window_event` and therefore this tracker.
-        tracker.on_window_event(&modifiers_changed(ModifiersState::CONTROL));
-
-        // Event 2: the key press that the paste intercept claims. It is
-        // handled in a later `window_event` call, and reads the state above.
-        // Feeding it here proves it neither clears nor alters that state.
-        tracker.on_window_event(&WindowEvent::RedrawRequested);
-        assert!(
-            tracker.current().command || cfg!(target_os = "macos"),
-            "the Ctrl established by the earlier event must still be readable \
-             when the later key event is handled"
-        );
-        assert!(tracker.current().ctrl);
-    }
-
+    /// The state is sticky: it changes only on `ModifiersChanged` or a focus
+    /// loss, and survives any number of intervening events untouched.
+    ///
+    /// This is as close as a unit test gets to the cross-call ordering in the
+    /// module doc — that a `Ctrl` from one `window_event` call is still
+    /// readable when a later call handles the `V`. The real sequence cannot be
+    /// pinned here, or anywhere: the second event would have to be a
+    /// `WindowEvent::KeyboardInput`, and `winit::KeyEvent` has a private
+    /// `platform_specific` field so it cannot be constructed outside winit.
+    /// Driving `event_loop::window_event` instead needs an `ActiveEventLoop`,
+    /// a real window and a GL context — the harness gap tracked in issue #440.
+    /// So the guarantee rests on the module doc's argument (modifier state
+    /// arrives as its own event, which no interception path claims) plus this
+    /// stickiness property, not on an end-to-end test.
     #[test]
     fn unrelated_events_leave_the_state_untouched() {
         let mut tracker = ModifierTracker::default();
@@ -252,6 +241,12 @@ mod tests {
 
         tracker.on_window_event(&WindowEvent::RedrawRequested);
         tracker.on_window_event(&WindowEvent::CloseRequested);
-        assert!(tracker.current().ctrl);
+        tracker.on_window_event(&WindowEvent::Focused(true));
+        tracker.on_window_event(&WindowEvent::Occluded(true));
+        assert!(
+            tracker.current().ctrl,
+            "modifier state must persist across unrelated events -- a read \
+             from a later `window_event` call still sees it"
+        );
     }
 }

--- a/freminal/benches/render_loop_bench.rs
+++ b/freminal/benches/render_loop_bench.rs
@@ -1237,10 +1237,16 @@ fn bench_chrome_frame_record(c: &mut Criterion) {
         // Warm the context once so the timed region measures the recurring
         // steady-state cost, not the first-frame font-atlas population.
         let ctx = egui::Context::default();
-        let _ = ctx.run_ui(chrome_bench_raw_input(), chrome_bench_ui);
+        // No painter here, so the egui 0.36 `TexturesDelta` drop-bomb (#8356)
+        // must be defused explicitly -- see A2 in EGUI_UPGRADE_ASSUMPTIONS.md.
+        let discarded_output = ctx.run_ui(chrome_bench_raw_input(), chrome_bench_ui);
+        discarded_output.drop_without_applying_deltas();
 
         b.iter(|| {
-            let full_output = ctx.run_ui(chrome_bench_raw_input(), chrome_bench_ui);
+            // No painter here, so the egui 0.36 `TexturesDelta` drop-bomb (#8356)
+            // must be defused explicitly -- see A2 in EGUI_UPGRADE_ASSUMPTIONS.md.
+            let mut full_output = ctx.run_ui(chrome_bench_raw_input(), chrome_bench_ui);
+            full_output.textures_delta.clear();
             let ppp = ctx.pixels_per_point();
             let clipped = ctx.tessellate(full_output.shapes, ppp);
             std::hint::black_box(clipped);

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -4760,7 +4760,9 @@ mod tests {
         // range.
         let mut extracted: Vec<egui::epaint::ClippedShape> = Vec::new();
         let mut chrome_shape_count = 0usize;
-        let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
+        // No painter here, so the egui 0.36 `TexturesDelta` drop-bomb (#8356)
+        // must be defused explicitly -- see A2 in EGUI_UPGRADE_ASSUMPTIONS.md.
+        let discarded_output = ctx.run_ui(egui::RawInput::default(), |ui| {
             // "Chrome" shape, painted before the band region starts.
             ui.painter().rect_filled(
                 egui::Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(5.0, 5.0)),
@@ -4798,6 +4800,7 @@ mod tests {
                     })
             });
         });
+        discarded_output.drop_without_applying_deltas();
 
         assert_eq!(
             chrome_shape_count, 1,
@@ -4821,7 +4824,9 @@ mod tests {
         // rendering is unaffected by the extraction seam existing.
         let ctx = egui::Context::default();
 
-        let full_output = ctx.run_ui(egui::RawInput::default(), |ui| {
+        // No painter here, so the egui 0.36 `TexturesDelta` drop-bomb (#8356)
+        // must be defused explicitly -- see A2 in EGUI_UPGRADE_ASSUMPTIONS.md.
+        let mut full_output = ctx.run_ui(egui::RawInput::default(), |ui| {
             let band_shape_start = ui.ctx().graphics(|g| {
                 g.get(egui::LayerId::background())
                     .map_or(0, |list| list.all_entries().len())
@@ -4843,6 +4848,7 @@ mod tests {
             });
             assert!(!extracted.is_empty());
         });
+        full_output.textures_delta.clear();
 
         assert!(
             !full_output.shapes.is_empty(),
@@ -4889,7 +4895,9 @@ mod tests {
         // `band_layer_id`. `big` mimics `CentralPanel`'s content-area
         // widget rect (which fully contains the band); `small` mimics a
         // band-region interactive widget (e.g. the command-block gutter).
-        let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
+        // No painter here, so the egui 0.36 `TexturesDelta` drop-bomb (#8356)
+        // must be defused explicitly -- see A2 in EGUI_UPGRADE_ASSUMPTIONS.md.
+        let discarded_output = ctx.run_ui(egui::RawInput::default(), |ui| {
             let _big = ui.interact(
                 big_rect,
                 egui::Id::new("root_content_area"),
@@ -4901,6 +4909,7 @@ mod tests {
                 egui::Sense::click(),
             );
         });
+        discarded_output.drop_without_applying_deltas();
 
         // Frame 2: pointer is over `small_rect`. Hit-testing (computed at
         // the start of this frame from frame 1's registered widget rects)
@@ -4913,7 +4922,9 @@ mod tests {
             ..Default::default()
         };
         let mut small_hovered = false;
-        let _ = ctx.run_ui(raw_input, |ui| {
+        // No painter here, so the egui 0.36 `TexturesDelta` drop-bomb (#8356)
+        // must be defused explicitly -- see A2 in EGUI_UPGRADE_ASSUMPTIONS.md.
+        let discarded_output = ctx.run_ui(raw_input, |ui| {
             let _big = ui.interact(
                 big_rect,
                 egui::Id::new("root_content_area"),
@@ -4926,6 +4937,7 @@ mod tests {
             );
             small_hovered = small_response.hovered();
         });
+        discarded_output.drop_without_applying_deltas();
 
         assert!(
             small_hovered,
@@ -4957,7 +4969,9 @@ mod tests {
         );
 
         let ctx = egui::Context::default();
-        let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
+        // No painter here, so the egui 0.36 `TexturesDelta` drop-bomb (#8356)
+        // must be defused explicitly -- see A2 in EGUI_UPGRADE_ASSUMPTIONS.md.
+        let discarded_output = ctx.run_ui(egui::RawInput::default(), |ui| {
             let _big = ui.interact(
                 big_rect,
                 egui::Id::new("root_content_area"),
@@ -4974,13 +4988,16 @@ mod tests {
                 egui::Sense::click(),
             );
         });
+        discarded_output.drop_without_applying_deltas();
 
         let raw_input = egui::RawInput {
             events: vec![egui::Event::PointerMoved(pointer_pos)],
             ..Default::default()
         };
         let mut small_hovered = false;
-        let _ = ctx.run_ui(raw_input, |ui| {
+        // No painter here, so the egui 0.36 `TexturesDelta` drop-bomb (#8356)
+        // must be defused explicitly -- see A2 in EGUI_UPGRADE_ASSUMPTIONS.md.
+        let discarded_output = ctx.run_ui(raw_input, |ui| {
             let _big = ui.interact(
                 big_rect,
                 egui::Id::new("root_content_area"),
@@ -4998,6 +5015,7 @@ mod tests {
             );
             small_hovered = small_response.hovered();
         });
+        discarded_output.drop_without_applying_deltas();
 
         assert!(
             !small_hovered,

--- a/freminal/src/gui/frame_drain.rs
+++ b/freminal/src/gui/frame_drain.rs
@@ -831,7 +831,9 @@ mod tests {
         let config = Config::default();
         let ctx = egui::Context::default();
         let mut events = None;
-        let full_output = ctx.run_ui(egui::RawInput::default(), |ui| {
+        // No painter here, so the egui 0.36 `TexturesDelta` drop-bomb (#8356)
+        // must be defused explicitly -- see A2 in EGUI_UPGRADE_ASSUMPTIONS.md.
+        let mut full_output = ctx.run_ui(egui::RawInput::default(), |ui| {
             events = Some(drain_window_manipulation_commands(
                 ui,
                 &mut tabs,
@@ -841,6 +843,7 @@ mod tests {
                 &config,
             ));
         });
+        full_output.textures_delta.clear();
         let Some(events) = events else {
             panic!("closure runs synchronously inside run_ui");
         };
@@ -892,7 +895,9 @@ mod tests {
 
         let config = Config::default();
         let ctx = egui::Context::default();
-        let full_output = ctx.run_ui(egui::RawInput::default(), |ui| {
+        // No painter here, so the egui 0.36 `TexturesDelta` drop-bomb (#8356)
+        // must be defused explicitly -- see A2 in EGUI_UPGRADE_ASSUMPTIONS.md.
+        let mut full_output = ctx.run_ui(egui::RawInput::default(), |ui| {
             let _ = drain_window_manipulation_commands(
                 ui,
                 &mut tabs,
@@ -902,6 +907,7 @@ mod tests {
                 &config,
             );
         });
+        full_output.textures_delta.clear();
 
         let minimize_commands: usize = full_output
             .viewport_output

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -3691,10 +3691,52 @@ fn shell_escape_path(path: &std::path::Path) -> String {
     out
 }
 
+/// Build the PTY payload for a set of dropped file paths: each path
+/// shell-escaped, space-separated, with a trailing space so the shell treats
+/// the insertion as a finished argument list the user can keep typing after.
+///
+/// Returns an empty string when there is nothing to send, which the caller
+/// uses as the "don't write to the PTY at all" signal.
+///
+/// **Empty paths are skipped.** egui 0.36 changed `dropped_files` to a
+/// `Vec<Arc<dyn DroppedFile>>` whose `path()` returns a plain `&Path`, where
+/// the pre-0.36 API had an `Option<PathBuf>` that this code gated on. On native
+/// that `Option` was always `Some` (`egui-winit` fills it straight from the
+/// winit event), but skipping empties preserves the old gate's behaviour for
+/// any source that cannot supply a real filesystem path — without it such an
+/// entry would shell-escape to a literal `''` and inject an empty argument into
+/// the user's command line.
+///
+/// Split out of [`handle_file_drop`] because that function needs a live
+/// `egui::Ui` and so cannot be called from a test, while this assembly step
+/// carries all the behaviour worth pinning (escaping, separator placement, the
+/// trailing space, and the empty-path skip).
+fn dropped_files_payload<'a>(paths: impl IntoIterator<Item = &'a std::path::Path>) -> String {
+    let mut payload = String::new();
+    for path in paths {
+        if path.as_os_str().is_empty() {
+            continue;
+        }
+        // Guarded on `payload`, not on the loop index: with empty paths
+        // skipped, an index-based check would emit a leading separator
+        // whenever the first entry was the one skipped.
+        if !payload.is_empty() {
+            payload.push(' ');
+        }
+        payload.push_str(&shell_escape_path(path));
+    }
+    if !payload.is_empty() {
+        payload.push(' ');
+    }
+    payload
+}
+
 /// Handle file drag-and-drop events on the terminal area.
 ///
 /// **Drop:** Shell-escapes each dropped file path and sends the result as
-/// keyboard input to the PTY (space-separated, with a trailing space).
+/// keyboard input to the PTY (space-separated, with a trailing space). The
+/// payload assembly itself lives in [`dropped_files_payload`], which is where
+/// its behaviour is tested.
 ///
 /// **Hover:** Draws a semi-transparent overlay with a "Drop files here" label
 /// while files are being dragged over the terminal area.
@@ -3711,20 +3753,8 @@ fn handle_file_drop(ui: &Ui, terminal_rect: Rect, input_tx: &Sender<InputEvent>)
     // ── Drop handling ────────────────────────────────────────────────
     let dropped_files = ui.ctx().input(|i| i.raw.dropped_files.clone());
     if pointer_over_terminal && !dropped_files.is_empty() {
-        let mut payload = String::new();
-        for (i, file) in dropped_files.iter().enumerate() {
-            if i > 0 {
-                payload.push(' ');
-            }
-            // egui 0.36 made `dropped_files` a `Vec<Arc<dyn DroppedFile>>`
-            // whose `path()` returns a plain `&Path` rather than the old
-            // `Option<PathBuf>` field. The `Option` was always `Some` on
-            // native anyway (`egui-winit` filled it from the winit event), so
-            // dropping the `if let` changes no behaviour here.
-            payload.push_str(&shell_escape_path(file.path()));
-        }
+        let payload = dropped_files_payload(dropped_files.iter().map(|file| file.path()));
         if !payload.is_empty() {
-            payload.push(' ');
             send_or_log!(
                 input_tx,
                 InputEvent::Key(payload.into_bytes()),
@@ -4776,7 +4806,7 @@ mod shell_escape_tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
     use std::path::Path;
 
-    use super::shell_escape_path;
+    use super::{dropped_files_payload, shell_escape_path};
 
     #[test]
     fn simple_path() {
@@ -4812,6 +4842,66 @@ mod shell_escape_tests {
     fn empty_path() {
         let result = shell_escape_path(Path::new(""));
         assert_eq!(result, "''");
+    }
+
+    // ── `dropped_files_payload` ──────────────────────────────────────
+
+    fn payload_of(paths: &[&str]) -> String {
+        dropped_files_payload(paths.iter().map(Path::new))
+    }
+
+    #[test]
+    fn payload_for_no_files_is_empty() {
+        assert_eq!(payload_of(&[]), "");
+    }
+
+    /// The trailing space is deliberate: it leaves the shell's argument
+    /// finished so the user can keep typing after the drop.
+    #[test]
+    fn payload_for_one_file_is_escaped_with_a_trailing_space() {
+        assert_eq!(payload_of(&["/tmp/a.txt"]), "'/tmp/a.txt' ");
+    }
+
+    #[test]
+    fn payload_separates_multiple_files_with_single_spaces() {
+        assert_eq!(
+            payload_of(&["/tmp/a.txt", "/tmp/b c.txt"]),
+            "'/tmp/a.txt' '/tmp/b c.txt' "
+        );
+    }
+
+    #[test]
+    fn payload_escapes_each_path_independently() {
+        assert_eq!(
+            payload_of(&["it's", "$plain"]),
+            "'it'\\''s' '$plain' ",
+            "quote escaping must apply per path, not to the joined string"
+        );
+    }
+
+    /// egui 0.36 replaced the `Option<PathBuf>` this code used to gate on with
+    /// a plain `&Path`. An empty path must be skipped, not escaped to `''`,
+    /// which would inject an empty argument into the user's command line.
+    #[test]
+    fn payload_skips_empty_paths() {
+        assert_eq!(payload_of(&[""]), "", "a lone empty path sends nothing");
+        assert_eq!(payload_of(&["", ""]), "");
+    }
+
+    /// Regression guard for the separator placement: the space is emitted
+    /// based on what has already been written, so a skipped *first* entry
+    /// must not leave a leading space.
+    #[test]
+    fn payload_does_not_emit_a_leading_space_when_the_first_path_is_skipped() {
+        assert_eq!(payload_of(&["", "/tmp/a.txt"]), "'/tmp/a.txt' ");
+    }
+
+    #[test]
+    fn payload_skips_an_empty_path_between_two_real_ones() {
+        assert_eq!(
+            payload_of(&["/tmp/a.txt", "", "/tmp/b.txt"]),
+            "'/tmp/a.txt' '/tmp/b.txt' "
+        );
     }
 }
 

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -3716,9 +3716,12 @@ fn handle_file_drop(ui: &Ui, terminal_rect: Rect, input_tx: &Sender<InputEvent>)
             if i > 0 {
                 payload.push(' ');
             }
-            if let Some(path) = &file.path {
-                payload.push_str(&shell_escape_path(path));
-            }
+            // egui 0.36 made `dropped_files` a `Vec<Arc<dyn DroppedFile>>`
+            // whose `path()` returns a plain `&Path` rather than the old
+            // `Option<PathBuf>` field. The `Option` was always `Some` on
+            // native anyway (`egui-winit` filled it from the winit event), so
+            // dropping the `if let` changes no behaviour here.
+            payload.push_str(&shell_escape_path(file.path()));
         }
         if !payload.is_empty() {
             payload.push(' ');

--- a/renovate.json
+++ b/renovate.json
@@ -40,9 +40,15 @@
         "winit",
         "raw-window-handle"
       ],
-      "description": "The chrome-caching work relies on undocumented internal behaviour of the egui 0.35.0 stack; egui/egui_glow/egui-winit are exact-pinned. Never auto-merge these, and require explicit Dependency-Dashboard approval before a bump PR is even opened, so a human consciously runs the Documents/EGUI_UPGRADE_ASSUMPTIONS.md re-verification checklist first.",
+      "description": "The chrome-caching work relies on undocumented internal behaviour of the egui stack; egui/egui_glow/egui-winit are exact-pinned. Never auto-merge these, and require explicit Dependency-Dashboard approval before a bump PR is even opened, so a human consciously runs the Documents/EGUI_UPGRADE_ASSUMPTIONS.md re-verification checklist first.",
       "automerge": false,
       "dependencyDashboardApproval": true
+    },
+    {
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["glow"],
+      "description": "glow is held below 0.18 because egui_glow declares `glow = \"0.17.0\"` and upstream cannot move (wgpu 30's wgpu-hal pins glow 0.17). We pass `Arc<glow::Context>` directly to `egui_glow::Painter`, so two glow versions is a type error, not just a duplicate dep. Without this constraint the egui group proposes glow 0.18 on every run, an update that cannot resolve. Remove once egui_glow's own declared glow requirement moves.",
+      "allowedVersions": "<0.18"
     },
     {
       "groupName": "tracing",


### PR DESCRIPTION
## What

Bumps the exact-pinned egui matched set (`egui` / `egui_glow` / `egui-winit`) from **0.35.0 to 0.36.1**, plus the routine `clap` / `futures` / `open` / `thiserror` floors that were queued on the Dependency Dashboard.

Closes the "egui + windowing stack" pending-approval item on #179.

## glow stays at 0.17 — Renovate's proposal was wrong

Renovate grouped `glow 0.17 -> 0.18` into this bump. That update **cannot resolve**:

- `egui_glow` 0.36.1's own manifest declares `glow = "0.17.0"`, and upstream cannot move to 0.18 because **wgpu 30's `wgpu-hal` pins glow 0.17** — a bump would split glow into two versions inside egui's own graph.
- We hand `Arc<glow::Context>` straight to `egui_glow::Painter`, so a mismatch here is a **type error across two copies of the crate**, not merely a duplicate dependency.

So `glow` is held, and this PR adds a `renovate.json` constraint (`allowedVersions: "<0.18"`) so the group stops re-proposing it every month. The reason is recorded in three places that a future bumper will actually read: the `Cargo.toml` line, the assumptions doc, and a new rule in the `freminal-egui-upgrade` skill.

## Assumption re-verification (the gate)

Per the `freminal-egui-upgrade` skill, every row of `Documents/EGUI_UPGRADE_ASSUMPTIONS.md` was walked against the 0.36.1 source. Method: extract the new crates and `diff -u` each named file against the 0.35.0 copies in `~/.cargo/registry/src/*/` — a zero-line diff discharges every assumption resting on that file at once.

| File | Diff | Assumptions |
| --- | --- | --- |
| `egui/src/layers.rs` | identical | A3 ✅ |
| `epaint/src/texture_atlas.rs` | identical | A6 upstream ✅ |
| `epaint/src/image.rs` | identical | A6 delta ✅ |
| `egui/src/ui.rs` | identical | A9 ✅ |
| `epaint/src/tessellator.rs` | cosmetic only | A4, A5 ✅ |
| `egui/src/hit_test.rs` | one attribute removed | A11 ✅ |
| `egui_glow/src/painter.rs` | `paint_and_update_textures` only | A1 ✅, **A2 changed** |
| `egui/src/context.rs` | `run_logic`, theme sync, hit-test filter | A5, A7, A8, A10 ✅ |
| `epaint/src/textures.rs` | `TexturesDelta` reshaped | **A2 changed** |
| `egui-winit/src/lib.rs` | modifiers, dropped files, IME | A12, A13 ✅ |

**11 of 13 hold unchanged.** The doc now carries a verification log with this table, so the next bump can tell a real re-verification from a rubber stamp.

### A2 changed — `TexturesDelta` reshape + drop bomb (upstream #8356)

Three things moved at once:

- `set` went from `Vec<(TextureId, ImageDelta)>` to `HashMap<TextureId, SmallVec<[ImageDelta; 1]>>`; `free` from `Vec` to `HashSet`. **One texture can now carry several queued deltas.**
- `TexturesDelta` gained a `Drop` impl that `debug_assert!`s it is empty, and upstream's `paint_and_update_textures` now takes `&mut` and `drain()`s both halves. Our hand-inlined set/paint/free split in `run_frame` **drains to match** — iterating by reference would panic at end of frame in debug, and silently drop atlas uploads in release.
- Every painter-less `run_ui` in the test and bench suites defuses the bomb explicitly (`drop_without_applying_deltas()`, or `textures_delta.clear()` where the output is partially moved).

### A6 held upstream, but its consumer needed rewriting

`atlas_grew` now asks whether **any** delta queued for the font atlas is whole, not whether *the* delta is. `TexturesDelta::push` only collapses the per-texture vector on a whole delta and **appends partials after it** — so a frame that resizes the atlas and then allocates further glyphs leaves `[whole, partial, …]`. The pre-0.36 shape would have missed that frame's growth, skipped the UV self-heal, and garbled cached chrome text with no visible cause. Two new tests pin it.

## Other 0.36 API changes absorbed

All compile-time, not silent — but one needed a design decision:

- **`RawInput::modifiers` was removed** (#8336) and `egui_winit::State`'s replacement copy is **private with no accessor**. `Context::input(|i| i.modifiers)` is *not* a substitute: it only advances when a pass runs, so the two pre-egui interception paths in `event_loop.rs` (the Wayland paste work-around and the Task 114 blocked-key routing) would read the **previous frame's** modifiers and miss a `Ctrl` pressed in the same frame interval as the `V` that follows it.

  Rather than accept a stale read or inline the mapping at the call sites, this adds **`freminal-windowing/src/modifier_tracker.rs`** — one concept, explicit surface, documented invariant, 8 unit tests covering the platform `command` split and the focus-loss reset that stops a modifier sticking down across an alt-tab. `EguiState::modifiers()`' signature is unchanged, so no call site moved. Flagged per `freminal-extend-or-extract`: the alternative was a fourth ad-hoc field on `EguiState` with the winit mapping inlined and untestable.
- **`dropped_files`** is now `Vec<Arc<dyn DroppedFile>>` whose `path()` returns `&Path`. The old `Option` was always `Some` on native, so behaviour is unchanged.
- **`Options::sync_window_theme`** is new and defaults to `true`, but is a **no-op here**: it derives from egui's own `theme_preference`, which freminal never sets (it manages themes entirely through its own palette system), and `process_viewport_command` does not handle `SetTheme` — the command falls into the catch-all and is logged at `trace`. Noted in the doc as the route to take if we ever *do* want the OS titlebar to follow freminal's theme.

## Verification

- `cargo test --all` — green (104 suites)
- `cargo test -p freminal-windowing --features frame-profiling` — green (128 tests)
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo machete` — clean
- `cargo fmt --all --check` — clean
- `cargo bench --no-run --all` — compiles
- `cargo xtask check-windows` — clean
- `Cargo.lock` carries exactly one `glow`, at 0.17.0

Two `cargo xtask ci` stages fail **identically on `main`** and are untouched by this PR: `typos` (8 `flate2` / `SCROLLL` false positives in `KITTY_PROTOCOL_REFERENCE.md` and `PLAN_VERSION_110.md`) and `cargo deny advisories` (`rustybuzz` / `ttf-parser` unmaintained). Both want a `typos.toml` / `deny.toml` allowlist entry rather than a text change — out of scope here, flagging so they are not mistaken for regressions.

## ⚠️ Still outstanding: pixel verification

The skill mandates pixel-level verification, and **a green `cargo test` is explicitly not sufficient** — the load-bearing failures in this subsystem are pixel-only, and the repo has no headless-GL harness yet (#440). Before merge, someone needs a manual visual smoke of the "Symptom if broken" scenarios:

- [ ] Idle cursor blink (REPLAY frames actually engage — check the `frame-profiling` duty-cycle counters)
- [ ] Multi-pane with an active post-process shader (sharpest test of A1's GL-state re-establishment)
- [ ] Atlas growth from a never-before-seen glyph mid-session (A5/A6 self-heal — paste some CJK or an unusual emoji)
- [ ] An open context menu / search bar / command palette / URL-hover tooltip left idle
- [ ] OS dark/light switch
- [ ] A DPI / scale-factor change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved keyboard modifier tracking across focus changes and platform-specific shortcuts.
  * Enhanced dropped-file handling with reliable shell argument formatting.
  * Updated graphics and command-line components for improved compatibility.

* **Bug Fixes**
  * Improved texture and font-atlas synchronization during rendering.
  * Prevented stale or incomplete texture updates after queued changes.
  * Preserved reliable theme, repaint, and input behavior.

* **Documentation**
  * Updated compatibility requirements, upgrade guidance, verification steps, and maintenance rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->