### PR TITLE
fix: v0.12.1 bug sweep — 10 fixes, rust 1.98.0

### DIFF
--- a/.opencode/skills/freminal-cursor-affordances/SKILL.md
+++ b/.opencode/skills/freminal-cursor-affordances/SKILL.md
@@ -56,14 +56,18 @@ covered and each needs `.clickable()`:
 | Widget | Covered by `interact_cursor`? |
 | ------------------------- | ----- |
 | `ui.button` / `small_button` / `Button::new` | yes — do nothing |
-| `ui.menu_button`, `ComboBox` header | yes — do nothing |
+| `ui.menu_button` | yes — do nothing |
+| `ComboBox` header | **no** — `.show_ui(..).response.clickable()` |
 | `ui.selectable_value` | **no** — add `.clickable()` |
 | `ui.selectable_label` | **no** — add `.clickable()` |
 | `ui.checkbox` | **no** — add `.clickable()` |
 | `ui.radio` / `radio_value` | **no** — add `.clickable()` |
 | `ui.toggle_value` | **no** — add `.clickable()` |
 | `ui.hyperlink` / `hyperlink_to` / `link` | **no** — add `.clickable()` |
+| `Slider` | **no** — add `.draggable()` |
 | anything hand-rolled via `ui.interact(..)` | **no** — add `.clickable()` |
+| `DragValue` | n/a — egui sets its own arrows, leave it |
+| scrollbars (egui's and ours) | n/a — no cursor, by convention |
 
 Use the vocabulary in `freminal/src/gui/hover_cursor.rs`:
 
@@ -75,19 +79,29 @@ ui.selectable_value(&mut cfg.mode, ThemeMode::Dark, "Dark").clickable();
 ui.add_enabled(can_save, save_widget).clickable_when(can_save);
 ```
 
-Three methods, naming intent rather than appearance:
+Four methods, naming intent rather than appearance:
 
 - `.clickable()` — pointing hand. Anything that performs an action on click.
 - `.disabled_affordance()` — `NotAllowed`. Present but not actionable; a hand
   on something inert is a lie.
 - `.clickable_when(enabled)` — picks between the two. Pairs with `add_enabled`.
+- `.draggable()` — `Grab`, becoming `Grabbing` mid-drag. For handles you pick
+  up and move; sliders, in practice.
 
 ### What must NOT get a hand
 
 - **Text fields.** egui already gives `TextEdit` an I-beam, which correctly
   says "type here", not "click here". Leave it.
-- **Drag handles.** They get a directional resize cursor so the drag axis is
-  visible. See Part 3.
+- **Pane dividers.** They get a directional resize cursor so the drag axis is
+  visible. See Part 3. (Sliders are different: `.draggable()`, because the
+  axis is already obvious from the rail.)
+- **`DragValue`** — the number box beside a slider. egui gives it
+  `ResizeEast`/`ResizeHorizontal`/`ResizeWest`, which is truthful: dragging is
+  its primary interaction, and the east/west variants signal that the value is
+  clamped at a limit. It looks like a text field and invites an I-beam; do not
+  give it one, that would hide the drag entirely.
+- **Scrollbars**, egui's and freminal's own. GTK, macOS and browsers all keep
+  the plain arrow over a scrollbar; deviating makes freminal the odd one out.
 - **Plain labels.** Obviously.
 
 ---

--- a/.opencode/skills/freminal-cursor-affordances/SKILL.md
+++ b/.opencode/skills/freminal-cursor-affordances/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: freminal-cursor-affordances
+description: Use ONLY when working in the freminal repository AND adding or debugging anything that changes the mouse cursor, or adding a new clickable/draggable element to the GUI — a chrome widget (button, menu entry, tab, checkbox, combo box, link), a hover affordance on the terminal surface (URL, command-block gutter, fold placeholder), or a drag handle (pane divider). Triggers on "the cursor doesn't change", "the hand only shows in one pane", "the cursor flickers while dragging", "the resize arrow region is smaller than the grab region", "hovering my new button shows a plain arrow", or any use of set_cursor_icon / output.cursor_icon / on_hover_cursor. Codifies the single-writer rule for output.cursor_icon and the per-widget-type affordance rules.
+---
+
+# Freminal: `output.cursor_icon` has exactly one writer per frame
+
+`egui::PlatformOutput::cursor_icon` is **one field for the whole window**, and
+egui resets it to `Default` at the start of every frame. `Context::set_cursor_icon`
+and `output_mut(|o| o.cursor_icon = ..)` are both plain unconditional writes with
+**no priority mechanism whatsoever**:
+
+```rust
+pub fn set_cursor_icon(&self, cursor_icon: CursorIcon) {
+    self.output_mut(|o| o.cursor_icon = cursor_icon);   // that is the entire body
+}
+```
+
+So when two pieces of code both want a say, **whichever runs later in the frame
+silently wins**. Nothing warns you. The losing call looks completely correct at
+its own call site.
+
+This has produced four separate bugs in this repo (issues #462, #493). Every one
+of them was "I wrote the correct cursor and nothing happened".
+
+## The rule
+
+> Compute what the cursor should be, resolve the contenders with an explicit
+> precedence, and write it **once**. Never write `cursor_icon` speculatively and
+> hope you run last.
+
+---
+
+## Part 1 — chrome widgets (menus, buttons, tabs, modals)
+
+### Buttons are handled globally — do nothing
+
+`freminal/src/gui/chrome_style.rs` sets:
+
+```rust
+visuals.interact_cursor = Some(egui::CursorIcon::PointingHand);
+```
+
+egui consults this from `Button`'s own paint path, so **anything built on
+`egui::Button` gets the pointing hand for free** — `ui.button`,
+`ui.small_button`, `ui.add(Button::new(..))`, `ui.add_enabled(.., Button::new(..))`,
+menu entries, and the `ComboBox` header.
+
+Do **not** add `.clickable()` to those. It is redundant.
+
+### Everything else must opt in explicitly
+
+egui only honours `interact_cursor` from `Button`. These widgets are **not**
+covered and each needs `.clickable()`:
+
+| Widget | Covered by `interact_cursor`? |
+| ------------------------- | ----- |
+| `ui.button` / `small_button` / `Button::new` | yes — do nothing |
+| `ui.menu_button`, `ComboBox` header | yes — do nothing |
+| `ui.selectable_value` | **no** — add `.clickable()` |
+| `ui.selectable_label` | **no** — add `.clickable()` |
+| `ui.checkbox` | **no** — add `.clickable()` |
+| `ui.radio` / `radio_value` | **no** — add `.clickable()` |
+| `ui.toggle_value` | **no** — add `.clickable()` |
+| `ui.hyperlink` / `hyperlink_to` / `link` | **no** — add `.clickable()` |
+| anything hand-rolled via `ui.interact(..)` | **no** — add `.clickable()` |
+
+Use the vocabulary in `freminal/src/gui/hover_cursor.rs`:
+
+```rust
+use super::hover_cursor::HoverAffordance;
+
+ui.checkbox(&mut cfg.ligatures, "Enable Ligatures").clickable();
+ui.selectable_value(&mut cfg.mode, ThemeMode::Dark, "Dark").clickable();
+ui.add_enabled(can_save, save_widget).clickable_when(can_save);
+```
+
+Three methods, naming intent rather than appearance:
+
+- `.clickable()` — pointing hand. Anything that performs an action on click.
+- `.disabled_affordance()` — `NotAllowed`. Present but not actionable; a hand
+  on something inert is a lie.
+- `.clickable_when(enabled)` — picks between the two. Pairs with `add_enabled`.
+
+### What must NOT get a hand
+
+- **Text fields.** egui already gives `TextEdit` an I-beam, which correctly
+  says "type here", not "click here". Leave it.
+- **Drag handles.** They get a directional resize cursor so the drag axis is
+  visible. See Part 3.
+- **Plain labels.** Obviously.
+
+---
+
+## Part 2 — the terminal surface
+
+Terminal panes do **not** use `HoverAffordance`. They have their own resolution
+in `freminal/src/gui/terminal/widget.rs`, because they must additionally
+arbitrate against the application's OSC 22 pointer shape.
+
+```rust
+let pointer_hover = PointerHover {
+    command_block_gutter: gutter_hovered,
+    fold_placeholder: placeholder_hovered,
+    url: cache.cached_hovered_url.is_some(),
+};
+```
+
+`PointerHover::resolve()` reduces those to a single `PointerTarget`, ordered by
+descending precedence: **gutter → fold placeholder → URL → terminal content**.
+Only `TerminalContent` defers to OSC 22. `cursor_icon_for` maps the winner to
+an icon, and it is written exactly once.
+
+**Adding a new hoverable thing on the terminal surface?** Add a field to
+`PointerHover`, a variant to `PointerTarget` at the right precedence position,
+and an arm to `cursor_icon_for`. Do not add another `set_cursor_icon` call.
+
+### Only the pane under the pointer may write
+
+Every pane runs this code every frame. An unconditional write means the **last
+pane rendered decides the cursor for the entire window** — which presents as
+"the hand only works in the bottom pane of a split" and, worse, stamps over the
+cursors egui set for its own chrome.
+
+```rust
+if ui.rect_contains_pointer(pane_rect) && split_border_hover == SplitBorderHover::Clear {
+    ui.ctx().output_mut(|o| o.cursor_icon = resolved_icon);
+}
+```
+
+`rect_contains_pointer` respects layer and clip rect, so a modal drawn above the
+pane keeps its own cursor. It does **not** account for same-layer overlaps —
+hence the explicit `SplitBorderHover` term, see Part 3.
+
+---
+
+## Part 3 — drag handles (pane dividers)
+
+Dividers are the awkward case and account for two of the four bugs.
+
+**Their hit sensor is intentionally wider than the thing it moves** (3px either
+side of a 1px line), so the pointer sits *geometrically inside an adjacent pane*
+while *logically over chrome*. Sensors are not a separate egui layer, so
+`rect_contains_pointer` cannot see them. They must be passed to the pane
+explicitly as `SplitBorderHover` so it abstains.
+
+Two invariants, both learned the hard way:
+
+1. **Drive the abstain-gate from the same condition that writes the cursor.**
+   The sensor rects are built from `borders`, computed at the top of the frame
+   and therefore *one frame behind* the divider that `resize_split` is actively
+   moving. During a drag the pointer routinely runs ahead of the stale rect. A
+   gate that independently hit-tests the published rects will disagree with the
+   write exactly when it matters, and the cursor flickers. Set a flag where the
+   cursor is applied (`response.hovered() || response.dragged()`), and gate on
+   that flag — plus `border_drag_active`, so an in-flight drag keeps the cursor
+   even on a frame where the rect has fallen behind entirely.
+
+2. **Request a repaint when the drag ends.** `drag_stopped` applies the final
+   resize, but this frame's rects predate it and nothing else schedules another
+   frame — so the cursor drops to the default arrow with the pointer still over
+   the divider. Call `ctx.request_repaint()` on release.
+
+The drag cursor stays the **directional resize arrow** for the whole gesture,
+rather than switching to `Grabbing`. That is a deliberate product decision: it
+matches GNOME/KDE/VS Code/browser splitters and keeps the drag axis visible.
+
+---
+
+## How to verify
+
+There is no automated test for the applied cursor — it needs a live egui
+context and a real pointer. The *decision* logic is unit-tested
+(`pointer_target_tests`, `input_suppressors_tests` in `widget.rs`); extend those
+when you change precedence. The rest is manual, and these are the checks that
+actually catch the bugs above:
+
+1. Hover the new element — cursor changes.
+2. **Do it in a split, in every pane**, not just one. Single-pane and
+   bottom-pane both mask the multi-writer bug.
+3. Move from the element onto plain terminal text — the cursor reverts. A
+   *stuck* cursor is as much a bug as an absent one.
+4. For a drag handle: the cursor must change at the same moment the handle
+   becomes grabbable (regions match), hold steady for the whole drag (no
+   flicker), and persist after release.
+5. With an app that sets OSC 22 running in one pane, confirm each pane keeps its
+   own shape.
+
+## When to stop and ask
+
+- You want a *new* precedence order on the terminal surface (e.g. URL should
+  outrank the gutter). That is a product decision, not an implementation
+  detail — confirm it.
+- You believe a widget needs a cursor other than hand / not-allowed / I-beam /
+  resize. Surface it rather than inventing a fourth vocabulary word.
+- You are tempted to write `cursor_icon` from a new location. Almost certainly
+  the answer is a new contender in an existing resolution, not a new writer.

--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786599213,
-        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "lastModified": 1787135253,
+        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
         "type": "github"
       },
       "original": {
@@ -90,11 +90,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1786599213,
-        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "lastModified": 1787135253,
+        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
         "type": "github"
       },
       "original": {
@@ -128,11 +128,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1786642535,
-        "narHash": "sha256-pZ9Tbmj5AUUezFpFLpK6p5GihP0GOZxaF+hR5r1wI5U=",
+        "lastModified": 1787255351,
+        "narHash": "sha256-IYaW/khfzDddfQpSveV3iQrGzf/Ti2NCDwFLZ2Z0gec=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "edd622fddbac6968ee7185e28abb3a7b9bc289f1",
+        "rev": "40049176bd78e79a84322502e11770db8e042e1f",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1786638241,
-        "narHash": "sha256-KJhq0HYg2gIZjpsj47z1kWrjoUUAqSqdD2mMWAsOg4k=",
+        "lastModified": 1787246814,
+        "narHash": "sha256-pEd4/iPY3Zm/EhhHmeB1QnIWXJSLx7gJzD/05mm2MCo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "892c035d7c2ff75acd5da10424a47ab454e1f3dc",
+        "rev": "c84e121aaede7ef8c7bd9fb5154ccc1599e07816",
         "type": "github"
       },
       "original": {
@@ -174,11 +174,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786638241,
-        "narHash": "sha256-KJhq0HYg2gIZjpsj47z1kWrjoUUAqSqdD2mMWAsOg4k=",
+        "lastModified": 1787246814,
+        "narHash": "sha256-pEd4/iPY3Zm/EhhHmeB1QnIWXJSLx7gJzD/05mm2MCo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "892c035d7c2ff75acd5da10424a47ab454e1f3dc",
+        "rev": "c84e121aaede7ef8c7bd9fb5154ccc1599e07816",
         "type": "github"
       },
       "original": {

--- a/freminal-buffer/src/buffer/mod.rs
+++ b/freminal-buffer/src/buffer/mod.rs
@@ -543,9 +543,7 @@ impl Buffer {
             return;
         }
         self.auto_detect_urls = enabled;
-        for entry in &mut self.row_cache {
-            *entry = None;
-        }
+        self.row_cache.fill(None);
         for row in &mut self.rows {
             row.mark_dirty();
         }
@@ -9398,9 +9396,7 @@ mod scrollback_compaction_tests {
             row.ensure_live();
             row.mark_dirty();
         }
-        for entry in &mut buf.row_cache {
-            *entry = None;
-        }
+        buf.row_cache.fill(None);
 
         let (live_vis_chars, live_vis_tags, ..) = buf.visible_as_tchars_and_tags(0);
         let (live_sb_chars, live_sb_tags, ..) = buf.scrollback_as_tchars_and_tags(0);

--- a/freminal-buffer/src/buffer/mod.rs
+++ b/freminal-buffer/src/buffer/mod.rs
@@ -689,17 +689,35 @@ impl Buffer {
         }
     }
 
-    /// Reset an existing row at `row_idx` to a soft-wrap continuation and update
-    /// `image_cell_count` for the cells being discarded.
+    /// Mark an existing row at `row_idx` as a soft-wrap continuation of the
+    /// logical line above it.
     ///
-    /// Called from `insert_text` whenever a new wrap causes an already-populated
-    /// row to be recycled as a continuation line.
+    /// Called from [`Self::advance_row_for_wrap`] whenever autowrap moves the
+    /// cursor onto a row that already exists in the grid.
+    ///
+    /// This updates the row's logical-line metadata **only**. It deliberately
+    /// does not clear the row's cells: autowrap is defined as cursor movement,
+    /// so the destination row's existing content survives and is overwritten
+    /// one cell at a time by whatever is actually printed. Clearing here
+    /// destroyed cells the wrapping text never wrote to, which broke the
+    /// extremely common TUI idiom of repainting a wrapped line by touching a
+    /// few cells and using `CUF`/absolute positioning to skip the rest --
+    /// neovim redrawing a long soft-wrapped line writes one space at column 0,
+    /// `CSI 122 C`, then the final character, and relies on autowrap alone to
+    /// step to the next row. With the clear, every such row lost every cell
+    /// except the two it explicitly wrote (issue #491).
+    ///
+    /// `image_cell_count` is therefore left alone as well: no cells are
+    /// discarded here, so nothing has left the grid to account for. Image
+    /// cells that the wrapping text does overwrite are debited by the normal
+    /// write path.
     fn reuse_row_as_softwrap(&mut self, row_idx: usize) {
         let row = &mut self.rows[row_idx];
-        self.image_cell_count -= row.count_image_cells();
         row.origin = RowOrigin::SoftWrap;
         row.join = RowJoin::ContinueLogicalLine;
-        row.clear();
+        // Metadata changed: `join`/`origin` feed wrapped-URL grouping, so the
+        // cached flat representation of this row must be rebuilt even though
+        // the cells themselves are untouched.
         self.row_cache[row_idx] = None;
     }
 

--- a/freminal-buffer/tests/buffer_tests.rs
+++ b/freminal-buffer/tests/buffer_tests.rs
@@ -359,23 +359,53 @@ fn autowrap_onto_existing_row_preserves_unwritten_cells() {
 
 /// The wrapped row is still marked as a continuation of the logical line
 /// above, even though its pre-existing cells survive.
+///
+/// The destination row is built through a **hard break** (`handle_lf`) and
+/// asserted to be one before the wrap. Reaching it via an earlier wrap would
+/// have left it already `SoftWrap`/`ContinueLogicalLine`, making the
+/// post-wrap assertions pass no matter what `reuse_row_as_softwrap` did.
 #[test]
 fn autowrap_onto_existing_row_still_marks_it_a_continuation() {
     use freminal_buffer::row::{RowJoin, RowOrigin};
 
     let mut buf = Buffer::new(5, 10);
+
+    // Fill row 0, then reach row 1 with a line feed rather than a wrap, so
+    // the destination row genuinely starts its own logical line.
     buf.insert_text(&[ascii('A'); 5]);
+    buf.handle_lf();
+    buf.set_cursor_pos(Some(0), Some(1));
     buf.insert_text(&[ascii('B'); 5]);
 
-    // Row 1 was created by the first wrap, so reset it to a hard break to
-    // prove the second wrap is what re-marks it.
+    assert_eq!(
+        buf.rows()[1].origin,
+        RowOrigin::HardBreak,
+        "precondition: the destination row starts as a hard break"
+    );
+    assert_eq!(
+        buf.rows()[1].join,
+        RowJoin::NewLogicalLine,
+        "precondition: the destination row starts its own logical line"
+    );
+
+    // Fill row 0 to the right margin, then print one more character so
+    // autowrap lands on row 1.
     buf.set_cursor_pos(Some(4), Some(0));
     buf.insert_text(&[ascii('Z')]);
     buf.insert_text(&[ascii('Q')]);
 
     let row = &buf.rows()[1];
-    assert_eq!(row.origin, RowOrigin::SoftWrap);
+    assert_eq!(
+        row.origin,
+        RowOrigin::SoftWrap,
+        "the wrap must re-mark the destination row as a continuation"
+    );
     assert_eq!(row.join, RowJoin::ContinueLogicalLine);
+    assert_eq!(
+        row_text(&buf, 1, 5),
+        "QBBBB",
+        "and it must still preserve the cells it did not write"
+    );
 }
 
 /// Text that wraps and then keeps writing must still overwrite the cells it

--- a/freminal-buffer/tests/buffer_tests.rs
+++ b/freminal-buffer/tests/buffer_tests.rs
@@ -310,3 +310,90 @@ fn bce_default_tag_leaves_rows_sparse() {
         );
     }
 }
+
+//
+// ─── autowrap must not erase the row it wraps onto (issue #491) ──────────────
+//
+
+/// Read a row's cells as a `String`, blanks included.
+fn row_text(buf: &Buffer, row: usize, width: usize) -> String {
+    let row = &buf.rows()[row];
+    (0..width)
+        .map(|col| row.resolve_cell(col).tchar().to_string())
+        .collect()
+}
+
+/// Autowrap is defined as cursor movement. Moving onto an already-populated
+/// row must leave that row's cells alone; only the cells actually written to
+/// may change.
+///
+/// This previously cleared the whole destination row, which destroyed content
+/// the wrapping text never wrote to.
+#[test]
+fn autowrap_onto_existing_row_preserves_unwritten_cells() {
+    let mut buf = Buffer::new(5, 10);
+
+    // Row 0 = AAAAA (fills the row, leaving the cursor in pending wrap),
+    // row 1 = BBBBB.
+    buf.insert_text(&[ascii('A'); 5]);
+    buf.insert_text(&[ascii('B'); 5]);
+    assert_eq!(row_text(&buf, 0, 5), "AAAAA");
+    assert_eq!(row_text(&buf, 1, 5), "BBBBB");
+
+    // Put the cursor at the end of row 0 and write one character, which leaves
+    // the cursor in the pending-wrap state.
+    buf.set_cursor_pos(Some(4), Some(0));
+    buf.insert_text(&[ascii('Z')]);
+    assert_eq!(row_text(&buf, 0, 5), "AAAAZ");
+
+    // The next character autowraps onto row 1 and writes a single cell there.
+    buf.insert_text(&[ascii('Q')]);
+    assert_eq!(buf.cursor().pos.y, 1);
+    assert_eq!(buf.cursor().pos.x, 1);
+    assert_eq!(
+        row_text(&buf, 1, 5),
+        "QBBBB",
+        "autowrap must overwrite only the cell it writes, not clear the row"
+    );
+}
+
+/// The wrapped row is still marked as a continuation of the logical line
+/// above, even though its pre-existing cells survive.
+#[test]
+fn autowrap_onto_existing_row_still_marks_it_a_continuation() {
+    use freminal_buffer::row::{RowJoin, RowOrigin};
+
+    let mut buf = Buffer::new(5, 10);
+    buf.insert_text(&[ascii('A'); 5]);
+    buf.insert_text(&[ascii('B'); 5]);
+
+    // Row 1 was created by the first wrap, so reset it to a hard break to
+    // prove the second wrap is what re-marks it.
+    buf.set_cursor_pos(Some(4), Some(0));
+    buf.insert_text(&[ascii('Z')]);
+    buf.insert_text(&[ascii('Q')]);
+
+    let row = &buf.rows()[1];
+    assert_eq!(row.origin, RowOrigin::SoftWrap);
+    assert_eq!(row.join, RowJoin::ContinueLogicalLine);
+}
+
+/// Text that wraps and then keeps writing must still overwrite the cells it
+/// actually covers -- the fix must not turn wrapping into a no-op paint.
+#[test]
+fn autowrap_still_overwrites_cells_the_text_covers() {
+    let mut buf = Buffer::new(5, 10);
+    buf.insert_text(&[ascii('A'); 5]);
+    buf.insert_text(&[ascii('B'); 5]);
+
+    buf.set_cursor_pos(Some(0), Some(0));
+    // 8 characters: 5 fill row 0, the remaining 3 wrap onto row 1.
+    buf.insert_text(&[ascii('C'); 8]);
+
+    assert_eq!(row_text(&buf, 0, 5), "CCCCC");
+    assert_eq!(
+        row_text(&buf, 1, 5),
+        "CCCBB",
+        "the wrapped text overwrites the cells it covers and no more"
+    );
+}

--- a/freminal-common/src/buffer_states/sixel.rs
+++ b/freminal-common/src/buffer_states/sixel.rs
@@ -294,11 +294,12 @@ impl SixelDecoder {
                 SixelBackground::Paint => {
                     let (r, g, b) = self.palette[0];
                     let mut buf = vec![0u8; size];
-                    for pixel in buf.chunks_exact_mut(4) {
-                        pixel[0] = r;
-                        pixel[1] = g;
-                        pixel[2] = b;
-                        pixel[3] = 255;
+                    // `as_chunks_mut` yields fixed-size arrays, so the four
+                    // component writes are bounds-check-free (clippy 1.98's
+                    // `chunks_exact_to_as_chunks`). `size` is a multiple of 4
+                    // by construction, so the remainder is always empty.
+                    for pixel in buf.as_chunks_mut::<4>().0 {
+                        *pixel = [r, g, b, 255];
                     }
                     buf
                 }
@@ -316,11 +317,9 @@ impl SixelDecoder {
             SixelBackground::Paint => {
                 let (r, g, b) = self.palette[0];
                 let mut buf = vec![0u8; new_total];
-                for pixel in buf.chunks_exact_mut(4) {
-                    pixel[0] = r;
-                    pixel[1] = g;
-                    pixel[2] = b;
-                    pixel[3] = 255;
+                // See the comment on the initial-allocation path above.
+                for pixel in buf.as_chunks_mut::<4>().0 {
+                    *pixel = [r, g, b, 255];
                 }
                 buf
             }

--- a/freminal-terminal-emulator/src/interface.rs
+++ b/freminal-terminal-emulator/src/interface.rs
@@ -752,7 +752,6 @@ impl TerminalEmulator {
         let scroll_changed = scroll_offset != self.previous_effective_scroll_offset;
         if scroll_changed {
             self.previous_visible_snap = None;
-            tracing::debug!(target: "freminal::selection", "snap cache invalidated: scroll offset changed");
             // The stashed other-buffer cache also covers a specific viewport.
             // A primary snapshot stashed while scrolled back must not be
             // restored after a scroll change (e.g. entering the alternate
@@ -770,7 +769,6 @@ impl TerminalEmulator {
         // reused.
         if extra_rows != self.previous_effective_extra_rows {
             self.previous_visible_snap = None;
-            tracing::debug!(target: "freminal::selection", "snap cache invalidated: extra flatten rows changed");
             // Same reasoning as the scroll-change case: the stashed cache
             // covers a specific flatten window and must not be restored across
             // an extra-row change.
@@ -788,7 +786,6 @@ impl TerminalEmulator {
         let current_size = (term_width, term_height);
         if current_size != self.previous_term_size {
             self.previous_visible_snap = None;
-            tracing::debug!(target: "freminal::selection", "snap cache invalidated: terminal size changed");
             // A resize applies to BOTH buffers, so the stashed other-buffer
             // cache is also the wrong dimensions and must not be restored on a
             // later buffer switch. Clear it too.
@@ -958,28 +955,6 @@ impl TerminalEmulator {
                 .previous_visible_snap
                 .as_ref()
                 .is_none_or(|(prev_chars, _, _, _)| prev_chars.as_ref() != vc.as_ref());
-
-            // Diagnostic for #470. `changed` conflates two very different
-            // things: the visible text actually differing, and the cache
-            // simply having been invalidated (by a scroll, an extra-row
-            // change, a resize, or an alt-screen swap) so there is nothing to
-            // compare against. Consumers that treat it as "the text moved" --
-            // notably the GUI's selection auto-clear -- care about the
-            // difference. Log which one it was.
-            if changed {
-                tracing::debug!(
-                    target: "freminal::selection",
-                    cache_was_invalidated = self.previous_visible_snap.is_none(),
-                    prev_len = self
-                        .previous_visible_snap
-                        .as_ref()
-                        .map_or(0, |(p, _, _, _)| p.len()),
-                    new_len = vc.len(),
-                    scroll_offset,
-                    extra_rows,
-                    "snapshot reports content_changed"
-                );
-            }
 
             self.previous_visible_snap = Some((
                 Arc::clone(&vc),

--- a/freminal-terminal-emulator/src/interface.rs
+++ b/freminal-terminal-emulator/src/interface.rs
@@ -752,6 +752,7 @@ impl TerminalEmulator {
         let scroll_changed = scroll_offset != self.previous_effective_scroll_offset;
         if scroll_changed {
             self.previous_visible_snap = None;
+            tracing::debug!(target: "freminal::selection", "snap cache invalidated: scroll offset changed");
             // The stashed other-buffer cache also covers a specific viewport.
             // A primary snapshot stashed while scrolled back must not be
             // restored after a scroll change (e.g. entering the alternate
@@ -769,6 +770,7 @@ impl TerminalEmulator {
         // reused.
         if extra_rows != self.previous_effective_extra_rows {
             self.previous_visible_snap = None;
+            tracing::debug!(target: "freminal::selection", "snap cache invalidated: extra flatten rows changed");
             // Same reasoning as the scroll-change case: the stashed cache
             // covers a specific flatten window and must not be restored across
             // an extra-row change.
@@ -786,6 +788,7 @@ impl TerminalEmulator {
         let current_size = (term_width, term_height);
         if current_size != self.previous_term_size {
             self.previous_visible_snap = None;
+            tracing::debug!(target: "freminal::selection", "snap cache invalidated: terminal size changed");
             // A resize applies to BOTH buffers, so the stashed other-buffer
             // cache is also the wrong dimensions and must not be restored on a
             // later buffer switch. Clear it too.
@@ -955,6 +958,28 @@ impl TerminalEmulator {
                 .previous_visible_snap
                 .as_ref()
                 .is_none_or(|(prev_chars, _, _, _)| prev_chars.as_ref() != vc.as_ref());
+
+            // Diagnostic for #470. `changed` conflates two very different
+            // things: the visible text actually differing, and the cache
+            // simply having been invalidated (by a scroll, an extra-row
+            // change, a resize, or an alt-screen swap) so there is nothing to
+            // compare against. Consumers that treat it as "the text moved" --
+            // notably the GUI's selection auto-clear -- care about the
+            // difference. Log which one it was.
+            if changed {
+                tracing::debug!(
+                    target: "freminal::selection",
+                    cache_was_invalidated = self.previous_visible_snap.is_none(),
+                    prev_len = self
+                        .previous_visible_snap
+                        .as_ref()
+                        .map_or(0, |(p, _, _, _)| p.len()),
+                    new_len = vc.len(),
+                    scroll_offset,
+                    extra_rows,
+                    "snapshot reports content_changed"
+                );
+            }
 
             self.previous_visible_snap = Some((
                 Arc::clone(&vc),

--- a/freminal-terminal-emulator/src/interface.rs
+++ b/freminal-terminal-emulator/src/interface.rs
@@ -135,6 +135,66 @@ pub fn split_format_data_for_scrollback(
 /// See `freminal-common/src/buffer_states/modes/sync_updates.rs` for spec references.
 const SYNC_UPDATES_TIMEOUT_MS: u64 = 200;
 
+/// Change signals carried forward across snapshots the GUI will not render.
+///
+/// `content_changed` and `scroll_changed` are edge-triggered: each is computed
+/// by diffing the current snapshot against the *previous* one. That is only
+/// sound if the GUI renders every snapshot — and it does not. A snapshot with
+/// `skip_draw = true` (Synchronized Output, DEC `?2026`) is deliberately
+/// dropped by the GUI without inspecting its content, so the edge it reported
+/// is never acted on. The next snapshot then diffs against the dropped one,
+/// finds no *further* change, and reports `content_changed = false`.
+///
+/// The result is a permanently stale screen: an application that wraps a paint
+/// in `?2026h` … `?2026l` loses the whole update whenever a PTY read boundary
+/// falls between the content and the closing `?2026l`, and nothing redraws
+/// until an unrelated event forces a rebuild (issue #490).
+///
+/// This type closes that gap by making the signals **level-triggered across
+/// skipped frames**: an edge observed while `skip_draw` is set is accumulated
+/// here and replayed on the first snapshot the GUI will actually render.
+///
+/// Both flags are tracked independently because they are independent
+/// simultaneous signals — a frame can change content, scroll, both, or
+/// neither — and downstream consumers distinguish the two (a pure scroll must
+/// not clear the user's text selection).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct DeferredChangeFlags {
+    /// A `content_changed` edge that has not yet reached a rendered snapshot.
+    content: bool,
+    /// A `scroll_changed` edge that has not yet reached a rendered snapshot.
+    scroll: bool,
+}
+
+impl DeferredChangeFlags {
+    /// Combine this frame's freshly computed edges with anything owed from
+    /// previously skipped frames, and return the values the snapshot should
+    /// actually carry.
+    ///
+    /// When the frame will be skipped the accumulated signal is retained, so
+    /// it survives an arbitrarily long run of skipped frames. When the frame
+    /// will be rendered the debt is paid and cleared.
+    const fn resolve_for_frame(
+        &mut self,
+        skip_draw: bool,
+        content_changed: bool,
+        scroll_changed: bool,
+    ) -> (bool, bool) {
+        let content = content_changed || self.content;
+        let scroll = scroll_changed || self.scroll;
+
+        if skip_draw {
+            self.content = content;
+            self.scroll = scroll;
+        } else {
+            self.content = false;
+            self.scroll = false;
+        }
+
+        (content, scroll)
+    }
+}
+
 pub struct TerminalEmulator {
     pub internal: TerminalState,
     /// PTY I/O layer (holds the terminfo `TempDir` and child-exit receiver).
@@ -216,6 +276,12 @@ pub struct TerminalEmulator {
     /// See `freminal-common/src/buffer_states/modes/sync_updates.rs` for the spec
     /// references.
     dont_draw_entered_at: Option<Instant>,
+    /// Change signals owed to the GUI from snapshots it was told to skip.
+    ///
+    /// See [`DeferredChangeFlags`] for why edge-triggered change detection is
+    /// unsound in the presence of `skip_draw`, and issue #490 for the user-
+    /// visible symptom.
+    deferred_changes: DeferredChangeFlags,
 }
 
 impl TerminalEmulator {
@@ -242,6 +308,7 @@ impl TerminalEmulator {
             previous_effective_extra_rows: 0,
             previous_term_size: (0, 0),
             dont_draw_entered_at: None,
+            deferred_changes: DeferredChangeFlags::default(),
         }
     }
 
@@ -272,6 +339,7 @@ impl TerminalEmulator {
             previous_effective_extra_rows: 0,
             previous_term_size: (0, 0),
             dont_draw_entered_at: None,
+            deferred_changes: DeferredChangeFlags::default(),
         };
         (emulator, write_rx)
     }
@@ -353,6 +421,7 @@ impl TerminalEmulator {
             previous_effective_extra_rows: 0,
             previous_term_size: (0, 0),
             dont_draw_entered_at: None,
+            deferred_changes: DeferredChangeFlags::default(),
         };
         Ok((ret, pty_rx))
     }
@@ -742,6 +811,17 @@ impl TerminalEmulator {
         self.apply_sync_updates_timeout();
 
         let mode_fields = self.collect_mode_fields();
+
+        // ── Carry change signals across frames the GUI will not render ───────
+        //
+        // Must run after `apply_sync_updates_timeout` and `collect_mode_fields`,
+        // because the timeout can flip `skip_draw` back to `false` and this
+        // decision depends on the *final* value the snapshot will carry.
+        let (content_changed, scroll_changed) = self.deferred_changes.resolve_for_frame(
+            mode_fields.skip_draw,
+            content_changed,
+            scroll_changed,
+        );
         let cursor_pos = self.internal.cursor_pos();
         // Hide the cursor when the user is scrolled back into history —
         // the live cursor line is not visible on screen.

--- a/freminal-terminal-emulator/src/recording.rs
+++ b/freminal-terminal-emulator/src/recording.rs
@@ -983,7 +983,7 @@ pub fn parse_recording_from_bytes(data: &[u8]) -> Result<ParsedRecording, ParseE
 }
 
 /// Read a little-endian `u32` from a byte slice at the given offset.
-fn read_u32_le(data: &[u8], offset: usize) -> u32 {
+const fn read_u32_le(data: &[u8], offset: usize) -> u32 {
     let bytes: [u8; 4] = [
         data[offset],
         data[offset + 1],
@@ -994,7 +994,7 @@ fn read_u32_le(data: &[u8], offset: usize) -> u32 {
 }
 
 /// Read a little-endian `u64` from a byte slice at the given offset.
-fn read_u64_le(data: &[u8], offset: usize) -> u64 {
+const fn read_u64_le(data: &[u8], offset: usize) -> u64 {
     let bytes: [u8; 8] = [
         data[offset],
         data[offset + 1],

--- a/freminal-terminal-emulator/src/terminal_handler/graphics_kitty.rs
+++ b/freminal-terminal-emulator/src/terminal_handler/graphics_kitty.rs
@@ -912,9 +912,11 @@ impl TerminalHandler {
                 }
                 let pixel_count = w_us.saturating_mul(h_us);
                 let mut rgba = Vec::with_capacity(pixel_count.saturating_mul(4));
-                for chunk in image_data.chunks_exact(3) {
-                    rgba.extend_from_slice(chunk);
-                    rgba.push(255);
+                // `as_chunks` yields fixed-size arrays rather than slices
+                // (clippy 1.98's `chunks_exact_to_as_chunks`). A trailing
+                // partial pixel is discarded exactly as `chunks_exact` did.
+                for [r, g, b] in image_data.as_chunks::<3>().0 {
+                    rgba.extend_from_slice(&[*r, *g, *b, 255]);
                 }
                 Some((rgba, w, h))
             }

--- a/freminal-terminal-emulator/src/terminal_handler/mod.rs
+++ b/freminal-terminal-emulator/src/terminal_handler/mod.rs
@@ -927,6 +927,40 @@ impl TerminalHandler {
         )
     }
 
+    /// Flatten the whole buffer -- scrollback followed by the visible window --
+    /// into a single corpus for scrollback search.
+    ///
+    /// Row `n` of the returned corpus is buffer row `n`: rows are separated by
+    /// exactly one [`TChar::NewLine`], **including at the scrollback/visible
+    /// seam**. That seam is the reason this method exists rather than callers
+    /// concatenating [`Self::data_and_format_data_for_gui`]'s two sections
+    /// themselves. Each section is flattened independently, and a flatten
+    /// deliberately emits no trailing separator after its own last row, so a
+    /// naive `scrollback.extend(visible)` fuses the last scrollback row and the
+    /// first visible row into one. Every row from the visible window onward
+    /// then counts one too low, which put search highlights a row above their
+    /// match and dropped matches on the first visible row entirely (#463).
+    ///
+    /// The separator is driven by the scrollback flatten's row count, not by
+    /// whether it produced any characters: a single blank scrollback row
+    /// flattens to zero characters but is still a row, and still needs a
+    /// separator after it.
+    ///
+    /// Pass `scroll_offset = 0` when calling from the PTY thread.
+    #[must_use]
+    pub fn search_corpus(&mut self, scroll_offset: usize) -> Vec<TChar> {
+        let (visible_chars, _, _, _) = self.buffer.visible_as_tchars_and_tags(scroll_offset);
+        let (scrollback_chars, _, scrollback_row_offsets, _) =
+            self.buffer.scrollback_as_tchars_and_tags(scroll_offset);
+
+        let mut corpus = scrollback_chars;
+        if !scrollback_row_offsets.is_empty() {
+            corpus.push(TChar::NewLine);
+        }
+        corpus.extend(visible_chars);
+        corpus
+    }
+
     /// Return the current cursor position in screen coordinates (0-indexed).
     ///
     /// This returns coordinates relative to the top of the visible window, so

--- a/freminal-terminal-emulator/tests/autowrap_incremental_repaint.rs
+++ b/freminal-terminal-emulator/tests/autowrap_incremental_repaint.rs
@@ -1,0 +1,128 @@
+// Copyright (C) 2024-2026 Fred Clausen
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Regression tests for issue #491: autowrap must not erase the row it wraps
+//! onto.
+//!
+//! Autowrap is defined as cursor movement. A TUI is entitled to repaint a
+//! soft-wrapped line by touching only the cells that changed and using
+//! cursor-forward / absolute positioning to skip the rest, relying on autowrap
+//! alone to step from one screen row to the next. Clearing the destination row
+//! on wrap destroyed every cell the repaint did not explicitly write.
+//!
+//! The concrete symptom was a long soft-wrapped line in neovim rendering as a
+//! column of single characters down the right-hand edge of the screen: neovim
+//! emits `<space>`, `CSI 122 C`, `<final char>` per row and lets autowrap
+//! advance, so each row kept only those two cells.
+
+mod vttest_common;
+
+use vttest_common::VtTestHelper;
+
+/// The minimal shape of the bug: fill two rows, then repaint the first one
+/// using `CUF` to skip its middle, and let autowrap carry the cursor onto the
+/// second row.
+#[test]
+fn autowrap_preserves_destination_row_contents() {
+    let mut h = VtTestHelper::new(10, 4);
+
+    h.feed_str("\x1b[HAAAAAAAAAA");
+    h.feed_str("BBBBBBBBBB");
+    assert_eq!(h.screen_text()[0], "AAAAAAAAAA");
+    assert_eq!(h.screen_text()[1], "BBBBBBBBBB");
+
+    // Repaint row 0's first and last cell only; CUF skips the middle.
+    h.feed_str("\x1b[H");
+    h.feed_str("X");
+    h.feed_str("\x1b[8C");
+    h.feed_str("Y");
+    assert_eq!(
+        h.screen_text()[0],
+        "XAAAAAAAAY",
+        "CUF must skip cells rather than erase them"
+    );
+
+    // Cursor is now in the pending-wrap state. The next printable character
+    // wraps onto row 1 and writes exactly one cell there.
+    h.feed_str("Z");
+    assert_eq!(
+        h.screen_text()[1],
+        "ZBBBBBBBBB",
+        "autowrap must not clear the row it wraps onto"
+    );
+}
+
+/// The full neovim idiom, repeated down the screen: `<space>`, `CUF width-2`,
+/// `<char>`, relying on autowrap to advance. Every row must retain the body
+/// text that was painted earlier.
+#[test]
+fn neovim_style_incremental_repaint_of_wrapped_line() {
+    const WIDTH: usize = 10;
+    const ROWS: usize = 4;
+    let mut h = VtTestHelper::new(WIDTH, ROWS);
+
+    // Initial full paint: four rows of distinct filler.
+    h.feed_str("\x1b[H");
+    for r in 0..ROWS {
+        let fill: String = std::iter::repeat_n(
+            char::from(b'a' + u8::try_from(r).expect("row index fits in u8")),
+            WIDTH,
+        )
+        .collect();
+        h.feed_str(&fill);
+    }
+    for r in 0..ROWS {
+        let expected: String = std::iter::repeat_n(
+            char::from(b'a' + u8::try_from(r).expect("row index fits in u8")),
+            WIDTH,
+        )
+        .collect();
+        assert_eq!(h.screen_text()[r], expected, "row {r} initial paint");
+    }
+
+    // Incremental repaint: rewrite only column 0 and the final column of every
+    // row, stepping between rows via autowrap alone.
+    h.feed_str("\x1b[H");
+    for r in 0..ROWS {
+        h.feed_str(" ");
+        h.feed_str(&format!("\x1b[{}C", WIDTH - 2));
+        h.feed_str(&r.to_string());
+    }
+
+    for r in 0..ROWS {
+        let body: String = std::iter::repeat_n(
+            char::from(b'a' + u8::try_from(r).expect("row index fits in u8")),
+            WIDTH - 2,
+        )
+        .collect();
+        let expected = format!(" {body}{r}");
+        assert_eq!(
+            h.screen_text()[r],
+            expected,
+            "row {r} must keep the body text the repaint skipped over"
+        );
+    }
+}
+
+/// Guard against over-correcting: wrapped text that genuinely covers cells
+/// must still overwrite them.
+#[test]
+fn autowrap_still_overwrites_what_it_writes() {
+    let mut h = VtTestHelper::new(10, 4);
+
+    h.feed_str("\x1b[HAAAAAAAAAA");
+    h.feed_str("BBBBBBBBBB");
+
+    // 13 characters from row 0 col 0: 10 fill row 0, 3 wrap onto row 1.
+    h.feed_str("\x1b[H");
+    h.feed_str("CCCCCCCCCCCCC");
+
+    assert_eq!(h.screen_text()[0], "CCCCCCCCCC");
+    assert_eq!(
+        h.screen_text()[1],
+        "CCCBBBBBBB",
+        "wrapped text overwrites the cells it covers, and only those"
+    );
+}

--- a/freminal-terminal-emulator/tests/interface_tests.rs
+++ b/freminal-terminal-emulator/tests/interface_tests.rs
@@ -488,6 +488,76 @@ fn test_sync_updates_content_change_survives_many_skipped_frames() {
     );
 }
 
+/// `scroll_changed` is deferred by the same mechanism as `content_changed`
+/// and needs its own coverage.
+///
+/// The block is left via the 200 ms auto-resume rather than `?2026l`, because
+/// `?2026l` is itself PTY output and new output auto-resets the scroll offset
+/// to the live bottom -- which manufactures a fresh, genuine scroll edge and
+/// would let this pass with the deferral removed.
+#[test]
+fn test_sync_updates_scroll_change_survives_skipped_frame() {
+    use std::time::Duration;
+
+    let (mut emu, _rx) = make_emulator();
+    // Enough output for a non-zero scroll offset to be reachable.
+    for i in 0..200 {
+        emu.handle_incoming_data(format!("line {i}\r\n").as_bytes());
+    }
+    let _ = emu.build_snapshot();
+
+    // Enter the synchronized block, then scroll while frames are skipped.
+    emu.handle_incoming_data(b"\x1b[?2026h");
+    let _ = emu.build_snapshot();
+    emu.set_requested_scroll_offset(5);
+    let skipped = emu.build_snapshot();
+    assert!(skipped.skip_draw, "precondition: the frame is skipped");
+    assert!(
+        skipped.scroll_changed,
+        "precondition: the scroll edge occurs on the skipped frame"
+    );
+
+    // Release rendering without feeding any bytes.
+    std::thread::sleep(Duration::from_millis(250));
+
+    let rendered = emu.build_snapshot();
+    assert!(
+        !rendered.skip_draw,
+        "precondition: the timeout released rendering"
+    );
+    assert!(
+        rendered.scroll_changed,
+        "the scroll edge from the skipped frame must be replayed; without \
+         deferral the offset now matches the previous one and this reports false"
+    );
+
+    // Delivered exactly once, like the content flag.
+    let idle = emu.build_snapshot();
+    assert!(!idle.scroll_changed);
+}
+
+/// The two deferred flags are tracked independently: a content-only change
+/// must not manufacture a scroll that never happened. This matters because
+/// the GUI's selection auto-clear keys off exactly that distinction -- a pure
+/// scroll leaves a selection alone, a content change does not.
+#[test]
+fn test_sync_updates_content_change_does_not_imply_scroll_change() {
+    let (mut emu, _rx) = make_emulator();
+    let _ = emu.build_snapshot();
+
+    emu.handle_incoming_data(b"\x1b[?2026h\x1b[Hcontent only");
+    let skipped = emu.build_snapshot();
+    assert!(skipped.skip_draw, "precondition: the frame is skipped");
+
+    emu.handle_incoming_data(b"\x1b[?2026l");
+    let rendered = emu.build_snapshot();
+    assert!(rendered.content_changed, "the content edge is replayed");
+    assert!(
+        !rendered.scroll_changed,
+        "a content change must not be reported as a scroll"
+    );
+}
+
 /// A skipped frame with genuinely no change must not manufacture one.
 #[test]
 fn test_sync_updates_skipped_frame_without_change_reports_none() {

--- a/freminal-terminal-emulator/tests/interface_tests.rs
+++ b/freminal-terminal-emulator/tests/interface_tests.rs
@@ -411,3 +411,127 @@ fn test_sync_updates_timer_cleared_on_reset() {
         "skip_draw must remain false after timeout period when DontDraw was already reset"
     );
 }
+
+// ─── synchronized updates (?2026): change signals across skipped frames ──────
+//
+// Regression coverage for issue #490. `content_changed` / `scroll_changed` are
+// edge-triggered against the previous snapshot, but the GUI does not render
+// snapshots carrying `skip_draw = true`. Without deferral the edge reported by
+// a skipped frame is lost forever and the screen stays stale.
+
+/// The canonical #490 repro: a paint arrives inside a synchronized-output
+/// block and the closing `?2026l` lands in a *later* PTY read.
+///
+/// The frame carrying the new content is skipped, and the content is then
+/// byte-identical on the following (renderable) frame — so a naive diff
+/// reports no change. The renderable frame must still report
+/// `content_changed = true`, or the GUI never rebuilds its vertex buffers.
+#[test]
+fn test_sync_updates_content_change_survives_skipped_frame() {
+    let (mut emu, _rx) = make_emulator();
+
+    // Settle: consume the initial "everything is new" snapshot.
+    let _ = emu.build_snapshot();
+
+    // Read 1: BSU plus the entire paint. The ESU has not arrived yet.
+    emu.handle_incoming_data(b"\x1b[?2026h\x1b[HHELLO WORLD");
+    let skipped = emu.build_snapshot();
+    assert!(
+        skipped.skip_draw,
+        "precondition: the frame carrying the paint must be skipped by the GUI"
+    );
+
+    // Read 2: just the ESU. The visible content is unchanged since the frame
+    // the GUI was told to throw away.
+    emu.handle_incoming_data(b"\x1b[?2026l");
+    let rendered = emu.build_snapshot();
+    assert!(
+        !rendered.skip_draw,
+        "precondition: the frame after ?2026l must be renderable"
+    );
+    assert!(
+        rendered.content_changed,
+        "the first renderable frame after a skipped one must replay the skipped \
+         frame's content_changed edge, otherwise the GUI keeps showing stale pixels"
+    );
+}
+
+/// The deferred edge must survive an arbitrarily long run of skipped frames,
+/// not just one, and must be reported exactly once.
+#[test]
+fn test_sync_updates_content_change_survives_many_skipped_frames() {
+    let (mut emu, _rx) = make_emulator();
+    let _ = emu.build_snapshot();
+
+    emu.handle_incoming_data(b"\x1b[?2026h\x1b[Hthe paint");
+    for _ in 0..5 {
+        let snap = emu.build_snapshot();
+        assert!(
+            snap.skip_draw,
+            "frames inside the ?2026 block must be skipped"
+        );
+    }
+
+    emu.handle_incoming_data(b"\x1b[?2026l");
+    let rendered = emu.build_snapshot();
+    assert!(
+        rendered.content_changed,
+        "a content edge must survive any number of skipped frames"
+    );
+
+    // Debt paid: a subsequent idle frame must not keep re-reporting it, or the
+    // GUI would rebuild its vertex buffers on every frame forever.
+    let idle = emu.build_snapshot();
+    assert!(
+        !idle.content_changed,
+        "the deferred edge must be cleared once it has been delivered"
+    );
+}
+
+/// A skipped frame with genuinely no change must not manufacture one.
+#[test]
+fn test_sync_updates_skipped_frame_without_change_reports_none() {
+    let (mut emu, _rx) = make_emulator();
+    emu.handle_incoming_data(b"\x1b[Hsettled");
+    let _ = emu.build_snapshot();
+
+    // Enter and leave the synchronized block without painting anything.
+    emu.handle_incoming_data(b"\x1b[?2026h");
+    let skipped = emu.build_snapshot();
+    assert!(skipped.skip_draw, "precondition: frame is skipped");
+
+    emu.handle_incoming_data(b"\x1b[?2026l");
+    let rendered = emu.build_snapshot();
+    assert!(
+        !rendered.content_changed,
+        "deferral must replay real edges only, never invent one"
+    );
+}
+
+/// The 200 ms auto-resume path is also a transition from skipped to rendered,
+/// so a content edge observed while `DontDraw` was stuck must be replayed on
+/// the frame the timeout releases.
+#[test]
+fn test_sync_updates_content_change_survives_timeout_resume() {
+    use std::time::Duration;
+
+    let (mut emu, _rx) = make_emulator();
+    let _ = emu.build_snapshot();
+
+    // A program that paints, sets DontDraw, and then crashes without resetting.
+    emu.handle_incoming_data(b"\x1b[?2026h\x1b[Horphaned paint");
+    let skipped = emu.build_snapshot();
+    assert!(skipped.skip_draw, "precondition: frame is skipped");
+
+    std::thread::sleep(Duration::from_millis(250));
+
+    let rendered = emu.build_snapshot();
+    assert!(
+        !rendered.skip_draw,
+        "precondition: the 200 ms timeout must have released rendering"
+    );
+    assert!(
+        rendered.content_changed,
+        "the timeout-released frame must replay the skipped frame's content edge"
+    );
+}

--- a/freminal-terminal-emulator/tests/search_corpus_seam.rs
+++ b/freminal-terminal-emulator/tests/search_corpus_seam.rs
@@ -1,0 +1,115 @@
+// Copyright (C) 2024-2026 Fred Clausen
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Regression tests for issue #463: the scrollback search corpus must place
+//! exactly one row separator at the scrollback/visible seam.
+//!
+//! `visible_as_tchars_and_tags` and `scrollback_as_tchars_and_tags` each
+//! flatten their own slice of rows and deliberately emit no trailing
+//! separator after their own last row. Concatenating the two therefore fuses
+//! the last scrollback row with the first visible row unless a separator is
+//! inserted between them, which made every match from the visible window
+//! onward report a row index one too low.
+
+use freminal_common::buffer_states::tchar::TChar;
+use freminal_terminal_emulator::interface::TerminalEmulator;
+
+/// Split a corpus into rows the same way `run_search` walks it.
+fn corpus_rows(corpus: &[TChar]) -> Vec<String> {
+    corpus
+        .split(|c| matches!(c, TChar::NewLine))
+        .map(|r| {
+            r.iter()
+                .map(std::string::ToString::to_string)
+                .collect::<String>()
+                .trim_end()
+                .to_owned()
+        })
+        .collect()
+}
+
+/// With scrollback present, corpus row `n` must be buffer row `n`.
+#[test]
+fn corpus_row_indices_match_buffer_rows_across_the_seam() {
+    let (mut emu, _rx) = TerminalEmulator::new_headless(None);
+    let _ = emu.set_win_size(10, 3, 8, 16);
+
+    // Six distinct lines on a three-row screen leaves scrollback behind.
+    for i in 0..6 {
+        emu.handle_incoming_data(format!("row{i}\r\n").as_bytes());
+    }
+
+    let corpus = emu.internal.handler.search_corpus(0);
+    let rows = corpus_rows(&corpus);
+    let total_rows = emu.internal.handler.buffer().rows().len();
+
+    assert_eq!(
+        rows.len(),
+        total_rows,
+        "corpus row count must equal the buffer's row count; got {rows:?}"
+    );
+    for i in 0..6 {
+        assert_eq!(
+            rows[i],
+            format!("row{i}"),
+            "corpus row {i} must be buffer row {i}; got {rows:?}"
+        );
+    }
+}
+
+/// No two rows may be fused: the seam row must not contain the text of the
+/// row that follows it.
+#[test]
+fn seam_does_not_fuse_last_scrollback_row_with_first_visible_row() {
+    let (mut emu, _rx) = TerminalEmulator::new_headless(None);
+    let _ = emu.set_win_size(10, 3, 8, 16);
+    for i in 0..6 {
+        emu.handle_incoming_data(format!("row{i}\r\n").as_bytes());
+    }
+
+    let rows = corpus_rows(&emu.internal.handler.search_corpus(0));
+    assert!(
+        !rows.iter().any(|r| r == "row3row4"),
+        "the scrollback/visible seam fused two rows: {rows:?}"
+    );
+}
+
+/// A completely blank scrollback row still occupies a row index. It flattens
+/// to zero characters, so the separator decision must be driven by the row
+/// count rather than by whether the scrollback produced any text.
+#[test]
+fn blank_scrollback_row_still_gets_a_separator() {
+    let (mut emu, _rx) = TerminalEmulator::new_headless(None);
+    let _ = emu.set_win_size(10, 3, 8, 16);
+
+    // One empty line, then enough content to push it into scrollback.
+    emu.handle_incoming_data(b"\r\n");
+    for i in 0..3 {
+        emu.handle_incoming_data(format!("row{i}\r\n").as_bytes());
+    }
+
+    let rows = corpus_rows(&emu.internal.handler.search_corpus(0));
+    let total_rows = emu.internal.handler.buffer().rows().len();
+    assert_eq!(
+        rows.len(),
+        total_rows,
+        "a blank scrollback row must still be counted; got {rows:?}"
+    );
+    assert_eq!(rows[0], "", "row 0 is the blank scrollback line");
+    assert_eq!(rows[1], "row0", "row 1 must not have been fused with row 0");
+}
+
+/// With no scrollback at all, no leading separator may be introduced --
+/// that would shift every row the other way.
+#[test]
+fn no_scrollback_means_no_leading_separator() {
+    let (mut emu, _rx) = TerminalEmulator::new_headless(None);
+    let _ = emu.set_win_size(10, 5, 8, 16);
+    emu.handle_incoming_data(b"alpha\r\nbeta");
+
+    let rows = corpus_rows(&emu.internal.handler.search_corpus(0));
+    assert_eq!(rows[0], "alpha", "row 0 must be the first visible row");
+    assert_eq!(rows[1], "beta");
+}

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -2120,6 +2120,10 @@ impl freminal_windowing::App for FreminalGui {
             // split border. This must happen before the per-pane
             // `scope_builder` calls so that pointer events on the border
             // are consumed here instead of reaching the terminal widgets.
+            // Whether a split-border sensor owns the cursor icon this frame.
+            // Set from the very same condition that applies the resize cursor
+            // below, so the gate and the write can never disagree (#462).
+            let mut border_owns_cursor = false;
             if has_multiple_panes && zoomed_pane.is_none() && !ui_overlay_open {
                 let borders = win
                     .tabs
@@ -2168,12 +2172,23 @@ impl freminal_windowing::App for FreminalGui {
                         ui.interact(sensor_rect, sensor_id, egui::Sense::click_and_drag());
 
                     // Change cursor when hovering or dragging a border.
+                    //
+                    // `dragged()` matters as much as `hovered()`: the sensor
+                    // rects are built from `borders`, computed at the top of
+                    // this frame and therefore one frame behind the divider
+                    // that `resize_split` is currently moving. During a drag
+                    // the pointer routinely runs ahead of the stale rect, so
+                    // a hover-only test would drop out intermittently and let
+                    // the pane underneath reclaim the icon -- the cursor
+                    // flickering between the resize arrow and the normal
+                    // pointer while dragging.
                     if response.hovered() || response.dragged() {
                         let cursor = match border.direction {
                             panes::SplitDirection::Horizontal => egui::CursorIcon::ResizeHorizontal,
                             panes::SplitDirection::Vertical => egui::CursorIcon::ResizeVertical,
                         };
                         ctx.set_cursor_icon(cursor);
+                        border_owns_cursor = true;
                     }
 
                     // On drag start, record which border we're resizing.
@@ -2248,6 +2263,13 @@ impl freminal_windowing::App for FreminalGui {
                             }
                         }
                         win.border_drag = None;
+                        // The divider has just moved to its final position,
+                        // but this frame's sensor rects were built before that
+                        // move. Force one more frame so hover is re-evaluated
+                        // against the settled layout, otherwise the resize
+                        // cursor drops to the default arrow on mouse-up even
+                        // though the pointer is still over the divider (#462).
+                        ctx.request_repaint();
                     }
                 }
 
@@ -2280,32 +2302,25 @@ impl freminal_windowing::App for FreminalGui {
             // `win.terminal_widget` (issue #453).
             let border_drag_active = win.border_drag.is_some();
 
-            // Whether the pointer is over one of this frame's split-border
-            // drag sensors. Those sensors are wider than the border line they
-            // straddle, so the pointer is geometrically inside an adjacent
-            // pane while logically over chrome that has already set a resize
-            // cursor. Panes must abstain from writing `output.cursor_icon`
-            // there, or the resize arrow only survives in the hairline gap
-            // between the two pane rects -- the reported "clickable region is
-            // much larger than the region that shows the cursor" (#462).
+            // Whether a split-border sensor owns the cursor icon this frame.
             //
-            // Read from the rects just published above, so it reflects this
-            // frame's layout, and computed here to avoid holding a borrow of
-            // `win.published` across the mutable borrow of
-            // `win.terminal_widget` in the pane loop.
-            let split_border_hover = {
-                let pointer = ctx.input(|i| i.pointer.latest_pos());
-                let over = pointer.is_some_and(|pos| {
-                    win.published
-                        .chrome_border_rects()
-                        .iter()
-                        .any(|r| r.contains(pos))
-                });
-                if over {
-                    SplitBorderHover::Over
-                } else {
-                    SplitBorderHover::Clear
-                }
+            // Those sensors are wider than the 1px border they straddle, so
+            // the pointer sits geometrically inside an adjacent pane while
+            // logically over chrome. Panes must abstain from writing
+            // `output.cursor_icon` there, or the resize arrow survives only in
+            // the hairline gap between the two pane rects.
+            //
+            // Driven by the same `hovered() || dragged()` test that actually
+            // applies the cursor, rather than an independent hit-test of the
+            // published rects: those rects are a frame behind the divider
+            // during a drag, so a separate test would disagree with the write
+            // exactly when it matters. `border_drag_active` is folded in so an
+            // in-flight drag keeps the cursor even on a frame where the
+            // stale sensor rect has fallen behind the pointer entirely (#462).
+            let split_border_hover = if border_owns_cursor || border_drag_active {
+                SplitBorderHover::Over
+            } else {
+                SplitBorderHover::Clear
             };
 
             // ── Terminal band: shape-index range capture (#436.2a, range

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -1131,7 +1131,18 @@ impl freminal_windowing::App for FreminalGui {
             );
         }
 
+        // Focus-follows-mouse turns pointer motion into a state change, so
+        // the gate must not suppress the frame that would apply it (#495).
+        // Narrow by construction: only motion that lands on a pane other than
+        // the active one qualifies, so moving around inside the focused pane
+        // still suppresses exactly as before.
+        let focus_change_pending = self.config.tabs.focus_follows_mouse
+            && pane_resolution
+                .resolved_pane
+                .is_some_and(|id| id != active_tab.active_pane);
+
         pointer_motion_needs_repaint_decision(
+            focus_change_pending,
             chrome_interactive,
             any_selecting,
             overlay_open,

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -33,7 +33,7 @@ use super::pointer_motion::{
 use super::renderer::WindowPostRenderer;
 use super::rendering;
 use super::tabs::{Tab, TabManager};
-use super::terminal::FreminalTerminalWidget;
+use super::terminal::{FreminalTerminalWidget, SplitBorderHover};
 use super::view_state;
 use super::window::PerWindowState;
 use super::{FreminalGui, PaneBorderDrag};
@@ -2280,6 +2280,34 @@ impl freminal_windowing::App for FreminalGui {
             // `win.terminal_widget` (issue #453).
             let border_drag_active = win.border_drag.is_some();
 
+            // Whether the pointer is over one of this frame's split-border
+            // drag sensors. Those sensors are wider than the border line they
+            // straddle, so the pointer is geometrically inside an adjacent
+            // pane while logically over chrome that has already set a resize
+            // cursor. Panes must abstain from writing `output.cursor_icon`
+            // there, or the resize arrow only survives in the hairline gap
+            // between the two pane rects -- the reported "clickable region is
+            // much larger than the region that shows the cursor" (#462).
+            //
+            // Read from the rects just published above, so it reflects this
+            // frame's layout, and computed here to avoid holding a borrow of
+            // `win.published` across the mutable borrow of
+            // `win.terminal_widget` in the pane loop.
+            let split_border_hover = {
+                let pointer = ctx.input(|i| i.pointer.latest_pos());
+                let over = pointer.is_some_and(|pos| {
+                    win.published
+                        .chrome_border_rects()
+                        .iter()
+                        .any(|r| r.contains(pos))
+                });
+                if over {
+                    SplitBorderHover::Over
+                } else {
+                    SplitBorderHover::Clear
+                }
+            };
+
             // ── Terminal band: shape-index range capture (#436.2a, range
             // exposed via `App::take_terminal_band_range` as of #436.4a) ───
             //
@@ -2644,6 +2672,7 @@ impl freminal_windowing::App for FreminalGui {
                             &mut pane.pending_copy,
                             &key_broadcast_targets,
                             &present_is_partial_for_panes,
+                            split_border_hover,
                         )
                     });
                 #[cfg(feature = "frame-profiling")]

--- a/freminal/src/gui/atlas.rs
+++ b/freminal/src/gui/atlas.rs
@@ -95,7 +95,7 @@ struct RasterizedGlyph {
 /// `data` must be a flat RGBA8 buffer (length a multiple of 4); any trailing
 /// partial pixel is ignored.
 fn premultiply_rgba_in_place(data: &mut [u8]) {
-    for px in data.chunks_exact_mut(4) {
+    for px in data.as_chunks_mut::<4>().0 {
         let a = u16::from(px[3]);
         // (channel * alpha + 127) / 255, rounded to nearest. Always <= 255.
         px[0] = u8::try_from((u16::from(px[0]) * a + 127) / 255).unwrap_or(px[0]);
@@ -912,7 +912,7 @@ mod tests {
         atlas.rasterize_and_insert(key, &fm_mut);
 
         // Check that the atlas pixels contain non-zero alpha in the glyph region.
-        let has_nonzero_alpha = atlas.pixels().chunks_exact(4).any(|px| px[3] > 0);
+        let has_nonzero_alpha = atlas.pixels().as_chunks::<4>().0.iter().any(|px| px[3] > 0);
         assert!(
             has_nonzero_alpha,
             "atlas should contain non-zero alpha pixels"

--- a/freminal/src/gui/box_drawing.rs
+++ b/freminal/src/gui/box_drawing.rs
@@ -106,11 +106,8 @@ fn fill_rect(buf: &mut [u8], w: usize, h: usize, x0: f32, y0: f32, x1: f32, y1: 
 
 /// Fill the whole cell with a uniform `alpha` (for the shade glyphs).
 fn fill_uniform(buf: &mut [u8], alpha: u8) {
-    for px in buf.chunks_exact_mut(BPP) {
-        px[0] = 255;
-        px[1] = 255;
-        px[2] = 255;
-        px[3] = alpha;
+    for px in buf.as_chunks_mut::<BPP>().0 {
+        *px = [255, 255, 255, alpha];
     }
 }
 
@@ -1109,7 +1106,7 @@ mod tests {
             let c = char::from_u32(cp).expect("valid codepoint");
             let buf = generate_alpha(c, w, h);
             assert!(
-                buf.chunks_exact(BPP).any(|px| px[3] > 0),
+                buf.as_chunks::<BPP>().0.iter().any(|px| px[3] > 0),
                 "{cp:#x} rendered fully transparent"
             );
         }

--- a/freminal/src/gui/chrome_style.rs
+++ b/freminal/src/gui/chrome_style.rs
@@ -290,6 +290,26 @@ pub fn build_visuals(
     // and selected elements use `selection.stroke` (OnAccent, set above).
     visuals.override_text_color = None;
 
+    // Give every clickable chrome widget a pointing-hand cursor (issue #493).
+    //
+    // egui leaves this `None` by default, on the grounds that native toolkits
+    // do not do it. freminal opts in: its chrome is flat and largely
+    // borderless, so without a cursor change there is frequently nothing to
+    // distinguish an actionable menu entry or button from a plain label.
+    //
+    // This covers every widget built on `egui::Button` -- menu entries, modal
+    // action buttons, the tab-strip close button -- which is the bulk of the
+    // chrome. It does NOT cover `SelectableLabel`, `Checkbox`, `RadioButton`,
+    // `Link`, `Slider`, `ComboBox`, or anything hand-rolled via `ui.interact`;
+    // egui only consults `interact_cursor` from `Button`'s own paint path.
+    // Those widgets opt in individually with `HoverAffordance::clickable`
+    // (see `crate::gui::hover_cursor`).
+    //
+    // Terminal content is unaffected: panes resolve their own cursor and only
+    // the pane under the pointer writes it (see `PointerHover` /
+    // `SplitBorderHover` in `crate::gui::terminal::widget`).
+    visuals.interact_cursor = Some(egui::CursorIcon::PointingHand);
+
     // ── Surface backgrounds ───────────────────────────────────────────────────
     //
     // These egui surfaces default to near-black in dark mode; left unset they

--- a/freminal/src/gui/font_manager.rs
+++ b/freminal/src/gui/font_manager.rs
@@ -1507,7 +1507,7 @@ fn find_system_face_for_char(font_db: &Database, c: char) -> Option<LoadedFace> 
 
 /// Read `usWinAscent` (u16 at byte offset 74) and `usWinDescent` (u16 at byte
 /// offset 76) from a raw OS/2 table.  Returns `None` if the table is too short.
-fn read_os2_win_metrics(os2_data: &[u8]) -> Option<(u16, u16)> {
+const fn read_os2_win_metrics(os2_data: &[u8]) -> Option<(u16, u16)> {
     // usWinAscent is at offset 74, usWinDescent at offset 76.
     // Each is a big-endian u16; the table must be at least 78 bytes.
     if os2_data.len() < 78 {

--- a/freminal/src/gui/hover_cursor.rs
+++ b/freminal/src/gui/hover_cursor.rs
@@ -1,0 +1,79 @@
+// Copyright (C) 2024-2026 Fred Clausen
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Hover-cursor affordances for freminal's egui chrome.
+//!
+//! egui does not change the mouse cursor for clickable widgets on its own: a
+//! `Button`, `SelectableLabel` or menu entry shows the ordinary arrow unless
+//! the caller explicitly asks otherwise via [`egui::Response::on_hover_cursor`].
+//! Without that, nothing in the menu bar, tab strip, settings window or any
+//! modal tells the user an element can be clicked (issue #493).
+//!
+//! This module provides the vocabulary for saying so once per widget, rather
+//! than repeating a bare `CursorIcon` at every call site. Naming the *intent*
+//! ("this is a clickable affordance") instead of the *appearance* ("pointing
+//! hand") keeps the choice of icon in one place.
+//!
+//! # Scope
+//!
+//! These helpers are for **chrome only**. The terminal surface resolves its own
+//! cursor through `PointerHover`/`PointerTarget` in
+//! `crate::gui::terminal::widget`, which additionally has to arbitrate against
+//! the application's OSC 22 pointer shape. Do not use these there.
+//!
+//! # What deliberately does not get a hand
+//!
+//! - **Text fields.** egui already gives a `TextEdit` an I-beam, which
+//!   correctly signals "type here" rather than "click here".
+//! - **Drag handles.** Pane dividers use a directional resize cursor so the
+//!   drag axis is visible; see `SplitBorderHover`.
+//! - **Disabled widgets.** A pointing hand on something that cannot be
+//!   activated is a lie. Use [`HoverAffordance::disabled_affordance`].
+
+use egui::{CursorIcon, Response};
+
+/// Attaches a hover cursor describing what a chrome widget does.
+///
+/// Deliberately not `#[must_use]`. `egui::Response` is not `must_use` itself,
+/// and many of the widgets these methods decorate are legitimately used as
+/// bare statements (`ui.checkbox(&mut flag, "Label").clickable();` -- the flag
+/// is mutated in place and the response is not needed). A `must_use` here
+/// would fire on every one of those and teach readers to ignore it.
+#[allow(clippy::return_self_not_must_use)]
+pub trait HoverAffordance {
+    /// Mark this widget as a clickable affordance: buttons, menu entries,
+    /// tab labels, checkboxes, radio buttons, links, and anything else that
+    /// performs an action when clicked.
+    fn clickable(self) -> Self;
+
+    /// Mark this widget as present but not currently actionable, so the
+    /// cursor says "no" instead of inviting a click that will do nothing.
+    fn disabled_affordance(self) -> Self;
+
+    /// Mark this widget as clickable only when `enabled` is true, otherwise as
+    /// disabled.
+    ///
+    /// Convenience for the common `add_enabled(cond, ...)` pattern, so callers
+    /// do not have to branch at the call site.
+    fn clickable_when(self, enabled: bool) -> Self;
+}
+
+impl HoverAffordance for Response {
+    fn clickable(self) -> Self {
+        self.on_hover_cursor(CursorIcon::PointingHand)
+    }
+
+    fn disabled_affordance(self) -> Self {
+        self.on_hover_cursor(CursorIcon::NotAllowed)
+    }
+
+    fn clickable_when(self, enabled: bool) -> Self {
+        if enabled {
+            self.clickable()
+        } else {
+            self.disabled_affordance()
+        }
+    }
+}

--- a/freminal/src/gui/hover_cursor.rs
+++ b/freminal/src/gui/hover_cursor.rs
@@ -101,3 +101,90 @@ impl HoverAffordance for Response {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::HoverAffordance;
+    use egui::{CursorIcon, Event, Pos2, RawInput, Rect, Sense, Vec2};
+
+    /// Run egui frames with the pointer parked over a widget decorated by
+    /// `add`, and report the cursor the last frame requested.
+    ///
+    /// A real frame with a real pointer is required: `on_hover_cursor` only
+    /// applies while the widget is hovered, so there is nothing to observe
+    /// otherwise. Two passes because egui resolves hover against the previous
+    /// frame's widget rects -- the first registers the widget, the second is
+    /// the frame where it is hovered.
+    fn cursor_over(add: impl Fn(egui::Response) -> egui::Response) -> CursorIcon {
+        let ctx = egui::Context::default();
+        let mut input = RawInput {
+            screen_rect: Some(Rect::from_min_size(Pos2::ZERO, Vec2::new(300.0, 300.0))),
+            ..Default::default()
+        };
+        input
+            .events
+            .push(Event::PointerMoved(Pos2::new(50.0, 50.0)));
+
+        let mut icon = CursorIcon::Default;
+        for _ in 0..2 {
+            let mut out = ctx.run_ui(input.clone(), |ui| {
+                // Large enough to contain the pointer wherever the layout
+                // starts it.
+                let response =
+                    ui.allocate_response(Vec2::new(250.0, 250.0), Sense::click_and_drag());
+                let _ = add(response);
+            });
+            icon = out.platform_output.cursor_icon;
+            // epaint asserts on a dropped `TexturesDelta` with unapplied
+            // entries; nothing here rasterises, so discard them explicitly.
+            out.textures_delta.clear();
+        }
+        icon
+    }
+
+    /// Guards the harness itself: an undecorated widget leaves the cursor
+    /// alone, so the assertions below are measuring the affordance and not an
+    /// egui default.
+    #[test]
+    fn an_undecorated_widget_leaves_the_cursor_alone() {
+        assert_eq!(cursor_over(|r| r), CursorIcon::Default);
+    }
+
+    #[test]
+    fn clickable_asks_for_the_pointing_hand() {
+        assert_eq!(
+            cursor_over(HoverAffordance::clickable),
+            CursorIcon::PointingHand
+        );
+    }
+
+    /// A disabled control must actively say it cannot be used, rather than
+    /// merely omitting the hand and looking inert.
+    #[test]
+    fn disabled_affordance_asks_for_not_allowed() {
+        assert_eq!(
+            cursor_over(HoverAffordance::disabled_affordance),
+            CursorIcon::NotAllowed
+        );
+    }
+
+    #[test]
+    fn clickable_when_picks_the_matching_affordance() {
+        assert_eq!(
+            cursor_over(|r| r.clickable_when(true)),
+            CursorIcon::PointingHand
+        );
+        assert_eq!(
+            cursor_over(|r| r.clickable_when(false)),
+            CursorIcon::NotAllowed
+        );
+    }
+
+    /// Hovering a drag handle offers the open hand. The closed-hand branch
+    /// needs an in-flight drag, which this harness does not simulate; it is
+    /// covered by the `dragged()` arm being the only other path.
+    #[test]
+    fn draggable_offers_the_open_hand_on_hover() {
+        assert_eq!(cursor_over(HoverAffordance::draggable), CursorIcon::Grab);
+    }
+}

--- a/freminal/src/gui/hover_cursor.rs
+++ b/freminal/src/gui/hover_cursor.rs
@@ -58,6 +58,17 @@ pub trait HoverAffordance {
     /// Convenience for the common `add_enabled(cond, ...)` pattern, so callers
     /// do not have to branch at the call site.
     fn clickable_when(self, enabled: bool) -> Self;
+
+    /// Mark this widget as a draggable handle: open hand on hover, closed
+    /// hand while actually being dragged.
+    ///
+    /// For controls whose primary interaction is picking something up and
+    /// moving it -- sliders, in practice. Deliberately distinct from the
+    /// directional resize arrow used by pane dividers, where the drag *axis*
+    /// is the useful information, and from `egui::DragValue`'s
+    /// `ResizeEast`/`ResizeWest` arrows, which additionally signal when the
+    /// value is clamped at a limit.
+    fn draggable(self) -> Self;
 }
 
 impl HoverAffordance for Response {
@@ -74,6 +85,19 @@ impl HoverAffordance for Response {
             self.clickable()
         } else {
             self.disabled_affordance()
+        }
+    }
+
+    fn draggable(self) -> Self {
+        if self.dragged() {
+            // `on_hover_cursor` only fires while the pointer is inside the
+            // widget, and a drag routinely travels outside it -- past the end
+            // of a slider's rail, most obviously. Write directly so the closed
+            // hand survives the whole gesture.
+            self.ctx.set_cursor_icon(CursorIcon::Grabbing);
+            self
+        } else {
+            self.on_hover_cursor(CursorIcon::Grab)
         }
     }
 }

--- a/freminal/src/gui/menu.rs
+++ b/freminal/src/gui/menu.rs
@@ -8,6 +8,7 @@ use freminal_common::config::TabTitlePolicy;
 use freminal_common::keybindings::KeyAction;
 
 use super::TabBarAction;
+use super::hover_cursor::HoverAffordance;
 use super::icons::ChromeIcon;
 use super::tabs::Tab;
 use super::window::PerWindowState;
@@ -413,7 +414,8 @@ impl super::FreminalGui {
                     ui.hyperlink_to(
                         "Third-party attributions",
                         "https://github.com/fredsystems/freminal/blob/main/ATTRIBUTIONS.md",
-                    );
+                    )
+                    .clickable();
                     ui.add_space(10.0);
                     if ui.button("Close").clicked() {
                         self.about_window_open = false;

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -47,6 +47,7 @@ mod frame_damage;
 mod frame_drain;
 mod geometry_interop;
 mod hot_reload;
+pub mod hover_cursor;
 pub(crate) mod icons;
 mod layout_ops;
 mod menu;

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -47,7 +47,7 @@ mod frame_damage;
 mod frame_drain;
 mod geometry_interop;
 mod hot_reload;
-pub mod hover_cursor;
+mod hover_cursor;
 pub(crate) mod icons;
 mod layout_ops;
 mod menu;

--- a/freminal/src/gui/pointer_motion.rs
+++ b/freminal/src/gui/pointer_motion.rs
@@ -199,6 +199,14 @@ pub(super) const fn animation_in_flight_composed(
 /// winit event loop).
 ///
 /// Returns `true` (a repaint is needed) if ANY of:
+///   - `focus_change_pending`: focus-follows-mouse is enabled and the pointer
+///     is over a pane that is not the active one, so this motion has a focus
+///     switch to apply. Without this term the switch is not applied until
+///     some unrelated event schedules the next frame -- in an otherwise idle
+///     terminal that is the ~500ms cursor-blink wake, which is what made
+///     hover-to-focus feel badly lagged. Suppression is preserved for motion
+///     within the already-active pane, which is the common case the gate
+///     exists to make cheap.
 ///   - `chrome_interactive`: `App::is_chrome_interactive_at` said so (menu
 ///     bar, tab bar, split-border drag sensor).
 ///   - `any_pane_selecting`: some pane in the active tab has an
@@ -222,13 +230,19 @@ pub(super) const fn animation_in_flight_composed(
 // allow for the same rationale.
 #[allow(clippy::fn_params_excessive_bools)]
 pub(super) const fn pointer_motion_needs_repaint_decision(
+    focus_change_pending: bool,
     chrome_interactive: bool,
     any_pane_selecting: bool,
     overlay_open: bool,
     pointer_pane_unresolved: bool,
     pane_signals: Option<PointerMotionPaneSignals>,
 ) -> bool {
-    if chrome_interactive || any_pane_selecting || overlay_open || pointer_pane_unresolved {
+    if focus_change_pending
+        || chrome_interactive
+        || any_pane_selecting
+        || overlay_open
+        || pointer_pane_unresolved
+    {
         return true;
     }
     match pane_signals {
@@ -298,6 +312,11 @@ pub(super) struct PaneResolution {
     /// See [`pane_hover_region_terms`]'s doc. `false` when `signals` is
     /// `None`.
     pub(super) gutter_active: bool,
+    /// Which pane the pointer resolved to, when one did.
+    ///
+    /// Needed by the focus-follows-mouse term: motion only matters for focus
+    /// if it lands on a pane that is not already the active one.
+    pub(super) resolved_pane: Option<panes::PaneId>,
 }
 
 impl PaneResolution {
@@ -312,6 +331,7 @@ impl PaneResolution {
             has_urls: false,
             scroll_offset_nonzero: false,
             gutter_active: false,
+            resolved_pane: None,
         }
     }
 }
@@ -407,6 +427,7 @@ pub(super) fn resolve_pane_under_pointer(
         has_urls,
         scroll_offset_nonzero,
         gutter_active,
+        resolved_pane: Some(pane_id),
     }
 }
 
@@ -553,35 +574,64 @@ mod tests {
     #[test]
     fn pointer_motion_needs_repaint_decision_all_clear_is_false() {
         assert!(!pointer_motion_needs_repaint_decision(
-            false, false, false, false, None
+            false, false, false, false, false, None
+        ));
+    }
+
+    /// Issue #495. With focus-follows-mouse on, motion onto a non-active pane
+    /// carries a pending focus switch, so the frame that applies it must not
+    /// be suppressed -- even over plain terminal content with every other
+    /// signal clear.
+    #[test]
+    fn pointer_motion_needs_repaint_decision_pending_focus_change_forces_true() {
+        assert!(pointer_motion_needs_repaint_decision(
+            true, false, false, false, false, None
+        ));
+    }
+
+    /// And the suppression this gate exists for is preserved: with no focus
+    /// switch pending (pointer inside the already-active pane) plain motion
+    /// still schedules nothing.
+    #[test]
+    fn pointer_motion_needs_repaint_decision_no_pending_focus_change_still_suppresses() {
+        assert!(!pointer_motion_needs_repaint_decision(
+            false,
+            false,
+            false,
+            false,
+            false,
+            Some(PointerMotionPaneSignals {
+                mouse_tracking_active: false,
+                hover_region_risk: false,
+            })
         ));
     }
 
     #[test]
     fn pointer_motion_needs_repaint_decision_chrome_interactive_forces_true() {
         assert!(pointer_motion_needs_repaint_decision(
-            true, false, false, false, None
+            false, true, false, false, false, None
         ));
     }
 
     #[test]
     fn pointer_motion_needs_repaint_decision_any_pane_selecting_forces_true() {
         assert!(pointer_motion_needs_repaint_decision(
-            false, true, false, false, None
+            false, false, true, false, false, None
         ));
     }
 
     #[test]
     fn pointer_motion_needs_repaint_decision_overlay_open_forces_true() {
         assert!(pointer_motion_needs_repaint_decision(
-            false, false, true, false, None
+            false, false, false, true, false, None
         ));
     }
 
     #[test]
     fn pointer_motion_needs_repaint_decision_unresolved_pane_forces_true() {
         assert!(pointer_motion_needs_repaint_decision(
-            false, false, false, true, None
+            false, false, false, false, true, None
         ));
     }
 
@@ -590,13 +640,14 @@ mod tests {
         // Pointer resolved to "no pane here" (e.g. inter-pane padding) --
         // NOT the same as unresolved; contributes false on its own.
         assert!(!pointer_motion_needs_repaint_decision(
-            false, false, false, false, None
+            false, false, false, false, false, None
         ));
     }
 
     #[test]
     fn pointer_motion_needs_repaint_decision_mouse_tracking_active_forces_true() {
         assert!(pointer_motion_needs_repaint_decision(
+            false,
             false,
             false,
             false,
@@ -615,6 +666,7 @@ mod tests {
             false,
             false,
             false,
+            false,
             Some(PointerMotionPaneSignals {
                 mouse_tracking_active: false,
                 hover_region_risk: true,
@@ -625,6 +677,7 @@ mod tests {
     #[test]
     fn pointer_motion_needs_repaint_decision_pane_signals_both_false_is_false() {
         assert!(!pointer_motion_needs_repaint_decision(
+            false,
             false,
             false,
             false,

--- a/freminal/src/gui/pty.rs
+++ b/freminal/src/gui/pty.rs
@@ -783,10 +783,7 @@ fn spawn_pty_consumer_thread(
                             // be requested or the search result can stall while the
                             // terminal is otherwise idle and the cursor-blink wake
                             // is suppressed (classified Repaint, #459 review finding).
-                            let (chars, _tags) =
-                                emulator.internal.handler.data_and_format_data_for_gui(0);
-                            let mut combined = chars.scrollback;
-                            combined.extend(chars.visible);
+                            let combined = emulator.internal.handler.search_corpus(0);
                             let total_rows = emulator.internal.handler.buffer().rows().len();
                             let _ = search_buffer_tx.send((total_rows, combined));
                         }

--- a/freminal/src/gui/pty.rs
+++ b/freminal/src/gui/pty.rs
@@ -633,7 +633,7 @@ fn spawn_pty_consumer_thread(
                               arc_swap: &ArcSwap<TerminalSnapshot>,
                               repaint_handle: &OnceLock<(RepaintProxy, WindowId)>,
                               request_repaint: bool| {
-                let cmds: Vec<_> = emulator.internal.window_commands.drain(..).collect();
+                let cmds = std::mem::take(&mut emulator.internal.window_commands);
                 for cmd in cmds {
                     let wc = match &cmd {
                             WindowManipulation::ReportWindowState

--- a/freminal/src/gui/search.rs
+++ b/freminal/src/gui/search.rs
@@ -30,6 +30,7 @@ use freminal_common::buffer_states::tchar::TChar;
 use freminal_terminal_emulator::{io::InputEvent, snapshot::TerminalSnapshot};
 use regex::Regex;
 
+use super::hover_cursor::HoverAffordance;
 use super::{
     panes::PaneId,
     renderer::MatchHighlight,
@@ -500,8 +501,10 @@ pub fn show_search_bar(
 
                     // ── Row 2: toggles + error ────────────────────────────
                     ui.horizontal(|ui| {
-                        ui.checkbox(&mut view_state.search_state.regex_mode, "Regex");
+                        ui.checkbox(&mut view_state.search_state.regex_mode, "Regex")
+                            .clickable();
                         ui.checkbox(&mut view_state.search_state.case_sensitive, "Aa")
+                            .clickable()
                             .on_hover_text("Match case");
                         if let Some(err) = error_msg {
                             let error_color = ui.visuals().error_fg_color;

--- a/freminal/src/gui/settings.rs
+++ b/freminal/src/gui/settings.rs
@@ -4,6 +4,7 @@
 // https://opensource.org/licenses/MIT.
 
 use super::font_manager;
+use super::hover_cursor::HoverAffordance;
 use super::icons::ChromeIcon;
 use egui::{self, ComboBox, DragValue, FontData, FontDefinitions, FontFamily, Panel, Slider, Ui};
 use freminal_common::config::{
@@ -925,7 +926,8 @@ impl SettingsModal {
                 .show(ui, |ui| {
                     ui.horizontal(|ui| {
                         for tab in SettingsTab::ALL {
-                            ui.selectable_value(&mut self.active_tab, tab, tab.label());
+                            ui.selectable_value(&mut self.active_tab, tab, tab.label())
+                                .clickable();
                         }
                     });
                 });
@@ -972,7 +974,8 @@ impl SettingsModal {
                         &mut self.draft.font.family,
                         entry.value.clone(),
                         entry.label.as_str(),
-                    );
+                    )
+                    .clickable();
                 }
             });
         ui.add_space(8.0);
@@ -992,7 +995,8 @@ impl SettingsModal {
         ui.add_space(8.0);
 
         // --- Ligatures toggle ---
-        ui.checkbox(&mut self.draft.font.ligatures, "Enable Ligatures");
+        ui.checkbox(&mut self.draft.font.ligatures, "Enable Ligatures")
+            .clickable();
         ui.colored_label(
             ui.visuals().weak_text_color(),
             "Render multi-character ligatures (e.g. =>, !=, ->).",
@@ -1042,20 +1046,25 @@ impl SettingsModal {
                     &mut self.draft.cursor.shape,
                     CursorShapeConfig::Block,
                     "Block",
-                );
+                )
+                .clickable();
                 ui.selectable_value(
                     &mut self.draft.cursor.shape,
                     CursorShapeConfig::Underline,
                     "Underline",
-                );
-                ui.selectable_value(&mut self.draft.cursor.shape, CursorShapeConfig::Bar, "Bar");
+                )
+                .clickable();
+                ui.selectable_value(&mut self.draft.cursor.shape, CursorShapeConfig::Bar, "Bar")
+                    .clickable();
             });
         ui.add_space(8.0);
 
-        ui.checkbox(&mut self.draft.cursor.blink, "Cursor Blink");
+        ui.checkbox(&mut self.draft.cursor.blink, "Cursor Blink")
+            .clickable();
         ui.add_space(8.0);
 
-        ui.checkbox(&mut self.draft.cursor.trail, "Cursor Trail");
+        ui.checkbox(&mut self.draft.cursor.trail, "Cursor Trail")
+            .clickable();
         ui.add_space(4.0);
 
         ui.add_enabled_ui(self.draft.cursor.trail, |ui| {
@@ -1073,13 +1082,16 @@ impl SettingsModal {
         // ── Mode selector ──────────────────────────────────────────────────
         ui.label("Theme Mode:");
         ui.horizontal(|ui| {
-            ui.selectable_value(&mut self.draft.theme.mode, ThemeMode::Dark, "Dark");
-            ui.selectable_value(&mut self.draft.theme.mode, ThemeMode::Light, "Light");
+            ui.selectable_value(&mut self.draft.theme.mode, ThemeMode::Dark, "Dark")
+                .clickable();
+            ui.selectable_value(&mut self.draft.theme.mode, ThemeMode::Light, "Light")
+                .clickable();
             ui.selectable_value(
                 &mut self.draft.theme.mode,
                 ThemeMode::Auto,
                 "Auto (follow OS)",
-            );
+            )
+            .clickable();
         });
         ui.add_space(4.0);
         if self.draft.theme.mode == ThemeMode::Auto {
@@ -1104,7 +1116,8 @@ impl SettingsModal {
                         &mut self.draft.theme.dark_name,
                         theme.slug.to_string(),
                         theme.name,
-                    );
+                    )
+                    .clickable();
                 }
             });
         ui.add_space(4.0);
@@ -1129,7 +1142,8 @@ impl SettingsModal {
                         &mut self.draft.theme.light_name,
                         theme.slug.to_string(),
                         theme.name,
-                    );
+                    )
+                    .clickable();
                 }
             });
         ui.add_space(4.0);
@@ -1194,7 +1208,8 @@ impl SettingsModal {
             .selected_text(selected.as_str())
             .show_ui(ui, |ui| {
                 for level in &["trace", "debug", "info", "warn", "error"] {
-                    ui.selectable_value(&mut selected, (*level).to_string(), *level);
+                    ui.selectable_value(&mut selected, (*level).to_string(), *level)
+                        .clickable();
                 }
             });
         // Persist choice into the draft config.
@@ -1248,8 +1263,10 @@ impl SettingsModal {
                 StyleProfile::Retro => "Retro",
             })
             .show_ui(ui, |ui| {
-                ui.selectable_value(&mut self.draft_profile, StyleProfile::Modern, "Modern");
-                ui.selectable_value(&mut self.draft_profile, StyleProfile::Retro, "Retro");
+                ui.selectable_value(&mut self.draft_profile, StyleProfile::Modern, "Modern")
+                    .clickable();
+                ui.selectable_value(&mut self.draft_profile, StyleProfile::Retro, "Retro")
+                    .clickable();
             });
         if self.draft_profile != before {
             self.pending_preview_profile = Some(self.draft_profile);
@@ -1266,7 +1283,8 @@ impl SettingsModal {
     }
 
     fn show_ui_tab(&mut self, ui: &mut Ui) {
-        ui.checkbox(&mut self.draft.ui.hide_menu_bar, "Hide Menu Bar");
+        ui.checkbox(&mut self.draft.ui.hide_menu_bar, "Hide Menu Bar")
+            .clickable();
         ui.add_space(4.0);
         ui.colored_label(
             ui.visuals().weak_text_color(),
@@ -1307,7 +1325,8 @@ impl SettingsModal {
         ui.checkbox(
             &mut self.draft.ui.auto_detect_urls,
             "Auto-detect URLs in terminal output",
-        );
+        )
+        .clickable();
         ui.add_space(4.0);
         ui.colored_label(
             ui.visuals().weak_text_color(),
@@ -1362,22 +1381,26 @@ impl SettingsModal {
                     &mut self.draft.ui.background_image_mode,
                     BackgroundImageMode::Fill,
                     "Fill (stretch, ignore aspect ratio)",
-                );
+                )
+                .clickable();
                 ui.selectable_value(
                     &mut self.draft.ui.background_image_mode,
                     BackgroundImageMode::Fit,
                     "Fit (letterbox, preserve aspect ratio)",
-                );
+                )
+                .clickable();
                 ui.selectable_value(
                     &mut self.draft.ui.background_image_mode,
                     BackgroundImageMode::Cover,
                     "Cover (crop, preserve aspect ratio)",
-                );
+                )
+                .clickable();
                 ui.selectable_value(
                     &mut self.draft.ui.background_image_mode,
                     BackgroundImageMode::Tile,
                     "Tile (repeat in both dimensions)",
-                );
+                )
+                .clickable();
             });
 
         ui.add_space(8.0);
@@ -1424,7 +1447,8 @@ impl SettingsModal {
 
         ui.add_space(8.0);
 
-        ui.checkbox(&mut self.draft.shader.hot_reload, "Hot Reload Shader");
+        ui.checkbox(&mut self.draft.shader.hot_reload, "Hot Reload Shader")
+            .clickable();
         ui.add_space(4.0);
         ui.colored_label(
             ui.visuals().weak_text_color(),
@@ -1432,38 +1456,14 @@ impl SettingsModal {
         );
     }
 
-    fn show_tabs_tab(&mut self, ui: &mut Ui) {
-        ui.checkbox(
-            &mut self.draft.tabs.show_single_tab,
-            "Show Tab Bar With Single Tab",
-        );
-        ui.add_space(4.0);
-        ui.colored_label(
-            ui.visuals().weak_text_color(),
-            "When disabled, the tab bar only appears with multiple tabs.",
-        );
-
-        ui.add_space(8.0);
-        ui.separator();
-        ui.add_space(4.0);
-
-        ui.label("Tab Bar Position:");
-        let current_label = tab_bar_position_label(self.draft.tabs.position);
-        ComboBox::from_id_salt("tab_bar_position")
-            .selected_text(current_label)
-            .show_ui(ui, |ui| {
-                ui.selectable_value(&mut self.draft.tabs.position, TabBarPosition::Top, "Top");
-                ui.selectable_value(
-                    &mut self.draft.tabs.position,
-                    TabBarPosition::Bottom,
-                    "Bottom",
-                );
-            });
-
-        ui.add_space(8.0);
-        ui.separator();
-        ui.add_space(4.0);
-
+    /// Tab-title policy controls: how a tab combines the user's custom name
+    /// with the title the shell sets via OSC 0/1/2, plus the separator and a
+    /// live preview.
+    ///
+    /// Split out of [`Self::show_tabs_tab`], which covers three unrelated
+    /// groups (tab-bar visibility, tab titles, pane focus) and had outgrown
+    /// the 100-line limit.
+    fn show_tab_title_policy(&mut self, ui: &mut Ui) {
         ui.label("Tab Title Policy:");
         ui.add_space(2.0);
         ui.colored_label(
@@ -1487,7 +1487,8 @@ impl SettingsModal {
                         &mut self.draft.tab_title.policy,
                         policy,
                         tab_title_policy_label(policy),
-                    );
+                    )
+                    .clickable();
                 }
             });
 
@@ -1520,6 +1521,44 @@ impl SettingsModal {
             ui.visuals().weak_text_color(),
             format!("Preview:  {preview}"),
         );
+    }
+
+    fn show_tabs_tab(&mut self, ui: &mut Ui) {
+        ui.checkbox(
+            &mut self.draft.tabs.show_single_tab,
+            "Show Tab Bar With Single Tab",
+        )
+        .clickable();
+        ui.add_space(4.0);
+        ui.colored_label(
+            ui.visuals().weak_text_color(),
+            "When disabled, the tab bar only appears with multiple tabs.",
+        );
+
+        ui.add_space(8.0);
+        ui.separator();
+        ui.add_space(4.0);
+
+        ui.label("Tab Bar Position:");
+        let current_label = tab_bar_position_label(self.draft.tabs.position);
+        ComboBox::from_id_salt("tab_bar_position")
+            .selected_text(current_label)
+            .show_ui(ui, |ui| {
+                ui.selectable_value(&mut self.draft.tabs.position, TabBarPosition::Top, "Top")
+                    .clickable();
+                ui.selectable_value(
+                    &mut self.draft.tabs.position,
+                    TabBarPosition::Bottom,
+                    "Bottom",
+                )
+                .clickable();
+            });
+
+        ui.add_space(8.0);
+        ui.separator();
+        ui.add_space(4.0);
+
+        self.show_tab_title_policy(ui);
 
         ui.add_space(8.0);
         ui.separator();
@@ -1530,7 +1569,8 @@ impl SettingsModal {
         ui.checkbox(
             &mut self.draft.tabs.focus_follows_mouse,
             "Focus follows mouse",
-        );
+        )
+        .clickable();
         ui.add_space(2.0);
         ui.colored_label(
             ui.visuals().weak_text_color(),
@@ -1575,7 +1615,8 @@ impl SettingsModal {
         ui.checkbox(
             &mut self.draft.tabs.confirm_broadcast,
             "Confirm before enabling broadcast",
-        );
+        )
+        .clickable();
         ui.add_space(2.0);
         ui.colored_label(
             ui.visuals().weak_text_color(),
@@ -1604,7 +1645,8 @@ impl SettingsModal {
         ui.checkbox(
             &mut self.draft.shell_integration.set_term_program,
             "Set TERM_PROGRAM=freminal",
-        );
+        )
+        .clickable();
         ui.add_space(4.0);
         ui.colored_label(
             ui.visuals().weak_text_color(),
@@ -1633,7 +1675,8 @@ impl SettingsModal {
         ui.checkbox(
             &mut self.draft.command_blocks.enabled,
             "Enable command block tracking",
-        );
+        )
+        .clickable();
         ui.add_space(4.0);
         ui.colored_label(
             ui.visuals().weak_text_color(),
@@ -1646,7 +1689,8 @@ impl SettingsModal {
         ui.checkbox(
             &mut self.draft.command_blocks.show_duration,
             "Show command duration",
-        );
+        )
+        .clickable();
         ui.add_space(4.0);
         ui.colored_label(
             ui.visuals().weak_text_color(),
@@ -1681,12 +1725,14 @@ impl SettingsModal {
                     &mut self.draft.command_blocks.gutter,
                     GutterPosition::Left,
                     "Left",
-                );
+                )
+                .clickable();
                 ui.selectable_value(
                     &mut self.draft.command_blocks.gutter,
                     GutterPosition::Off,
                     "Off",
-                );
+                )
+                .clickable();
             });
         ui.add_space(4.0);
         ui.colored_label(
@@ -1707,10 +1753,14 @@ impl SettingsModal {
                     &mut self.draft.bell.mode,
                     config::BellMode::Visual,
                     "Visual",
-                );
-                ui.selectable_value(&mut self.draft.bell.mode, config::BellMode::Audio, "Audio");
-                ui.selectable_value(&mut self.draft.bell.mode, config::BellMode::Both, "Both");
-                ui.selectable_value(&mut self.draft.bell.mode, config::BellMode::None, "None");
+                )
+                .clickable();
+                ui.selectable_value(&mut self.draft.bell.mode, config::BellMode::Audio, "Audio")
+                    .clickable();
+                ui.selectable_value(&mut self.draft.bell.mode, config::BellMode::Both, "Both")
+                    .clickable();
+                ui.selectable_value(&mut self.draft.bell.mode, config::BellMode::None, "None")
+                    .clickable();
             });
 
         ui.add_space(4.0);
@@ -1725,7 +1775,8 @@ impl SettingsModal {
         ui.checkbox(
             &mut self.draft.bell.on_command_finished,
             "Ring bell on command completion",
-        );
+        )
+        .clickable();
         ui.add_space(4.0);
         ui.colored_label(
             ui.visuals().weak_text_color(),
@@ -1739,7 +1790,8 @@ impl SettingsModal {
         ui.checkbox(
             &mut self.draft.notifications.enabled,
             "Enable notifications",
-        );
+        )
+        .clickable();
         ui.add_space(4.0);
         ui.colored_label(
             ui.visuals().weak_text_color(),
@@ -1752,19 +1804,23 @@ impl SettingsModal {
         ui.checkbox(
             &mut self.draft.notifications.osc_9,
             "OSC 9 (iTerm2 / WezTerm text)",
-        );
+        )
+        .clickable();
         ui.checkbox(
             &mut self.draft.notifications.osc_777,
             "OSC 777 (urxvt notify;TITLE;BODY)",
-        );
+        )
+        .clickable();
         ui.checkbox(
             &mut self.draft.notifications.osc_99,
             "OSC 99 (kitty stateful notifications)",
-        );
+        )
+        .clickable();
         ui.checkbox(
             &mut self.draft.notifications.on_command_finished,
             "Command finished (OSC 133 D)",
-        );
+        )
+        .clickable();
 
         ui.add_space(12.0);
         ui.horizontal(|ui| {
@@ -1829,7 +1885,8 @@ impl SettingsModal {
         ui.checkbox(
             &mut self.draft.bell.on_command_finished,
             "Ring bell on command completion",
-        );
+        )
+        .clickable();
         ui.add_space(4.0);
         ui.colored_label(
             ui.visuals().weak_text_color(),
@@ -1886,7 +1943,8 @@ impl SettingsModal {
         ui.checkbox(
             &mut self.draft.notifications.show_resize_overlay,
             "Show resize overlay (cols×rows while resizing)",
-        );
+        )
+        .clickable();
     }
 
     /// Render one labeled routing combo box. Extracted so the routing
@@ -1906,29 +1964,34 @@ impl SettingsModal {
                         routing,
                         config::NotificationRouting::Toast,
                         notification_routing_label(config::NotificationRouting::Toast),
-                    );
+                    )
+                    .clickable();
                     ui.selectable_value(
                         routing,
                         config::NotificationRouting::System,
                         notification_routing_label(config::NotificationRouting::System),
-                    );
+                    )
+                    .clickable();
                     ui.selectable_value(
                         routing,
                         config::NotificationRouting::Both,
                         notification_routing_label(config::NotificationRouting::Both),
-                    );
+                    )
+                    .clickable();
                     ui.selectable_value(
                         routing,
                         config::NotificationRouting::SystemWhenUnfocused,
                         notification_routing_label(
                             config::NotificationRouting::SystemWhenUnfocused,
                         ),
-                    );
+                    )
+                    .clickable();
                     ui.selectable_value(
                         routing,
                         config::NotificationRouting::Disabled,
                         notification_routing_label(config::NotificationRouting::Disabled),
-                    );
+                    )
+                    .clickable();
                 });
         });
     }
@@ -1951,12 +2014,14 @@ impl SettingsModal {
                         routing,
                         config::FreminalToastRouting::Toast,
                         freminal_toast_routing_label(config::FreminalToastRouting::Toast),
-                    );
+                    )
+                    .clickable();
                     ui.selectable_value(
                         routing,
                         config::FreminalToastRouting::Disabled,
                         freminal_toast_routing_label(config::FreminalToastRouting::Disabled),
-                    );
+                    )
+                    .clickable();
                 });
         });
     }
@@ -1965,7 +2030,8 @@ impl SettingsModal {
         ui.checkbox(
             &mut self.draft.security.allow_clipboard_read,
             "Allow Clipboard Read (OSC 52)",
-        );
+        )
+        .clickable();
         ui.add_space(4.0);
         ui.colored_label(
             ui.visuals().weak_text_color(),
@@ -1980,7 +2046,8 @@ impl SettingsModal {
         ui.checkbox(
             &mut self.draft.security.password_indicator,
             "Password Indicator",
-        );
+        )
+        .clickable();
         ui.add_space(4.0);
         ui.colored_label(
             ui.visuals().weak_text_color(),
@@ -2011,7 +2078,8 @@ impl SettingsModal {
         );
         ui.add_space(8.0);
 
-        ui.checkbox(&mut self.draft.close_guard.enabled, "Enable close guard");
+        ui.checkbox(&mut self.draft.close_guard.enabled, "Enable close guard")
+            .clickable();
 
         // The remaining toggles are only meaningful while the guard is on.
         ui.add_enabled_ui(self.draft.close_guard.enabled, |ui| {
@@ -2019,11 +2087,13 @@ impl SettingsModal {
             ui.checkbox(
                 &mut self.draft.close_guard.unknown_blocks,
                 "Also guard panes with unknown status (no shell integration)",
-            );
+            )
+            .clickable();
             ui.checkbox(
                 &mut self.draft.close_guard.guard_app_quit,
                 "Guard application quit",
-            );
+            )
+            .clickable();
         });
     }
 
@@ -2038,7 +2108,8 @@ impl SettingsModal {
         );
         ui.add_space(8.0);
 
-        ui.checkbox(&mut self.draft.paste_guard.enabled, "Enable paste guard");
+        ui.checkbox(&mut self.draft.paste_guard.enabled, "Enable paste guard")
+            .clickable();
 
         // The per-trigger toggles are only meaningful while the guard is on.
         ui.add_enabled_ui(self.draft.paste_guard.enabled, |ui| {
@@ -2046,15 +2117,18 @@ impl SettingsModal {
             ui.checkbox(
                 &mut self.draft.paste_guard.multiline,
                 "Confirm multi-line pastes",
-            );
+            )
+            .clickable();
             ui.checkbox(
                 &mut self.draft.paste_guard.control_chars,
                 "Confirm pastes containing control characters",
-            );
+            )
+            .clickable();
             ui.checkbox(
                 &mut self.draft.paste_guard.patterns,
                 "Confirm pastes matching dangerous patterns",
-            );
+            )
+            .clickable();
 
             // Pattern list editor — only relevant when pattern matching is on.
             ui.add_enabled_ui(self.draft.paste_guard.patterns, |ui| {
@@ -2539,7 +2613,8 @@ impl SettingsModal {
             ui.checkbox(
                 &mut self.draft.startup.restore_last_session,
                 "Restore last session on startup",
-            );
+            )
+            .clickable();
             ui.add_space(2.0);
             ui.label(
                 egui::RichText::new(
@@ -2656,7 +2731,11 @@ impl SettingsModal {
                 .as_deref()
                 .is_some_and(|n| n == current);
             let label = format!("{current}  (missing)");
-            if ui.selectable_label(is_selected, label).clicked() {
+            if ui
+                .selectable_label(is_selected, label)
+                .clickable()
+                .clicked()
+            {
                 self.draft.startup.layout = Some(current.to_string());
             }
         }
@@ -2671,7 +2750,11 @@ impl SettingsModal {
                 || layout.name.clone(),
                 |d| format!("{}  —  {d}", layout.name),
             );
-            if ui.selectable_label(is_selected, label).clicked() {
+            if ui
+                .selectable_label(is_selected, label)
+                .clickable()
+                .clicked()
+            {
                 self.draft.startup.layout = Some(layout.name.clone());
             }
         }

--- a/freminal/src/gui/settings.rs
+++ b/freminal/src/gui/settings.rs
@@ -977,7 +977,9 @@ impl SettingsModal {
                     )
                     .clickable();
                 }
-            });
+            })
+            .response
+            .clickable();
         ui.add_space(8.0);
 
         // --- Font Size slider ---
@@ -1056,7 +1058,9 @@ impl SettingsModal {
                 .clickable();
                 ui.selectable_value(&mut self.draft.cursor.shape, CursorShapeConfig::Bar, "Bar")
                     .clickable();
-            });
+            })
+            .response
+            .clickable();
         ui.add_space(8.0);
 
         ui.checkbox(&mut self.draft.cursor.blink, "Cursor Blink")
@@ -1119,7 +1123,9 @@ impl SettingsModal {
                     )
                     .clickable();
                 }
-            });
+            })
+            .response
+            .clickable();
         ui.add_space(4.0);
         if let Some(theme) = themes::by_slug(&self.draft.theme.dark_name)
             && self.draft.theme.mode != ThemeMode::Light
@@ -1145,7 +1151,9 @@ impl SettingsModal {
                     )
                     .clickable();
                 }
-            });
+            })
+            .response
+            .clickable();
         ui.add_space(4.0);
         if let Some(theme) = themes::by_slug(&self.draft.theme.light_name)
             && self.draft.theme.mode == ThemeMode::Light
@@ -1211,7 +1219,9 @@ impl SettingsModal {
                     ui.selectable_value(&mut selected, (*level).to_string(), *level)
                         .clickable();
                 }
-            });
+            })
+            .response
+            .clickable();
         // Persist choice into the draft config.
         self.draft.logging.level = if selected == "debug" {
             None // default — omit from TOML
@@ -1267,7 +1277,9 @@ impl SettingsModal {
                     .clickable();
                 ui.selectable_value(&mut self.draft_profile, StyleProfile::Retro, "Retro")
                     .clickable();
-            });
+            })
+            .response
+            .clickable();
         if self.draft_profile != before {
             self.pending_preview_profile = Some(self.draft_profile);
             // Persist into the draft so Apply (which saves `self.draft`) writes
@@ -1401,7 +1413,9 @@ impl SettingsModal {
                     "Tile (repeat in both dimensions)",
                 )
                 .clickable();
-            });
+            })
+            .response
+            .clickable();
 
         ui.add_space(8.0);
 
@@ -1490,7 +1504,9 @@ impl SettingsModal {
                     )
                     .clickable();
                 }
-            });
+            })
+            .response
+            .clickable();
 
         // The separator only applies to the combining policies.
         let separator_relevant = matches!(
@@ -1552,7 +1568,9 @@ impl SettingsModal {
                     "Bottom",
                 )
                 .clickable();
-            });
+            })
+            .response
+            .clickable();
 
         ui.add_space(8.0);
         ui.separator();
@@ -1733,7 +1751,9 @@ impl SettingsModal {
                     "Off",
                 )
                 .clickable();
-            });
+            })
+            .response
+            .clickable();
         ui.add_space(4.0);
         ui.colored_label(
             ui.visuals().weak_text_color(),
@@ -1761,7 +1781,9 @@ impl SettingsModal {
                     .clickable();
                 ui.selectable_value(&mut self.draft.bell.mode, config::BellMode::None, "None")
                     .clickable();
-            });
+            })
+            .response
+            .clickable();
 
         ui.add_space(4.0);
         ui.colored_label(
@@ -1992,7 +2014,9 @@ impl SettingsModal {
                         notification_routing_label(config::NotificationRouting::Disabled),
                     )
                     .clickable();
-                });
+                })
+                .response
+                .clickable();
         });
     }
 
@@ -2022,7 +2046,9 @@ impl SettingsModal {
                         freminal_toast_routing_label(config::FreminalToastRouting::Disabled),
                     )
                     .clickable();
-                });
+                })
+                .response
+                .clickable();
         });
     }
 
@@ -2687,7 +2713,9 @@ impl SettingsModal {
                             &current,
                             configured_missing,
                         );
-                    });
+                    })
+                    .response
+                    .clickable();
             });
             ui.add_space(2.0);
             ui.label(

--- a/freminal/src/gui/settings.rs
+++ b/freminal/src/gui/settings.rs
@@ -1438,6 +1438,23 @@ impl SettingsModal {
         );
     }
 
+    /// Replace the draft with a default config, as the "Reset to Defaults"
+    /// button does.
+    ///
+    /// `draft_profile` is the chrome-style picker's own copy of
+    /// `draft.chrome.profile`, kept separate so the picker can detect a change
+    /// and emit a live preview. It is synced on open and whenever the user
+    /// moves the picker -- but a reset moves `draft.chrome.profile` underneath
+    /// it without the picker being touched, so it must be re-synced here.
+    /// Otherwise the picker keeps displaying the pre-reset profile while Apply
+    /// writes the default one, and the change-detection in
+    /// `show_style_profile_picker` sees no difference to correct.
+    fn reset_draft_to_defaults(&mut self) {
+        self.draft = Config::default();
+        self.draft_profile = self.draft.chrome.profile;
+        self.status_message = Some("Reset to defaults (not saved yet)".to_string());
+    }
+
     /// The dialog's action row: `[Reset to Defaults] ... [Cancel] [Apply] [OK]`.
     ///
     /// Shared by the standalone window and the inline modal, which previously
@@ -1463,8 +1480,7 @@ impl SettingsModal {
                 .clickable_when(!is_read_only)
                 .clicked()
             {
-                self.draft = Config::default();
-                self.status_message = Some("Reset to defaults (not saved yet)".to_string());
+                self.reset_draft_to_defaults();
             }
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                 let ok_btn = egui::Button::new("OK");
@@ -3160,9 +3176,36 @@ mod tests {
         live.font.size = 42.0;
         modal.open(&live, Vec::new(), false);
 
-        // Simulate clicking "Reset to Defaults" by resetting the draft.
-        modal.draft = Config::default();
+        // Call the real reset rather than re-implementing it here: an inline
+        // `modal.draft = Config::default()` is what let the profile-picker
+        // desync below go unnoticed.
+        modal.reset_draft_to_defaults();
         assert!((modal.draft.font.size - 12.0).abs() < f32::EPSILON);
+    }
+
+    /// The chrome-style picker keeps its own copy of `draft.chrome.profile`.
+    /// A reset moves the draft underneath it, and the picker's own
+    /// change-detection cannot notice, so the reset must re-sync it. Without
+    /// this the picker displays the pre-reset profile while Apply writes the
+    /// default one.
+    #[test]
+    fn reset_to_defaults_resyncs_the_style_profile_picker() {
+        use freminal_common::gui_theme::StyleProfile;
+
+        let mut modal = SettingsModal::new(None);
+        let mut live = Config::default();
+        // Open with a non-default profile so a reset has something to change.
+        live.chrome.profile = StyleProfile::Retro;
+        modal.open(&live, Vec::new(), false);
+        assert_eq!(modal.draft_profile, StyleProfile::Retro);
+
+        modal.reset_draft_to_defaults();
+
+        assert_eq!(
+            modal.draft_profile, modal.draft.chrome.profile,
+            "the picker must show what Apply would save"
+        );
+        assert_eq!(modal.draft_profile, Config::default().chrome.profile);
     }
 
     #[test]

--- a/freminal/src/gui/settings.rs
+++ b/freminal/src/gui/settings.rs
@@ -580,10 +580,20 @@ impl SettingsModal {
                     self.draft = Config::default();
                     self.status_message = Some("Reset to defaults (not saved yet)".to_string());
                 }
+                // Right-to-left layout, so these read [Cancel] [Apply] [OK]
+                // on screen -- the conventional order, with the dismissing
+                // commit furthest right.
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    let ok_btn = egui::Button::new("OK");
+                    if ui.add_enabled(!is_read_only, ok_btn).clicked() {
+                        action = self.try_apply();
+                    }
+                    // Apply commits without dismissing, so a change can be
+                    // judged against a live terminal and then adjusted again
+                    // without reopening the dialog (issue #452).
                     let apply_btn = egui::Button::new("Apply");
                     if ui.add_enabled(!is_read_only, apply_btn).clicked() {
-                        action = self.try_apply();
+                        action = self.apply_without_dismissing();
                     }
                     if ui.button("Cancel").clicked() {
                         // Route through the dirty-state guard so unsaved
@@ -758,11 +768,17 @@ impl SettingsModal {
                         self.status_message = Some("Reset to defaults (not saved yet)".to_string());
                     }
 
-                    // Right-align Apply and Cancel.
+                    // Right-to-left layout, so these read
+                    // [Cancel] [Apply] [OK] on screen.
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        let ok_btn = egui::Button::new("OK");
+                        if ui.add_enabled(!is_read_only, ok_btn).clicked() {
+                            action = self.try_apply();
+                        }
+                        // Commits without dismissing (issue #452).
                         let apply_btn = egui::Button::new("Apply");
                         if ui.add_enabled(!is_read_only, apply_btn).clicked() {
-                            action = self.try_apply();
+                            action = self.apply_without_dismissing();
                         }
                         if ui.button("Cancel").clicked() {
                             // Route through the dirty-state guard so unsaved
@@ -2613,14 +2629,26 @@ impl SettingsModal {
     //  Apply logic
     // -------------------------------------------------------------------------
 
-    fn try_apply(&mut self) -> SettingsAction {
+    /// Persist the draft and re-baseline, leaving the dialog open.
+    ///
+    /// Shared by both commit paths. On success the draft becomes the new
+    /// clean baseline, so a subsequent Cancel has nothing to revert and the
+    /// unsaved-changes guard stays quiet.
+    ///
+    /// Crucially this also re-baselines `original_theme_slug` /
+    /// `original_opacity`, the values the close path reverts a live preview
+    /// to. Once the user has committed, the committed appearance *is* the
+    /// original; without this, applying a new theme and then cancelling would
+    /// revert the terminal to the theme in force when the dialog was first
+    /// opened, silently undoing a change already written to disk.
+    fn commit_draft(&mut self) -> SettingsAction {
         match config::save_config(&self.draft, self.config_path.as_deref()) {
             Ok(()) => {
-                self.is_open = false;
                 self.status_message = None;
-                // Refresh baseline so any subsequent reopen sees the saved
-                // state as clean.
                 self.baseline_toml = Self::serialize_for_baseline(&self.draft);
+                self.original_theme_slug =
+                    self.draft.theme.active_slug(self.os_dark_mode).to_string();
+                self.original_opacity = self.draft.ui.background_opacity;
                 self.pending_close = PendingClose::None;
                 SettingsAction::Applied
             }
@@ -2629,6 +2657,29 @@ impl SettingsModal {
                 SettingsAction::None
             }
         }
+    }
+
+    /// Commit the draft and dismiss the dialog (the OK button).
+    fn try_apply(&mut self) -> SettingsAction {
+        let action = self.commit_draft();
+        if action == SettingsAction::Applied {
+            self.is_open = false;
+        }
+        action
+    }
+
+    /// Commit the draft and stay open (the Apply button, issue #452).
+    ///
+    /// Lets the user try a change against a live terminal and keep adjusting
+    /// without reopening the dialog for every iteration. A failed save leaves
+    /// the dialog open with the error in `status_message`, exactly as the OK
+    /// path does.
+    fn apply_without_dismissing(&mut self) -> SettingsAction {
+        let action = self.commit_draft();
+        if action == SettingsAction::Applied {
+            self.status_message = Some("Settings applied.".to_string());
+        }
+        action
     }
 
     // ── Startup tab ──────────────────────────────────────────────────────────
@@ -3489,6 +3540,116 @@ mod tests {
         modal.draft.ui.background_opacity =
             (modal.draft.ui.background_opacity - 0.25).clamp(0.0, 1.0);
         assert!(modal.is_dirty(), "edited draft should be dirty");
+    }
+
+    // ── Apply without dismissing (issue #452) ────────────────────────────
+
+    /// Open a modal writing to a throwaway config path, so the commit paths
+    /// can be exercised without touching the user's real config.
+    fn modal_with_temp_config() -> (SettingsModal, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.toml");
+        let mut modal = SettingsModal::new(Some(path));
+        modal.open(&Config::default(), Vec::new(), false);
+        modal.read_only_reason = None;
+        (modal, dir)
+    }
+
+    /// The point of #452: commit the draft and stay open, so the user can
+    /// judge the change against a live terminal and keep adjusting.
+    #[test]
+    fn apply_without_dismissing_commits_and_keeps_the_dialog_open() {
+        let (mut modal, _dir) = modal_with_temp_config();
+        modal.draft.ui.background_opacity = 0.5;
+        assert!(modal.is_dirty());
+
+        let action = modal.apply_without_dismissing();
+
+        assert_eq!(action, SettingsAction::Applied, "config must be adopted");
+        assert!(modal.is_open, "Apply must NOT dismiss the dialog");
+        assert!(
+            !modal.is_dirty(),
+            "the committed draft becomes the new clean baseline"
+        );
+        assert!(modal.status_message.is_some(), "commit is acknowledged");
+    }
+
+    /// OK keeps its existing behaviour: commit and dismiss.
+    #[test]
+    fn ok_commits_and_dismisses() {
+        let (mut modal, _dir) = modal_with_temp_config();
+        modal.draft.ui.background_opacity = 0.5;
+
+        let action = modal.try_apply();
+
+        assert_eq!(action, SettingsAction::Applied);
+        assert!(!modal.is_open, "OK dismisses the dialog");
+        assert!(!modal.is_dirty());
+    }
+
+    /// After an Apply, a later Cancel must revert to what was applied -- not
+    /// to whatever was live when the dialog was first opened. Otherwise
+    /// cancelling would silently undo a change already written to disk.
+    #[test]
+    fn apply_rebaselines_the_revert_target() {
+        let (mut modal, _dir) = modal_with_temp_config();
+        let opened_with = modal.original_opacity;
+
+        modal.draft.ui.background_opacity = 0.25;
+        let _ = modal.apply_without_dismissing();
+
+        assert!(
+            (modal.original_opacity - 0.25).abs() < f32::EPSILON,
+            "the applied value is the new revert target, was {opened_with}"
+        );
+        assert_eq!(
+            modal.original_theme_slug,
+            modal.draft.theme.active_slug(modal.os_dark_mode),
+            "the applied theme is the new revert target"
+        );
+    }
+
+    /// Applying repeatedly is the expected workflow, and each commit
+    /// re-baselines cleanly.
+    #[test]
+    fn apply_can_be_used_repeatedly() {
+        let (mut modal, _dir) = modal_with_temp_config();
+
+        for opacity in [0.9_f32, 0.6, 0.3] {
+            modal.draft.ui.background_opacity = opacity;
+            assert!(modal.is_dirty());
+            assert_eq!(modal.apply_without_dismissing(), SettingsAction::Applied);
+            assert!(modal.is_open);
+            assert!(!modal.is_dirty());
+        }
+    }
+
+    /// A failed save must not dismiss, must not re-baseline, and must
+    /// surface the error -- the same contract the OK path has.
+    #[test]
+    fn a_failed_apply_keeps_the_dialog_open_and_stays_dirty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // A directory where the config file should be: writing must fail.
+        let path = dir.path().join("unwritable");
+        std::fs::create_dir(&path).expect("create blocking dir");
+        let mut modal = SettingsModal::new(Some(path));
+        modal.open(&Config::default(), Vec::new(), false);
+        modal.read_only_reason = None;
+
+        modal.draft.ui.background_opacity = 0.5;
+        let action = modal.apply_without_dismissing();
+
+        assert_eq!(action, SettingsAction::None, "a failed save adopts nothing");
+        assert!(modal.is_open, "a failed save must not dismiss");
+        assert!(modal.is_dirty(), "a failed save must not re-baseline");
+        assert!(
+            modal
+                .status_message
+                .as_ref()
+                .is_some_and(|m| m.contains("Save failed")),
+            "the failure must be surfaced, got {:?}",
+            modal.status_message
+        );
     }
 
     #[test]

--- a/freminal/src/gui/settings.rs
+++ b/freminal/src/gui/settings.rs
@@ -574,34 +574,7 @@ impl SettingsModal {
                 let warn = ui.visuals().warn_fg_color;
                 ui.colored_label(warn, msg);
             }
-            ui.horizontal(|ui| {
-                let reset_btn = egui::Button::new("Reset to Defaults");
-                if ui.add_enabled(!is_read_only, reset_btn).clicked() {
-                    self.draft = Config::default();
-                    self.status_message = Some("Reset to defaults (not saved yet)".to_string());
-                }
-                // Right-to-left layout, so these read [Cancel] [Apply] [OK]
-                // on screen -- the conventional order, with the dismissing
-                // commit furthest right.
-                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    let ok_btn = egui::Button::new("OK");
-                    if ui.add_enabled(!is_read_only, ok_btn).clicked() {
-                        action = self.try_apply();
-                    }
-                    // Apply commits without dismissing, so a change can be
-                    // judged against a live terminal and then adjusted again
-                    // without reopening the dialog (issue #452).
-                    let apply_btn = egui::Button::new("Apply");
-                    if ui.add_enabled(!is_read_only, apply_btn).clicked() {
-                        action = self.apply_without_dismissing();
-                    }
-                    if ui.button("Cancel").clicked() {
-                        // Route through the dirty-state guard so unsaved
-                        // edits surface a confirmation prompt.
-                        self.request_close();
-                    }
-                });
-            });
+            self.show_action_buttons(ui, is_read_only, &mut action);
             ui.add_space(4.0);
         });
 
@@ -760,33 +733,7 @@ impl SettingsModal {
                     ui.colored_label(warn, msg);
                 }
 
-                // --- Bottom buttons ---
-                ui.horizontal(|ui| {
-                    let reset_btn = egui::Button::new("Reset to Defaults");
-                    if ui.add_enabled(!is_read_only, reset_btn).clicked() {
-                        self.draft = Config::default();
-                        self.status_message = Some("Reset to defaults (not saved yet)".to_string());
-                    }
-
-                    // Right-to-left layout, so these read
-                    // [Cancel] [Apply] [OK] on screen.
-                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        let ok_btn = egui::Button::new("OK");
-                        if ui.add_enabled(!is_read_only, ok_btn).clicked() {
-                            action = self.try_apply();
-                        }
-                        // Commits without dismissing (issue #452).
-                        let apply_btn = egui::Button::new("Apply");
-                        if ui.add_enabled(!is_read_only, apply_btn).clicked() {
-                            action = self.apply_without_dismissing();
-                        }
-                        if ui.button("Cancel").clicked() {
-                            // Route through the dirty-state guard so unsaved
-                            // edits surface a confirmation prompt.
-                            self.request_close();
-                        }
-                    });
-                });
+                self.show_action_buttons(ui, is_read_only, &mut action);
             });
 
         // Handle the X button on the window title bar.  When the user clicks
@@ -1489,6 +1436,63 @@ impl SettingsModal {
             ui.visuals().weak_text_color(),
             "Automatically recompile the shader when the file changes on disk.",
         );
+    }
+
+    /// The dialog's action row: `[Reset to Defaults] ... [Cancel] [Apply] [OK]`.
+    ///
+    /// Shared by the standalone window and the inline modal, which previously
+    /// carried byte-identical copies of it.
+    ///
+    /// Right-to-left layout, so the buttons added first sit furthest right --
+    /// the conventional order, with the dismissing commit at the end. When the
+    /// config is read-only the three committing buttons are disabled and say
+    /// so with the cursor rather than inviting a click that cannot work.
+    ///
+    /// Writes through `action` only when a button is actually clicked, so an
+    /// action a caller already resolved this frame is left intact.
+    fn show_action_buttons(
+        &mut self,
+        ui: &mut Ui,
+        is_read_only: bool,
+        action: &mut SettingsAction,
+    ) {
+        ui.horizontal(|ui| {
+            let reset_btn = egui::Button::new("Reset to Defaults");
+            if ui
+                .add_enabled(!is_read_only, reset_btn)
+                .clickable_when(!is_read_only)
+                .clicked()
+            {
+                self.draft = Config::default();
+                self.status_message = Some("Reset to defaults (not saved yet)".to_string());
+            }
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                let ok_btn = egui::Button::new("OK");
+                if ui
+                    .add_enabled(!is_read_only, ok_btn)
+                    .clickable_when(!is_read_only)
+                    .clicked()
+                {
+                    *action = self.try_apply();
+                }
+                // Apply commits without dismissing, so a change can be judged
+                // against a live terminal and then adjusted again without
+                // reopening the dialog (issue #452).
+                let apply_btn = egui::Button::new("Apply");
+                if ui
+                    .add_enabled(!is_read_only, apply_btn)
+                    .clickable_when(!is_read_only)
+                    .clicked()
+                {
+                    *action = self.apply_without_dismissing();
+                }
+                if ui.button("Cancel").clicked() {
+                    // Route through the dirty-state guard so unsaved edits
+                    // surface a confirmation prompt.
+                    self.request_close();
+                }
+            });
+        });
     }
 
     /// Tab-title policy controls: how a tab combines the user's custom name

--- a/freminal/src/gui/settings.rs
+++ b/freminal/src/gui/settings.rs
@@ -984,12 +984,14 @@ impl SettingsModal {
 
         // --- Font Size slider ---
         ui.label("Font Size:");
-        ui.add(Slider::new(&mut self.draft.font.size, 4.0..=96.0).step_by(0.5));
+        ui.add(Slider::new(&mut self.draft.font.size, 4.0..=96.0).step_by(0.5))
+            .draggable();
         ui.add_space(8.0);
 
         // --- Line Height slider ---
         ui.label("Line Height:");
-        ui.add(Slider::new(&mut self.draft.font.line_height, 1.0..=2.0).step_by(0.01));
+        ui.add(Slider::new(&mut self.draft.font.line_height, 1.0..=2.0).step_by(0.01))
+            .draggable();
         ui.colored_label(
             ui.visuals().weak_text_color(),
             "Vertical spacing between rows (multiplier of the font's ascent + descent).",
@@ -1077,7 +1079,8 @@ impl SettingsModal {
                 ui.add(egui::Slider::new(
                     &mut self.draft.cursor.trail_duration_ms,
                     10..=500,
-                ));
+                ))
+                .draggable();
             });
         });
     }
@@ -1319,7 +1322,8 @@ impl SettingsModal {
         ui.add_space(4.0);
 
         ui.label("Background Opacity:");
-        ui.add(Slider::new(&mut self.draft.ui.background_opacity, 0.0..=1.0).step_by(0.05));
+        ui.add(Slider::new(&mut self.draft.ui.background_opacity, 0.0..=1.0).step_by(0.05))
+            .draggable();
         ui.add_space(4.0);
         ui.colored_label(
             ui.visuals().weak_text_color(),
@@ -1420,7 +1424,8 @@ impl SettingsModal {
         ui.add_space(8.0);
 
         ui.label("Background Image Opacity:");
-        ui.add(Slider::new(&mut self.draft.ui.background_image_opacity, 0.0..=1.0).step_by(0.05));
+        ui.add(Slider::new(&mut self.draft.ui.background_image_opacity, 0.0..=1.0).step_by(0.05))
+            .draggable();
         ui.add_space(4.0);
         ui.colored_label(
             ui.visuals().weak_text_color(),

--- a/freminal/src/gui/terminal/frame_dirty.rs
+++ b/freminal/src/gui/terminal/frame_dirty.rs
@@ -340,30 +340,38 @@ pub(super) fn evaluate_frame_dirty_state(
     // that arrives on the same frame as the release would set
     // `snap.content_changed` and immediately wipe the
     // just-committed selection (defect 2, Task 116.2).
+    // `snap.content_changed` is edge-triggered per *snapshot build*, but the
+    // GUI renders only a subset of the snapshots the PTY thread produces. A
+    // change that reverts before the next rendered frame -- a prompt clearing
+    // and rewriting its own line, say -- therefore arrives as
+    // `content_changed = true` on a snapshot whose text is identical to what
+    // this pane already drew:
+    //
+    //     snapshot A: text X                  -> rendered
+    //     snapshot B: text Y, changed = true  -> never rendered
+    //     snapshot C: text X, changed = true  -> rendered (Y != X at build C)
+    //
+    // Acting on that wiped selections for no reason, intermittently, whenever
+    // a mouse release happened to land across such a flicker (#470).
+    //
+    // So confirm against what was actually last rendered before discarding
+    // anything. This is a content comparison, deliberately not the
+    // `Arc::ptr_eq` check used for `content_changed` above: the PTY thread
+    // allocates a fresh Arc for cursor-blink dirty rows even when the text is
+    // byte-identical, so pointer identity would re-introduce the ~500ms
+    // clear-on-blink bug that `snap.content_changed` was chosen to avoid.
+    //
+    // Evaluated last so the O(visible_chars) comparison only runs on the rare
+    // frame where every cheap condition already passed.
     if snap.content_changed
         && !snap.scroll_changed
         && !view_state.selection.is_selecting
         && !view_state.selection_committed_this_frame
+        && cache
+            .last_rendered_visible
+            .as_ref()
+            .is_none_or(|prev| prev.as_ref() != snap.visible_chars.as_ref())
     {
-        // `snap.content_changed` conflates two different things: the visible
-        // text genuinely differing, and the snapshot cache merely having been
-        // invalidated (by an extra-row change, a resize, or an alt-screen
-        // swap) so there was nothing to compare against. This clear only
-        // wants the former. Log enough to tell them apart when a selection
-        // disappears unexpectedly (#470); this sits on the clear path, which
-        // is rare, not on the per-frame or per-snapshot path.
-        if view_state.selection.has_selection() {
-            tracing::debug!(
-                target: "freminal::selection",
-                total_rows = snap.total_rows,
-                term_width = snap.term_width,
-                term_height = snap.term_height,
-                window_extra_rows = snap.window_extra_rows,
-                scroll_offset = snap.scroll_offset,
-                visible_chars = snap.visible_chars.len(),
-                "content-changed auto-clear is about to discard a selection"
-            );
-        }
         view_state.selection.clear();
     }
     // Reset the per-frame edge flag unconditionally so it does not
@@ -801,6 +809,107 @@ mod evaluate_frame_dirty_state_tests {
 
         assert_eq!(outcome.rebuild, VertexRebuild::ReevaluateFullRebuild);
         assert!(outcome.observations.content_changed);
+    }
+
+    // ── content-changed selection auto-clear (issue #470) ────────────────
+
+    /// Put a committed (not in-progress) selection on `view_state`.
+    fn with_committed_selection(view_state: &mut ViewState) {
+        view_state.selection.anchor = Some(CellCoord { col: 2, row: 1 });
+        view_state.selection.end = Some(CellCoord { col: 8, row: 3 });
+        view_state.selection.is_selecting = false;
+        view_state.selection_committed_this_frame = false;
+    }
+
+    /// The #470 regression. `content_changed` is edge-triggered per snapshot
+    /// build and the GUI renders only some snapshots, so a change that reverts
+    /// between rendered frames arrives as `content_changed = true` on a
+    /// snapshot identical to what was already drawn. That must not discard a
+    /// selection.
+    #[test]
+    fn spurious_content_changed_does_not_discard_a_selection() {
+        let mut snap = base_snapshot();
+        snap.content_changed = true;
+        snap.scroll_changed = false;
+        let cache = settled_cache(&snap, true, true);
+        // `settled_cache` records this exact buffer as last-rendered, so the
+        // text has demonstrably not moved since.
+        let mut view_state = ViewState::new();
+        with_committed_selection(&mut view_state);
+        let render_state = render_state_with_deco_verts(true);
+
+        let _ = call(&snap, &mut view_state, &cache, &render_state, true, true);
+
+        assert!(
+            view_state.selection.has_selection(),
+            "a content_changed flag contradicted by the rendered text must not \
+             clear the selection"
+        );
+    }
+
+    /// The behaviour being preserved: when the text really did move, a stale
+    /// highlight would sit over different content, so it is still discarded.
+    #[test]
+    fn genuine_content_change_still_discards_a_selection() {
+        let mut snap = base_snapshot();
+        snap.content_changed = true;
+        snap.scroll_changed = false;
+        let mut cache = settled_cache(&snap, true, true);
+        // Last-rendered text differs from the snapshot's.
+        cache.last_rendered_visible = Some(Arc::new(vec![
+            freminal_common::buffer_states::tchar::TChar::Ascii(b'z'),
+        ]));
+        let mut view_state = ViewState::new();
+        with_committed_selection(&mut view_state);
+        let render_state = render_state_with_deco_verts(true);
+
+        let _ = call(&snap, &mut view_state, &cache, &render_state, true, true);
+
+        assert!(
+            !view_state.selection.has_selection(),
+            "a real content change must still clear the selection"
+        );
+    }
+
+    /// A pure scroll never invalidates a selection: coordinates are
+    /// buffer-absolute, so the same text is still selected.
+    #[test]
+    fn scroll_change_does_not_discard_a_selection() {
+        let mut snap = base_snapshot();
+        snap.content_changed = true;
+        snap.scroll_changed = true;
+        let mut cache = settled_cache(&snap, true, true);
+        cache.last_rendered_visible = Some(Arc::new(vec![
+            freminal_common::buffer_states::tchar::TChar::Ascii(b'z'),
+        ]));
+        let mut view_state = ViewState::new();
+        with_committed_selection(&mut view_state);
+        let render_state = render_state_with_deco_verts(true);
+
+        let _ = call(&snap, &mut view_state, &cache, &render_state, true, true);
+
+        assert!(view_state.selection.has_selection());
+    }
+
+    /// The Task 116 guarantee: output landing on the same frame as the mouse
+    /// release must not wipe the just-committed selection.
+    #[test]
+    fn selection_committed_this_frame_survives_a_genuine_content_change() {
+        let mut snap = base_snapshot();
+        snap.content_changed = true;
+        snap.scroll_changed = false;
+        let mut cache = settled_cache(&snap, true, true);
+        cache.last_rendered_visible = Some(Arc::new(vec![
+            freminal_common::buffer_states::tchar::TChar::Ascii(b'z'),
+        ]));
+        let mut view_state = ViewState::new();
+        with_committed_selection(&mut view_state);
+        view_state.selection_committed_this_frame = true;
+        let render_state = render_state_with_deco_verts(true);
+
+        let _ = call(&snap, &mut view_state, &cache, &render_state, true, true);
+
+        assert!(view_state.selection.has_selection());
     }
 
     #[test]

--- a/freminal/src/gui/terminal/frame_dirty.rs
+++ b/freminal/src/gui/terminal/frame_dirty.rs
@@ -363,7 +363,14 @@ pub(super) fn evaluate_frame_dirty_state(
     //
     // Evaluated last so the O(visible_chars) comparison only runs on the rare
     // frame where every cheap condition already passed.
-    if snap.content_changed
+    // `has_selection()` first: with nothing selected the clear is a no-op, so
+    // this skips the comparison below on every frame of continuous PTY output.
+    // Equivalent, not merely cheaper -- a degenerate selection (`anchor ==
+    // end`, or `end == None`) reports `false` here and `clear()` would have
+    // done nothing to it either, so a later primary press still starts a
+    // fresh drag rather than being consumed dismissing a phantom.
+    if view_state.selection.has_selection()
+        && snap.content_changed
         && !snap.scroll_changed
         && !view_state.selection.is_selecting
         && !view_state.selection_committed_this_frame

--- a/freminal/src/gui/terminal/frame_dirty.rs
+++ b/freminal/src/gui/terminal/frame_dirty.rs
@@ -112,12 +112,9 @@ pub(super) struct DirtyTrackingOutcome {
     /// The selection translated into snapshot-row space, clamped to the
     /// flattened window, for the renderer.
     pub(super) screen_selection: Option<(usize, usize, usize, usize)>,
-    /// Number of search matches this frame (cached for next frame's
-    /// comparison).
-    pub(super) search_match_count: usize,
-    /// Current search match index this frame (cached for next frame's
-    /// comparison).
-    pub(super) search_current_match: usize,
+    /// Fingerprint of this frame's search-highlight state (cached for next
+    /// frame's comparison). See `SearchState::render_epoch`.
+    pub(super) search_epoch: u64,
     /// Command-block gutter hover-tint rendered-row range this frame.
     pub(super) command_block_hover_rows: Option<(usize, usize)>,
     /// Whether the cursor should actually be drawn this frame (DECTCEM,
@@ -359,10 +356,11 @@ pub(super) fn evaluate_frame_dirty_state(
     let selection_changed = current_selection != cache.previous_selection;
 
     // Check whether search highlight state has changed since last frame.
-    let search_match_count = view_state.search_state.matches.len();
-    let search_current_match = view_state.search_state.current_match;
-    let search_changed = search_match_count != cache.previous_search_match_count
-        || search_current_match != cache.previous_search_current_match;
+    // Compares a fingerprint of everything that determines the highlight
+    // geometry, not just the match count and focused index -- see
+    // `SearchState::render_epoch` and issue #463.
+    let search_epoch = view_state.search_state.render_epoch();
+    let search_changed = search_epoch != cache.previous_search_epoch;
 
     // Convert buffer-absolute selection coordinates to snapshot-row
     // space for the renderer.  `win_start` is the flattened window top
@@ -570,8 +568,7 @@ pub(super) fn evaluate_frame_dirty_state(
         },
         current_selection,
         screen_selection,
-        search_match_count,
-        search_current_match,
+        search_epoch,
         command_block_hover_rows: command_block_hover_rows_early,
         effective_show_cursor,
         cursor_pixel_pos,
@@ -596,6 +593,7 @@ mod evaluate_frame_dirty_state_tests {
     use super::super::widget::new_render_state;
     use super::*;
     use crate::gui::renderer::WindowPostRenderer;
+    use crate::gui::view_state::SearchState;
     use freminal_common::config::CommandBlocksConfig;
     use freminal_terminal_emulator::snapshot::TerminalSnapshot;
     use freminal_terminal_emulator::{
@@ -632,8 +630,10 @@ mod evaluate_frame_dirty_state_tests {
         cache.last_rendered_visible = Some(Arc::clone(&snap.visible_chars));
         cache.last_rendered_line_widths = Some(Arc::clone(&snap.visible_line_widths));
         cache.previous_selection = None;
-        cache.previous_search_match_count = 0;
-        cache.previous_search_current_match = 0;
+        // These tests drive `ViewState::new()`, whose search state is
+        // default-constructed, so a settled cache is one that already agrees
+        // with that state's fingerprint.
+        cache.previous_search_epoch = SearchState::default().render_epoch();
         cache.previous_command_block_hover_rows = None;
         cache.previous_cursor_blink_on = cursor_blink_on;
         cache.previous_cursor_pos = snap.cursor_pos;
@@ -791,7 +791,9 @@ mod evaluate_frame_dirty_state_tests {
         // `search_changed` must veto it.
         let snap = base_snapshot();
         let mut cache = settled_cache(&snap, true, true);
-        cache.previous_search_match_count = 1;
+        // Any value that differs from this frame's epoch stands in for "the
+        // search state changed since the last rendered frame".
+        cache.previous_search_epoch = cache.previous_search_epoch.wrapping_add(1);
         let mut view_state = ViewState::new();
         let render_state = render_state_with_deco_verts(true);
 

--- a/freminal/src/gui/terminal/frame_dirty.rs
+++ b/freminal/src/gui/terminal/frame_dirty.rs
@@ -345,6 +345,25 @@ pub(super) fn evaluate_frame_dirty_state(
         && !view_state.selection.is_selecting
         && !view_state.selection_committed_this_frame
     {
+        // `snap.content_changed` conflates two different things: the visible
+        // text genuinely differing, and the snapshot cache merely having been
+        // invalidated (by an extra-row change, a resize, or an alt-screen
+        // swap) so there was nothing to compare against. This clear only
+        // wants the former. Log enough to tell them apart when a selection
+        // disappears unexpectedly (#470); this sits on the clear path, which
+        // is rare, not on the per-frame or per-snapshot path.
+        if view_state.selection.has_selection() {
+            tracing::debug!(
+                target: "freminal::selection",
+                total_rows = snap.total_rows,
+                term_width = snap.term_width,
+                term_height = snap.term_height,
+                window_extra_rows = snap.window_extra_rows,
+                scroll_offset = snap.scroll_offset,
+                visible_chars = snap.visible_chars.len(),
+                "content-changed auto-clear is about to discard a selection"
+            );
+        }
         view_state.selection.clear();
     }
     // Reset the per-frame edge flag unconditionally so it does not

--- a/freminal/src/gui/terminal/input.rs
+++ b/freminal/src/gui/terminal/input.rs
@@ -1521,6 +1521,12 @@ fn finalize_selection_drag(
         // arrived on this same frame (defect 2,
         // Task 116.2).
         view_state.selection_committed_this_frame = true;
+        tracing::debug!(
+            target: "freminal::selection",
+            anchor = ?view_state.selection.anchor,
+            end = ?view_state.selection.end,
+            "selection committed on release"
+        );
     }
 }
 

--- a/freminal/src/gui/terminal/input.rs
+++ b/freminal/src/gui/terminal/input.rs
@@ -410,10 +410,24 @@ pub fn drain_pending_raw_keys(
         return;
     }
     let modes = InputModes::from_snapshot(snap);
+    // Kitty keyboard protocol: key *releases* are reported only when
+    // `REPORT_EVENT_TYPES` (bit 1) is set. Without it the encoder falls back
+    // to the legacy press encoding for a release, so forwarding one emits a
+    // second, byte-identical copy of the key and the application sees two
+    // presses. The egui key path already gates on exactly this
+    // (`kkp & 2 != 0`, see the release block in `write_input_to_terminal`);
+    // the raw-key path was missing the same guard.
+    let report_event_types = snap.kitty_keyboard_flags & 2 != 0;
     for (event, mods) in pending.drain(..) {
         let Some(codepoint) = kitty_keycode_to_codepoint(event.key_code) else {
             continue;
         };
+
+        // A release with no way to mark it as such would be indistinguishable
+        // from a press. Drop it rather than duplicate the key.
+        if !event.pressed && !report_event_types {
+            continue;
+        }
 
         let key_mods = raw_mods_to_key_modifiers(mods, super_pressed);
         let meta = if !event.pressed {
@@ -3385,6 +3399,125 @@ mod raw_key_tests {
             rx.try_recv().is_err(),
             "no bytes should be sent when KKP is off"
         );
+    }
+
+    /// Kitty keyboard protocol: a release is reported only when
+    /// `REPORT_EVENT_TYPES` (bit 1) is set. Without it the encoder falls back
+    /// to the legacy press encoding, so forwarding the release emits a second
+    /// byte-identical copy and the application sees the key twice.
+    #[test]
+    fn drain_does_not_duplicate_a_key_when_event_types_are_not_reported() {
+        // Flag sets that enable KKP but leave bit 1 clear. Flag 1
+        // (disambiguate) on its own is the single most commonly requested
+        // configuration.
+        for flags in [1u32, 8, 9] {
+            let snap = snap_with_kkp_flags(flags);
+            let (tx, rx) = crossbeam_channel::unbounded();
+            let mut pending = vec![
+                (
+                    RawKeyEvent {
+                        key_code: KeyCode::Numpad1,
+                        pressed: true,
+                        repeat: false,
+                    },
+                    RawKeyMods::default(),
+                ),
+                (
+                    RawKeyEvent {
+                        key_code: KeyCode::Numpad1,
+                        pressed: false,
+                        repeat: false,
+                    },
+                    RawKeyMods::default(),
+                ),
+            ];
+
+            drain_pending_raw_keys(&mut pending, &tx, &snap, false, &[]);
+
+            let mut sent = Vec::new();
+            while let Ok(InputEvent::Key(bytes)) = rx.try_recv() {
+                sent.push(bytes);
+            }
+            assert_eq!(
+                sent.len(),
+                1,
+                "flags {flags}: one press must produce exactly one report, got {sent:?}"
+            );
+        }
+    }
+
+    /// With `REPORT_EVENT_TYPES` set, the release IS reported -- and is
+    /// distinguishable from the press by its `:3` event-type field.
+    #[test]
+    fn drain_reports_a_distinguishable_release_when_event_types_are_on() {
+        let snap = snap_with_kkp_flags(3);
+        let (tx, rx) = crossbeam_channel::unbounded();
+        let mut pending = vec![
+            (
+                RawKeyEvent {
+                    key_code: KeyCode::Numpad1,
+                    pressed: true,
+                    repeat: false,
+                },
+                RawKeyMods::default(),
+            ),
+            (
+                RawKeyEvent {
+                    key_code: KeyCode::Numpad1,
+                    pressed: false,
+                    repeat: false,
+                },
+                RawKeyMods::default(),
+            ),
+        ];
+
+        drain_pending_raw_keys(&mut pending, &tx, &snap, false, &[]);
+
+        let mut sent = Vec::new();
+        while let Ok(InputEvent::Key(bytes)) = rx.try_recv() {
+            sent.push(bytes);
+        }
+        assert_eq!(sent.len(), 2, "press and release are both reported");
+        assert_ne!(
+            sent[0], sent[1],
+            "the release must not be byte-identical to the press"
+        );
+        assert_eq!(sent[0], b"\x1b[57400u");
+        assert_eq!(sent[1], b"\x1b[57400;1:3u");
+    }
+
+    /// With KKP off entirely the legacy keypad byte is emitted once, on press
+    /// only -- the release has no legacy encoding.
+    #[test]
+    fn drain_emits_one_legacy_byte_per_keypad_press() {
+        let snap = snap_with_kkp_flags(0);
+        let (tx, rx) = crossbeam_channel::unbounded();
+        let mut pending = vec![
+            (
+                RawKeyEvent {
+                    key_code: KeyCode::Numpad1,
+                    pressed: true,
+                    repeat: false,
+                },
+                RawKeyMods::default(),
+            ),
+            (
+                RawKeyEvent {
+                    key_code: KeyCode::Numpad1,
+                    pressed: false,
+                    repeat: false,
+                },
+                RawKeyMods::default(),
+            ),
+        ];
+
+        drain_pending_raw_keys(&mut pending, &tx, &snap, false, &[]);
+
+        let mut sent = Vec::new();
+        while let Ok(InputEvent::Key(bytes)) = rx.try_recv() {
+            sent.push(bytes);
+        }
+        assert_eq!(sent, vec![b"1".to_vec()]);
     }
 
     #[test]

--- a/freminal/src/gui/terminal/input.rs
+++ b/freminal/src/gui/terminal/input.rs
@@ -1253,6 +1253,97 @@ pub(super) fn handle_scroll_fallback(
     }
 }
 
+/// Outcome of [`scroll_overlay_passthrough`].
+pub(super) struct ScrollPassthrough {
+    /// Sub-character-cell scroll remainder to carry into the next frame.
+    pub(super) carry: f32,
+    /// Whether the pane's scroll offset actually moved.
+    pub(super) scrolled: bool,
+}
+
+/// Apply mouse-wheel scrolling to the pane's scrollback while an overlay is
+/// open that otherwise suppresses every pane input event.
+///
+/// The search overlay is a *find in this pane's scrollback* tool, so blocking
+/// scroll makes it impossible to look around the matches it just found. The
+/// blanket input suppression that stops keystrokes leaking to the PTY (see
+/// `freminal-modal-input-suppression`) also swallowed wheel events, because
+/// scroll is handled inside [`write_input_to_terminal`], which that
+/// suppression bypasses wholesale.
+///
+/// This is deliberately **not** a general re-enable of input:
+///
+/// - Only wheel events are read; keys, clicks, drags and paste stay suppressed.
+/// - Only the **primary screen** scrolls. On the alternate screen
+///   [`handle_scroll_fallback`] translates scroll into arrow keys *sent to the
+///   PTY*, which is application input, not view movement -- injecting that
+///   while a modal holds focus would move the cursor in the running program.
+///   The alternate screen has no scrollback to look through anyway.
+/// - Nothing is reported to the terminal's mouse-tracking protocol, for the
+///   same reason.
+///
+/// Returns the carry remainder to store back on the pane cache, and whether
+/// the view moved (so the caller can request a repaint -- do that *outside*
+/// the `ui.input` closure, which holds a read lock on the egui context).
+pub(super) fn scroll_overlay_passthrough(
+    input: &egui::InputState,
+    snap: &TerminalSnapshot,
+    input_tx: &Sender<InputEvent>,
+    view_state: &mut ViewState,
+    character_size_y: f32,
+    carry: f32,
+) -> ScrollPassthrough {
+    let mut scroll_amount = carry;
+
+    for event in &input.events {
+        if let Event::MouseWheel { delta, unit, .. } = event {
+            match unit {
+                egui::MouseWheelUnit::Point => scroll_amount += delta.y,
+                egui::MouseWheelUnit::Line => {
+                    scroll_amount = delta.y.mul_add(character_size_y, scroll_amount);
+                }
+                // Matches `write_input_to_terminal`: page-unit wheels are not
+                // produced by any backend freminal supports.
+                egui::MouseWheelUnit::Page => {}
+            }
+        }
+    }
+
+    // Below one cell of travel there is nothing to do yet; keep accumulating.
+    if scroll_amount.abs() < character_size_y {
+        return ScrollPassthrough {
+            carry: scroll_amount,
+            scrolled: false,
+        };
+    }
+
+    // `trunc()` rounds toward zero so the remainder keeps its sign, matching
+    // the main scroll path's trackpad-smoothing behaviour.
+    let scroll_amount_to_do = scroll_amount.trunc();
+    scroll_amount -= scroll_amount_to_do;
+
+    if snap.is_alternate_screen {
+        return ScrollPassthrough {
+            carry: scroll_amount,
+            scrolled: false,
+        };
+    }
+
+    let before = view_state.scroll_offset;
+    handle_scroll_fallback(
+        scroll_amount_to_do,
+        character_size_y,
+        snap,
+        input_tx,
+        view_state,
+    );
+
+    ScrollPassthrough {
+        carry: scroll_amount,
+        scrolled: view_state.scroll_offset != before,
+    }
+}
+
 /// Whether the pane [`write_input_to_terminal`] is processing input for is
 /// the currently-focused (active) pane.
 ///

--- a/freminal/src/gui/terminal/mod.rs
+++ b/freminal/src/gui/terminal/mod.rs
@@ -15,4 +15,5 @@ pub(crate) mod input;
 pub(crate) mod widget;
 
 pub use widget::FreminalTerminalWidget;
+pub use widget::SplitBorderHover;
 pub use widget::{PaneRenderCache, RenderState, new_render_state};

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -2017,6 +2017,7 @@ impl FreminalTerminalWidget {
         // response is only used for the repaint wake-up and the hand cursor.
         // We also force one repaint on the frame the pointer leaves so the
         // clearing frame is guaranteed.
+        let mut gutter_hovered = false;
         if gutter_inset > 0.0 && command_blocks_config.enabled && !snap.is_alternate_screen {
             let gutter_hit_rect = egui::Rect::from_min_max(
                 pane_rect.min,
@@ -2039,9 +2040,13 @@ impl FreminalTerminalWidget {
                 pointer_in_window,
                 cache.pointer_in_gutter_last_frame,
             );
-            if effectively_hovered {
-                ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
-            }
+            // Recorded rather than applied here: every cursor-icon write in
+            // this frame is resolved once, at the end of `show`, by
+            // `PointerHover`. Setting it at this point had no visible effect
+            // at all, because the URL / OSC-22 block below unconditionally
+            // overwrote `output.cursor_icon` a few hundred lines later
+            // (issue #462).
+            gutter_hovered = effectively_hovered;
             if needs_repaint {
                 // 16ms, not `Duration::ZERO` (subtask 121.12, comment
                 // corrected per review NIT #10): scheduling is unchanged
@@ -3436,20 +3441,6 @@ impl FreminalTerminalWidget {
                     });
                 }
 
-                // Update cursor icon from cached URL state.
-                // URL hover (pointing hand) takes priority over OSC 22 shape.
-                // Must be set unconditionally every frame because egui resets
-                // output.cursor_icon to Default at the start of each frame.
-                let new_icon = if cache.cached_hovered_url.is_some() {
-                    CursorIcon::PointingHand
-                } else {
-                    pointer_shape_to_cursor_icon(snap.pointer_shape)
-                };
-
-                ui.ctx().output_mut(|output| {
-                    output.cursor_icon = new_icon;
-                });
-
                 // Tooltip: show the target URL at the pointer so the user
                 // can verify before Ctrl+clicking. Suppressed while the
                 // user is actively dragging out a selection so it does
@@ -3495,37 +3486,42 @@ impl FreminalTerminalWidget {
                     }
                 }
             } else {
-                // Mouse left the terminal area — fall back to OSC 22 shape.
+                // Mouse left the terminal area. Only the URL-hover cache is
+                // cleared here; the icon itself is resolved once below.
                 cache.previous_hover_cell = None;
                 cache.cached_hovered_url = None;
-                let base_icon = pointer_shape_to_cursor_icon(snap.pointer_shape);
-                ui.ctx().output_mut(|output| {
-                    output.cursor_icon = base_icon;
-                });
             }
         } else {
-            // No URLs — apply OSC 22 shape (or default if none set).
+            // No URLs in the visible window, so nothing can be URL-hovered.
             cache.previous_hover_cell = None;
             cache.cached_hovered_url = None;
-            let base_icon = pointer_shape_to_cursor_icon(snap.pointer_shape);
-            ui.ctx().output_mut(|output| {
-                output.cursor_icon = base_icon;
-            });
         }
 
-        // Fold placeholder hover: override the cursor icon to a pointing
-        // hand whenever the mouse is over a placeholder row, regardless
-        // of URL or OSC 22 shape state. Runs every frame because egui
-        // resets `output.cursor_icon` to Default at the start of each
-        // frame, so the override must be reapplied.
-        if !cache.placeholder_hit_rects.is_empty()
-            && let Some(mouse_position) = view_state.mouse_position
-            && hit_test_placeholder(&cache.placeholder_hit_rects, mouse_position).is_some()
-        {
-            ui.ctx().output_mut(|output| {
-                output.cursor_icon = CursorIcon::PointingHand;
+        // ── Cursor icon ──────────────────────────────────────────────
+        //
+        // Every source that wants a say in the pointer shape is gathered here
+        // and resolved by one explicit precedence rule, then written exactly
+        // once. This replaces four independent unconditional writes whose
+        // relative outcome was decided purely by which one happened to run
+        // last in `show` -- which silently discarded the command-block
+        // gutter's pointing-hand entirely (issue #462).
+        //
+        // The write is unconditional because egui resets
+        // `output.cursor_icon` to `Default` at the start of every frame.
+        let placeholder_hovered = !cache.placeholder_hit_rects.is_empty()
+            && view_state.mouse_position.is_some_and(|pos| {
+                hit_test_placeholder(&cache.placeholder_hit_rects, pos).is_some()
             });
-        }
+
+        let pointer_hover = PointerHover {
+            command_block_gutter: gutter_hovered,
+            fold_placeholder: placeholder_hovered,
+            url: cache.cached_hovered_url.is_some(),
+        };
+        let resolved_icon = cursor_icon_for(pointer_hover.resolve(), snap.pointer_shape);
+        ui.ctx().output_mut(|output| {
+            output.cursor_icon = resolved_icon;
+        });
 
         // ── Drag-and-drop ────────────────────────────────────────────
         handle_file_drop(ui, terminal_rect, input_tx);
@@ -3661,6 +3657,70 @@ impl FreminalTerminalWidget {
 ///
 /// [`PointerShape::Default`] and any value that has no direct egui equivalent
 /// both produce [`CursorIcon::Default`].
+/// What the mouse pointer is over, for the purpose of choosing a cursor icon.
+///
+/// Variants are listed in **descending precedence**: when several apply at
+/// once, the earliest wins.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PointerTarget {
+    /// The command-block gutter strip down the left edge of the pane. A
+    /// clickable chrome affordance that sits outside the terminal grid, so it
+    /// outranks anything the application asks for.
+    CommandBlockGutter,
+    /// A collapsed command-block fold placeholder row. Also chrome, also
+    /// clickable, and drawn over the grid.
+    FoldPlaceholder,
+    /// A hyperlink in the terminal grid.
+    Url,
+    /// Ordinary terminal content -- the application's OSC 22 pointer shape
+    /// applies, which is `Default` when it has not set one.
+    TerminalContent,
+}
+
+/// Which cursor-icon sources are active this frame.
+///
+/// These are independent simultaneous observations -- the pointer can be over
+/// a fold placeholder that happens to contain a URL -- so a set of bools is
+/// the right representation. The *precedence* between them, which is the part
+/// that was previously implicit and wrong, lives in [`Self::resolve`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct PointerHover {
+    /// Pointer is over the command-block gutter strip.
+    pub(super) command_block_gutter: bool,
+    /// Pointer is over a collapsed fold placeholder row.
+    pub(super) fold_placeholder: bool,
+    /// Pointer is over a hyperlink.
+    pub(super) url: bool,
+}
+
+impl PointerHover {
+    /// Reduce the active sources to the single highest-precedence target.
+    pub(super) const fn resolve(self) -> PointerTarget {
+        if self.command_block_gutter {
+            PointerTarget::CommandBlockGutter
+        } else if self.fold_placeholder {
+            PointerTarget::FoldPlaceholder
+        } else if self.url {
+            PointerTarget::Url
+        } else {
+            PointerTarget::TerminalContent
+        }
+    }
+}
+
+/// The cursor icon for a resolved [`PointerTarget`].
+///
+/// Chrome affordances all use the pointing hand; only ordinary terminal
+/// content defers to the application's OSC 22 shape.
+const fn cursor_icon_for(target: PointerTarget, osc22_shape: PointerShape) -> CursorIcon {
+    match target {
+        PointerTarget::CommandBlockGutter | PointerTarget::FoldPlaceholder | PointerTarget::Url => {
+            CursorIcon::PointingHand
+        }
+        PointerTarget::TerminalContent => pointer_shape_to_cursor_icon(osc22_shape),
+    }
+}
+
 const fn pointer_shape_to_cursor_icon(shape: PointerShape) -> CursorIcon {
     match shape {
         PointerShape::Default => CursorIcon::Default,
@@ -4706,6 +4766,101 @@ impl InputSuppressors {
             && !self.context_menu
             && !self.command_history
             && !self.scrollbar_drag
+    }
+}
+
+#[cfg(test)]
+mod pointer_target_tests {
+    use super::{
+        CursorIcon, PointerHover, PointerShape, PointerTarget, cursor_icon_for,
+        pointer_shape_to_cursor_icon,
+    };
+
+    /// Nothing hovered.
+    const NONE: PointerHover = PointerHover {
+        command_block_gutter: false,
+        fold_placeholder: false,
+        url: false,
+    };
+
+    #[test]
+    fn nothing_hovered_defers_to_the_application_shape() {
+        assert_eq!(NONE.resolve(), PointerTarget::TerminalContent);
+        assert_eq!(
+            cursor_icon_for(NONE.resolve(), PointerShape::Crosshair),
+            CursorIcon::Crosshair,
+            "ordinary terminal content must honour the OSC 22 shape"
+        );
+    }
+
+    /// The regression: hovering the gutter must actually produce a pointing
+    /// hand, even though the application has set its own OSC 22 shape. This
+    /// previously lost to the URL/OSC-22 write that ran later in `show`.
+    #[test]
+    fn gutter_hover_beats_the_application_shape() {
+        let hover = PointerHover {
+            command_block_gutter: true,
+            ..NONE
+        };
+        assert_eq!(hover.resolve(), PointerTarget::CommandBlockGutter);
+        assert_eq!(
+            cursor_icon_for(hover.resolve(), PointerShape::Text),
+            CursorIcon::PointingHand
+        );
+    }
+
+    /// Precedence is total and deterministic, not last-writer-wins.
+    #[test]
+    fn precedence_is_gutter_then_placeholder_then_url() {
+        let all = PointerHover {
+            command_block_gutter: true,
+            fold_placeholder: true,
+            url: true,
+        };
+        assert_eq!(all.resolve(), PointerTarget::CommandBlockGutter);
+
+        let no_gutter = PointerHover {
+            command_block_gutter: false,
+            ..all
+        };
+        assert_eq!(no_gutter.resolve(), PointerTarget::FoldPlaceholder);
+
+        let url_only = PointerHover { url: true, ..NONE };
+        assert_eq!(url_only.resolve(), PointerTarget::Url);
+    }
+
+    /// Every chrome affordance uses the same icon, so which one wins is not
+    /// visually observable -- but the rule must still be defined.
+    #[test]
+    fn all_chrome_targets_use_the_pointing_hand() {
+        for target in [
+            PointerTarget::CommandBlockGutter,
+            PointerTarget::FoldPlaceholder,
+            PointerTarget::Url,
+        ] {
+            assert_eq!(
+                cursor_icon_for(target, PointerShape::Wait),
+                CursorIcon::PointingHand,
+                "{target:?} must not defer to the application shape"
+            );
+        }
+    }
+
+    /// Terminal content maps straight through the OSC 22 table.
+    #[test]
+    fn terminal_content_matches_the_osc22_table() {
+        for shape in [
+            PointerShape::Default,
+            PointerShape::Text,
+            PointerShape::Wait,
+            PointerShape::Grab,
+            PointerShape::None,
+        ] {
+            assert_eq!(
+                cursor_icon_for(PointerTarget::TerminalContent, shape),
+                pointer_shape_to_cursor_icon(shape)
+            );
+        }
     }
 }
 

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -2233,11 +2233,6 @@ impl FreminalTerminalWidget {
         } else {
             let repeat_characters = snap.repeat_keys;
             let ctx = ui.ctx().clone();
-            let pane_focus = if is_active_pane {
-                PaneFocus::Active
-            } else {
-                PaneFocus::Inactive
-            };
             let result = ui.input(|input_state| {
                 write_input_to_terminal(WriteInputParams {
                     input: input_state,
@@ -2249,7 +2244,7 @@ impl FreminalTerminalWidget {
                     terminal_rect,
                     repeat_characters,
                     binding_map,
-                    pane_focus,
+                    pane_focus: pane_focus_now,
                     recording_ctx,
                     placeholder_rects: &cache.placeholder_hit_rects,
                     key_broadcast_targets,

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -48,7 +48,10 @@ use super::{
         CursorFrameInputs, FrameDirtyContext, FrameDirtyGeometry, VertexRebuild,
         evaluate_frame_dirty_state,
     },
-    input::{InputCarryState, PaneFocus, WriteInputParams, write_input_to_terminal},
+    input::{
+        InputCarryState, PaneFocus, WriteInputParams, scroll_overlay_passthrough,
+        write_input_to_terminal,
+    },
 };
 
 use conv2::{ApproxFrom, ConvUtil, RoundToZero};
@@ -2161,15 +2164,44 @@ impl FreminalTerminalWidget {
         // Set to `true` below iff a non-empty local selection is actually
         // copied to the system clipboard this frame (Subtask D3).
         let mut copied_to_clipboard = false;
-        if suppress_input
-            || context_menu_open
-            || view_state.search_state.is_open
-            || view_state.command_history.is_open
-            || cache.scrollbar_dragging
-        {
+        let pane_focus_now = if is_active_pane {
+            PaneFocus::Active
+        } else {
+            PaneFocus::Inactive
+        };
+        let suppressors = InputSuppressors {
+            modal_or_drag: suppress_input,
+            context_menu: context_menu_open,
+            search_overlay: view_state.search_state.is_open,
+            command_history: view_state.command_history.is_open,
+            scrollbar_drag: cache.scrollbar_dragging,
+        };
+        if suppressors.any() {
+            let request_scroll_repaint = if suppressors.scroll_passes_through(pane_focus_now) {
+                let result = ui.input(|input_state| {
+                    scroll_overlay_passthrough(
+                        input_state,
+                        snap,
+                        input_tx,
+                        view_state,
+                        logical_cell_h,
+                        cache.previous_scroll_amount,
+                    )
+                });
+                cache.previous_scroll_amount = result.carry;
+                result.scrolled
+            } else {
+                cache.previous_scroll_amount = 0.0;
+                false
+            };
+            // Must be outside the `ui.input` closure above, which holds a read
+            // lock on the egui context.
+            if request_scroll_repaint {
+                ui.ctx().request_repaint();
+            }
+
             cache.previous_key = None;
             cache.previous_mouse_state = None;
-            cache.previous_scroll_amount = 0.0;
             if border_drag_active {
                 // A pane-border drag geometrically overlaps the adjacent
                 // pane's `terminal_rect`; the same press+drag would
@@ -4605,6 +4637,208 @@ mod gutter_hover_trigger_tests {
             cell_h,
         );
         assert_eq!(rows, None);
+    }
+}
+
+/// The reasons pane input can be suppressed on a given frame.
+///
+/// Several can hold simultaneously (a modal open *and* a scrollbar drag in
+/// flight), and no combination is illegal, so this is the documented case
+/// where a set of independent bool signals is the correct representation
+/// rather than a single enum (`freminal-state-representation`).
+///
+/// Grouping them gives the suppression rule one place to live. It was
+/// previously spelled out twice -- once to decide whether to suppress, once
+/// to decide what may still get through -- which meant the two lists had to
+/// be kept in sync by hand.
+// Each field is a separate, independently-observed condition, and every
+// combination of them is legal and meaningful -- which is exactly the case
+// `freminal-state-representation` names as the correct use of bools rather
+// than an enum. Collapsing them into a state machine would assert an ordering
+// and mutual exclusion that does not exist (a modal can be open while a
+// scrollbar drag is in flight). `SearchState` carries the same allow for the
+// same reason.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Copy)]
+pub(super) struct InputSuppressors {
+    /// A modal/menu overlay or pane-border drag, including the deliberate
+    /// one-frame release tail that stops a dismiss-click leaking through.
+    pub(super) modal_or_drag: bool,
+    /// The right-click context menu is open.
+    pub(super) context_menu: bool,
+    /// The find-in-scrollback overlay is open.
+    pub(super) search_overlay: bool,
+    /// The command-history palette is open.
+    pub(super) command_history: bool,
+    /// A scrollbar drag is in progress.
+    pub(super) scrollbar_drag: bool,
+}
+
+impl InputSuppressors {
+    /// Whether anything at all is suppressing pane input this frame.
+    pub(super) const fn any(self) -> bool {
+        self.modal_or_drag
+            || self.context_menu
+            || self.search_overlay
+            || self.command_history
+            || self.scrollbar_drag
+    }
+
+    /// Whether mouse-wheel events should still reach the pane despite
+    /// suppression.
+    ///
+    /// True only when the search overlay is the *sole* reason input is
+    /// suppressed, and only for the active pane. Search finds matches in this
+    /// pane's scrollback, so swallowing the wheel leaves those matches
+    /// unreachable -- the user cannot look at what they just found. Every
+    /// other suppressor keeps the wheel blocked: a context menu or palette has
+    /// its own scrollable content, a scrollbar drag is already driving the
+    /// offset, and a modal's dismiss-click tail must not move the view.
+    ///
+    /// Note this governs *whether* wheel events are read at all; what they are
+    /// then allowed to do is further restricted in
+    /// [`super::input::scroll_overlay_passthrough`] (primary screen only, no
+    /// PTY writes, no mouse-tracking reports).
+    pub(super) const fn scroll_passes_through(self, pane_focus: PaneFocus) -> bool {
+        self.search_overlay
+            && matches!(pane_focus, PaneFocus::Active)
+            && !self.modal_or_drag
+            && !self.context_menu
+            && !self.command_history
+            && !self.scrollbar_drag
+    }
+}
+
+#[cfg(test)]
+mod input_suppressors_tests {
+    use super::{InputSuppressors, PaneFocus};
+
+    /// Nothing suppressing.
+    const CLEAR: InputSuppressors = InputSuppressors {
+        modal_or_drag: false,
+        context_menu: false,
+        search_overlay: false,
+        command_history: false,
+        scrollbar_drag: false,
+    };
+
+    #[test]
+    fn any_is_false_only_when_every_suppressor_is_clear() {
+        assert!(!CLEAR.any());
+        assert!(
+            InputSuppressors {
+                modal_or_drag: true,
+                ..CLEAR
+            }
+            .any()
+        );
+        assert!(
+            InputSuppressors {
+                context_menu: true,
+                ..CLEAR
+            }
+            .any()
+        );
+        assert!(
+            InputSuppressors {
+                search_overlay: true,
+                ..CLEAR
+            }
+            .any()
+        );
+        assert!(
+            InputSuppressors {
+                command_history: true,
+                ..CLEAR
+            }
+            .any()
+        );
+        assert!(
+            InputSuppressors {
+                scrollbar_drag: true,
+                ..CLEAR
+            }
+            .any()
+        );
+    }
+
+    /// The reported case: with only the search overlay open, the wheel must
+    /// still reach the active pane so the user can look at the matches.
+    #[test]
+    fn scroll_passes_through_for_search_overlay_on_the_active_pane() {
+        let s = InputSuppressors {
+            search_overlay: true,
+            ..CLEAR
+        };
+        assert!(s.any(), "search must still suppress everything else");
+        assert!(s.scroll_passes_through(PaneFocus::Active));
+    }
+
+    /// Scroll targets the active pane only, matching `write_input_to_terminal`.
+    #[test]
+    fn scroll_does_not_pass_through_on_an_inactive_pane() {
+        let s = InputSuppressors {
+            search_overlay: true,
+            ..CLEAR
+        };
+        assert!(!s.scroll_passes_through(PaneFocus::Inactive));
+    }
+
+    /// Any other suppressor present alongside search keeps the wheel blocked.
+    #[test]
+    fn any_other_suppressor_blocks_scroll_even_with_search_open() {
+        for s in [
+            InputSuppressors {
+                search_overlay: true,
+                modal_or_drag: true,
+                ..CLEAR
+            },
+            InputSuppressors {
+                search_overlay: true,
+                context_menu: true,
+                ..CLEAR
+            },
+            InputSuppressors {
+                search_overlay: true,
+                command_history: true,
+                ..CLEAR
+            },
+            InputSuppressors {
+                search_overlay: true,
+                scrollbar_drag: true,
+                ..CLEAR
+            },
+        ] {
+            assert!(
+                !s.scroll_passes_through(PaneFocus::Active),
+                "search must not re-enable scroll while {s:?} also suppresses"
+            );
+        }
+    }
+
+    /// Overlays other than search keep the old behaviour: fully blocked.
+    #[test]
+    fn non_search_suppressors_never_pass_scroll_through() {
+        for s in [
+            InputSuppressors {
+                modal_or_drag: true,
+                ..CLEAR
+            },
+            InputSuppressors {
+                context_menu: true,
+                ..CLEAR
+            },
+            InputSuppressors {
+                command_history: true,
+                ..CLEAR
+            },
+            InputSuppressors {
+                scrollbar_drag: true,
+                ..CLEAR
+            },
+        ] {
+            assert!(!s.scroll_passes_through(PaneFocus::Active));
+        }
     }
 }
 

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -1882,6 +1882,7 @@ impl FreminalTerminalWidget {
         pending_copy: &mut bool,
         key_broadcast_targets: &[Sender<InputEvent>],
         present_is_partial: &Arc<std::sync::atomic::AtomicBool>,
+        split_border_hover: SplitBorderHover,
     ) -> (bool, bool, Vec<freminal_common::keybindings::KeyAction>) {
         const BLINK_TICK_SECONDS: f64 = 0.50;
 
@@ -3532,8 +3533,10 @@ impl FreminalTerminalWidget {
         // would stamp its own icon over them after they were set.
         //
         // `rect_contains_pointer` respects layer and clip rect, so a modal
-        // drawn above the pane correctly keeps its own cursor.
-        if ui.rect_contains_pointer(pane_rect) {
+        // drawn above the pane correctly keeps its own cursor. Split-border
+        // sensors are not a separate layer -- they overlap the pane
+        // geometrically -- so they are excluded explicitly.
+        if ui.rect_contains_pointer(pane_rect) && split_border_hover == SplitBorderHover::Clear {
             let resolved_icon = cursor_icon_for(pointer_hover.resolve(), snap.pointer_shape);
             ui.ctx().output_mut(|output| {
                 output.cursor_icon = resolved_icon;
@@ -3674,6 +3677,23 @@ impl FreminalTerminalWidget {
 ///
 /// [`PointerShape::Default`] and any value that has no direct egui equivalent
 /// both produce [`CursorIcon::Default`].
+/// Whether the pointer is over a pane-split drag sensor this frame.
+///
+/// The sensor rects are built and hit-tested in `app_impl`, which sets the
+/// resize cursor before any pane renders. They are deliberately wider than
+/// the 1px border line they straddle, which means the pointer sits
+/// *geometrically inside* one of the two adjacent panes while *logically*
+/// over chrome. A pane must therefore abstain from writing the cursor icon
+/// here, or it overwrites the resize arrow for all but the hairline sliver
+/// that falls between the two pane rects (issue #462).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SplitBorderHover {
+    /// Pointer is over a split-border drag sensor; that chrome owns the icon.
+    Over,
+    /// Pointer is not over any split border.
+    Clear,
+}
+
 /// What the mouse pointer is over, for the purpose of choosing a cursor icon.
 ///
 /// Variants are listed in **descending precedence**: when several apply at

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -3518,10 +3518,27 @@ impl FreminalTerminalWidget {
             fold_placeholder: placeholder_hovered,
             url: cache.cached_hovered_url.is_some(),
         };
-        let resolved_icon = cursor_icon_for(pointer_hover.resolve(), snap.pointer_shape);
-        ui.ctx().output_mut(|output| {
-            output.cursor_icon = resolved_icon;
-        });
+
+        // Only the pane the pointer is actually over may set the icon.
+        //
+        // `output.cursor_icon` is a single window-wide field, and every pane
+        // runs this code every frame. Writing unconditionally therefore means
+        // the last pane to render decides the cursor for the entire window,
+        // clobbering whatever the pane under the pointer resolved. That made
+        // gutter and URL hover appear to work only in whichever pane happened
+        // to render last (the bottom of a vertical split), and it also
+        // overwrote the cursors egui sets for its own chrome -- the I-beam
+        // over a text field, resize arrows over a splitter -- because a pane
+        // would stamp its own icon over them after they were set.
+        //
+        // `rect_contains_pointer` respects layer and clip rect, so a modal
+        // drawn above the pane correctly keeps its own cursor.
+        if ui.rect_contains_pointer(pane_rect) {
+            let resolved_icon = cursor_icon_for(pointer_hover.resolve(), snap.pointer_shape);
+            ui.ctx().output_mut(|output| {
+                output.cursor_icon = resolved_icon;
+            });
+        }
 
         // ── Drag-and-drop ────────────────────────────────────────────
         handle_file_drop(ui, terminal_rect, input_tx);

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -1326,10 +1326,9 @@ pub struct PaneRenderCache {
     /// from `overlay_was_open_last_frame` so each latch tracks only its own
     /// cause.
     pub(super) border_drag_was_active_last_frame: bool,
-    /// Number of search matches from the most recently rendered frame.
-    pub(super) previous_search_match_count: usize,
-    /// Current match index from the most recently rendered frame.
-    pub(super) previous_search_current_match: usize,
+    /// Fingerprint of the search-highlight state from the most recently
+    /// rendered frame (see `SearchState::render_epoch`).
+    pub(super) previous_search_epoch: u64,
     /// The terminal cell `(col, row)` the mouse was hovering over in the
     /// previous frame.
     pub(super) previous_hover_cell: Option<(usize, usize)>,
@@ -1485,8 +1484,7 @@ impl PaneRenderCache {
             previous_text_blink_fast_visible: true,
             overlay_was_open_last_frame: false,
             border_drag_was_active_last_frame: false,
-            previous_search_match_count: 0,
-            previous_search_current_match: 0,
+            previous_search_epoch: 0,
             previous_hover_cell: None,
             previous_command_block_hover_rows: None,
             cached_hovered_url: None,
@@ -2455,8 +2453,7 @@ impl FreminalTerminalWidget {
             let text_blink_changed = dirty.observations.text_blink_changed;
             let current_selection = dirty.current_selection;
             let screen_selection = dirty.screen_selection;
-            let search_match_count = dirty.search_match_count;
-            let search_current_match = dirty.search_current_match;
+            let search_epoch = dirty.search_epoch;
             let command_block_hover_rows_early = dirty.command_block_hover_rows;
             effective_show_cursor = dirty.effective_show_cursor;
             let cursor_pixel_pos = dirty.cursor_pixel_pos;
@@ -2846,8 +2843,7 @@ impl FreminalTerminalWidget {
                         cache.previous_selection = current_selection;
                         cache.previous_text_blink_slow_visible = view_state.text_blink_slow_visible;
                         cache.previous_text_blink_fast_visible = view_state.text_blink_fast_visible;
-                        cache.previous_search_match_count = search_match_count;
-                        cache.previous_search_current_match = search_current_match;
+                        cache.previous_search_epoch = search_epoch;
                         cache.previous_command_block_hover_rows = command_block_hover_rows_early;
                         cache.previous_term_width = snap.term_width;
                         cache.previous_term_height = snap.term_height;

--- a/freminal/src/gui/view_state.rs
+++ b/freminal/src/gui/view_state.rs
@@ -147,7 +147,32 @@ impl SelectionState {
     }
 
     /// Clear the selection entirely, including block mode.
-    pub const fn clear(&mut self) {
+    ///
+    /// Every path that drops a selection funnels through here -- the
+    /// content-changed auto-clear, the click-to-dismiss press, an interrupted
+    /// drag, a fold/unfold, a completed copy. When a selection vanishes
+    /// unexpectedly, the question is always *which* of those fired, and the
+    /// call sites are spread across three modules.
+    ///
+    /// So this logs the caller's source location whenever it actually discards
+    /// something. `#[track_caller]` makes that the real call site rather than
+    /// this line. Off by default; enable with:
+    ///
+    /// ```text
+    /// RUST_LOG=none,freminal::selection=debug freminal
+    /// ```
+    #[track_caller]
+    pub fn clear(&mut self) {
+        if self.anchor.is_some() || self.end.is_some() {
+            tracing::debug!(
+                target: "freminal::selection",
+                caller = %std::panic::Location::caller(),
+                anchor = ?self.anchor,
+                end = ?self.end,
+                is_selecting = self.is_selecting,
+                "selection cleared"
+            );
+        }
         self.anchor = None;
         self.end = None;
         self.is_selecting = false;

--- a/freminal/src/gui/view_state.rs
+++ b/freminal/src/gui/view_state.rs
@@ -293,6 +293,42 @@ impl SearchState {
         self.last_searched_case_sensitive = self.case_sensitive;
     }
 
+    /// A cheap fingerprint of everything that determines how the search
+    /// highlights should be drawn.
+    ///
+    /// The per-frame dirty check compares this against the previous frame's
+    /// value to decide whether the highlight geometry must be rebuilt. It
+    /// previously compared only `matches.len()` and `current_match`, which
+    /// misses any edit that changes *where* a match starts or ends without
+    /// changing how many there are — narrowing "day" to "days" over the same
+    /// single hit being the obvious case. The highlight quads then kept
+    /// drawing the old, shorter box until something unrelated (a scroll, new
+    /// output, a pane switch) forced a full rebuild (#463).
+    ///
+    /// The inputs are the `last_searched_*` fields rather than the live
+    /// `query`/`regex_mode`/`case_sensitive`, because those record what
+    /// actually produced the current `matches` — which is what gets rendered.
+    /// A query edit that has not been searched yet correctly does not move
+    /// this value; the frame that re-runs the search does.
+    ///
+    /// Deliberately does **not** hash the `matches` themselves: matches are a
+    /// pure function of (query, flags, corpus), corpus changes are already
+    /// covered by the snapshot's `content_changed`, and a broad search can
+    /// produce tens of thousands of spans that would then be re-hashed on
+    /// every single frame.
+    #[must_use]
+    pub fn render_epoch(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        self.is_open.hash(&mut h);
+        self.last_searched_query.hash(&mut h);
+        self.last_searched_regex.hash(&mut h);
+        self.last_searched_case_sensitive.hash(&mut h);
+        self.matches.len().hash(&mut h);
+        self.current_match.hash(&mut h);
+        h.finish()
+    }
+
     /// Move to the next match, wrapping around.
     ///
     /// Does nothing when there are no matches.
@@ -2715,5 +2751,152 @@ mod tests {
             due > Duration::from_millis(0),
             "next_due must be positive, got {due:?}"
         );
+    }
+
+    // ─── SearchState::render_epoch (issue #463) ──────────────────────────────
+
+    /// Build a search state as it would be right after a search completed.
+    fn searched(query: &str, matches: Vec<MatchSpan>) -> SearchState {
+        let mut st = SearchState {
+            is_open: true,
+            query: query.to_owned(),
+            matches,
+            ..SearchState::default()
+        };
+        st.mark_fresh();
+        st
+    }
+
+    /// The reported case: narrowing "day" to "days" keeps a single match and
+    /// keeps the focused index at 0, but the highlight must still be rebuilt.
+    #[test]
+    fn render_epoch_changes_when_a_query_edit_keeps_the_match_count() {
+        let before = searched(
+            "day",
+            vec![MatchSpan {
+                row: 4,
+                col_start: 10,
+                col_end: 12,
+            }],
+        );
+        let after = searched(
+            "days",
+            vec![MatchSpan {
+                row: 4,
+                col_start: 10,
+                col_end: 13,
+            }],
+        );
+
+        assert_eq!(before.matches.len(), after.matches.len());
+        assert_eq!(before.current_match, after.current_match);
+        assert_ne!(
+            before.render_epoch(),
+            after.render_epoch(),
+            "an edit that only widens the match must still force a rebuild"
+        );
+    }
+
+    /// Stepping between matches must force a rebuild -- the focused match is
+    /// drawn in a different colour from the others.
+    #[test]
+    fn render_epoch_changes_when_the_focused_match_moves() {
+        let mut st = searched(
+            "x",
+            vec![
+                MatchSpan {
+                    row: 1,
+                    col_start: 0,
+                    col_end: 0,
+                },
+                MatchSpan {
+                    row: 2,
+                    col_start: 0,
+                    col_end: 0,
+                },
+            ],
+        );
+        let before = st.render_epoch();
+        st.next_match();
+        assert_ne!(before, st.render_epoch());
+    }
+
+    /// Toggling a search mode re-runs the search, so it must invalidate.
+    #[test]
+    fn render_epoch_changes_when_a_search_mode_is_toggled() {
+        let base = searched("abc", vec![]);
+        let mut regex = searched("abc", vec![]);
+        regex.regex_mode = true;
+        regex.mark_fresh();
+        assert_ne!(base.render_epoch(), regex.render_epoch());
+
+        let mut case = searched("abc", vec![]);
+        case.case_sensitive = true;
+        case.mark_fresh();
+        assert_ne!(base.render_epoch(), case.render_epoch());
+    }
+
+    /// Opening and closing the overlay changes whether highlights are drawn.
+    #[test]
+    fn render_epoch_changes_when_the_overlay_opens_or_closes() {
+        let mut st = searched("abc", vec![]);
+        let open = st.render_epoch();
+        st.is_open = false;
+        assert_ne!(open, st.render_epoch());
+    }
+
+    /// An unsettled edit -- typed but not yet searched -- must NOT invalidate:
+    /// `matches` still describes the previous query, and rebuilding would just
+    /// redraw the same geometry.
+    #[test]
+    fn render_epoch_is_stable_until_the_search_actually_reruns() {
+        let mut st = searched(
+            "day",
+            vec![MatchSpan {
+                row: 4,
+                col_start: 10,
+                col_end: 12,
+            }],
+        );
+        let settled = st.render_epoch();
+
+        st.query.push('s');
+        assert!(st.needs_refresh(), "the edit must be pending a re-search");
+        assert_eq!(
+            settled,
+            st.render_epoch(),
+            "a query edit alone must not invalidate; the re-search does"
+        );
+
+        st.matches = vec![MatchSpan {
+            row: 4,
+            col_start: 10,
+            col_end: 13,
+        }];
+        st.mark_fresh();
+        assert_ne!(settled, st.render_epoch());
+    }
+
+    /// Identical state must produce an identical fingerprint, or every frame
+    /// would rebuild.
+    #[test]
+    fn render_epoch_is_stable_for_unchanged_state() {
+        let a = searched(
+            "hello",
+            vec![MatchSpan {
+                row: 3,
+                col_start: 1,
+                col_end: 5,
+            }],
+        );
+        let b = searched(
+            "hello",
+            vec![MatchSpan {
+                row: 3,
+                col_start: 1,
+                col_end: 5,
+            }],
+        );
+        assert_eq!(a.render_epoch(), b.render_epoch());
     }
 }

--- a/sequence_decoder.py
+++ b/sequence_decoder.py
@@ -89,7 +89,7 @@ for arg in sys.argv[1:]:
 
 # --framed only means anything as a modifier to --raw-pty. Fail loudly rather
 # than silently producing an unframed file the caller will misparse.
-if raw_pty_framed and raw_pty_out is None:
+if raw_pty_framed and not raw_pty_out:
     print("Error: --framed is a modifier for --raw-pty and requires it")
     sys.exit(1)
 

--- a/sequence_decoder.py
+++ b/sequence_decoder.py
@@ -22,6 +22,8 @@
 #   python3 sequence_decoder.py --recording-path=path/to/file --summary          # v2 only
 #   python3 sequence_decoder.py --recording-path=path/to/file --pane 0           # v2 only
 #   python3 sequence_decoder.py --recording-path=path/to/file --events-only      # v2 only
+#   python3 sequence_decoder.py --recording-path=path/to/file --raw-pty=out.bin
+#   python3 sequence_decoder.py --recording-path=path/to/file --raw-pty=out.bin --framed
 
 import struct
 import sys
@@ -39,6 +41,7 @@ summary_only = False
 filter_pane = None
 events_only = False
 raw_pty_out = None
+raw_pty_framed = False
 
 for arg in sys.argv[1:]:
     if arg.startswith("--recording-path"):
@@ -51,6 +54,18 @@ for arg in sys.argv[1:]:
         if not raw_pty_out:
             print("Error: --raw-pty requires a value (e.g. --raw-pty=out.bin)")
             sys.exit(1)
+    elif arg == "--framed":
+        # Modifier for --raw-pty: preserve the original PTY read boundaries by
+        # length-prefixing each event's payload with a u32 LE byte count,
+        # instead of concatenating them into one undifferentiated stream.
+        #
+        # Boundaries matter: a terminal emulator's behaviour can legitimately
+        # differ depending on how a byte stream is split across reads (a batch
+        # of printable characters that fills a row exactly is a different
+        # input than the same characters split in two). Replaying a flat
+        # concatenation can therefore both hide real bugs and manufacture
+        # artificial ones.
+        raw_pty_framed = True
     elif arg == "--convert-escape":
         convert_escape = True
     elif arg == "--split-commands":
@@ -71,6 +86,12 @@ for arg in sys.argv[1:]:
                 sys.exit(1)
     elif arg == "--events-only":
         events_only = True
+
+# --framed only means anything as a modifier to --raw-pty. Fail loudly rather
+# than silently producing an unframed file the caller will misparse.
+if raw_pty_framed and raw_pty_out is None:
+    print("Error: --framed is a modifier for --raw-pty and requires it")
+    sys.exit(1)
 
 # ---------------------------------------------------------------------------
 # Read file
@@ -335,6 +356,7 @@ event_num = 0
 
 if raw_pty_out is not None:
     collected = bytearray()
+    event_count = 0
     truncated = False
     decode_failures = []  # byte offsets of events whose payload failed to decode
     while pos + 13 <= end:
@@ -373,11 +395,20 @@ if raw_pty_out is not None:
         if isinstance(raw, list):
             raw = bytes(raw)
         if isinstance(raw, bytes):
+            if raw_pty_framed:
+                collected.extend(struct.pack("<I", len(raw)))
+                event_count += 1
             collected.extend(raw)
 
     with open(raw_pty_out, "wb") as out:
         out.write(collected)
-    print(f"Wrote {len(collected)} bytes of PtyOutput to {raw_pty_out}")
+    if raw_pty_framed:
+        print(
+            f"Wrote {len(collected)} bytes ({event_count} length-framed PtyOutput "
+            f"events) to {raw_pty_out}"
+        )
+    else:
+        print(f"Wrote {len(collected)} bytes of PtyOutput to {raw_pty_out}")
 
     # A partial export (truncated stream or undecodable payloads) must fail
     # loudly so callers never silently replay incomplete data.


### PR DESCRIPTION
Ten bugs, nine of them user-confirmed fixed against a live terminal. Four were
found while investigating others; three were filed during this work.

Also bumps stable to 1.98.0 and remediates the new lints locally, so CI does
not discover them on this PR.

## What's fixed

| Issue | Symptom | Cause |
| --- | --- | --- |
| **#490** | Screen keeps a stale half-painted frame | A change signal is lost when DEC `?2026` skips the frame carrying it |
| **#491** | Long soft-wrapped lines render one character per row | Autowrap cleared the row it wrapped onto |
| **#463** | Search highlight one row high, under-highlights | Missing separator at the scrollback/visible seam; rebuild gate ignored match content |
| **#492** | Scroll blocked while the search overlay is open | Overlay input suppression swallowed wheel events |
| **#462** | Gutter/URL/divider cursors wrong or absent | Four unconditional writers to one window-wide field |
| **#493** | No hover cursor on any chrome | egui does not do this by default and we never asked |
| **#494** | Keypad keys duplicate under KKP | Releases reported without `REPORT_EVENT_TYPES` |
| **#452** | Settings "Apply" dismissed the dialog | It was an OK button wearing the wrong label |
| **#470** | Selection lost after exiting a TUI | `content_changed` edge contradicted by the rendered pixels |
| **#495** | focus-follows-mouse lags ~500ms | Pointer-repaint gate did not know focus is a state change |

## Two findings worth reading

**#490 and #470 are the same defect class, mirrored.** `content_changed` is
edge-triggered per snapshot build, but the GUI renders only a subset of
snapshots. In #490 an edge is **lost** because the frame carrying it was
skipped; in #470 an edge is **spurious** because the frames that would have
cancelled it were skipped. Both are edge-triggered signals crossing a boundary
that does not observe every event. If a third turns up, that pattern is worth a
skill.

**#462 was four instances of one mistake.** `output.cursor_icon` is a single
window-wide field that egui resets each frame, and `set_cursor_icon` has no
priority mechanism — so whichever call runs last silently wins and the losing
call looks perfectly correct where it sits. Fixed by giving cursor selection a
stated precedence and exactly one writer, and recorded in a new
`freminal-cursor-affordances` skill so the next one does not repeat it.

## Method

The reported symptom was misleading three times, so most of these were settled
with evidence rather than reading:

- **#491** was reported as a soft-wrap rendering bug. Replaying the recording
  into a headless emulator showed the buffer correct at every read granularity;
  the defect was in the write path. `sequence_decoder.py --framed` was added to
  replay recordings at true PTY read boundaries, since a flat concatenation both
  hides and manufactures boundary-dependent bugs.
- **#470** was diagnosed by making `SelectionState::clear` report its caller via
  `#[track_caller]`, then checking the snapshot's claim against the pixels. Two
  leading theories (stale mouse tracking, focus reporting) were killed by the
  reporter's own recordings before either was implemented.
- **#494** was found while investigating a numpad report that it does **not**
  explain. It is fixed and labelled as such; the original report is
  unreproduced and still open.

## Not in scope

- **The numpad double at a bare shell prompt** remains unreproduced. It runs
  with KKP off, where the path provably emits one byte per press, so #494 is a
  different bug that shares a symptom.
- **#452's second half** — threading every setting live with undo-on-cancel —
  is deliberately not attempted. The issue stays open.
- **`pointer_motion_needs_repaint_decision` now takes six positional bools.**
  A real hazard, flagged in its commit; it wants a named-field struct, which
  belongs to Task 121/122 rather than a bug fix.

## Verification

`cargo test --all` (106 binaries), `cargo clippy --all-targets --all-features
-D warnings`, `cargo fmt --check`, `cargo machete`, and `cargo xtask
check-windows` all clean on **rustc 1.98.0**.

Every fix has regression tests, and each was checked to fail without its fix.
Nine of the ten were verified interactively against a real terminal by the
reporter.

Closes #490, Closes #491, Closes #463, Closes #492, Closes #462, Closes #493, Closes #494, Closes #470, Closes #495
Refs #452


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer hover cursors for buttons, links, draggable areas, terminal URLs, and pane dividers.
  - Added framed raw-PTY export with payload lengths.
  - Added scrollback search across visible and historical terminal content.
  - Added primary-screen scroll passthrough for search overlays.
  - Settings Apply now saves while keeping the dialog open; OK saves and closes.

- **Bug Fixes**
  - Improved autowrap, incremental repainting, and synchronized-output rendering.
  - Preserved selections and search results across unchanged or skipped frames.
  - Prevented duplicate key presses and corrected pane-resize cursor behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->