### PR TITLE
docs: Task 121 recon findings, egui 0.36.1 citation refresh, and onboarding fixes

### DIFF
--- a/Documents/MASTER_PLAN.md
+++ b/Documents/MASTER_PLAN.md
@@ -198,7 +198,7 @@ into v0.14.0–v0.16.0 and v0.20.0) and remaining Category C housekeeping (Tasks
 | 119 | Scrollback Compression (LZ4)              | `PLAN_VERSION_120.md` (Task 119)              | Complete  | Task 118               |
 | 120 | Compression-Aware Windowed Reflow         | `PLAN_VERSION_120.md` (Task 120)              | Stub      | Tasks 118, 119         |
 | 121 | Performance Remediation                   | `PLAN_121_PERF_REMEDIATION.md` (Task 121)     | In progress | None                 |
-| 122 | Orchestration Extraction                  | `PLAN_122_ORCHESTRATION_EXTRACTION.md`        | Pending merge | None               |
+| 122 | Orchestration Extraction                  | `PLAN_122_ORCHESTRATION_EXTRACTION.md`        | Complete  | None                   |
 
 ---
 
@@ -723,7 +723,7 @@ Update this section as tasks complete:
 | 118  | 2026-07-14 | 2026-07-14 | 118.1-118.9 compact repr + idle compaction; default 4k->10k; 118.10 -> Task 120  |
 | 119  | 2026-07-20 | 2026-07-20 | 119.1-119.6 LZ4 block compression + idle-driven; ~13-22x vs cell; merged PR #419 |
 | 121  | 2026-07-27 |            | 121.1-121.14 (PR #467), 121.23, 121.26 done; 121.25 partial; rest open           |
-| 122  | 2026-07-30 |            | All subtasks done (19, incl. 3 added). Pending merge; 121.17 seam landed (122.15) |
+| 122  | 2026-07-30 | 2026-08-03 | All subtasks done (19, incl. 3 added); merged via PR #472; 121.17 seam (122.15)  |
 
 ---
 

--- a/Documents/MASTER_PLAN.md
+++ b/Documents/MASTER_PLAN.md
@@ -480,15 +480,18 @@ creating it closes that tracking gap rather than starting new work. Fourteen sub
 merged: 121.1–121.11 from that original run, plus the Group B bug fixes 121.12–121.14
 (PR #467), and 121.23 (the profiling methodology reference,
 `Documents/PROFILING.md`) and 121.26 landed directly. Outstanding: 121.15 (left to
-121.17, blocked behind Task 122), 121.16 (withdrawn), 121.17, issue #459's unactioned
-candidate list (121.18–121.22, 121.24), measurement debt (121.25, partly captured, plus
-121.27–121.28), and two items the Group B fixes themselves surfaced
-(121.29–121.31). The
+121.17, unblocked now that Task 122 merged), 121.16 (withdrawn), 121.17, issue #459's
+unactioned candidate list (121.18–121.22, 121.24), measurement debt (121.25, partly
+captured, plus 121.27–121.28), three items the Group B fixes themselves surfaced
+(121.29–121.31), and Group G, the beta.7 chrome-cache regression and its follow-ups
+(121.32–121.36): 121.32 is complete (chrome cache disabled by default), with 121.33,
+121.34 (the decision gate), 121.35 (deferred), and 121.36 (conditional) outstanding. The
 task is an umbrella, so several subtasks will outlive v0.12.0; the version does not gate on
 Task 121 reaching Complete. **Task 121 is not the egui-decoupling decision** —
 `Documents/DECOUPLING_FRAMEWORK.md` is the decision record for whether freminal should stop
-using egui for the main window, and its status is reopened and leaning against the rewrite.
-Task 121 is the performance work, and it stands either way.
+using egui for the main window, and its status is reopened and leaning against the rewrite —
+but `DECOUPLING_FRAMEWORK.md` §2A is the source of truth for Task 121's own Phase 0
+measurements. Task 121 is the performance work, and it stands either way.
 
 **Task 122 (v0.12.0, orchestration extraction):** decompose the GUI binary's god functions
 and give orchestration logic (event triage, view window, input encoding, frame decisions) a

--- a/Documents/PLAN_121_PERF_REMEDIATION.md
+++ b/Documents/PLAN_121_PERF_REMEDIATION.md
@@ -597,6 +597,67 @@ same cost as a full-screen rebuild. Measured at 4.80% self under btop. The exist
 quantify the recoverable headroom. Also listed as issue #405 Part B's own
 suggested-next-step 4.
 
+### 121.18 recon finding (2026-08-16): this is a redesign, not a subtask
+
+The premise is confirmed: both builders `clear()` and walk every visible row
+unconditionally. `build_background_instances` is
+`freminal/src/gui/renderer/vertex.rs:361-646`, `build_foreground_instances` is
+`vertex.rs:722-784`. Called only from `freminal/src/gui/terminal/widget.rs:2740`
+(bg) and `:2798` (fg), plus benches.
+
+**Blocker 1 — the instance buffers are variable-length per row, not
+fixed-stride.** Background skips `TerminalColor::DefaultBackground` runs
+entirely (`vertex.rs:408-415`, a `continue`); foreground skips zero-size glyphs
+i.e. spaces (`vertex.rs:1436-1439`). So a row's instance count is a function of
+its *content*. A single cell changing default-background→coloured changes that
+row's count and shifts every subsequent row's offset in the flat buffer. There
+is no row-start-offset index anywhere, so locating "row N's data" costs a full
+re-walk — the same cost as the rebuild it is trying to avoid.
+
+**Blocker 2 — `deco_verts` is not row-major past its first section.** The
+per-row underline/strikethrough pass runs in the row loop (`vertex.rs:434-503`),
+but search-match highlights (`vertex.rs:509-531`), the command-block hover tint
+(`546-566`) and selection highlights (`569-617`) are each appended afterwards as
+bulk global blocks spanning arbitrary row ranges, with the cursor quad always
+last (`619-643`). One row's decoration output can therefore live in up to three
+non-adjacent regions plus a shared tail.
+
+**Blocker 3 — no per-row dirty signal survives to the call site.**
+`evaluate_frame_dirty_state` in `freminal/src/gui/terminal/frame_dirty.rs:265-314`
+derives `content_changed` from `Arc::ptr_eq` over the whole `visible_chars` /
+`visible_line_widths` arrays, so one changed cell flips a single global bit for
+the entire screen. `freminal-buffer` does track per-row dirty bits internally,
+but they are consumed inside `rows_as_tchars_and_tags_cached` and never cross
+the snapshot boundary. `ShapingCache` (`freminal/src/gui/shaping.rs:196-228`)
+*does* compute per-row change via hash comparison, but discards which indices
+changed the moment it returns its `Vec<Arc<ShapedLine>>`.
+
+**Blocker 4 — the GL upload pattern forbids a partial write.** `upload_verts`
+(`freminal/src/gui/renderer/gpu.rs:1665-1682`) orphans the buffer
+(`buffer_data_size` + `STREAM_DRAW`) before every write specifically to avoid a
+sync stall, which leaves prior GPU-side contents undefined. A genuine partial
+`glBufferSubData` is therefore impossible without abandoning that pattern, and
+there is a double-buffered VBO discipline (`gpu.rs:587-623`) that issue #432
+depends on for correctness.
+
+**Assessment.** Making this incremental requires, in order: propagating
+per-row dirtiness out of `ShapingCache`; giving `bg_instances`/`fg_instances`
+either a fixed stride (padding blank cells, a real GPU-side cost needing its
+own benchmark) or a maintained per-row offset index (bookkeeping that silently
+corrupts unrelated rows when wrong — exactly the bug class issue #432 already
+produced once for the far simpler cursor-quad offset); deciding that
+`deco_verts` stays a full rebuild; and only then changing the upload strategy.
+That is a redesign of the CPU-side vertex representation plus a new dirty
+channel plus a GL-upload change, to recover a measured 4.80% self time.
+
+**Recommendation:** do not attempt 121.18 in its current framing. Either
+re-scope it explicitly as that redesign (and price it accordingly), or pursue
+the cheaper alternative of reducing how often the full rebuild is triggered at
+all — better dirty granularity at the snapshot level — which touches no buffer
+layout. Note the existing `instanced_bg_partial_dirty` /
+`instanced_fg_partial_dirty` benches quantify the headroom but are explicitly
+*not* an incremental implementation.
+
 ### 121.19 — ASCII / simple-text shaping fast path (#459 item 4)
 
 `<char as UnicodeGeneralCategory>::general_category` was 8.56% self under btop,
@@ -605,6 +666,75 @@ freminal code and not cacheable by us. `ShapingCache` already avoids re-shaping
 unchanged rows, so this is genuine reshape cost. The lever is a fast path that skips
 full rustybuzz shaping for runs that cannot need ligatures or complex script
 shaping. **Confirm no such path exists today before scoping.**
+
+### 121.19 recon finding (2026-08-16): the ASCII gate is dead on arrival at default config
+
+The entry asked to "confirm no such path exists today". **Confirmed: none
+exists.** Every `TextRun` reaches `rustybuzz` via `shape_single_run` →
+`FontManager::shape_cached` → `rustybuzz::shape_with_plan`
+(`freminal/src/gui/shaping.rs:661`, `freminal/src/gui/font_manager.rs:787`)
+with no complexity-based bypass. The only ASCII fast path in the tree is
+`TChar::from_string`'s grapheme-segmentation skip in
+`freminal-common/src/buffer_states/tchar.rs:143-146`, which is upstream in the
+buffer layer and unrelated to shaping.
+
+The cost attribution is confirmed too: `general_category` is called per
+character from inside rustybuzz's own `GlyphInfo::init_unicode_props`, during
+`shape_with_plan`. It is not reachable or cacheable from freminal code, so the
+only way to avoid it is to not call rustybuzz for that run.
+
+**The blocker: ASCII does not imply "cannot ligate".** `->`, `=>`, `!=` are
+pure ASCII and are precisely what ligature substitution targets.
+`shaping_features` (`shaping.rs:494-508`) enables `liga` and `calt` under the
+config flag, always enables `kern`, and always disables `dlig`. So the only
+formulation that is obviously safe is to gate the fast path on
+`ligatures == false` — and `FontConfig::default` sets `ligatures: true`
+(`freminal-common/src/config.rs:122`, with a test pinning it at
+`config.rs:2206`). The fast path would therefore be dead code for every user on
+default config, which is the overwhelming majority.
+
+**One risk is smaller than it looks.** Glyph positions are snapped to the cell
+grid (`shaping.rs:774-777`, `x_px = col * cell_width`), so rustybuzz's
+positional output is discarded for placement. `kern` is a GPOS pair adjustment
+and is positional-only, never substitutive, so kerning cannot change a glyph
+id. That narrows the substantive risk to the substitutive features `liga` /
+`calt` alone.
+
+**One risk is larger than it looks.** A fast path would have to source glyph
+ids from `FontManager::resolve_glyph` (`font_manager.rs:690-698`), which
+returns a swash **charmap** lookup. That is a different provenance from
+rustybuzz's shaped output, and nothing in the tree currently proves the two
+agree even for plain ASCII. The existing identity test
+(`shape_with_plan_matches_old_shape_for_mixed_content`) compares `shape_cached`
+against the old `rustybuzz::shape()` path — it does not compare charmap ids
+against shaped ids. Any fast path needs that proof first.
+
+**No coupling risk to selection/search/URLs.** `ShapedGlyph` / `ShapedRun` /
+`ShapedLine` are consumed only by `freminal/src/gui/renderer/vertex.rs` and
+`widget.rs`; selection, search and URL hit-testing work off the raw `TChar`
+grid and their own byte-offset maps, so a fast path's only obligation is
+producing identical rendered output.
+
+**Two alternative levers, both compatible with `ligatures = true`:**
+
+1. A content-addressed **run-level** shaping cache keyed on `(face_id,
+   ligatures, run text)` storing the raw shaped `(glyph_id, cluster)` pairs.
+   Today's `ShapingCache` (`shaping.rs:127`) is keyed by **line index**, so it
+   cannot hit across a scroll, and one changed character re-shapes every run
+   on that row. A run cache is provably behaviour-preserving (shaping is
+   deterministic given face + features + text) and positions are re-derived
+   from `col_start`/`cell_width`, which stay out of the key. Needs bounding
+   for memory.
+2. Per-run allocation reduction in `build_shaped_glyphs`
+   (`shaping.rs:701-802`), which builds four `Vec`s per run per cache miss
+   (`byte_to_char`, `run_chars`, `cum_cols`, and the output).
+
+**Do not implement either speculatively.** There is no shaping cache hit/miss
+instrumentation, and no benchmark models the full-screen TUI redraw workload
+that produced the 8.56% figure — the existing `shaping_ligatures` group
+benches a cold cache and a fully-warm cache, not a realistic
+partial-invalidation stream. Per this document's own standing instruction in
+121.24, measure first.
 
 ### 121.20 — GPU buffer-orphaning for `deco_verts` (#459 item 5)
 

--- a/Documents/PLAN_121_PERF_REMEDIATION.md
+++ b/Documents/PLAN_121_PERF_REMEDIATION.md
@@ -1,11 +1,15 @@
 # PLAN_121_PERF_REMEDIATION.md — Task 121 "Performance Remediation"
 
 > **STATUS: IN PROGRESS.** Fourteen subtasks have merged to `main` across six pull
-> requests (#458, #460, #461, #464, #465, #467), plus 121.23 and 121.26 landed
-> directly. The remainder — one bug blocked behind Task 122, one unifying improvement,
-> six unactioned issue #459 items, two-and-a-half pieces of measurement debt (121.25
-> is partly captured), and three items surfaced by the Group B work and its
-> measurement — are outstanding and unscheduled.
+> requests (#458, #460, #461, #464, #465, #467) — though **121.13 was subsequently
+> reverted**, so thirteen stand — plus 121.23, 121.26 and 121.32 landed directly.
+> The remainder — one bug now routed through 121.17 rather than blocked, one
+> unifying improvement (121.17, whose Task 122 dependency was discharged on
+> 2026-08-03 but whose measured numbers are stale), six unactioned issue #459 items
+> (of which 121.18 and 121.19 carry 2026-08-16 recon findings that re-scope them),
+> two-and-a-half pieces of measurement debt (121.25 is partly captured), three items
+> surfaced by the Group B work, and Group G's four open chrome-cache follow-ups
+> (121.33–121.36) — are outstanding and unscheduled.
 
 Task 121 is carried by v0.12.0. The version-level summary lives in
 `PLAN_VERSION_120.md` ("Task 121 — Performance Remediation"); this document is the
@@ -265,7 +269,8 @@ These were surfaced by Group A. 121.12, 121.13 and 121.14 were **merged to `main
 PR #467 (merge commit `f7dac216`, one atomic commit per subtask on `task-121/group-b`).
 **121.13 was subsequently reverted (2026-08-02) — it shipped a user-visible interaction
 regression in 0.12.0-beta.7; see 121.32.** 121.12 and 121.14 stand. 121.15 remains
-unfixed and is deliberately left to 121.17, which is blocked behind Task 122. 121.16 is
+unfixed and is deliberately left to 121.17, whose Task 122 dependency was discharged
+when that task merged on 2026-08-03. 121.16 is
 withdrawn.
 
 ### 121.12 — The 250 ms fallback makes blink-off slower than blink-on
@@ -468,7 +473,9 @@ the benefit it costs is nearly all of it.
 shipped without it. An interim narrowing here would mean adding a fifth round to the
 suppression predicate in its current shape — exactly what 121.17 warns is how the
 maintainability argument for the egui rewrite gets stronger for no good reason. It
-stays blocked behind Task 122 → 121.17.
+remains routed through 121.17 — the Task 122 dependency that once blocked both was
+discharged when that task merged on 2026-08-03, so what defers 121.15 now is the
+decision to fix it via 121.17 rather than separately, not a blocker.
 
 ### 121.16 — Config kill switch for the suppression (WITHDRAWN)
 
@@ -542,18 +549,28 @@ exactly what Task 122 builds a home for. §2A records that the suppression predi
 maintainability argument for the egui rewrite gets stronger for no good reason. Do
 Task 122 first.
 
-### 121.17 measured prize (harness, 2026-07-29)
+### 121.17 measured prize (harness, 2026-07-29) — STALE, see caveat above
+
+Refining the caveat at the top of this entry: these numbers predate 121.32
+disabling the chrome cache. The suppression
+percentages and veto counts are still indicative — they concern
+`pointer_motion_needs_repaint`, which 121.32 did not touch — but the `Replay %`
+column is now meaningless, because `ChromeMode::Replay` is never chosen. The
+whole table must be re-captured before it is used to justify a design.
 
 No longer an argument. Captured with `--features frame-profiling`, wiggling the
 pointer over terminal content in three scenarios, flushes differenced:
 
-| Scenario | checks | suppressed | veto firing | `Replay` % | µs/frame |
+| Scenario | checks | suppressed | veto firing | `Replay` % (void)² | µs/frame |
 | --- | --- | --- | --- | --- | --- |
 | Clean pane | 15,265 | **99.16%** | `overlay_open` 126 (0.8%) | 58.3% | 729¹ |
 | One OSC 8 URL on screen | 792 | **1.68%** | `has_urls` **792 (100%)** | 5.8% | 185 |
 | btop | 217 | **0%** | `mouse_tracking_active` **216 (99.5%)** | 40.4% | 521 |
 
 ¹ single flush, so warm-up is included; the others are differenced.
+² retained only as a record of what was observed while the chrome cache was
+live; `Replay` is never chosen since 121.32, so this column has no bearing on
+current behaviour.
 
 **A single hyperlink on screen takes suppression from 99.16% to 1.68%.** `has_urls`
 fired on 792 of 792 checks — total defeat. btop confirms `mouse_tracking_active` does

--- a/Documents/PLAN_121_PERF_REMEDIATION.md
+++ b/Documents/PLAN_121_PERF_REMEDIATION.md
@@ -11,6 +11,25 @@ Task 121 is carried by v0.12.0. The version-level summary lives in
 `PLAN_VERSION_120.md` ("Task 121 — Performance Remediation"); this document is the
 full breakdown.
 
+> **Citation re-verification (2026-08-16).** The egui stack moved 0.35.0 → 0.36.1 in
+> `06701ce8`; that bump re-verified `EGUI_UPGRADE_ASSUMPTIONS.md` but left this
+> document's internal-line citations pointing at the old source tree. All
+> `egui-0.35.0` citations below (121.9, 121.29, 121.30, 121.32) have been re-checked
+> against 0.36.1 and updated where the line moved. Two citations turned out to be
+> wrong in **both** versions — a four-line offset in 121.29 item 2, and an incorrect
+> claim in 121.32 that `potential_drag_id` is cleared the same way as
+> `potential_click_id` (it is not; egui deliberately leaves it alone). Both are
+> pre-existing errors, not bump-induced ones, and are fixed in place below. No
+> subtask's status or verdict changes as a result.
+>
+> **Dated harness captures are deliberately NOT re-pointed.** Where this document
+> quotes what `repaint_cause_top8` actually logged (121.29 and 121.30, both
+> "harness, 2026-07-29"), the `egui-0.35.0` paths are left verbatim, because that
+> is the version the run observed and a log is not a citation. So the same
+> mechanism legitimately appears twice at two versions: `context.rs:525` inside
+> the 0.35.0 capture, and `context.rs:536-537` as the live 0.36.1 reference. Do
+> not "fix" the captures to match.
+
 ---
 
 ## Goal
@@ -208,7 +227,7 @@ validated.
 ### 121.9 — egui repaint-cause instrumentation
 
 Commit `ab88d0f5`. Named the culprit behind Finding 2 exactly:
-`egui-0.35.0/src/context.rs` `begin_pass` calling
+`egui-0.36.1/src/context.rs` `begin_pass` calling
 `InputState::wants_repaint_after()`, which returns `Duration::ZERO` whenever
 `!self.events.is_empty()`. Zero freminal call sites appeared in the causes, which
 excluded the gutter, scrollbar and cursor-trail hypotheses by measurement rather
@@ -691,7 +710,10 @@ formulation that is obviously safe is to gate the fast path on
 `ligatures == false` — and `FontConfig::default` sets `ligatures: true`
 (`freminal-common/src/config.rs:122`, with a test pinning it at
 `config.rs:2206`). The fast path would therefore be dead code for every user on
-default config, which is the overwhelming majority.
+default config. There is no telemetry on how many users set `ligatures = false`,
+so no claim is made about the size of that population — but an optimisation that
+is inert unless a non-default option is set is a poor use of the effort either
+way.
 
 **One risk is smaller than it looks.** Glyph positions are snapped to the cell
 grid (`shaping.rs:774-777`, `x_px = col * cell_width`), so rustybuzz's
@@ -925,7 +947,7 @@ animations are unrepresentable in it and are masked by egui's events-driven zero
 `Duration::MAX` would freeze such an animation at partial alpha until an unrelated
 event arrived.
 
-A mechanism exists to discriminate. `egui-0.35.0/src/context.rs:524-525` pushes the
+A mechanism exists to discriminate. `egui-0.36.1/src/context.rs:536-537` pushes the
 events-driven zero as a `RepaintCause`, and `ContextImpl::request_repaint_after`
 pushes `causes` **unconditionally**, before the `delay < repaint_delay` early-out, so
 the list survives even though the delay value is flattened to zero.
@@ -938,7 +960,13 @@ internals, two of which are present-day holes rather than future-bump risks:
 1. The events-driven zero is recorded as a cause at all, identifiable by `file`+`line`
    — making an egui *source line number* load-bearing runtime data, in a repo whose
    own upgrade checklist says line numbers drift and must not be trusted.
-2. `causes.push` happening unconditionally (`context.rs:157-159`).
+2. `causes.push` happening unconditionally. **Correction (2026-08-16): the original
+   citation here, `context.rs:157-159`, was off by four lines in both 0.35.0 and
+   0.36.1 — a pre-existing error, not something the version bump introduced.** The
+   actual push, `viewport.repaint.causes.push(cause);`, is at `context.rs:153`; the
+   `if delay < viewport.repaint.repaint_delay {` early-out it precedes is at
+   `context.rs:158`. The substance of the claim is unaffected: the push genuinely
+   happens unconditionally, before that early-out.
 3. `repaint_causes()` returning `prev_causes` — exactly one pass stale
    (`context.rs:102-105`).
 4. **`outstanding`-driven repaints push no cause at all** (`context.rs:110-118`).
@@ -946,9 +974,10 @@ internals, two of which are present-day holes rather than future-bump risks:
    in two repaints, just to give some things time to settle"); the following pass is
    forced to `ZERO` down a path that never touches `causes`. A cause-based test is
    structurally blind to egui's own settling mechanism.
-5. **`run_dyn` is a multi-pass loop** (`context.rs:822-860`); `request_discard`
-   reruns `begin_pass`/`end_pass`, swapping `causes` again, so after a discarded pass
-   `repaint_causes()` is the second-to-last pass's causes.
+5. **`run_dyn` is a multi-pass loop** (`context.rs:835-875` in egui-0.36.1 — the loop
+   itself opens at `835` and closes at `875`; the enclosing `fn run_dyn` begins at
+   `823`); `request_discard` reruns `begin_pass`/`end_pass`, swapping `causes` again,
+   so after a discarded pass `repaint_causes()` is the second-to-last pass's causes.
 
 `set_request_repaint_callback` looked like the documented escape hatch but is not: it
 fires only when `delay < repaint_delay`, so once the events-zero lands at
@@ -1002,6 +1031,13 @@ Both mechanisms are documented at the constant.
 > "the widgets are not built" is a statement about the widget **set**, and egui uses
 > that set for interaction as well as painting. Enumerating one consumer of it
 > under-scoped the risk.
+>
+> **Refined 2026-08-16.** "That broke tab clicks and pane-border drags" is too
+> broad: non-construction accounts for the **tab clicks only**. Pane-border drag
+> sensors are built on both paths (121.33), so they are never absent and this
+> mechanism cannot be what breaks them. The lesson above still stands unchanged —
+> the widget set is used for interaction, not just painting — but see 121.32's
+> 2026-08-16 correction for the click/drag split.
 
 ### 121.31 — Every frame is a full present during pointer motion
 
@@ -1053,18 +1089,68 @@ repeatedly produced confident wrong answers. 121.13 shipped the same way — its
 module states its wiring has no automated coverage. **Do not accept a code-reading
 argument about this subsystem. Measure it** (see "How to measure" below).
 
-**Established fact (verified against `egui-0.35.0` source, not inferred).** egui resolves
-interaction entirely against the **previous** frame's widget set:
+**Established fact (verified against `egui-0.35.0` source at the time; re-verified
+against `egui-0.36.1` on 2026-08-16 — unchanged in substance, only line numbers
+moved).** egui resolves interaction entirely against the **previous** frame's widget
+set:
 
-- `context.rs:475` — `hit_test(&viewport.prev_pass.widgets, …)`
-- `context.rs:488` — `interact(…, &viewport.prev_pass.widgets, …)`
+- `context.rs:487` — `hit_test(&viewport.prev_pass.widgets, …)`
+- `context.rs:500` — `interact(…, &viewport.prev_pass.widgets, …)`
 - `interaction.rs:109-123` — if `potential_click_id` is not in that set it is cleared
-  (*"The widget we were interested in clicking is gone"*); same for `potential_drag_id`
+  (*"The widget we were interested in clicking is gone"*). **`potential_drag_id` is
+  handled differently, and this entry previously stated it wrong.** When absent from
+  the set, egui deliberately leaves it alone — the comment at that site reads "this
+  could be drag-and-drop, and the widget being dragged is now 'in the air' and thus
+  not registered in the new frame." Corrected 2026-08-16; see the consequences below
+  for what that changes.
 
-Consequences, both load-bearing:
+Consequences:
 
-1. A press on frame N can only hit a widget that was **built on frame N-1**.
-2. A **single** `Replay` frame anywhere in a gesture discards the in-flight click/drag.
+1. A press on frame N can only hit a widget that was **built on frame N-1**. This
+   holds for **both** clicks and drags — it is what breaks a gesture from *starting*
+   at all, regardless of which kind of gesture it is.
+2. A **single** `Replay` frame anywhere in a gesture discards the in-flight **click**
+   (`potential_click_id` is cleared). This does **not** hold for drags: per the
+   corrected fact above, an in-flight drag survives a `Replay` frame by design.
+
+**Correction (2026-08-16), and what it does NOT say.** These two consequences were
+previously stated as one, covering "click/drag" together. They diverge: consequence 2
+is click-only.
+
+Apply that split to the two observed symptoms separately, because they have different
+mechanisms and conflating them is what this correction is fixing:
+
+- **Tab clicks** are fully explained by consequence 1. The tab strip is built only on
+  `ChromeMode::Full`, so on a `Replay` frame it is genuinely **absent** from
+  `prev_pass.widgets` — and consequence 2 then discards any click that was already in
+  flight. Both apply.
+- **Pane-border drags are explained by NEITHER.** Consequence 1 does not apply,
+  because per 121.33 those sensors are built on **both** paths and so are never
+  absent. Consequence 2 does not apply, because an in-flight drag is deliberately
+  preserved. This correction therefore **eliminates the last mechanism in this entry
+  that could have accounted for the drag half of the symptom**, leaving 121.33's
+  `Ui` id churn as the explanation — which is exactly what 121.33 already says ("they
+  fail by id churn rather than by absence"). Before this correction, consequence 2's
+  "discards the in-flight click/drag" wording made it look as though 121.32 alone
+  covered drags too. It never did.
+
+The net effect is to **promote 121.33 from "probably an active participant" to the
+only remaining candidate mechanism for the drag symptom**, and to make it a hard
+prerequisite for any re-enabling work rather than a nice-to-have.
+
+**This does not reopen the decision below.** Consequence 1 is sufficient on its own to
+condemn the cache on the tab-click evidence, the drag symptom is still explained (by
+121.33), and the maintainer confirmed the fix under real daily use. Nothing here
+weakens that.
+
+**Forward-looking note (2026-08-16).** 0.36.1 adds a filter step —
+`.filter(|layer_id| self.memory.areas().is_interactable(*layer_id))` — when building
+the candidate layer list passed into `hit_test` (new `Areas::is_interactable` at
+`memory/mod.rs:1214`, wired around `context.rs:475-481`). Non-interactable layers are
+now excluded from hit-testing before it runs. This is **orthogonal** to the
+`prev_pass` unsoundness above and changes none of this subtask's conclusions — it did
+not exist when the original analysis was written, so any future reasoning about which
+layers get hit-tested must account for it.
 
 Since freminal builds the tab strip only on `ChromeMode::Full`, any `Replay` frame
 adjacent to a click is fatal to it. **Hover is not evidence against this**: on a `Replay`
@@ -1234,6 +1320,13 @@ aggregate number; the whole point is which workload the cost lands in.
 
 **Deferred by maintainer decision (2026-08-02): written up now, not scheduled.
 Task 122 takes priority.**
+
+> **The stated reason has lapsed (2026-08-16).** Task 122 merged on 2026-08-03,
+> so "Task 122 takes priority" no longer defers anything. This entry is left
+> `Deferred` rather than re-scheduled, because that was a maintainer call and
+> only the *reason* expired, not the decision. Note the sequencing constraint
+> below still binds: it should land before 121.34's RSS arm, or the cache-on and
+> cache-off arms are not comparable on memory.
 
 121.32 bypassed the cache **read** but not the **write**. `chrome_mode` is forced to
 `Full`, and the `Full` arm still populates `ChromeCache` on every single frame:

--- a/Documents/PLAN_122_ORCHESTRATION_EXTRACTION.md
+++ b/Documents/PLAN_122_ORCHESTRATION_EXTRACTION.md
@@ -1,10 +1,10 @@
 # PLAN_122_ORCHESTRATION_EXTRACTION.md — Task 122 "Orchestration Extraction"
 
-> **STATUS: EXECUTED, AWAITING MERGE (2026-08-02).** All 19 subtasks are
-> complete on `task-122/orchestration-extraction` and the branch is green.
-> This document remains the authoritative plan content for Task 122 and
-> **supersedes `Documents/DECOUPLING_FRAMEWORK.md` §8 Phase 1**, which has been
-> annotated accordingly.
+> **STATUS: COMPLETE. Merged to `main` on 2026-08-03 via PR #472 (merge commit
+> `e533ed00`).** All 19 subtasks are complete and merged. This document remains
+> the authoritative plan content for Task 122 and **supersedes
+> `Documents/DECOUPLING_FRAMEWORK.md` §8 Phase 1**, which has been annotated
+> accordingly.
 >
 > Read the **Execution state** section immediately below before anything else:
 > it records what was done, three subtasks added beyond the signed-off plan,
@@ -16,11 +16,11 @@ version summary and `Documents/MASTER_PLAN.md` for roadmap position.
 
 ---
 
-## Execution state — updated 2026-08-02
+## Execution state — updated 2026-08-03
 
 **Branch: `task-122/orchestration-extraction`.** All subtasks and all three
-cleanup entries are complete and committed; the branch is green. **Awaiting PR /
-merge** (PR #472).
+cleanup entries are complete and committed. **Merged to `main` on 2026-08-03
+via PR #472** (merge commit `e533ed00`).
 
 ### Done — 19 subtasks plus 3 cleanup entries
 

--- a/Documents/PLAN_VERSION_120.md
+++ b/Documents/PLAN_VERSION_120.md
@@ -837,7 +837,7 @@ redraw — to the level set by wezterm and ghostty on the same hardware.
 | Group                                 | Subtasks              | Status      | Covers                                                                                           |
 | ------------------------------------- | --------------------- | ----------- | ------------------------------------------------------------------------------------------------ |
 | A — Completed work                    | 121.1–121.11          | Complete    | PRs #458, #460, #461, #464, #465                                                                 |
-| B — Bugs found and fixed              | 121.12–121.14         | Complete    | blink-off fallback, chrome cache off during motion, animation signal                             |
+| B — Bugs found and fixed              | 121.12–121.14         | Complete    | blink-off fallback; animation signal. NB 121.13 was reverted 2026-08-02 — see 121.32             |
 | B — Bug blocked behind Task 122       | 121.15                | Unblocked   | pane-wide `has_urls` / `scroll_offset` vetoes; left to 121.17                                    |
 | B — Withdrawn                         | 121.16                | Withdrawn   | config kill switch — rejected; revert-and-fix is the remedy                                      |
 | C — Unifying improvement              | 121.17                | Not started | cell-granular pointer suppression; Task 122 seam landed, chrome-cache numbers stale (re-measure) |

--- a/Documents/PLAN_VERSION_120.md
+++ b/Documents/PLAN_VERSION_120.md
@@ -33,8 +33,8 @@ hot, so it ships together):
 
 **Theme 3 — structural cleanup:**
 
-- **Task 122 — Orchestration Extraction** (planned, activated 2026-07-30): decompose the
-  GUI binary's god functions and give orchestration logic (event triage, view window, input
+- **Task 122 — Orchestration Extraction** (complete, merged 2026-08-03 via PR #472): decompose
+  the GUI binary's god functions and give orchestration logic (event triage, view window, input
   encoding, frame decisions) a home. A no-behaviour-change refactor. Required whichever way
   the egui decision falls. Broken down in
   `Documents/PLAN_122_ORCHESTRATION_EXTRACTION.md`; summarised in the Task 122 section below.
@@ -63,7 +63,7 @@ before executing.
 | 119 | Scrollback Compression (LZ4)      | Large     | Complete    | Task 118       |
 | 120 | Compression-Aware Windowed Reflow | Large     | Stub        | Tasks 118, 119 |
 | 121 | Performance Remediation           | Large     | In progress | None           |
-| 122 | Orchestration Extraction          | Large     | Pending merge | None         |
+| 122 | Orchestration Extraction          | Large     | Complete    | None           |
 
 ---
 
@@ -834,19 +834,24 @@ redraw — to the level set by wezterm and ghostty on the same hardware.
 
 ### 121 Subtask summary
 
-| Group                                 | Subtasks      | Status      | Covers                                                                    |
-| ------------------------------------- | ------------- | ----------- | ------------------------------------------------------------------------- |
-| A — Completed work                    | 121.1–121.11  | Complete      | PRs #458, #460, #461, #464, #465                                        |
-| B — Bugs found and fixed              | 121.12–121.14 | Complete      | blink-off fallback, chrome cache off during motion, animation signal    |
-| B — Bug blocked behind Task 122       | 121.15        | Not started   | pane-wide `has_urls` / `scroll_offset` vetoes; left to 121.17            |
-| B — Withdrawn                         | 121.16        | Withdrawn     | config kill switch — rejected; revert-and-fix is the remedy             |
-| C — Unifying improvement              | 121.17        | Not started   | cell-granular pointer suppression (depends on Task 122)                 |
-| D — Unactioned issue #459 items       | 121.18–121.22, 121.24 | Not started | items 3–7 plus per-`CursorMoved` allocations                    |
-| D — Profiling methodology             | 121.23        | Complete      | `Documents/PROFILING.md`; fixed a `Cargo.toml` ref to a nonexistent file |
-| E — Measurement debt                  | 121.27–121.28 | Not started   | `DESIGN_DECISIONS.md` entry, issue #440 pixel harness                   |
-| E — Measurement debt (partly done)    | 121.25        | In progress   | clean Finding 3 re-run done; typing and btop outstanding                |
-| E — Blink-off comparison              | 121.26        | Complete      | blink-off ≈ blink-on ≈ 0.0–0.1% at idle; resolution-limited             |
-| F — Surfaced by the Group B work      | 121.29–121.31 | Not started   | `repaint_causes()`; chrome not built on `Replay`; full present on motion |
+| Group                                 | Subtasks              | Status      | Covers                                                                                           |
+| ------------------------------------- | --------------------- | ----------- | ------------------------------------------------------------------------------------------------ |
+| A — Completed work                    | 121.1–121.11          | Complete    | PRs #458, #460, #461, #464, #465                                                                 |
+| B — Bugs found and fixed              | 121.12–121.14         | Complete    | blink-off fallback, chrome cache off during motion, animation signal                             |
+| B — Bug blocked behind Task 122       | 121.15                | Unblocked   | pane-wide `has_urls` / `scroll_offset` vetoes; left to 121.17                                    |
+| B — Withdrawn                         | 121.16                | Withdrawn   | config kill switch — rejected; revert-and-fix is the remedy                                      |
+| C — Unifying improvement              | 121.17                | Not started | cell-granular pointer suppression; Task 122 seam landed, chrome-cache numbers stale (re-measure) |
+| D — Unactioned issue #459 items       | 121.18–121.22, 121.24 | Not started | items 3–7 plus per-`CursorMoved` allocations                                                     |
+| D — Profiling methodology             | 121.23                | Complete    | `Documents/PROFILING.md`; fixed a `Cargo.toml` ref to a nonexistent file                         |
+| E — Measurement debt                  | 121.27–121.28         | Not started | `DESIGN_DECISIONS.md` entry, issue #440 pixel harness                                            |
+| E — Measurement debt (partly done)    | 121.25                | In progress | clean Finding 3 re-run done; typing and btop outstanding                                         |
+| E — Blink-off comparison              | 121.26                | Complete    | blink-off ≈ blink-on ≈ 0.0–0.1% at idle; resolution-limited                                      |
+| F — Surfaced by the Group B work      | 121.29–121.31         | Not started | `repaint_causes()`; chrome not built on `Replay`; full present on motion                         |
+| G — beta.7 interaction regression     | 121.32                | Complete    | chrome cache disabled by default; tab-click / border-drag regression fixed                       |
+| G — Surfaced by 121.32                | 121.33                | Not started | `Full`/`Replay` `Ui` id divergence churns pane-border drag state                                 |
+| G — Chrome-cache decision gate        | 121.34                | Not started | measure always-`Full` cost; decides keep/delete/confine (121.32)                                 |
+| G — Chrome-cache waste while disabled | 121.35                | Deferred    | stop populating cache while disabled; Task 122 takes priority                                    |
+| G — Confine Replay to non-chrome      | 121.36                | Conditional | confine `Replay` to pointer-not-over-chrome frames; conditional on 121.34, blocked on 121.33     |
 
 ### 121 Headline result
 
@@ -884,10 +889,11 @@ those numbers and do not contradict them.
 
 ## Task 122 — Orchestration Extraction
 
-> **STATUS: PLANNED (activated 2026-07-30), awaiting sign-off.** The full per-subtask
-> breakdown is `Documents/PLAN_122_ORCHESTRATION_EXTRACTION.md` (17 subtasks in five
-> groups). That document **supersedes** `Documents/DECOUPLING_FRAMEWORK.md` §8 Phase 1,
-> whose subtasks 1.1–1.6 and line counts are stale. This section is a summary only.
+> **STATUS: COMPLETE.** Merged to `main` on 2026-08-03 via PR #472 (merge commit
+> `e533ed00`). The full per-subtask breakdown is
+> `Documents/PLAN_122_ORCHESTRATION_EXTRACTION.md` (17 subtasks in five groups). That
+> document **supersedes** `Documents/DECOUPLING_FRAMEWORK.md` §8 Phase 1, whose subtasks
+> 1.1–1.6 and line counts are stale. This section is a summary only.
 
 ### 122 Summary
 
@@ -924,17 +930,19 @@ priced accurately.
 
 ### 122 Sequencing within the version
 
-Independent of Tasks 118–120 entirely (different crates). Against Task 121 it is a blocker
-for exactly one subtask:
+Independent of Tasks 118–120 entirely (different crates). Against Task 121 it was a blocker
+for exactly one subtask, now discharged:
 
-- **121.17 (cell-granular suppression) depends on Task 122.** It needs per-pane render-time
-  geometry captured during `update()` and read from the event layer, which is the seam this
-  task builds. Adding a fifth round to the suppression predicate in its current shape is how
-  the maintainability argument for the rewrite gets stronger for no good reason.
-- **Everything else in Task 121 is independent.** Groups D and E live in `shaping.rs`,
+- **121.17 (cell-granular suppression) depended on Task 122** for per-pane render-time
+  geometry captured during `update()` and read from the event layer — the seam this task
+  built. Adding a fifth round to the suppression predicate in its current shape would have
+  made the maintainability argument for the rewrite stronger for no good reason. Task 122
+  merged (PR #472, 2026-08-03) and subtask 122.15 publishes that seam, so 121.17 is now
+  **unblocked** — see its entry in `PLAN_121_PERF_REMEDIATION.md` for the re-check-your-
+  assumptions caveat left by the chrome-cache changes.
+- **Everything else in Task 121 was independent.** Groups D and E live in `shaping.rs`,
   `vertex.rs`, `atlas.rs`, the GL layer and `freminal-windowing`, none of which Task 122
-  touches; 121.12–121.15 sit in already-extracted predicates. Do not gate the live bug fixes
-  behind this refactor.
+  touched; 121.12–121.15 sit in already-extracted predicates.
 
 ### 122 Activation outcome (2026-07-30)
 

--- a/agents.md
+++ b/agents.md
@@ -282,12 +282,23 @@ decomposing.
 For tasks with ordered dependencies (e.g. multi-phase refactors):
 
 1. Read the entire task document before doing anything.
-2. Find the first incomplete step.
-3. Execute it. Keep its scope exactly as written.
-4. Run the verification suite -- confirm it passes.
-5. Update the tracking document: mark the step complete, add a brief
+2. Reconcile the document against git before trusting it: check the
+   current branch, whether it is pushed, and whether it is ahead of
+   or behind the target branch -- recent commits may already
+   implement steps the document still shows as open. A plan document
+   records intent; only git records what actually landed. Where they
+   disagree on *bookkeeping* -- a step done but still shown open --
+   git wins and the document gets corrected in passing (for
+   `MASTER_PLAN.md` specifically, `freminal-plan-status-lifecycle`
+   governs the status values). Where they disagree on *substance* --
+   the plan's technical premise no longer matches the code -- that is
+   an `autonomy-boundaries` hard stop, not a correction.
+3. Find the first incomplete step.
+4. Execute it. Keep its scope exactly as written.
+5. Run the verification suite -- confirm it passes.
+6. Update the tracking document: mark the step complete, add a brief
    note.
-6. Continue to the next step.
+7. Continue to the next step.
 
 Each step must leave `cargo test --all` passing before the next one
 starts -- a red suite is a full stop, not something to fix on the way

--- a/freminal-windowing/src/egui_integration.rs
+++ b/freminal-windowing/src/egui_integration.rs
@@ -607,17 +607,25 @@ struct ChromeGatePredicates {
 /// never needs the chrome widgets on a `Replay` frame — and it does, because
 /// egui resolves *interaction*, not just painting, against the widget set:
 ///
-/// | Site                  | Code                                            |
-/// | --------------------- | ----------------------------------------------- |
-/// | `context.rs:475`      | `hit_test(&viewport.prev_pass.widgets, …)`      |
-/// | `context.rs:488`      | `interact(…, &viewport.prev_pass.widgets, …)`   |
-/// | `interaction.rs:109`  | clears `potential_click_id` if absent from it   |
+/// | Site                     | Code                                                       |
+/// | ------------------------ | ----------------------------------------------------------- |
+/// | `context.rs:487`         | `hit_test(&viewport.prev_pass.widgets, …)`                |
+/// | `context.rs:500`         | `interact(…, &viewport.prev_pass.widgets, …)`             |
+/// | `interaction.rs:109-123` | absent from that set: `potential_click_id` is **cleared**; `potential_drag_id` is deliberately **left alone** ("this could be drag-and-drop, and the widget being dragged is now 'in the air'") |
 ///
-/// Note `prev_pass` — the PREVIOUS frame's set. So a press on frame N can
-/// only hit a widget built on frame N-1, and a single `Replay` frame
-/// anywhere in a gesture discards the in-flight click or drag. In
-/// 0.12.0-beta.7 this made tab clicks mostly fail and pane-border drags
-/// unusable, worst while a TUI ran in a pane (a TUI supplies a stream of
+/// Note `prev_pass` — the PREVIOUS frame's set. A press on frame N can only
+/// hit a widget built on frame N-1, and a single `Replay` frame discards an
+/// in-flight *click*. Neither of those covers drags: an in-flight drag is
+/// deliberately preserved by egui (above), so the click and drag symptoms in
+/// 0.12.0-beta.7 do NOT share one mechanism:
+///
+/// - **Tab clicks** fail here. The tab strip is built only on `Full`, so on a
+///   `Replay` frame it is genuinely absent from the set.
+/// - **Pane-border drags do NOT fail here.** Those sensors are built on both
+///   paths, so they are never absent — they fail by `Ui` id churn across a
+///   `Full`/`Replay` toggle, which is subtask 121.33, not this mechanism.
+///
+/// Both were worst while a TUI ran in a pane (a TUI supplies a stream of
 /// PTY-driven frames, every one eligible for `Replay`, during the moment the
 /// pointer is at rest before a click).
 ///
@@ -626,7 +634,9 @@ struct ChromeGatePredicates {
 /// that `Replay` frames do not register widgets. Any re-enabling must first
 /// make `Replay` construct the chrome widgets (and only skip their
 /// tessellation/paint), or otherwise guarantee `Full` on every frame the user
-/// could interact on **and the frame before it**. See 121.32 / 121.33 in
+/// could interact on **and the frame before it** — *and* must fix 121.33
+/// first, since that is the whole of the drag symptom and is untouched by
+/// either remedy. See 121.32 / 121.33 in
 /// `Documents/PLAN_121_PERF_REMEDIATION.md`.
 ///
 /// The env var exists so the two states can be A/B'd in one binary, using the


### PR DESCRIPTION
Documentation-only. No production logic changes; the single source file touched is a comment-only edit to `freminal-windowing/src/egui_integration.rs`.

Four atomic commits, each independently verifiable.

## 1. Task 122 status reconciliation (`65ecca12`)

Task 122 merged on 2026-08-03 via #472, but three documents still described it as pending merge / awaiting sign-off. Per `freminal-plan-status-lifecycle` the merge is the `Complete` trigger and the two `MASTER_PLAN` tables must agree.

Also brought `PLAN_VERSION_120`'s Task 121 subtask table into agreement with `PLAN_121` (authoritative) — it was missing Group G entirely.

No status other than Task 122's is advanced. Task 121 and v0.12.0 stay `In progress`; Task 120 stays a `Stub`.

## 2. Group D recon findings (`8419e65b`)

Read-only recon on the two highest-priority Group D subtasks. **Both are mis-scoped in their current entries.** No implementation here — recording evidence so neither gets re-derived.

**121.18 is a redesign, not a subtask.** Four blockers, each sufficient alone:

- instance buffers are variable-length per row (bg skips `DefaultBackground`, fg skips zero-size glyphs) with no row-offset index, so one cell's change shifts every later row
- `deco_verts` is not row-major past its first section
- no per-row dirty signal survives to the call site — `frame_dirty` derives one global bit from `Arc::ptr_eq` over the whole visible array
- `upload_verts` orphans the VBO before every write, forbidding partial `glBufferSubData` without abandoning the anti-stall pattern and the double-buffer discipline #432 depends on

That is a vertex-representation redesign plus a new dirty channel plus a GL upload change, to recover a measured 4.80% self time.

**121.19's premise holds but its proposed fix is dead on arrival.** No fast path exists and `general_category` genuinely is unreachable from freminal code. But ASCII is exactly where ligatures fire (`->`, `=>`, `!=`), so the only safe gate is `ligatures == false` — and that defaults to `true`. Records two alternatives that work with ligatures enabled, explicitly not implemented: per 121.24's standing rule there is no shaping cache instrumentation and no benchmark modelling the TUI-redraw workload that produced the 8.56%.

All 25 file:line citations verified exact.

## 3. egui 0.36.1 citation re-verification (`9718110d`)

The 0.35.0 → 0.36.1 bump (`06701ce8`) re-verified `EGUI_UPGRADE_ASSUMPTIONS.md` but left Task 121's citations of egui internals pointing at the old tree.

**Every conclusion survives.** Drift is pure line-number churn. `context.rs:102-105`, `109-122`, `158-168` and all of `interaction.rs` are byte-identical across versions.

Two citations were wrong in **both** versions — pre-existing, not bump-induced:

1. 121.29 cited `context.rs:157-159` for the unconditional `causes.push`. It is at `:153`; the early-out it precedes is at `:158`. Substance right, reference off by four.
2. **121.32 asserted as established fact that `potential_drag_id` is cleared like `potential_click_id`. It is not** — egui detects the missing drag widget and deliberately does nothing.

The second matters for future decisions. Splitting click from drag shows the two beta.7 symptoms never shared a mechanism: tab clicks are explained by the tab strip being absent on `Replay`, but pane-border drags are explained by **neither** consequence — those sensors are built on both paths (121.33), so are never absent, and an in-flight drag is preserved by design.

This eliminates the last mechanism in 121.32 that could have covered the drag symptom, promoting **121.33** from "probably an active participant" to the only remaining candidate and a hard prerequisite for re-enabling. **121.32's verdict is unchanged and the cache stays disabled** — consequence 1 alone condemns it on the tab-click evidence, and the fix is maintainer-confirmed under real use.

## 4. Onboarding gaps from a cold-start test (`6d8381c4`)

A fresh agent was given only *"pick up the work in 121"* and asked where it stumbled. It navigated correctly and picked a defensible subtask, but found three gaps:

- **Nothing told it to check git.** It reconciled against git on its own initiative and only thereby found unpushed work the plan described as done. `agents.md`'s Multi-Step Task Protocol gains a step for this, deliberately distinguishing bookkeeping drift (correct in passing) from substantive disagreement (an `autonomy-boundaries` hard stop).
- **121.17's measured-prize table was a skimmer's trap** — staleness warning 40 lines above, table headed "measured prize" opening "No longer an argument". Marked stale at the heading; the now-meaningless `Replay %` column annotated.
- **`DECOUPLING_FRAMEWORK.md` was invisible from `MASTER_PLAN`** despite being source of truth for 121's Phase 0 measurements.

Also fixed drift these paragraphs had accumulated: `MASTER_PLAN` still called 121.15 blocked behind Task 122, omitted Group G, and miscounted 121.29–121.31 as two items; `PLAN_121` contradicted its own summary table in three places and counted the reverted 121.13 among the merged.

## Verification

- `cargo test -p freminal-windowing` — 103 passed
- `cargo clippy -p freminal-windowing --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- markdownlint + codespell clean under the actual hook config
- Full pre-commit suite incl. `xtask-check` passed on all four commits

Every commit reviewed by an adversarial sub-agent before landing. That review caught a genuine blocking error in commit 3 — an incorrect drag-mechanism attribution that contradicted 121.33 — which was corrected in both the plan and the code comment before commit.

## Not included

The Group D performance work itself remains unimplemented. The open question is whether to instrument first (shaping cache hit/miss counters plus a TUI-redraw benchmark) or implement speculatively. Recommendation is instrument first, since neither candidate lever currently has a measured hit rate to justify it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project plans and task tracking to reflect completed and merged work.
  * Clarified dependencies, outstanding performance investigations, and current subtask statuses.
  * Documented findings related to tab-click and pane-border drag behavior.
  * Added Git reconciliation checks to the multi-step task workflow.
  * Expanded technical guidance for safely re-enabling chrome caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->