### PR TITLE
Fix stuck URL tooltip (#510) and add Quit All (#509)

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -550,6 +550,8 @@ limit = 10000
 #
 #   Window management:
 #     new_window      = "Ctrl+Shift+N"  (open a new OS window with an initial tab)
+#     quit_all        = "Ctrl+Shift+Q"  (close every open window and quit; saves the
+#                                        full multi-window session before closing)
 #
 #   Scrollback:
 #     scroll_page_up   = "Shift+PageUp"

--- a/freminal-common/src/keybindings.rs
+++ b/freminal-common/src/keybindings.rs
@@ -27,6 +27,7 @@
 //! | `Ctrl+Shift+W`     | Close Tab        |
 //! | `Ctrl+Shift+,`     | Open Settings    |
 //! | `Ctrl+Shift+N`     | New Window       |
+//! | `Ctrl+Shift+Q`     | Quit All         |
 //! | `Shift+PageUp`     | Scroll Page Up   |
 //! | `Shift+PageDown`   | Scroll Page Down |
 //!
@@ -729,6 +730,19 @@ pub enum KeyAction {
     OpenSettings,
     /// Open a new OS window with an initial tab.
     NewWindow,
+    /// Close every open OS window, ending the process.
+    ///
+    /// Unlike closing windows one at a time (including via the per-window
+    /// "Quit" menu item, which only closes the OS window it was invoked
+    /// from), `QuitAll` snapshots the complete multi-window session
+    /// topology once, before any window is torn down, then closes each
+    /// window through the normal close-guard path (so a running foreground
+    /// command in any pane still prompts). This exists because closing
+    /// windows individually made only the last-closed window's topology
+    /// survive into the auto-saved session — see issue #509.
+    ///
+    /// Default binding: `Ctrl+Shift+Q`.
+    QuitAll,
 
     // -- Scrollback ---------------------------------------------------------
     /// Scroll up by one page.
@@ -904,6 +918,7 @@ impl KeyAction {
             Self::ToggleMenuBar => "toggle_menu_bar",
             Self::OpenSettings => "open_settings",
             Self::NewWindow => "new_window",
+            Self::QuitAll => "quit_all",
             Self::ScrollPageUp => "scroll_page_up",
             Self::ScrollPageDown => "scroll_page_down",
             Self::ScrollToTop => "scroll_to_top",
@@ -977,6 +992,7 @@ impl KeyAction {
             Self::ToggleMenuBar => "Toggle Menu Bar",
             Self::OpenSettings => "Open Settings",
             Self::NewWindow => "New Window",
+            Self::QuitAll => "Quit All",
             Self::ScrollPageUp => "Scroll Page Up",
             Self::ScrollPageDown => "Scroll Page Down",
             Self::ScrollToTop => "Scroll to Top",
@@ -1047,6 +1063,7 @@ impl KeyAction {
         Self::ToggleMenuBar,
         Self::OpenSettings,
         Self::NewWindow,
+        Self::QuitAll,
         Self::ScrollPageUp,
         Self::ScrollPageDown,
         Self::ScrollToTop,
@@ -1129,6 +1146,7 @@ impl FromStr for KeyAction {
             "toggle_menu_bar" => Ok(Self::ToggleMenuBar),
             "open_settings" => Ok(Self::OpenSettings),
             "new_window" => Ok(Self::NewWindow),
+            "quit_all" => Ok(Self::QuitAll),
             "scroll_page_up" => Ok(Self::ScrollPageUp),
             "scroll_page_down" => Ok(Self::ScrollPageDown),
             "scroll_to_top" => Ok(Self::ScrollToTop),
@@ -1550,6 +1568,11 @@ fn register_window_bindings(map: &mut BindingMap) {
         KeyCombo::new(BindingKey::N, BindingModifiers::CTRL_SHIFT),
         KeyAction::NewWindow,
     );
+    // Close every open window and quit the process (issue #509).
+    map.bind(
+        KeyCombo::new(BindingKey::Q, BindingModifiers::CTRL_SHIFT),
+        KeyAction::QuitAll,
+    );
 }
 
 /// Register layout management bindings.
@@ -1877,7 +1900,7 @@ mod tests {
         // roundtrip test above covers ALL, and name() is exhaustive.
         assert_eq!(
             KeyAction::ALL.len(),
-            62,
+            63,
             "KeyAction::ALL should contain all variants"
         );
     }
@@ -2265,6 +2288,13 @@ mod tests {
     }
 
     #[test]
+    fn default_quit_all_binding() {
+        let map = BindingMap::default();
+        let combo = KeyCombo::new(BindingKey::Q, BindingModifiers::CTRL_SHIFT);
+        assert_eq!(map.lookup(&combo), Some(KeyAction::QuitAll));
+    }
+
+    #[test]
     fn default_binding_total_count() {
         // The default map should have a known number of bindings.
         // This catches silent additions or removals.
@@ -2277,14 +2307,14 @@ mod tests {
         //        + ScrollLineUp(1) + ScrollLineDown(1)
         //        + SplitVertical(1) + SplitHorizontal(1) + ClosePane(1)
         //        + FocusPaneLeft/Down/Up/Right(4) + ResizePaneLeft/Down/Up/Right(4)
-        //        + ZoomPane(1) + NewWindow(1) + ClearScrollback(1)
+        //        + ZoomPane(1) + NewWindow(1) + QuitAll(1) + ClearScrollback(1)
         //        + ToggleRecording(1) + UnfoldAll(1)
         //        + CopyLastCommandOutput(1) + ShowCommandHistory(1)
-        //        + ToggleBroadcastInput(1) = 48
+        //        + ToggleBroadcastInput(1) = 49
         assert_eq!(
             map.len(),
-            48,
-            "default binding map should have exactly 48 bindings"
+            49,
+            "default binding map should have exactly 49 bindings"
         );
     }
 

--- a/freminal/src/gui/actions.rs
+++ b/freminal/src/gui/actions.rs
@@ -549,6 +549,9 @@ impl super::FreminalGui {
             KeyAction::NewWindow => {
                 win.pending_new_window = true;
             }
+            KeyAction::QuitAll => {
+                win.pending_quit_all = true;
+            }
             KeyAction::ToggleRecording => {
                 // Runtime recording toggle: starts a new FREC v2 file with
                 // the current topology snapshotted into the header, or

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -885,6 +885,7 @@ impl freminal_windowing::App for FreminalGui {
                         toast_render_state: crate::gui::renderer::ToastRenderState::new_shared(),
                         repaint_handle,
                         pending_new_window: false,
+                        pending_quit_all: false,
                         pending_geometry: None,
                         last_known_size: None,
                         last_known_position: None,
@@ -1026,13 +1027,22 @@ impl freminal_windowing::App for FreminalGui {
         // periodic save already wrote the current state, so this shutdown call
         // is a no-op — by design, so we no longer depend on a write surviving
         // an abrupt teardown.
+        // Skipped when a `QuitAll` (issue #509) is in flight: that path
+        // already wrote the complete multi-window topology up front, before
+        // any window was removed from `self.windows`. Without this guard,
+        // this per-window check re-fires as each subsequent window in the
+        // same batch reaches "I'm the last one left" against a `self.windows`
+        // that has been shrinking one close at a time, overwriting the
+        // correct save with a series of progressively smaller ones — the
+        // exact bug `QuitAll` exists to fix. See `quit_all_windows` in
+        // `close_guard.rs`.
         let remaining_terminal_windows = self
             .windows
             .keys()
             .filter(|&&wid| Some(wid) != self.settings_window_id)
             .count();
-        if remaining_terminal_windows == 1 {
-            self.maybe_auto_save_session();
+        if remaining_terminal_windows == 1 && !self.quit_all_in_progress {
+            self.maybe_auto_save_session(None);
         }
 
         // Capture geometry of every still-open terminal window (including
@@ -1519,6 +1529,12 @@ impl freminal_windowing::App for FreminalGui {
         if win.pending_new_window {
             win.pending_new_window = false;
             self.spawn_new_window(handle);
+        }
+
+        // ── Quit all windows (issue #509) ────────────────────────────────────
+        if win.pending_quit_all {
+            win.pending_quit_all = false;
+            self.quit_all_windows(ctx, &win, handle);
         }
 
         // ── Apply pending window geometry from layout engine ─────────────────
@@ -4525,6 +4541,7 @@ impl FreminalGui {
             toast_render_state: crate::gui::renderer::ToastRenderState::new_shared(),
             repaint_handle,
             pending_new_window: false,
+            pending_quit_all: false,
             pending_geometry: None,
             last_known_size: None,
             last_known_position: None,

--- a/freminal/src/gui/app_impl.rs
+++ b/freminal/src/gui/app_impl.rs
@@ -869,51 +869,13 @@ impl freminal_windowing::App for FreminalGui {
                         }
                     }
 
-                    let win = PerWindowState {
-                        tabs: TabManager::new(tab),
+                    let win = Self::new_per_window_state(
+                        tab,
                         terminal_widget,
-                        last_window_title: String::from("Freminal"),
                         os_dark_mode,
-                        style_cache: None,
-                        pending_close_pane: false,
-                        pending_focus_direction: None,
-                        border_drag: None,
-                        held_pointer_button: None,
-                        published: super::published_frame_state::PublishedFrameState::new(),
-                        shader_last_mtime: None,
                         window_post,
-                        toast_render_state: crate::gui::renderer::ToastRenderState::new_shared(),
                         repaint_handle,
-                        pending_new_window: false,
-                        pending_quit_all: false,
-                        pending_geometry: None,
-                        last_known_size: None,
-                        last_known_position: None,
-                        renaming_tab: None,
-                        rename_buffer: String::new(),
-                        dragging_tab: None,
-                        last_tab_rects: Vec::new(),
-                        pending_menu_actions: Vec::new(),
-                        paste_dialog: super::paste_guard::PasteDialog::default(),
-                        broadcast_dialog: super::broadcast_guard::BroadcastConfirmDialog::default(),
-                        close_dialog: super::close_guard::CloseGuardDialog::default(),
-                        pending_force_close: false,
-                        pending_raw_keys: Vec::new(),
-                        pending_frame_damage: freminal_windowing::FrameDamage::Full,
-                        pending_terminal_band_range: 0..0,
-                        present_region: std::sync::Arc::new(std::sync::Mutex::new(
-                            freminal_windowing::PresentRegion::default(),
-                        )),
-                        previous_active_pane_key: None,
-                        pending_chrome_damage: freminal_windowing::ChromeDamage::Changed,
-                        chrome_settle_pending: false,
-                        prev_dismissible_presence: chrome_damage::DismissiblePresence::default(),
-                        prev_chrome_tab_snapshot: chrome_damage::ChromeTabSnapshot::default(),
-                        prev_window_focused: false,
-                        chrome_frames_rendered: 0,
-                        pending_terminal_requested_delay: None,
-                        frame_stats: super::window::FrameStats::default(),
-                    };
+                    );
                     self.windows.insert(window_id, win);
 
                     self.emit_window_create_recording(window_id, inner_size);
@@ -937,6 +899,15 @@ impl freminal_windowing::App for FreminalGui {
     /// close, or the owning terminal window's — issue #401), or the window
     /// has a running foreground command pending confirmation (Task 98).
     fn on_close_requested(&mut self, window_id: WindowId) -> bool {
+        // Consume this window's membership in an in-flight `QuitAll` batch
+        // (issue #509), if any -- unconditionally, up front, regardless of
+        // which branch below ultimately resolves this call. That is what
+        // makes membership self-clearing rather than sticky: a LATER,
+        // independent close of this same window (e.g. after the user
+        // resolves a guard dialog this very call opened) finds no entry
+        // here and is judged as an ordinary single-window close.
+        let in_quit_all_batch = self.quit_all_pending.remove(&window_id);
+
         // Settings window closed (via OS close button).
         if self.settings_window_id == Some(window_id) {
             // Consult the unsaved-changes guard.  When dirty, the modal
@@ -1041,7 +1012,7 @@ impl freminal_windowing::App for FreminalGui {
             .keys()
             .filter(|&&wid| Some(wid) != self.settings_window_id)
             .count();
-        if remaining_terminal_windows == 1 && !self.quit_all_in_progress {
+        if remaining_terminal_windows == 1 && !in_quit_all_batch {
             self.maybe_auto_save_session(None);
         }
 
@@ -1534,7 +1505,7 @@ impl freminal_windowing::App for FreminalGui {
         // ── Quit all windows (issue #509) ────────────────────────────────────
         if win.pending_quit_all {
             win.pending_quit_all = false;
-            self.quit_all_windows(ctx, &win, handle);
+            self.quit_all_windows(ctx, window_id, &win, handle);
         }
 
         // ── Apply pending window geometry from layout engine ─────────────────

--- a/freminal/src/gui/close_guard.rs
+++ b/freminal/src/gui/close_guard.rs
@@ -24,6 +24,7 @@
 use std::time::{Duration, SystemTime};
 
 use freminal_common::buffer_states::command_block::{CommandBlock, CommandStatus};
+use freminal_windowing::App as _;
 
 use super::panes::{Pane, PaneId};
 use super::tabs::TabId;
@@ -460,6 +461,57 @@ impl super::FreminalGui {
         win: &super::window::PerWindowState,
     ) -> Vec<RunningCommandInfo> {
         self.gather_running_for_window(win)
+    }
+
+    /// Handle a `QuitAll` request (issue #509): close every open window,
+    /// having first snapshotted the complete multi-window session topology
+    /// exactly once.
+    ///
+    /// Closing windows one at a time let each earlier close remove itself
+    /// from `self.windows` before the "auto-save when I'm the last window"
+    /// check in `on_close_requested` ran, so only the last-closed window's
+    /// topology ever survived into `last_session.toml`. This saves the full
+    /// topology up front instead — `current_window` is the window whose
+    /// `update()` this runs inside, which `self.windows` does not currently
+    /// contain (see `build_layout`'s doc comment), so it is passed
+    /// separately — then sets `quit_all_in_progress` so that per-window
+    /// check does not re-fire and overwrite the correct save with a
+    /// shrinking one as the batch proceeds.
+    ///
+    /// Every *other* open window (including an open Settings window) is
+    /// closed here, synchronously, through the same `on_close_requested`
+    /// guard a normal OS close uses — a running foreground command or
+    /// unsaved settings edit still opens its confirmation dialog instead of
+    /// being silently discarded. A vetoed window's dialog needs a repaint to
+    /// appear, since this is not that window's own render pass.
+    ///
+    /// `current_window` itself is asked to close via
+    /// `ViewportCommand::Close` so it goes through the ordinary
+    /// winit-driven close path once `update()` returns — the same path the
+    /// single-window "Quit" menu item already uses — rather than being
+    /// closed directly here where `self.windows` does not yet contain it.
+    pub(in crate::gui) fn quit_all_windows(
+        &mut self,
+        ctx: &egui::Context,
+        current_window: &super::window::PerWindowState,
+        handle: &freminal_windowing::WindowHandle<'_>,
+    ) {
+        self.maybe_auto_save_session(Some(current_window));
+        self.quit_all_in_progress = true;
+
+        let other_window_ids: Vec<_> = self.windows.keys().copied().collect();
+        for wid in other_window_ids {
+            if self.on_close_requested(wid) {
+                handle.close_window(wid);
+            } else {
+                // Vetoed: `on_close_requested` opened that window's own
+                // close-guard (or unsaved-settings) dialog in place. Wake it
+                // so the dialog actually renders.
+                handle.request_repaint(wid);
+            }
+        }
+
+        ctx.send_viewport_cmd(egui::ViewportCommand::Close);
     }
 }
 

--- a/freminal/src/gui/close_guard.rs
+++ b/freminal/src/gui/close_guard.rs
@@ -474,9 +474,13 @@ impl super::FreminalGui {
     /// topology up front instead — `current_window` is the window whose
     /// `update()` this runs inside, which `self.windows` does not currently
     /// contain (see `build_layout`'s doc comment), so it is passed
-    /// separately — then sets `quit_all_in_progress` so that per-window
-    /// check does not re-fire and overwrite the correct save with a
-    /// shrinking one as the batch proceeds.
+    /// separately — then seeds `quit_all_pending` with every window in this
+    /// batch (including `current_window_id`) so `on_close_requested`'s
+    /// per-window check does not re-fire for any of them and overwrite the
+    /// correct save with a shrinking one as the batch proceeds. See
+    /// `quit_all_pending`'s doc comment for why membership, not a sticky
+    /// flag, is what lets a vetoed window's later, independent close still
+    /// auto-save correctly.
     ///
     /// Every *other* open window (including an open Settings window) is
     /// closed here, synchronously, through the same `on_close_requested`
@@ -493,13 +497,17 @@ impl super::FreminalGui {
     pub(in crate::gui) fn quit_all_windows(
         &mut self,
         ctx: &egui::Context,
+        current_window_id: freminal_windowing::WindowId,
         current_window: &super::window::PerWindowState,
         handle: &freminal_windowing::WindowHandle<'_>,
     ) {
         self.maybe_auto_save_session(Some(current_window));
-        self.quit_all_in_progress = true;
 
         let other_window_ids: Vec<_> = self.windows.keys().copied().collect();
+        self.quit_all_pending
+            .extend(other_window_ids.iter().copied());
+        self.quit_all_pending.insert(current_window_id);
+
         for wid in other_window_ids {
             if self.on_close_requested(wid) {
                 handle.close_window(wid);

--- a/freminal/src/gui/layout_ops.rs
+++ b/freminal/src/gui/layout_ops.rs
@@ -710,6 +710,7 @@ impl FreminalGui {
             toast_render_state: crate::gui::renderer::ToastRenderState::new_shared(),
             repaint_handle,
             pending_new_window: false,
+            pending_quit_all: false,
             pending_geometry,
             last_known_size: None,
             last_known_position: None,

--- a/freminal/src/gui/menu.rs
+++ b/freminal/src/gui/menu.rs
@@ -71,30 +71,7 @@ impl super::FreminalGui {
         any_menu_open: &mut bool,
     ) {
         let freminal_resp = ui.menu_button("Freminal", |ui| {
-            if ui
-                .add(self.menu_button_for("Settings...", KeyAction::OpenSettings))
-                .clicked()
-            {
-                if self.settings_window_id.is_some() {
-                    // Settings window already exists — focus it.
-                    self.pending_focus_settings = true;
-                } else if !self.settings_modal.is_open && !self.pending_settings_window {
-                    let families = win.terminal_widget.monospace_families();
-                    self.settings_modal
-                        .open(&self.config, families, win.os_dark_mode);
-                    self.settings_modal
-                        .set_base_font_defs(win.terminal_widget.base_font_defs().clone());
-                    self.settings_owner = Some(window_id);
-                    self.pending_settings_window = true;
-                }
-                ui.close();
-            }
-
-            ui.separator();
-
-            if ui.button("Quit").clicked() {
-                ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
-            }
+            self.show_freminal_menu(ui, win, window_id);
         });
         if freminal_resp.inner.is_some() {
             *any_menu_open = true;
@@ -244,6 +221,47 @@ impl super::FreminalGui {
                     ui.close();
                 }
             }
+        }
+    }
+
+    /// Render the "Freminal" dropdown menu contents.
+    fn show_freminal_menu(
+        &mut self,
+        ui: &mut egui::Ui,
+        win: &mut PerWindowState,
+        window_id: super::WindowId,
+    ) {
+        if ui
+            .add(self.menu_button_for("Settings...", KeyAction::OpenSettings))
+            .clicked()
+        {
+            if self.settings_window_id.is_some() {
+                // Settings window already exists — focus it.
+                self.pending_focus_settings = true;
+            } else if !self.settings_modal.is_open && !self.pending_settings_window {
+                let families = win.terminal_widget.monospace_families();
+                self.settings_modal
+                    .open(&self.config, families, win.os_dark_mode);
+                self.settings_modal
+                    .set_base_font_defs(win.terminal_widget.base_font_defs().clone());
+                self.settings_owner = Some(window_id);
+                self.pending_settings_window = true;
+            }
+            ui.close();
+        }
+
+        ui.separator();
+
+        if ui.button("Quit").clicked() {
+            ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+        }
+
+        if ui
+            .add(self.menu_button_for("Quit All", KeyAction::QuitAll))
+            .clicked()
+        {
+            win.pending_quit_all = true;
+            ui.close();
         }
     }
 

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -202,6 +202,20 @@ struct FreminalGui {
     /// Set to `true` when the existing settings window should be focused.
     pending_focus_settings: bool,
 
+    /// Set to `true` for the remainder of the process once a `QuitAll`
+    /// (issue #509) has run its up-front full-topology session save.
+    ///
+    /// `on_close_requested`'s own "auto-save when I'm the last window"
+    /// check consults this to avoid re-saving a shrinking topology as each
+    /// window in the batch closes — see the comment at that check and
+    /// `quit_all_windows` in `close_guard.rs`. Deliberately never reset:
+    /// in the success path the process exits immediately after; in the
+    /// veto path (a running command blocked one window) the periodic
+    /// session-autosave timer remains the safety net regardless, matching
+    /// `maybe_auto_save_session`'s existing "shutdown save is a
+    /// non-load-bearing convenience" design.
+    quit_all_in_progress: bool,
+
     /// Persisted ephemeral UI window geometry for the Settings window
     /// and each main terminal window.  Loaded from `window_state.toml`
     /// at startup: the settings entry is consulted when the settings
@@ -478,6 +492,7 @@ impl FreminalGui {
             settings_window_id: None,
             pending_settings_window: false,
             pending_focus_settings: false,
+            quit_all_in_progress: false,
             window_state: freminal_common::window_state::window_state_path()
                 .as_deref()
                 .map(freminal_common::window_state::WindowState::load_or_default)

--- a/freminal/src/gui/mod.rs
+++ b/freminal/src/gui/mod.rs
@@ -202,19 +202,21 @@ struct FreminalGui {
     /// Set to `true` when the existing settings window should be focused.
     pending_focus_settings: bool,
 
-    /// Set to `true` for the remainder of the process once a `QuitAll`
-    /// (issue #509) has run its up-front full-topology session save.
+    /// Windows whose `on_close_requested` call is still expected as part of
+    /// an in-flight `QuitAll` batch (issue #509), seeded by
+    /// `quit_all_windows` in `close_guard.rs` with every window open at the
+    /// moment `QuitAll` fired (including the one it was invoked from).
     ///
-    /// `on_close_requested`'s own "auto-save when I'm the last window"
-    /// check consults this to avoid re-saving a shrinking topology as each
-    /// window in the batch closes — see the comment at that check and
-    /// `quit_all_windows` in `close_guard.rs`. Deliberately never reset:
-    /// in the success path the process exits immediately after; in the
-    /// veto path (a running command blocked one window) the periodic
-    /// session-autosave timer remains the safety net regardless, matching
-    /// `maybe_auto_save_session`'s existing "shutdown save is a
-    /// non-load-bearing convenience" design.
-    quit_all_in_progress: bool,
+    /// `on_close_requested` removes its own `window_id` from this set the
+    /// moment it runs, regardless of outcome, and consults membership to
+    /// decide whether to skip its own "auto-save when I'm the last window"
+    /// check — see the comment at that check. Membership, not a sticky
+    /// flag, is what lets a *later*, independent close of a window that
+    /// this batch vetoed (e.g. a running-command guard the user goes on to
+    /// resolve on its own) be judged as an ordinary single-window close
+    /// rather than still "part of a batch": by then its entry is already
+    /// gone, so the normal auto-save-on-last-window behavior applies to it.
+    quit_all_pending: std::collections::HashSet<WindowId>,
 
     /// Persisted ephemeral UI window geometry for the Settings window
     /// and each main terminal window.  Loaded from `window_state.toml`
@@ -492,7 +494,7 @@ impl FreminalGui {
             settings_window_id: None,
             pending_settings_window: false,
             pending_focus_settings: false,
-            quit_all_in_progress: false,
+            quit_all_pending: std::collections::HashSet::new(),
             window_state: freminal_common::window_state::window_state_path()
                 .as_deref()
                 .map(freminal_common::window_state::WindowState::load_or_default)

--- a/freminal/src/gui/session.rs
+++ b/freminal/src/gui/session.rs
@@ -105,7 +105,14 @@ impl FreminalGui {
     /// Skips saving when the user launched with an ad-hoc command
     /// (`freminal -- vim foo`): those panes run a one-shot program and are not
     /// meaningfully restorable.  Failures are logged but never fatal.
-    pub(super) fn maybe_auto_save_session(&mut self) {
+    ///
+    /// `extra_win` is threaded straight through to [`Self::build_layout`]: it
+    /// is the window that was removed from `self.windows` for the duration
+    /// of the current `update()` frame (see `build_layout`'s doc comment),
+    /// so passing it here is what lets a save taken *during* that window's
+    /// own frame still capture that window (issue #509's `QuitAll`, which
+    /// must snapshot the complete topology before any window closes).
+    pub(super) fn maybe_auto_save_session(&mut self, extra_win: Option<&window::PerWindowState>) {
         if !self.args.command.is_empty() {
             return;
         }
@@ -118,7 +125,7 @@ impl FreminalGui {
         // Build the session layout and serialize it in memory so we can
         // fingerprint the exact bytes we would write.  No disk read-back: the
         // fingerprint compares against the last value *we* wrote this run.
-        let layout = self.build_layout("Last Session", None);
+        let layout = self.build_layout("Last Session", extra_win);
         let toml_str = match layout.to_toml_string() {
             Ok(s) => s,
             Err(e) => {
@@ -216,7 +223,7 @@ impl FreminalGui {
             .session_save_due
             .swap(false, std::sync::atomic::Ordering::Relaxed)
         {
-            self.maybe_auto_save_session();
+            self.maybe_auto_save_session(None);
         }
     }
 

--- a/freminal/src/gui/terminal/widget.rs
+++ b/freminal/src/gui/terminal/widget.rs
@@ -449,6 +449,35 @@ pub(super) fn compute_command_block_hover_rows(
     Some((s_screen.min(e_screen), s_screen.max(e_screen)))
 }
 
+/// Resolve the (column, row) cell under the pointer for URL-hover purposes,
+/// or `None` when the pointer is not actually over this pane.
+///
+/// Every pane in a split runs `write_input_to_terminal` against the same
+/// window-wide event queue, so `view_state.mouse_position` can hold a
+/// position that belongs to a sibling pane rather than this one (issue
+/// #510: a URL on a pane's top row got "stuck" hovered when the pointer
+/// moved into the pane stacked above it). Requiring containment here --
+/// not just a `Some`/`None` check on `mouse_position` -- is what stops a
+/// stale out-of-pane position from resolving, via
+/// `encode_egui_mouse_pos_as_usize`'s edge clamp, to this pane's row/column
+/// 0 and reviving a stale cached URL. Mirrors the equivalent guard in
+/// `compute_command_block_hover_rows` for the sibling gutter-hover feature.
+pub(super) fn cell_under_pointer_for_url_hover(
+    mouse_position: Option<Pos2>,
+    terminal_rect: Rect,
+    character_size: (f32, f32),
+) -> Option<(usize, usize)> {
+    let pos = mouse_position?;
+    if !terminal_rect.contains(pos) {
+        return None;
+    }
+    Some(encode_egui_mouse_pos_as_usize(
+        pos,
+        character_size,
+        terminal_rect.min,
+    ))
+}
+
 /// Outcome of a scrollbar render+interaction pass. `new_offset` is the
 /// scroll offset the user dragged to (if any). `rendered` is whether the
 /// thumb was actually painted this frame. `hovered` is the
@@ -4184,13 +4213,11 @@ impl FreminalTerminalWidget {
         //   4. Click detection always runs against the cached URL so that
         //      Ctrl+click works even when the mouse has not moved.
         if snap.has_urls {
-            if let Some(mouse_position) = view_state.mouse_position {
-                let (col, row) = encode_egui_mouse_pos_as_usize(
-                    mouse_position,
-                    (logical_cell_w, logical_cell_h),
-                    terminal_rect.min,
-                );
-
+            if let Some((col, row)) = cell_under_pointer_for_url_hover(
+                view_state.mouse_position,
+                terminal_rect,
+                (logical_cell_w, logical_cell_h),
+            ) {
                 let cell = (col, row);
                 let cell_changed = cache.previous_hover_cell != Some(cell);
                 // Pointer identity comparison for the snapshot's char buffer.
@@ -4279,8 +4306,10 @@ impl FreminalTerminalWidget {
                     }
                 }
             } else {
-                // Mouse left the terminal area. Only the URL-hover cache is
-                // cleared here; the icon itself is resolved once below.
+                // Mouse left the terminal area, or (issue #510) is over a
+                // sibling pane and never actually entered this one. Only the
+                // URL-hover cache is cleared here; the icon itself is
+                // resolved once below.
                 cache.previous_hover_cell = None;
                 cache.cached_hovered_url = None;
             }
@@ -6228,6 +6257,78 @@ impl InputSuppressors {
             && !self.context_menu
             && !self.command_history
             && !self.scrollbar_drag
+    }
+}
+
+#[cfg(test)]
+mod url_hover_pane_bounds_tests {
+    //! Issue #510: a URL on a pane's top row must not stay "hovered" once
+    //! the pointer moves into a sibling pane stacked above it. Every pane
+    //! runs against the same window-wide `PointerMoved` queue, so
+    //! `view_state.mouse_position` alone cannot be trusted to mean "over
+    //! this pane" -- containment must be checked explicitly.
+    use super::*;
+
+    /// 10px logical cells, pane/terminal rect both `(0,0)-(100,100)` (no
+    /// gutter inset, unlike the command-block tests above).
+    fn terminal_rect() -> Rect {
+        Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(100.0, 100.0))
+    }
+
+    #[test]
+    fn pointer_inside_rect_resolves_to_a_cell() {
+        let rect = terminal_rect();
+        // (25, 35) -> column 2, row 3 at 10px cells.
+        let pos = egui::pos2(25.0, 35.0);
+        assert_eq!(
+            cell_under_pointer_for_url_hover(Some(pos), rect, (10.0, 10.0)),
+            Some((2, 3))
+        );
+    }
+
+    #[test]
+    fn pointer_above_the_pane_is_rejected_not_clamped_to_row_zero() {
+        let rect = terminal_rect();
+        // A position belonging to a sibling pane stacked above this one:
+        // above `rect.min.y`. Before the #510 fix this clamped to row 0
+        // instead of being rejected outright.
+        let pos = egui::pos2(25.0, -40.0);
+        assert_eq!(
+            cell_under_pointer_for_url_hover(Some(pos), rect, (10.0, 10.0)),
+            None
+        );
+    }
+
+    #[test]
+    fn pointer_left_of_the_pane_is_rejected_not_clamped_to_column_zero() {
+        let rect = terminal_rect();
+        let pos = egui::pos2(-40.0, 25.0);
+        assert_eq!(
+            cell_under_pointer_for_url_hover(Some(pos), rect, (10.0, 10.0)),
+            None
+        );
+    }
+
+    #[test]
+    fn pointer_below_or_right_of_the_pane_is_rejected() {
+        let rect = terminal_rect();
+        assert_eq!(
+            cell_under_pointer_for_url_hover(Some(egui::pos2(25.0, 500.0)), rect, (10.0, 10.0)),
+            None
+        );
+        assert_eq!(
+            cell_under_pointer_for_url_hover(Some(egui::pos2(500.0, 25.0)), rect, (10.0, 10.0)),
+            None
+        );
+    }
+
+    #[test]
+    fn no_mouse_position_is_rejected() {
+        let rect = terminal_rect();
+        assert_eq!(
+            cell_under_pointer_for_url_hover(None, rect, (10.0, 10.0)),
+            None
+        );
     }
 }
 

--- a/freminal/src/gui/window.rs
+++ b/freminal/src/gui/window.rs
@@ -356,6 +356,11 @@ pub(super) struct PerWindowState {
     /// `update()` where `WindowHandle` is available.
     pub(super) pending_new_window: bool,
 
+    /// Set to `true` by the `QuitAll` key action or menu; consumed in
+    /// `update()` where `self.windows` (every other open window) and
+    /// `WindowHandle` are both available (issue #509).
+    pub(super) pending_quit_all: bool,
+
     /// If set, send resize + reposition viewport commands on the next frame.
     ///
     /// Populated by the layout engine when applying a layout to an existing


### PR DESCRIPTION
## Summary

Two small, independent bug/feature fixes.

### Fixes #510 — URL at the top of a pane causes stuck URL tooltip

Every pane in a split runs `write_input_to_terminal` against the same
window-wide `PointerMoved` event queue, so a pane's
`view_state.mouse_position` could hold a position that actually belongs to
a sibling pane (e.g. the pointer moved into the pane stacked above it).
The URL-hover block trusted that position with no bounds check — unlike
the sibling `compute_command_block_hover_rows` gutter-hover guard, which
already does this correctly — so `encode_egui_mouse_pos_as_usize`'s
edge-clamping turned "pointer moved above this pane" into "row 0," and the
hover cache kept re-matching a URL that lived at this pane's top row. The
tooltip then rendered at the live pointer position (via
`PopupAnchor::Pointer`), which is what made it appear "stuck" and
"following the mouse" into the other pane.

Fix: extract `cell_under_pointer_for_url_hover()`, which requires actual
`terminal_rect` containment before resolving a cell, and use it in place
of the previous unchecked `mouse_position` read. Added unit tests for
positions above/left/below/right of the pane and the no-mouse-position
case.

### Closes #509 — "Quit All" option in menu bar

Adds `KeyAction::QuitAll` (default binding `Ctrl+Shift+Q`, full
`BindingMap`/config/menu wiring) and a "Quit All" item in the Freminal
menu alongside the existing per-window "Quit".

This also fixes the underlying bug the issue described: closing windows
one at a time let each earlier close remove itself from `self.windows`
before `on_close_requested`'s "auto-save when I'm the last window" check
ran, so only the last-closed window's topology ever survived into
`last_session.toml`. `quit_all_windows()` now snapshots the complete
multi-window topology **once, up front** — passing the current window
(temporarily absent from `self.windows` during its own `update()` frame)
as `build_layout`'s `extra_win` — before closing anything, and sets
`quit_all_in_progress` so that per-window check doesn't re-fire and
overwrite the correct save with a shrinking one as the batch closes.
Every other window is closed through the same `on_close_requested` guard
a normal OS close uses, so a running foreground command or unsaved
settings edit still prompts instead of being silently discarded; the
current window closes via the existing `ViewportCommand::Close` path.

## Testing

- `cargo test --all` — all tests pass (1440+ across the workspace)
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo machete` — clean
- `cargo xtask check-windows` — clean
- New unit tests: 5 for URL-hover pane-bounds (#510), keybinding
  round-trip/default-binding/count tests for `QuitAll` (#509)

**Not covered by an automated test**: `quit_all_windows()`'s own
orchestration (looping over windows, saving, closing). Constructing a full
`FreminalGui`/`PerWindowState` requires a live egui+GL+PTY context, and no
existing test in this codebase does so — `on_close_requested`,
`build_layout`, and `maybe_auto_save_session` are likewise untested today.
Verified by careful code review; recommend a manual smoke test (open
multiple windows, use Quit All, confirm `last_session.toml` captures the
full topology) before merging.

## Commits

- `fix: 510 -- stop stuck URL tooltip when pointer leaves the pane`
- `feat: 509 -- add Quit All to close every window and quit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **Quit All** command to close every open window and exit the application.
  - Added a menu option and default `Ctrl+Shift+Q` shortcut.
  - The complete multi-window session is saved before closing.

- **Bug Fixes**
  - Improved URL hover detection so panes no longer respond to pointer positions outside their bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->